### PR TITLE
Multiple collations in spellcheckresult get ignored, only the last one gets saved

### DIFF
--- a/library/Solarium/Client/ResponseParser/Select/Component/Spellcheck.php
+++ b/library/Solarium/Client/ResponseParser/Select/Component/Spellcheck.php
@@ -66,7 +66,7 @@ class Solarium_Client_ResponseParser_Select_Component_Spellcheck
 
             $suggestions = array();
             $correctlySpelled = null;
-            $collation = null;
+            $collations = array();
 
             $index = 0;
             while (isset($spellcheckResults[$index]) && isset($spellcheckResults[$index+1])) {
@@ -78,7 +78,7 @@ class Solarium_Client_ResponseParser_Select_Component_Spellcheck
                         $correctlySpelled = $value;
                         break;
                     case 'collation':
-                        $collation = $this->_parseCollation($value);
+                        $collations[] = $this->_parseCollation($value);
                         break;
                     default:
                         $suggestions[] = $this->_parseSuggestion($key, $value);
@@ -87,7 +87,7 @@ class Solarium_Client_ResponseParser_Select_Component_Spellcheck
                 $index +=2;
             }
 
-            return new Solarium_Result_Select_Spellcheck($suggestions, $collation, $correctlySpelled);
+            return new Solarium_Result_Select_Spellcheck($suggestions, $collations, $correctlySpelled);
         } else {
             return null;
         }

--- a/library/Solarium/Result/Select/Spellcheck.php
+++ b/library/Solarium/Result/Select/Spellcheck.php
@@ -53,11 +53,11 @@ class Solarium_Result_Select_Spellcheck implements IteratorAggregate, Countable
     protected $_suggestions;
 
     /**
-     * Collation object
+     * Collation object array
      *
-     * @var Solarium_Result_Select_Spellcheck_Collation
+     * @var array
      */
-    protected $_collation;
+    protected $_collations;
 
     /**
      * Correctly spelled?
@@ -74,21 +74,42 @@ class Solarium_Result_Select_Spellcheck implements IteratorAggregate, Countable
      * @param boolean $correctlySpelled
      * @return void
      */
-    public function __construct($suggestions, $collation, $correctlySpelled)
+    public function __construct($suggestions, $collations, $correctlySpelled)
     {
         $this->_suggestions = $suggestions;
-        $this->_collation = $collation;
+        $this->_collations = $collations;
         $this->_correctlySpelled = $correctlySpelled;
     }
 
     /**
      * Get the collation result
-     *
+     * 
+     * @param int $key
      * @return Solarium_Result_Select_Spellcheck_Collation
      */
-    public function getCollation()
+    public function getCollation($key = null)
     {
-        return $this->_collation;
+        $nrOfCollations = count($this->_collations);
+        if ($nrOfCollations == 0) {
+            return null;
+        } else {
+
+            if ($key === null) {
+                $key = $nrOfCollations - 1; // for backwards compatibility
+            }
+
+            return $this->_collations[$key];
+        }
+    }
+
+    /**
+     * Get all collations
+     *
+     * @return array
+     */
+    public function getCollations()
+    {
+        return $this->_collations;
     }
 
     /**


### PR DESCRIPTION
A spellcheckresult can actually contain more than 1 collation, but only 1 was saved. Collations are saved as an array now and you can use the getCollation() function with a key. If no key is provided it takes the last collation in the array, to simulate original behavior and provide backwards compatibility.
