### PR TITLE
Add PHPUnit as a dev requirement in Composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         "php": ">=5.3.2",
         "symfony/event-dispatcher": "~2.1"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~3.7"
+    },
     "autoload": {
         "psr-0": { "Solarium\\": "library/" }
     }


### PR DESCRIPTION
This will allow developers to install PHPUnit and run the tests more easily via Composer.
