### PR TITLE
corrected setField method of read/write documents

### DIFF
--- a/library/Solarium/Document/ReadWrite.php
+++ b/library/Solarium/Document/ReadWrite.php
@@ -124,7 +124,7 @@ class Solarium_Document_ReadWrite extends Solarium_Document_ReadOnly
      */
     public function setField($key, $value, $boost = null)
     {
-        if ($value == null) {
+        if ($value === null) {
             $this->removeField($key);
         } else {
             $this->_fields[$key] = $value;

--- a/tests/Solarium/Document/ReadWriteTest.php
+++ b/tests/Solarium/Document/ReadWriteTest.php
@@ -128,6 +128,20 @@ class Solarium_Document_ReadWriteTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testSetFieldWithFalsyValue()
+    {
+        $falsy_value = '';
+        $this->_doc->setField('name', $falsy_value);
+ 
+        $expectedFields = $this->_fields;
+        $expectedFields['name'] = $falsy_value;
+ 
+        $this->assertEquals(
+            $expectedFields,
+            $this->_doc->getFields()
+        );
+    }
+
     public function testRemoveField()
     {
         $this->_doc->removeField('name');


### PR DESCRIPTION
Corrected setField method of read/write documents so passing in false but not null value does not mean field is removed.

The doc against this method states that if you pass in NULL as a value that will remove the field in question - however, because the double equals operator was being used, the field would also be removed if the value was an empty string, 0 or '0'.  Changing this to a triple equals operator enforces the intent of the documentation.
