### PR TITLE
Add ability to remove q param from Select request

### DIFF
--- a/library/Solarium/Query/Select.php
+++ b/library/Solarium/Query/Select.php
@@ -272,8 +272,12 @@ class Solarium_Query_Select extends Solarium_Query
         if (!is_null($bind)) {
             $query = $this->getHelper()->assemble($query, $bind);
         }
+        
+        if (!is_null($query)) {
+            $query = trim($query);
+        }
 
-        return $this->_setOption('query', trim($query));
+        return $this->_setOption('query', $query);
     }
 
     /**


### PR DESCRIPTION
- Some Solr configurations have complex queries
    defined in solrconfig.xml with custom parameters,
    because of this, you might not always want the
    'q' parameter sent, this patch allows you to set
    'query' to NULL so that when you do it prevents
    'q' from being sent at all.
