### PR TITLE
Replacing relative classes sub-namespaces in PHPDocs by absolute ones to improve IDE support

### DIFF
--- a/library/Solarium/Core/Query/ResponseParserInterface.php
+++ b/library/Solarium/Core/Query/ResponseParserInterface.php
@@ -55,7 +55,7 @@ interface ResponseParserInterface
      *
      * When this method is called the actual response parsing is started.
      *
-     * @param  Result\Result $result
+     * @param  \Solarium\Core\Query\Result\Result $result
      * @return mixed
      */
     public function parse($result);

--- a/library/Solarium/QueryType/Select/Query/Component/FacetSet.php
+++ b/library/Solarium/QueryType/Select/Query/Component/FacetSet.php
@@ -308,8 +308,8 @@ class FacetSet extends Component
      * Add a facet
      *
      * @throws InvalidArgumentException
-     * @param  Facet\Facet|array        $facet
-     * @return self                     Provides fluent interface
+     * @param  \Solarium\QueryType\Select\Query\Component\Facet\Facet|array $facet
+     * @return self                                                         Provides fluent interface
      */
     public function addFacet($facet)
     {
@@ -440,7 +440,7 @@ class FacetSet extends Component
      * @param  string               $type
      * @param  array|object|null    $options
      * @param  boolean              $add
-     * @return Facet\Facet
+     * @return \Solarium\QueryType\Select\Query\Component\Facet\Facet
      */
     public function createFacet($type, $options = null, $add = true)
     {
@@ -471,7 +471,7 @@ class FacetSet extends Component
      *
      * @param  mixed       $options
      * @param  bool        $add
-     * @return Facet\Field
+     * @return \Solarium\QueryType\Select\Query\Component\Facet\Field
      */
     public function createFacetField($options = null, $add = true)
     {
@@ -483,7 +483,7 @@ class FacetSet extends Component
      *
      * @param  mixed       $options
      * @param  bool        $add
-     * @return Facet\Query
+     * @return \Solarium\QueryType\Select\Query\Component\Facet\Query
      */
     public function createFacetQuery($options = null, $add = true)
     {
@@ -495,7 +495,7 @@ class FacetSet extends Component
      *
      * @param  mixed            $options
      * @param  bool             $add
-     * @return Facet\MultiQuery
+     * @return \Solarium\QueryType\Select\Query\Component\Facet\MultiQuery
      */
     public function createFacetMultiQuery($options = null, $add = true)
     {
@@ -507,7 +507,7 @@ class FacetSet extends Component
      *
      * @param  mixed       $options
      * @param  bool        $add
-     * @return Facet\Range
+     * @return \Solarium\QueryType\Select\Query\Component\Facet\Range
      */
     public function createFacetRange($options = null, $add = true)
     {
@@ -519,7 +519,7 @@ class FacetSet extends Component
      *
      * @param  mixed       $options
      * @param  bool        $add
-     * @return Facet\Pivot
+     * @return \Solarium\QueryType\Select\Query\Component\Facet\Pivot
      */
     public function createFacetPivot($options = null, $add = true)
     {

--- a/library/Solarium/QueryType/Select/Query/Query.php
+++ b/library/Solarium/QueryType/Select/Query/Query.php
@@ -890,7 +890,7 @@ class Query extends BaseQuery
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Component\MoreLikeThis
+     * @return \Solarium\QueryType\Select\Query\Component\MoreLikeThis
      */
     public function getMoreLikeThis()
     {
@@ -902,7 +902,7 @@ class Query extends BaseQuery
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Component\FacetSet
+     * @return \Solarium\QueryType\Select\Query\Component\FacetSet
      */
     public function getFacetSet()
     {
@@ -914,7 +914,7 @@ class Query extends BaseQuery
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Component\DisMax
+     * @return \Solarium\QueryType\Select\Query\Component\DisMax
      */
     public function getDisMax()
     {
@@ -926,7 +926,7 @@ class Query extends BaseQuery
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Component\EdisMax
+     * @return \Solarium\QueryType\Select\Query\Component\EdisMax
      */
     public function getEDisMax()
     {
@@ -938,7 +938,7 @@ class Query extends BaseQuery
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Component\Highlighting\Highlighting
+     * @return \Solarium\QueryType\Select\Query\Component\Highlighting\Highlighting
      */
     public function getHighlighting()
     {
@@ -950,7 +950,7 @@ class Query extends BaseQuery
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Component\Grouping
+     * @return \Solarium\QueryType\Select\Query\Component\Grouping
      */
     public function getGrouping()
     {
@@ -962,7 +962,7 @@ class Query extends BaseQuery
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Component\Spellcheck
+     * @return \Solarium\QueryType\Select\Query\Component\Spellcheck
      */
     public function getSpellcheck()
     {
@@ -974,7 +974,7 @@ class Query extends BaseQuery
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Component\DistributedSearch
+     * @return \Solarium\QueryType\Select\Query\Component\DistributedSearch
      */
     public function getDistributedSearch()
     {
@@ -986,7 +986,7 @@ class Query extends BaseQuery
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Component\Stats\Stats
+     * @return \Solarium\QueryType\Select\Query\Component\Stats\Stats
      */
     public function getStats()
     {
@@ -998,7 +998,7 @@ class Query extends BaseQuery
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Component\Debug
+     * @return \Solarium\QueryType\Select\Query\Component\Debug
      */
     public function getDebug()
     {

--- a/library/Solarium/QueryType/Select/Result/Result.php
+++ b/library/Solarium/QueryType/Select/Result/Result.php
@@ -216,7 +216,7 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return MoreLikeThis\Result
+     * @return \Solarium\QueryType\Select\Result\MoreLikeThis\Result
      */
     public function getMoreLikeThis()
     {
@@ -228,7 +228,7 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Highlighting\Result
+     * @return \Solarium\QueryType\Select\Result\Highlighting\Result
      */
     public function getHighlighting()
     {
@@ -240,7 +240,7 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Grouping\Result
+     * @return \Solarium\QueryType\Select\Result\Grouping\Result
      */
     public function getGrouping()
     {
@@ -264,7 +264,7 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Spellcheck\Result
+     * @return \Solarium\QueryType\Select\Result\Spellcheck\Result
      */
     public function getSpellcheck()
     {
@@ -276,7 +276,7 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Stats\Result
+     * @return \Solarium\QueryType\Select\Result\Stats\Result
      */
     public function getStats()
     {
@@ -288,7 +288,7 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * This is a convenience method that maps presets to getComponent
      *
-     * @return Debug\Result
+     * @return \Solarium\QueryType\Select\Result\Debug\Result
      */
     public function getDebug()
     {

--- a/library/Solarium/QueryType/Update/RequestBuilder.php
+++ b/library/Solarium/QueryType/Update/RequestBuilder.php
@@ -107,7 +107,7 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build XML for an add command
      *
-     * @param  Query\Command\Add $command
+     * @param  \Solarium\QueryType\Update\Query\Command\Add $command
      * @param  UpdateQuery $query
      * @return string
      */
@@ -178,7 +178,7 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build XML for a delete command
      *
-     * @param  Query\Command\Delete $command
+     * @param  \Solarium\QueryType\Update\Query\Command\Delete $command
      * @return string
      */
     public function buildDeleteXml($command)
@@ -198,7 +198,7 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build XML for an update command
      *
-     * @param  Query\Command\Optimize $command
+     * @param  \Solarium\QueryType\Update\Query\Command\Optimize $command
      * @return string
      */
     public function buildOptimizeXml($command)
@@ -215,7 +215,7 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build XML for a commit command
      *
-     * @param  Query\Command\Commit $command
+     * @param  \Solarium\QueryType\Update\Query\Command\Commit $command
      * @return string
      */
     public function buildCommitXml($command)


### PR DESCRIPTION
PhpStorm support for relative sub-namespace is not working very well with this library, resulting in a lot of "Multiple implementations" warning.

By using the absolute namespace, the problem does not arise anymore.
