### PR TITLE
Backported multiple suggestions in spellchecker from 3.x

### DIFF
--- a/library/Solarium/Client/ResponseParser/Select/Component/Spellcheck.php
+++ b/library/Solarium/Client/ResponseParser/Select/Component/Spellcheck.php
@@ -161,16 +161,19 @@ class Solarium_Client_ResponseParser_Select_Component_Spellcheck
         $endOffset = (isset($value['endOffset'])) ? $value['endOffset'] : null;
         $originalFrequency = (isset($value['origFreq'])) ? $value['origFreq'] : null;
 
-        if (is_string($value['suggestion'][0])) {
-            $word = $value['suggestion'][0];
-            $frequency = null;
-        } else {
-            $word = $value['suggestion'][0]['word'];
-            $frequency = $value['suggestion'][0]['freq'];
+        $words = array();
+        foreach($value['suggestion'] as $suggestion) {
+            if (is_string($suggestion)) {
+                $suggestion = array(
+                    'word' => $suggestion,
+                    'freq' => null,
+                );
+            }
+            $words[] = $suggestion;
         }
 
         return new Solarium_Result_Select_Spellcheck_Suggestion(
-            $numFound, $startOffset, $endOffset, $originalFrequency, $word, $frequency
+            $numFound, $startOffset, $endOffset, $originalFrequency, $words
         );
     }
 }

--- a/library/Solarium/Result/Select/Spellcheck/Suggestion.php
+++ b/library/Solarium/Result/Select/Spellcheck/Suggestion.php
@@ -52,17 +52,15 @@ class Solarium_Result_Select_Spellcheck_Suggestion
      * @param int $startOffset
      * @param int $endOffset
      * @param int $originalFrequency
-     * @param string $word
-     * @param int $frequency
+     * @param array $words
      */
-    public function __construct($numFound, $startOffset, $endOffset, $originalFrequency, $word, $frequency)
+    public function __construct($numFound, $startOffset, $endOffset, $originalFrequency, $words)
     {
         $this->_numFound = $numFound;
         $this->_startOffset = $startOffset;
         $this->_endOffset = $endOffset;
         $this->_originalFrequency = $originalFrequency;
-        $this->_word = $word;
-        $this->_frequency = $frequency;
+        $this->_words = $words;
     }
 
     /**
@@ -108,13 +106,28 @@ class Solarium_Result_Select_Spellcheck_Suggestion
     }
 
     /**
-     * Get word
+     * Get first word
      *
-     * @return string
+     * @return string|null
      */
     public function getWord()
     {
-        return $this->_word;
+        $word = reset($this->_words);
+        if (isset($word['word'])) {
+            return $word['word'];
+        } else {
+            return $word;
+        }
+    }
+
+    /**
+     * Get all words (and frequencies)
+     *
+     * @return array
+     */
+    public function getWords()
+    {
+        return $this->_words;
     }
 
     /**
@@ -126,7 +139,11 @@ class Solarium_Result_Select_Spellcheck_Suggestion
      */
     public function getFrequency()
     {
-        return $this->_frequency;
+        $word = reset($this->_words);
+        if (isset($word['freq'])) {
+            return $word['freq'];
+        } else {
+            return null;
+        }
     }
-
 }

--- a/tests/Solarium/Result/Select/Spellcheck/SuggestionTest.php
+++ b/tests/Solarium/Result/Select/Spellcheck/SuggestionTest.php
@@ -45,11 +45,19 @@ class Solarium_Result_Select_Spellcheck_SuggestionTest extends PHPUnit_Framework
         $this->_startOffset = 2;
         $this->_endOffset = 3;
         $this->_originalFrequency = 4;
-        $this->_word = 'dummyword';
-        $this->_frequency = 5;
+        $this->_words = array(
+            array(
+                'word' => 'dummyword',
+                'freq' => 5
+            ),
+            array(
+                'word' => 'secondword',
+                'freq' => 1
+            )
+        );
 
         $this->_result = new Solarium_Result_Select_Spellcheck_Suggestion(
-            $this->_numFound, $this->_startOffset, $this->_endOffset, $this->_originalFrequency, $this->_word, $this->_frequency
+            $this->_numFound, $this->_startOffset, $this->_endOffset, $this->_originalFrequency, $this->_words
         );
     }
 
@@ -75,12 +83,17 @@ class Solarium_Result_Select_Spellcheck_SuggestionTest extends PHPUnit_Framework
 
     public function testGetWord()
     {
-         $this->assertEquals($this->_word, $this->_result->getWord());
+         $this->assertEquals($this->_words[0]['word'], $this->_result->getWord());
     }
 
     public function testGetFrequency()
     {
-         $this->assertEquals($this->_frequency, $this->_result->getFrequency());
+         $this->assertEquals($this->_words[0]['freq'], $this->_result->getFrequency());
+    }
+
+    public function testGetWords()
+    {
+         $this->assertEquals($this->_words, $this->_result->getWords());
     }
 
 }


### PR DESCRIPTION
This PR backports some improvements from the 3.x branch to 2.4.x. I needed to do this for compatibility issues that prevent me from using 3.x. Are you fine with accepting this patch and tagging it as 2.4.2? If you want me to re-target it to a different branch please let me know :)

Thank you very much,

Aldo.
