### PR TITLE
liberalised version of Symfony Event Dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/event-dispatcher": "2.1.4"
+        "symfony/event-dispatcher": ">=2.1.0,<2.3-dev"
     },
     "autoload": {
         "psr-0": { "Solarium": "library/" }


### PR DESCRIPTION
Depending on a specific version of the Symfony Event Dispatcher in the composer.json means you can't use Solarium in an application running another version of Symfony (including 2.1.6, which is the latest at time of writing). This change liberalises the requirement to allow any 2.1/2.2 version for now (the component isn't currently due to be altered functionally for 2.2).
