### PR TITLE
Add fixture loading capabilities

### DIFF
--- a/library/Solarium/Support/DataFixtures/Executor.php
+++ b/library/Solarium/Support/DataFixtures/Executor.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Solarium\Support\DataFixtures;
+
+use Solarium\Core\Client\Client;
+
+/**
+ * @author Baldur Rensch <brensch@gmail.com>
+ */
+class Executor 
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param FixtureInterface[] $fixtures
+     */
+    public function execute(array $fixtures)
+    {
+        foreach ($fixtures as $fixture) {
+            $fixture->load($this->client);
+        }
+    }
+}

--- a/library/Solarium/Support/DataFixtures/FixtureInterface.php
+++ b/library/Solarium/Support/DataFixtures/FixtureInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Solarium\Support\DataFixtures;
+
+use Solarium\Core\Client\Client;
+
+/**
+ * @author Baldur Rensch <brensch@gmail.com>
+ */
+interface FixtureInterface
+{
+    /**
+     * @param Client $client
+     */
+    public function load(Client $client);
+}

--- a/library/Solarium/Support/DataFixtures/FixtureLoader.php
+++ b/library/Solarium/Support/DataFixtures/FixtureLoader.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Solarium\Support\DataFixtures;
+
+/**
+ * @author Baldur Rensch <brensch@gmail.com>
+ */
+class FixtureLoader 
+{
+    /**
+     * @var Loader
+     */
+    private $loader;
+
+    /**
+     * @var Purger
+     */
+    private $purger;
+
+    /**
+     * @param Loader $loader
+     * @param Purger $purger
+     */
+    public function __construct(Loader $loader, Purger $purger)
+    {
+        $this->loader = $loader;
+        $this->purger = $purger;
+    }
+
+    /**
+     * @param      $dir
+     * @param bool $append
+     */
+    public function loadFixturesFromDir($dir, $append = true)
+    {
+        if (!$append) {
+            $this->purger->purge();
+        }
+
+        $this->loader->loadFromDirectory($dir);
+    }
+}

--- a/library/Solarium/Support/DataFixtures/Loader.php
+++ b/library/Solarium/Support/DataFixtures/Loader.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Solarium\Support\DataFixtures;
+
+/**
+ * @author Baldur Rensch <brensch@gmail.com>
+ */
+class Loader 
+{
+    /**
+     * @var FixtureInterface[]
+     */
+    private $fixtures;
+
+    /**
+     * The file extension of fixture files.
+     *
+     * @var string
+     */
+    private $fileExtension = '.php';
+
+    public function __construct()
+    {
+        $this->fixtures = array();
+    }
+
+    /**
+     * @param FixtureInterface $fixture
+     */
+    public function addFixture(FixtureInterface $fixture)
+    {
+        $this->fixtures[] = $fixture;
+    }
+
+    /**
+     * @return FixtureInterface[]
+     */
+    public function getFixtures()
+    {
+        return $this->fixtures;
+    }
+
+    /**
+     * @param $dir
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function loadFromDirectory($dir)
+    {
+        if (!is_dir($dir)) {
+            throw new \InvalidArgumentException(sprintf('"%s" does not exist', $dir));
+        }
+
+        $includedFiles = array();
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir),
+            \RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        /** @var $file \DirectoryIterator */
+        foreach ($iterator as $file) {
+            if (($fileName = $file->getBasename($this->fileExtension)) == $file->getBasename()) {
+                continue;
+            }
+            $sourceFile = realpath($file->getPathName());
+            /** @noinspection PhpIncludeInspection */
+            require_once $sourceFile;
+            $includedFiles[] = $sourceFile;
+        }
+        $declared = get_declared_classes();
+
+        foreach ($declared as $className) {
+            $reflClass = new \ReflectionClass($className);
+            $sourceFile = $reflClass->getFileName();
+
+            if (in_array($sourceFile, $includedFiles)) {
+                $fixture = new $className;
+
+                $this->addFixture($fixture);
+            }
+        }
+    }
+}

--- a/library/Solarium/Support/DataFixtures/Purger.php
+++ b/library/Solarium/Support/DataFixtures/Purger.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Solarium\Support\DataFixtures;
+
+use Solarium\Core\Client\Client;
+
+class Purger
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @var string
+     */
+    private $deleteQuery = '*:*';
+
+    /**
+     * @param Client $client
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @return bool
+     */
+    public function purge()
+    {
+        $update = $this->client->createUpdate();
+
+        $update->addDeleteQuery($this->deleteQuery);
+        $update->addCommit();
+
+        $result = $this->client->update($update);
+
+        return 0 == $result->getStatus();
+    }
+}

--- a/tests/Solarium/Tests/Support/DataFixtures/ExecutorTest.php
+++ b/tests/Solarium/Tests/Support/DataFixtures/ExecutorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Solarium\Tests\Support\DataFixtures;
+
+use Solarium\Support\DataFixtures\Executor;
+
+class ExecutorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLoad()
+    {
+        $solarium = $this->getMock('Solarium\Core\Client\Client');
+
+        $mockFixtures = array(
+            $this->getMockFixture($solarium),
+            $this->getMockFixture($solarium),
+        );
+
+        $executor = new Executor($solarium);
+        $executor->execute($mockFixtures);
+    }
+
+    private function getMockFixture($client)
+    {
+        $fixture = $this->getMock('Solarium\Support\DataFixtures\FixtureInterface');
+        $fixture->expects($this->once())
+            ->method('load')
+            ->with($client);
+
+        return $fixture;
+    }
+}

--- a/tests/Solarium/Tests/Support/DataFixtures/FixtureLoaderTest.php
+++ b/tests/Solarium/Tests/Support/DataFixtures/FixtureLoaderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Solarium\Tests\Support\DataFixtures;
+
+use Solarium\Support\DataFixtures\FixtureLoader;
+
+class FixtureLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    private $fixturePath;
+
+    private $client;
+
+    public function testWithAppending()
+    {
+        $loader = $this->mockLoader();
+        $purger = $this->mockPurger(false);
+
+        $fixtureLoader = new FixtureLoader($loader, $purger);
+
+        $fixtureLoader->loadFixturesFromDir($this->fixturePath);
+    }
+
+    public function testWithPurging()
+    {
+        $loader = $this->mockLoader();
+        $purger = $this->mockPurger(true);
+
+        $fixtureLoader = new FixtureLoader($loader, $purger);
+
+        $fixtureLoader->loadFixturesFromDir($this->fixturePath, false);
+    }
+
+    protected function setUp()
+    {
+        $this->client = $this->getMock('Solarium\Core\Client\Client');
+        $this->fixturePath = __DIR__ . '/Fixtures/';
+    }
+
+    private function mockLoader()
+    {
+        $loader = $this->getMock('Solarium\Support\DataFixtures\Loader', array(), array($this->client));
+
+        $loader->expects($this->once())
+            ->method('loadFromDirectory')
+            ->with($this->fixturePath);
+
+        return $loader;
+    }
+
+    private function mockPurger($expectPurge)
+    {
+        $purger = $this->getMock('Solarium\Support\DataFixtures\Purger', array(), array($this->client));
+
+        $purger->expects($expectPurge ? $this->once() : $this->never())
+            ->method('purge');
+
+        return $purger;
+    }
+}

--- a/tests/Solarium/Tests/Support/DataFixtures/Fixtures/MockFixture1.php
+++ b/tests/Solarium/Tests/Support/DataFixtures/Fixtures/MockFixture1.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Solarium\Tests\Support\DataFixtures\Fixtures;
+
+use Solarium\Core\Client\Client;
+use Solarium\Support\DataFixtures\FixtureInterface;
+
+class MockFixture1 implements FixtureInterface
+{
+    /**
+     * @param Client $client
+     */
+    public function load(Client $client)
+    {
+        // Not needed in unit test
+    }
+}

--- a/tests/Solarium/Tests/Support/DataFixtures/Fixtures/MockFixture2.php
+++ b/tests/Solarium/Tests/Support/DataFixtures/Fixtures/MockFixture2.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Solarium\Tests\Support\DataFixtures\Fixtures;
+
+use Solarium\Core\Client\Client;
+use Solarium\Support\DataFixtures\FixtureInterface;
+
+class MockFixture2 implements FixtureInterface
+{
+    /**
+     * @param Client $client
+     */
+    public function load(Client $client)
+    {
+        // Not needed in unit test
+    }
+}
+
+class MockFixture3 implements FixtureInterface
+{
+    /**
+     * @param Client $client
+     */
+    public function load(Client $client)
+    {
+        // Not needed in unit test
+    }
+}

--- a/tests/Solarium/Tests/Support/DataFixtures/LoaderTest.php
+++ b/tests/Solarium/Tests/Support/DataFixtures/LoaderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Solarium\Tests\Support\DataFixtures;
+
+use Solarium\Support\DataFixtures\Loader;
+
+class LoaderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetEmptyFixtures()
+    {
+        $loader = new Loader();
+        $this->assertEmpty($loader->getFixtures());
+    }
+
+    public function testAddFixtures()
+    {
+        $loader = new Loader();
+
+        $fixtures = array(
+            $this->getMock('Solarium\Support\DataFixtures\FixtureInterface'),
+            $this->getMock('Solarium\Support\DataFixtures\FixtureInterface'),
+        );
+
+        foreach ($fixtures as $fixture) {
+            $loader->addFixture($fixture);
+        }
+
+        $this->assertEquals($fixtures, $loader->getFixtures());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testLoadFromInvalidDir()
+    {
+        $loader = new Loader();
+        $loader->loadFromDirectory('bla');
+    }
+
+    public function testLoadFromDir()
+    {
+        $loader = new Loader();
+        $loader->loadFromDirectory(__DIR__ . '/Fixtures/');
+
+        $loadedFixtures = $loader->getFixtures();
+        $this->assertCount(3, $loadedFixtures);
+        foreach ($loadedFixtures as $fixture) {
+            $this->assertInstanceOf('Solarium\Support\DataFixtures\FixtureInterface', $fixture);
+        }
+    }
+}

--- a/tests/Solarium/Tests/Support/DataFixtures/PurgerTest.php
+++ b/tests/Solarium/Tests/Support/DataFixtures/PurgerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Solarium\Tests\Support\DataFixtures;
+
+use Solarium\Support\DataFixtures\Purger;
+
+class PurgerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPurge()
+    {
+        $solarium = $this->getMock('Solarium\Core\Client\Client');
+
+        $update = $this->getMock('\Solarium\QueryType\Update\Query\Query');
+        $update->expects($this->once())
+            ->method('addDeleteQuery')
+            ->with('*:*');
+        $update->expects($this->once())
+            ->method('addCommit');
+
+        $queryResult = $this->getMockBuilder('\Solarium\QueryType\Update\Result')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $queryResult->expects($this->once())
+            ->method('getStatus')
+            ->will($this->returnValue(0));
+
+        $solarium->expects($this->once())
+            ->method('createUpdate')
+            ->will($this->returnValue($update));
+
+        $solarium->expects($this->once())
+            ->method('update')
+            ->with($update)
+            ->will($this->returnValue($queryResult));
+
+        $purger = new Purger($solarium);
+        $purger->purge();
+    }
+}


### PR DESCRIPTION
This PR adds a loader and purger to the library. This is heavily modeled after the Doctrine DataFixtures library. Updates to the documentation are necessary of course.

This is a follow up to https://github.com/basdenooijer/solarium/pull/211
