### PR TITLE
Clear fluent

### DIFF
--- a/library/Solarium/Document/ReadWrite.php
+++ b/library/Solarium/Document/ReadWrite.php
@@ -205,12 +205,14 @@ class Solarium_Document_ReadWrite extends Solarium_Document_ReadOnly
     /**
      * Clear all fields
      *
-     * @return void
+     * @return Solarium_Document_ReadWrite Provides fluent interface
      **/
     public function clear()
     {
         $this->_fields = array();
         $this->_fieldBoosts = array();
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
- made clear method for read/write documents provide fluent interface like other mutators

This is a fix for the previous PR for making read/write documents clearable - realised that the other mutators had fluent interface and that I'd broken the pattern!  This'll fix that.
