### PR TITLE
Expose and passthrough add parameter in FacetSet createFacet* helpers

### DIFF
--- a/library/Solarium/Query/Select/Component/FacetSet.php
+++ b/library/Solarium/Query/Select/Component/FacetSet.php
@@ -411,44 +411,48 @@ class Solarium_Query_Select_Component_FacetSet extends Solarium_Query_Select_Com
      * Get a facet field instance
      *
      * @param mixed $options
+     * @param bool $add
      * @return Solarium_Query_Select_Component_Facet_Field
      */
-    public function createFacetField($options = null)
+    public function createFacetField($options = null, $add = true)
     {
-        return $this->createFacet(self::FACET_FIELD, $options);
+        return $this->createFacet(self::FACET_FIELD, $options, $add);
     }
 
     /**
      * Get a facet query instance
      *
      * @param mixed $options
+     * @param bool $add
      * @return Solarium_Query_Select_Component_Facet_Query
      */
-    public function createFacetQuery($options = null)
+    public function createFacetQuery($options = null, $add = true)
     {
-        return $this->createFacet(self::FACET_QUERY, $options);
+        return $this->createFacet(self::FACET_QUERY, $options, $add);
     }
 
     /**
      * Get a facet multiquery instance
      *
      * @param mixed $options
+     * @param bool $add
      * @return Solarium_Query_Select_Component_Facet_MultiQuery
      */
-    public function createFacetMultiQuery($options = null)
+    public function createFacetMultiQuery($options = null, $add = true)
     {
-        return $this->createFacet(self::FACET_MULTIQUERY, $options);
+        return $this->createFacet(self::FACET_MULTIQUERY, $options, $add);
     }
 
     /**
      * Get a facet range instance
      *
      * @param mixed $options
+     * @param bool $add
      * @return Solarium_Query_Select_Component_Facet_Range
      */
-    public function createFacetRange($options = null)
+    public function createFacetRange($options = null, $add = true)
     {
-        return $this->createFacet(self::FACET_RANGE, $options);
+        return $this->createFacet(self::FACET_RANGE, $options, $add);
     }
 
 }

--- a/tests/Solarium/Query/Select/Component/FacetSetTest.php
+++ b/tests/Solarium/Query/Select/Component/FacetSetTest.php
@@ -318,52 +318,72 @@ class Solarium_Query_Select_Component_FacetSetTest extends PHPUnit_Framework_Tes
         $this->_facetSet->createFacet('invalidtype');
     }
 
-    public function testCreateFacetField()
+    public function createFacetAddProvider()
     {
-        $options = array('optionA' => 1, 'optionB' => 2);
-
-        $observer = $this->getMock('Solarium_Query_Select_Component_FacetSet', array('createFacet'));
-        $observer->expects($this->once())
-                 ->method('createFacet')
-                 ->with($this->equalTo(Solarium_Query_Select_Component_FacetSet::FACET_FIELD), $this->equalTo($options));
-
-        $observer->createFacetField($options);
+        return array(
+            array(true),
+            array(false),
+        );
     }
 
-    public function testCreateFacetQuery()
+    /**
+     * @dataProvider createFacetAddProvider
+     */
+    public function testCreateFacetField($add)
     {
         $options = array('optionA' => 1, 'optionB' => 2);
 
         $observer = $this->getMock('Solarium_Query_Select_Component_FacetSet', array('createFacet'));
         $observer->expects($this->once())
                  ->method('createFacet')
-                 ->with($this->equalTo(Solarium_Query_Select_Component_FacetSet::FACET_QUERY), $this->equalTo($options));
+                 ->with($this->equalTo(Solarium_Query_Select_Component_FacetSet::FACET_FIELD), $this->equalTo($options), $add);
 
-        $observer->createFacetQuery($options);
+        $observer->createFacetField($options, $add);
     }
 
-    public function testCreateFacetMultiQuery()
+    /**
+     * @dataProvider createFacetAddProvider
+     */
+    public function testCreateFacetQuery($add)
     {
         $options = array('optionA' => 1, 'optionB' => 2);
 
         $observer = $this->getMock('Solarium_Query_Select_Component_FacetSet', array('createFacet'));
         $observer->expects($this->once())
                  ->method('createFacet')
-                 ->with($this->equalTo(Solarium_Query_Select_Component_FacetSet::FACET_MULTIQUERY), $this->equalTo($options));
+                 ->with($this->equalTo(Solarium_Query_Select_Component_FacetSet::FACET_QUERY), $this->equalTo($options), $add);
 
-        $observer->createFacetMultiQuery($options);
+        $observer->createFacetQuery($options, $add);
     }
 
-    public function testCreateFacetRange()
+    /**
+     * @dataProvider createFacetAddProvider
+     */
+    public function testCreateFacetMultiQuery($add)
     {
         $options = array('optionA' => 1, 'optionB' => 2);
 
         $observer = $this->getMock('Solarium_Query_Select_Component_FacetSet', array('createFacet'));
         $observer->expects($this->once())
                  ->method('createFacet')
-                 ->with($this->equalTo(Solarium_Query_Select_Component_FacetSet::FACET_RANGE), $this->equalTo($options));
+                 ->with($this->equalTo(Solarium_Query_Select_Component_FacetSet::FACET_MULTIQUERY), $this->equalTo($options), $add);
 
-        $observer->createFacetRange($options);
+        $observer->createFacetMultiQuery($options, $add);
+    }
+
+    /**
+     * @dataProvider createFacetAddProvider
+     */
+    public function testCreateFacetRange($add)
+    {
+        $options = array('optionA' => 1, 'optionB' => 2);
+
+        $observer = $this->getMock('Solarium_Query_Select_Component_FacetSet', array('createFacet'));
+        $observer->expects($this->once())
+                 ->method('createFacet')
+                 ->with($this->equalTo(Solarium_Query_Select_Component_FacetSet::FACET_RANGE), $this->equalTo($options), $add);
+
+        $observer->createFacetRange($options, $add);
     }
     
 }


### PR DESCRIPTION
Hi,

Solarium_Query_Select_Component_FacetSet::createFacet has an $add parameter.
It would be good to have this exposed in the createFacet\* helper functions too.

Cheers
