### PR TITLE
Dismax RequestBuilder used even if edismax is specified

### DIFF
--- a/library/Solarium/QueryType/Select/Query/Component/EdisMax.php
+++ b/library/Solarium/QueryType/Select/Query/Component/EdisMax.php
@@ -38,6 +38,7 @@
  */
 namespace Solarium\QueryType\Select\Query\Component;
 use Solarium\QueryType\Select\Query\Query as SelectQuery;
+use Solarium\QueryType\Select\RequestBuilder\Component\EdisMax as RequestBuilder;
 
 /**
  * EdisMax component
@@ -64,6 +65,16 @@ class EdisMax extends DisMax
     public function getType()
     {
         return SelectQuery::COMPONENT_EDISMAX;
+    }
+
+	  /**
+     * Get a requestbuilder for this query
+     *
+     * @return RequestBuilder
+     */
+    public function getRequestBuilder()
+    {
+        return new RequestBuilder;
     }
 
     /**


### PR DESCRIPTION
Hi,

A bugfix for Dismax was used even if edismax was specified

To reproduce : 
$client = new Solarium\Client($config);
$query = $client->createSelect();
$edismax = $query->getEDisMax();
$edismax->setBoostFunctionsMult("sqrt(salecount)");

Then check query, boost is absent from query because Dismax RequestBuilder is used rather than Edismax RequestBuilder
