### PR TITLE
add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "solarium/solarium",
+    "type": "library",
+    "description": "PHP Solr client",
+    "keywords": ["solr", "search"],
+    "homepage": "http://www.solarium-project.org",
+    "version": "2.3.0",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Bas de Nooijer",
+            "email": "github@raspberry.nl"
+        },
+        {
+            "name": "Gasol Wu",
+            "email": "gasol.wu@gmail.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.2.0"
+    },
+    "autoload": {
+        "psr-0": { "Solarium": "library/" }
+    }
+}


### PR DESCRIPTION
[Composer](https://github.com/composer/composer) is a new package manager for PHP. It allows you to specify dependencies on a per-project basis. It takes lots of inspiration from NPM and ruby's bundler.

All you need to support composer is a composer.json file. In order to allow easy installation, the repository needs to be added to [packagist](http://packagist.org/), which is the standard repository for composer. Packagist will fetch all the versions from your github repository tags.

Once it has been added, adding solarium to a project will be as easy as creating this composer.json file in the project's directory:

```
{
    "require": {
        "solarium/solarium": ">=2.3.0"
    }
}
```

And running this command:

```
$ php composer.phar install
```

I'm working on adding a search feature to packagist, and I'm using solarium for that. Hence my interest.

Check out the following information on composer and packagist:
- [github.com/composer/composer](https://github.com/composer/composer)
- [packagist.org/about](http://packagist.org/about)
- [packagist.org](http://packagist.org)

Cheers!
