### PR TITLE
Traversable documents

### DIFF
--- a/library/Solarium/Query/Update/Command/Add.php
+++ b/library/Solarium/Query/Update/Command/Add.php
@@ -80,12 +80,26 @@ class Solarium_Query_Update_Command_Add extends Solarium_Query_Update_Command
     /**
      * Add multiple documents
      *
-     * @param array $documents
+     * @param array|Traversable $documents
      * @return Solarium_Query_Update_Add Provides fluent interface
      */
     public function addDocuments($documents)
     {
-        $this->_documents = array_merge($this->_documents, $documents);
+        //if we don't have documents so far, accept arrays or Traversable objects as-is
+        if (empty($this->_documents)) {
+            $this->_documents = $documents;
+            return $this;
+        }
+
+        //if something Traversable is passed in, and there are existing documents, convert all to arrays before merging
+        if ($documents instanceof Traversable) {
+            $documents = iterator_to_array($documents);
+        }
+        if ($this->_documents instanceof Traversable) {
+            $this->_documents = array_merge(iterator_to_array($this->_documents), $documents);
+        } else {
+            $this->_documents = array_merge($this->_documents, $documents);
+        }
 
         return $this;
     }

--- a/tests/Solarium/Query/Update/Command/AddTest.php
+++ b/tests/Solarium/Query/Update/Command/AddTest.php
@@ -67,6 +67,74 @@ class Solarium_Query_Update_Command_AddTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testAddDocumentsIteration()
+    {
+        $doc1 = new Solarium_Document_ReadWrite(array('id' => 1));
+        $doc2 = new Solarium_Document_ReadWrite(array('id' => 2));
+
+        $it = new ArrayIterator(array($doc1, $doc2));
+
+        $this->_command->addDocuments($it);
+
+        if ($this->_command->getDocuments() instanceof Traversable) {
+            $command_documents = iterator_to_array($this->_command->getDocuments());
+        } else {
+            $command_documents = $this->_command->getDocuments();
+        }
+
+        $this->assertEquals(
+            array($doc1, $doc2),
+            $command_documents,
+            'checking first two documents are added correctly'
+        );
+
+        $doc3 = new Solarium_Document_ReadWrite(array('id' => 3));
+        $doc4 = new Solarium_Document_ReadWrite(array('id' => 4));
+        $doc5 = new Solarium_Document_ReadWrite(array('id' => 5));
+
+        $it2 = new ArrayIterator(array($doc3, $doc4, $doc5));
+
+        $this->_command->addDocuments($it2);
+
+        if ($this->_command->getDocuments() instanceof Traversable) {
+            $command_documents = iterator_to_array($this->_command->getDocuments());
+        } else {
+            $command_documents = $this->_command->getDocuments();
+        }
+
+        $this->assertEquals(
+            array($doc1, $doc2, $doc3, $doc4, $doc5),
+            $command_documents,
+            'checking second three documents are added correctly to first two'
+        );
+    }
+
+    /**
+     * @depends testAddDocumentsIteration
+     */
+    public function testAddDocumentToIteration()
+    {
+        $doc1 = new Solarium_Document_ReadWrite(array('id' => 1));
+        $doc2 = new Solarium_Document_ReadWrite(array('id' => 2));
+
+        $this->_command->addDocuments(new ArrayIterator(array($doc1, $doc2)));
+
+        $doc3 = new Solarium_Document_ReadWrite(array('id' => 3));
+
+        $this->_command->addDocument($doc3);
+
+        if ($this->_command->getDocuments() instanceof Traversable) {
+            $command_documents = iterator_to_array($this->_command->getDocuments());
+        } else {
+            $command_documents = $this->_command->getDocuments();
+        }
+
+        $this->assertEquals(
+            array($doc1, $doc2, $doc3),
+            $command_documents
+        );
+    }
+
     public function testGetAndSetOverwrite()
     {
         $this->_command->setOverwrite(false);


### PR DESCRIPTION
- added support for adding traversable objects as document collections when performing updates

I think it's a problem that the current addDocuments() method on update queries doesn't allow traversable objects (because of the automatic array_merge).  There can also be large update sets one wouldn't want to copy into memory all in one go.  This change allows the passing in of iterations, not just simple arrays.
