### PR TITLE
Fix example 5.2.

### DIFF
--- a/examples/5.2-extending.php
+++ b/examples/5.2-extending.php
@@ -20,7 +20,7 @@ class MyClient extends Client
      /**
      * Querytype mappings
      */
-    protected $_queryTypes = array(
+    protected $queryTypes = array(
         self::QUERY_SELECT => array(
             'query'          => 'MyQuery',
             'requestbuilder' => 'Solarium\QueryType\Select\RequestBuilder\RequestBuilder',


### PR DESCRIPTION
Small fix for the example 5.2. The parent property is called `$queryTypes`, not `$_queryTypes`. It also remove a PSR-2 warning (use of underscore in a variable).
