### PR TITLE
Add multiple collations to the Spellcheck Response Parser

### DIFF
--- a/examples/2.1.5.9-spellcheck.php
+++ b/examples/2.1.5.9-spellcheck.php
@@ -41,10 +41,13 @@ foreach($spellcheckResult as $suggestion) {
     echo '<hr/>';
 }
 
-$collation = $spellcheckResult->getCollation();
-echo '<h1>Collation</h1>';
-echo 'Query: '.$collation->getQuery().'<br/>';
-echo 'Hits: '.$collation->getHits().'<br/>';
+$collations = $spellcheckResult->getCollations();
+echo '<h1>Collations</h1>';
+foreach($collations as $collation) {
+    echo 'Query: '.$collation->getQuery().'<br/>';
+    echo 'Hits: '.$collation->getHits().'<br/>';
+    echo '<hr/>';
+}
 echo 'Corrections:<br/>';
 foreach($collation->getCorrections() as $input => $correction) {
     echo $input . ' => ' . $correction .'<br/>';

--- a/library/Solarium/Client/ResponseParser/Select/Component/Spellcheck.php
+++ b/library/Solarium/Client/ResponseParser/Select/Component/Spellcheck.php
@@ -66,7 +66,7 @@ class Solarium_Client_ResponseParser_Select_Component_Spellcheck
 
             $suggestions = array();
             $correctlySpelled = null;
-            $collation = null;
+            $collations = array();
 
             $index = 0;
             while (isset($spellcheckResults[$index]) && isset($spellcheckResults[$index+1])) {
@@ -78,7 +78,7 @@ class Solarium_Client_ResponseParser_Select_Component_Spellcheck
                         $correctlySpelled = $value;
                         break;
                     case 'collation':
-                        $collation = $this->_parseCollation($value);
+                        $collations[] = $this->_parseCollation($value);
                         break;
                     default:
                         $suggestions[] = $this->_parseSuggestion($key, $value);
@@ -87,7 +87,7 @@ class Solarium_Client_ResponseParser_Select_Component_Spellcheck
                 $index +=2;
             }
 
-            return new Solarium_Result_Select_Spellcheck($suggestions, $collation, $correctlySpelled);
+            return new Solarium_Result_Select_Spellcheck($suggestions, $collations, $correctlySpelled);
         } else {
             return null;
         }

--- a/library/Solarium/Result/Select/Spellcheck.php
+++ b/library/Solarium/Result/Select/Spellcheck.php
@@ -53,11 +53,11 @@ class Solarium_Result_Select_Spellcheck implements IteratorAggregate, Countable
     protected $_suggestions;
 
     /**
-     * Collation object
+     * Collations array
      *
-     * @var Solarium_Result_Select_Spellcheck_Collation
+     * @var array
      */
-    protected $_collation;
+    protected $_collations;
 
     /**
      * Correctly spelled?
@@ -70,25 +70,35 @@ class Solarium_Result_Select_Spellcheck implements IteratorAggregate, Countable
      * Constructor
      *
      * @param array $suggestions
-     * @param Solarium_Result_Select_Spellcheck_Collation $collation
+     * @param array $collations
      * @param boolean $correctlySpelled
      * @return void
      */
-    public function __construct($suggestions, $collation, $correctlySpelled)
+    public function __construct($suggestions, $collations, $correctlySpelled)
     {
         $this->_suggestions = $suggestions;
-        $this->_collation = $collation;
+        $this->_collations = $collations;
         $this->_correctlySpelled = $correctlySpelled;
     }
 
     /**
-     * Get the collation result
+     * Get the first collation result
      *
      * @return Solarium_Result_Select_Spellcheck_Collation
      */
     public function getCollation()
     {
-        return $this->_collation;
+        return empty($this->_collations) ? null : reset($this->_collations);
+    }
+
+    /**
+     * Get all collations
+     *
+     * @return array
+     */
+    public function getCollations()
+    {
+        return $this->_collations;
     }
 
     /**

--- a/tests/Solarium/Client/ResponseParser/Select/Component/SpellcheckTest.php
+++ b/tests/Solarium/Client/ResponseParser/Select/Component/SpellcheckTest.php
@@ -85,6 +85,21 @@ class Solarium_Client_ResponseParser_Select_Component_SpellcheckTest extends PHP
                             3 => 'ultrasharp'
                         ),
                     ),
+                    8 => 'collation',
+                    9 => array (
+                        0 => 'collationQuery',
+                        1 => 'dell ultrasharp new',
+                        2 => 'hits',
+                        3 => 0,
+                        4 => 'misspellingsAndCorrections',
+                        5 => array (
+                            0 => 'delll',
+                            1 => 'dell',
+                            2 => 'ultrashar',
+                            3 => 'ultrasharp'
+                        ),
+                    ),
+
                 )
             )
         );
@@ -95,6 +110,9 @@ class Solarium_Client_ResponseParser_Select_Component_SpellcheckTest extends PHP
         $this->assertEquals(false, $result->getCorrectlySpelled());
         $this->assertEquals('dell', $suggestions[0]->getWord());
         $this->assertEquals('dell ultrasharp', $result->getCollation()->getQuery());
+        $collations = $result->getCollations();
+        $this->assertEquals('dell ultrasharp', $collations[0]->getQuery());
+        $this->assertEquals('dell ultrasharp new', $collations[1]->getQuery());
     }
 
     public function testParse()
@@ -129,6 +147,8 @@ class Solarium_Client_ResponseParser_Select_Component_SpellcheckTest extends PHP
                     5 => false,
                     6 => 'collation',
                     7 => 'dell ultrasharp',
+                    8 => 'collation',
+                    9 => 'dell ultrasharp new',
                 )
             )
         );
@@ -139,6 +159,10 @@ class Solarium_Client_ResponseParser_Select_Component_SpellcheckTest extends PHP
         $this->assertEquals(false, $result->getCorrectlySpelled());
         $this->assertEquals('dell', $suggestions[0]->getWord());
         $this->assertEquals('dell ultrasharp', $result->getCollation()->getQuery());
+        $collations = $result->getCollations();
+        $this->assertEquals('dell ultrasharp', $collations[0]->getQuery());
+        $this->assertEquals('dell ultrasharp new', $collations[1]->getQuery());
+
     }
 
     public function testParseNoData()

--- a/tests/Solarium/Result/Select/SpellcheckTest.php
+++ b/tests/Solarium/Result/Select/SpellcheckTest.php
@@ -37,7 +37,7 @@ class Solarium_Result_Select_SpellcheckTest extends PHPUnit_Framework_TestCase
      */
     protected $_result;
 
-    protected $_suggestions, $_collation, $_correctlySpelled;
+    protected $_suggestions, $_collations, $_correctlySpelled;
 
     public function setUp()
     {
@@ -45,15 +45,19 @@ class Solarium_Result_Select_SpellcheckTest extends PHPUnit_Framework_TestCase
             'key1' => 'content1',
             'key2' => 'content2',
         );
-        $this->_collation = 'dummy1';
+        $this->_collations = array(
+             'dummy1',
+             'dummy2',
+        );
         $this->_correctlySpelled = false;
 
-        $this->_result = new Solarium_Result_Select_Spellcheck($this->_suggestions, $this->_collation, $this->_correctlySpelled);
+        $this->_result = new Solarium_Result_Select_Spellcheck($this->_suggestions, $this->_collations, $this->_correctlySpelled);
     }
 
     public function testGetCollation()
     {
-        $this->assertEquals($this->_collation, $this->_result->getCollation());
+        $this->assertEquals($this->_collations, $this->_result->getCollations());
+        $this->assertEquals(reset($this->_collations), $this->_result->getCollation());
     }
 
     public function testGetCorrectlySpelled()


### PR DESCRIPTION
As i already pointed out in issue #103 Solr has the option to return multiple collations. To maintain full compatibility with previous Solarium versions i have kept the original getCollation() version. I also wrote some more tests and updated the examples to reflect the changes.
