### PR TITLE
[composer] Loosen symfony/event-dispatcher constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/event-dispatcher": "v2.0.15"
+        "symfony/event-dispatcher": "2.*"
     },
     "autoload": {
         "psr-0": { "Solarium": "library/" }


### PR DESCRIPTION
This allows solarium to be used with any 2.x version of the event dispatcher. It should stay backwards compatible, and this way you will not get unexpected version conflicts, for example when trying to use solarium with symfony 2.1.
