### PR TITLE
Fix proposition for maxScore related notice + unit test (Issue #175)

### DIFF
--- a/library/Solarium/QueryType/Select/ResponseParser/Component/MoreLikeThis.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/MoreLikeThis.php
@@ -74,7 +74,7 @@ class MoreLikeThis implements ComponentParserInterface
 
                 $results[$key] = new Result(
                     $result['numFound'],
-                    $result['maxScore'],
+                    isset($result['maxScore']) ? $result['maxScore'] : null,
                     $docs
                 );
             }

--- a/library/Solarium/QueryType/Select/Result/MoreLikeThis/Result.php
+++ b/library/Solarium/QueryType/Select/Result/MoreLikeThis/Result.php
@@ -72,7 +72,7 @@ class Result implements \IteratorAggregate, \Countable
      * Constructor
      *
      * @param  int   $numFound
-     * @param  float $maxScore
+     * @param  float|null $maxScore
      * @param  array $documents
      * @return void
      */

--- a/tests/Solarium/Tests/QueryType/Select/ResponseParser/Component/MoreLikeThisTest.php
+++ b/tests/Solarium/Tests/QueryType/Select/ResponseParser/Component/MoreLikeThisTest.php
@@ -77,4 +77,28 @@ class MoreLikeThisTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $result->getResults());
     }
 
+    public function testParseWithoutMaxScore()
+    {
+        $query = new Query();
+        $data = array(
+            'moreLikeThis' => array(
+                'id1' => array(
+                    'numFound' => 12,
+                    'docs' => array(
+                        array('field1' => 'value1')
+                    )
+                )
+            )
+        );
+
+        $docs = array(new Document(array('field1' => 'value1')));
+        $expected = array(
+            'id1' => new Result(12, null, $docs)
+        );
+
+        $result = $this->parser->parse($query, null, $data);
+
+        $this->assertEquals($expected, $result->getResults());
+    }
+
 }


### PR DESCRIPTION
This a bug fix proposition for Issue #175 initialy reported and fixed by @mcorne along with a unit test extension.

Here is an example of a test to reproduce the case

```
/select?q=id:466623&fl=id,score,title&mlt=true&mlt.fl=title => maxScore in the result
/select?q=id:466623&fl=id,score,title&mlt=true&mlt.fl=title&mlt.count=10 => maxScore not in the result
```
