### PR TITLE
Fixed the fixture laoder not having an executor

### DIFF
--- a/library/Solarium/Support/DataFixtures/FixtureLoader.php
+++ b/library/Solarium/Support/DataFixtures/FixtureLoader.php
@@ -3,6 +3,8 @@
 namespace Solarium\Support\DataFixtures;
 
 /**
+ * This class is just a convenience wrapper around the fixture loading process.
+ *
  * @author Baldur Rensch <brensch@gmail.com>
  */
 class FixtureLoader 
@@ -18,13 +20,20 @@ class FixtureLoader
     private $purger;
 
     /**
-     * @param Loader $loader
-     * @param Purger $purger
+     * @var Executor
      */
-    public function __construct(Loader $loader, Purger $purger)
+    private $executor;
+
+    /**
+     * @param Loader   $loader
+     * @param Purger   $purger
+     * @param Executor $executor
+     */
+    public function __construct(Loader $loader, Purger $purger, Executor $executor)
     {
         $this->loader = $loader;
         $this->purger = $purger;
+        $this->executor = $executor;
     }
 
     /**
@@ -38,5 +47,7 @@ class FixtureLoader
         }
 
         $this->loader->loadFromDirectory($dir);
+
+        $this->executor->execute($this->loader->getFixtures());
     }
 }

--- a/tests/Solarium/Tests/Support/DataFixtures/FixtureLoaderTest.php
+++ b/tests/Solarium/Tests/Support/DataFixtures/FixtureLoaderTest.php
@@ -3,6 +3,7 @@
 namespace Solarium\Tests\Support\DataFixtures;
 
 use Solarium\Support\DataFixtures\FixtureLoader;
+use Solarium\Tests\Support\DataFixtures\Fixtures\MockFixture1;
 
 class FixtureLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -14,8 +15,9 @@ class FixtureLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $loader = $this->mockLoader();
         $purger = $this->mockPurger(false);
+        $executor = $this->mockExecutor();
 
-        $fixtureLoader = new FixtureLoader($loader, $purger);
+        $fixtureLoader = new FixtureLoader($loader, $purger, $executor);
 
         $fixtureLoader->loadFixturesFromDir($this->fixturePath);
     }
@@ -24,8 +26,9 @@ class FixtureLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $loader = $this->mockLoader();
         $purger = $this->mockPurger(true);
+        $executor = $this->mockExecutor();
 
-        $fixtureLoader = new FixtureLoader($loader, $purger);
+        $fixtureLoader = new FixtureLoader($loader, $purger, $executor);
 
         $fixtureLoader->loadFixturesFromDir($this->fixturePath, false);
     }
@@ -44,6 +47,16 @@ class FixtureLoaderTest extends \PHPUnit_Framework_TestCase
             ->method('loadFromDirectory')
             ->with($this->fixturePath);
 
+        $loader->expects($this->once())
+            ->method('getFixtures')
+            ->will(
+                $this->returnValue(
+                    array(
+                        $this->getMockFixture()
+                    )
+                )
+            );
+
         return $loader;
     }
 
@@ -55,5 +68,17 @@ class FixtureLoaderTest extends \PHPUnit_Framework_TestCase
             ->method('purge');
 
         return $purger;
+    }
+
+    private function mockExecutor()
+    {
+        $executor = $this->getMock('Solarium\Support\DataFixtures\Executor', array(), array($this->client));
+
+        return $executor;
+    }
+
+    private function getMockFixture()
+    {
+        return new MockFixture1();
     }
 }


### PR DESCRIPTION
I forgot to add the executor to the data fixtures class (I am not using that class directly, but are using the 3 other parts (purger, loader, executor) separately. That way it was utterly useless. :-) I am still working on compiling documentation and will send it to you once I get it done (I am currently working on integrating the fixture loading into a Symfony command. Once that's done, I will know better what is all needed for the documentation. 

Also, as a side note, may I suggest changing the repository's default branch to `develop`, so that PRs are by default opened against that branch? Just a thought. 
