### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "description": "PHP Solr client",
     "keywords": ["solr", "search", "php"],
     "homepage": "http://www.solarium-project.org",
-    "version": "2.4.0",
     "license": "NewBSD",
     "authors": [
         {
@@ -17,5 +16,11 @@
     },
     "autoload": {
         "psr-0": { "Solarium": "library/" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "2.4-dev",
+            "dev-feature-nextgen": "3.0-dev"
+        }
     }
 }


### PR DESCRIPTION
You should not have the version in composer.json. If you do, the tagged version must always match it, so you always would need to update it. That's why 2.4.1 is not available on packagist. Also, by having branch aliases, it becomes possible to install the develop branch using `2.4.*@dev`.

These changes need to be propagated/replicated to the develop and nextgen branches as well.
