### PR TITLE
Clear documents

### DIFF
--- a/library/Solarium/Document/ReadWrite.php
+++ b/library/Solarium/Document/ReadWrite.php
@@ -203,6 +203,17 @@ class Solarium_Document_ReadWrite extends Solarium_Document_ReadOnly
     }
 
     /**
+     * Clear all fields
+     *
+     * @return void
+     **/
+    public function clear()
+    {
+        $this->_fields = array();
+        $this->_fieldBoosts = array();
+    }
+
+    /**
      * Set field value
      *
      * Magic method for setting fields as properties of this document

--- a/tests/Solarium/Document/ReadWriteTest.php
+++ b/tests/Solarium/Document/ReadWriteTest.php
@@ -272,5 +272,30 @@ class Solarium_Document_ReadWriteTest extends PHPUnit_Framework_TestCase
             $this->_doc->getFields()
         );
     }
+
+    public function testClearFields()
+    {
+        $this->_doc->clear();
+
+        $expectedFields = array();
+
+        $this->assertEquals(
+            $expectedFields,
+            $this->_doc->getFields()
+        );
+    }
+
+    public function testClearFieldsBoostRemoval()
+    {
+        $this->_doc->setFieldBoost('name', 3.2);
+        $this->_doc->clear();
+
+        $expectedFields = array();
+
+        $this->assertEquals(
+            null,
+            $this->_doc->getFieldBoost('name')
+        );
+    }
     
 }


### PR DESCRIPTION
- added clear method for readwrite documents for easy clearing of fields and boosts

This can be a useful method on the document object in the solr-php-client library - so this is adding the same convenience method to Solarium for read-write documents.
