### PR TITLE
remove unwanted whitespace before php opening tag in Solarium_Client class

### DIFF
--- a/library/Solarium/Client.php
+++ b/library/Solarium/Client.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * Copyright 2011 Bas de Nooijer. All rights reserved.


### PR DESCRIPTION
description as title.
