### PR TITLE
Optional params for facet range

### DIFF
--- a/library/Solarium/Client/RequestBuilder/Select/Component/FacetSet.php
+++ b/library/Solarium/Client/RequestBuilder/Select/Component/FacetSet.php
@@ -175,14 +175,18 @@ class Solarium_Client_RequestBuilder_Select_Component_FacetSet extends Solarium_
         $request->addParam("f.$field.facet.range.gap", $facet->getGap());
         $request->addParam("f.$field.facet.range.hardend", $facet->getHardend());
 
-        $other = explode(',', $facet->getOther());
-        foreach ($other AS $otherValue) {
-            $request->addParam("f.$field.facet.range.other", trim($otherValue));
+        if (null !== $facet->getOther()) {
+            $other = explode(',', $facet->getOther());
+            foreach ($other AS $otherValue) {
+                $request->addParam("f.$field.facet.range.other", trim($otherValue));
+            }
         }
 
-        $include = explode(',', $facet->getInclude());
-        foreach ($include AS $includeValue) {
-            $request->addParam("f.$field.facet.range.include", trim($includeValue));
+        if (null !== $facet->getOther()) {
+            $include = explode(',', $facet->getInclude());
+            foreach ($include AS $includeValue) {
+                $request->addParam("f.$field.facet.range.include", trim($includeValue));
+            }
         }
     }
 }

--- a/tests/Solarium/Client/RequestBuilder/Select/Component/FacetSetTest.php
+++ b/tests/Solarium/Client/RequestBuilder/Select/Component/FacetSetTest.php
@@ -111,6 +111,31 @@ class Solarium_Client_RequestBuilder_Select_Component_FacetSetTest extends PHPUn
         );
     }
 
+    public function testBuildWithRangeFacetExcludingOptionalParams()
+    {
+        $this->_component->addFacet(new Solarium_Query_Select_Component_Facet_Range(
+            array(
+                'key' => 'f1',
+                'field' => 'price',
+                'start' => '1',
+                'end' => 100,
+                'gap' => 10,
+            )
+        ));
+
+        $request = $this->_builder->buildComponent($this->_component, $this->_request);
+
+        $this->assertEquals(
+            null,
+            $request->getRawData()
+        );
+
+        $this->assertEquals(
+            '?facet=true&facet.range={!key=f1}price&f.price.facet.range.start=1&f.price.facet.range.end=100&f.price.facet.range.gap=10',
+            urldecode($request->getUri())
+        );
+    }
+
     public function testBuildWithFacetsAndGlobalFacetSettings()
     {
         $this->_component->setMissing(true);


### PR DESCRIPTION
If the params facet.range.other and facet.range.include are not set, either for a specific facet range or from the general configuration, these options are currently sent to Solr with an empty value, which invokes an error at the Solr end (this is experienced on Solr 3.5) of the following type:

SEVERE: org.apache.solr.common.SolrException:  is not a valid type of 'other' range facet information

This commit makes sure that the options are not sent to Solr if they are not set.
