### PR TITLE
Upgrade to beat the rule of solr ...

### DIFF
--- a/library/Solarium/QueryType/Update/Query/Document/Document.php
+++ b/library/Solarium/QueryType/Update/Query/Document/Document.php
@@ -199,7 +199,7 @@ class Document extends AbstractDocument implements DocumentInterface
      */
     public function setField($key, $value, $boost = null, $modifier = null)
     {
-        if ($value === null) {
+        if ($value === null && $modifier == null) {
             $this->removeField($key);
         } else {
             $this->fields[$key] = $value;

--- a/library/Solarium/QueryType/Update/RequestBuilder.php
+++ b/library/Solarium/QueryType/Update/RequestBuilder.php
@@ -169,6 +169,9 @@ class RequestBuilder extends BaseRequestBuilder
         $xml = '<field name="' . $name . '"';
         $xml .= $this->attrib('boost', $boost);
         $xml .= $this->attrib('update', $modifier);
+        if($value === null){
+            $xml .= $this->attrib('null', 'true');
+        }
         $xml .= '>' . htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8');
         $xml .= '</field>';
 


### PR DESCRIPTION
Example of "add" with optional update attribute to set a field to null (i.e. delete a field):

``` xml
<add>
  <doc>
    <field name="employeeId">05991</field>
    <field name="skills" update="set" null="true" />
  </doc>
</add>
```

http://wiki.apache.org/solr/UpdateXmlMessages#Optional_attributes_for_.22field.22
