### PR TITLE
Add option to mark a field as null

### DIFF
--- a/library/Solarium/QueryType/Update/Query/Document/Document.php
+++ b/library/Solarium/QueryType/Update/Query/Document/Document.php
@@ -114,6 +114,14 @@ class Document extends AbstractDocument implements DocumentInterface
     protected $modifiers = array();
 
     /**
+     * Allows to mark fields as "null".
+     *
+     * @var array
+     */
+    protected $nullFields = array();
+
+
+    /**
      * This field needs to be explicitly set to observe the rules of atomic updates
      *
      * @var string
@@ -303,6 +311,7 @@ class Document extends AbstractDocument implements DocumentInterface
         $this->fields = array();
         $this->fieldBoosts = array();
         $this->modifiers = array();
+        $this->nullFields = array();
 
         return $this;
     }
@@ -384,6 +393,34 @@ class Document extends AbstractDocument implements DocumentInterface
     public function getFieldModifier($key)
     {
         return isset($this->modifiers[$key]) ? $this->modifiers[$key] : null;
+    }
+
+    /**
+     * Sets the null attribute for the provided field
+     *
+     * @param string $key
+     * @param bool $null
+     * @throws RuntimeException
+     * @return self
+     */
+    public function setFieldNull($key, $null = null)
+    {
+        if (! is_bool($null) ) {
+            throw new RuntimeException('Null atribute must be true or false');
+        }
+        $this->nullFields[$key] = $null;
+        return $this;
+    }
+
+    /**
+     * Returns the null attribute for a field.
+     *
+     * @param string $key
+     * @return null|string
+     */
+    public function getFieldNull($key)
+    {
+        return isset($this->nullFields[$key]) ? $this->nullFields[$key] : null;
     }
 
     /**

--- a/library/Solarium/QueryType/Update/RequestBuilder.php
+++ b/library/Solarium/QueryType/Update/RequestBuilder.php
@@ -126,12 +126,13 @@ class RequestBuilder extends BaseRequestBuilder
             foreach ($doc->getFields() as $name => $value) {
                 $boost = $doc->getFieldBoost($name);
                 $modifier = $doc->getFieldModifier($name);
+                $null= $doc->getFieldNull($name);
                 if (is_array($value)) {
                     foreach ($value as $multival) {
-                        $xml .= $this->buildFieldXml($name, $boost, $multival, $modifier, $query);
+                        $xml .= $this->buildFieldXml($name, $boost, $multival, $modifier, $null, $query);
                     }
                 } else {
-                    $xml .= $this->buildFieldXml($name, $boost, $value, $modifier, $query);
+                    $xml .= $this->buildFieldXml($name, $boost, $value, $modifier, $null, $query);
                 }
             }
 
@@ -160,7 +161,7 @@ class RequestBuilder extends BaseRequestBuilder
      * @param  UpdateQuery $query
      * @return string
      */
-    protected function buildFieldXml($name, $boost, $value, $modifier = null, $query = null)
+    protected function buildFieldXml($name, $boost, $value, $modifier = null, $null = null, $query = null)
     {
         if ($value instanceof \DateTime) {
             $value = $query->getHelper()->formatDate($value);
@@ -169,6 +170,9 @@ class RequestBuilder extends BaseRequestBuilder
         $xml = '<field name="' . $name . '"';
         $xml .= $this->attrib('boost', $boost);
         $xml .= $this->attrib('update', $modifier);
+        if( !is_null( $null ) ) {
+            $xml .= $this->attrib('null', $null ? 'true' : 'false');
+        }
         $xml .= '>' . htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8');
         $xml .= '</field>';
 


### PR DESCRIPTION
To remove date fields from Solr when doing Atomic updates, there's need for an option to mark a field as "null" (i.e. delete a field). Currently there does not seem to be a way to do this using Solarium.

For example:

```
<field name="DateField" null="true"></field>
```

Simply leaving the field empty does not work, because it's not accepted as a valid date value.

http://wiki.apache.org/solr/UpdateXmlMessages#Examples_of_adding_docs_with_various_optional_attributes
