### PR TITLE
[RFC] Allow Event Dispatcher versions greater than 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/event-dispatcher": "~2.1"
+        "symfony/event-dispatcher": ">=2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7",


### PR DESCRIPTION
Hi,

Thanks very much for the library.

My application runs on Symfony 2.3 LTS and the current composer.json requirement for the event dispatcher is `"symfony/event-dispatcher": "~2.1"`. This is problematic as it only allows versions from the `2.1` branch. Being on Symfony 2.3 I cannot install newer versions of Solarium.

I changed the dependency to allow for Symfony Event Dispatchers _above_ 2.1 and it appears working in my application on the `2.3` branch and I just ran your tests using the Event Dispatcher `2.4` branch and the tests passed (results below).

Is it possible to change this dependency? I went through your open issues and I see no mention of why only the `2.1` branch of the Event Dispatcher is allowed.

Thank you very much. 

```
~ composer install --dev
Loading composer repositories with package information
Installing dependencies (including require-dev)
  - Installing symfony/event-dispatcher (v2.4.2)
    Downloading: 100%

  - Installing symfony/yaml (v2.4.2)
    Downloading: 100%

  - Installing phpunit/php-text-template (1.2.0)
    Loading from cache

  - Installing phpunit/phpunit-mock-objects (1.2.3)
    Downloading: 100%

  - Installing phpunit/php-timer (1.0.5)
    Downloading: 100%

  - Installing phpunit/php-token-stream (1.2.1)
    Loading from cache

  - Installing phpunit/php-file-iterator (1.3.4)
    Loading from cache

  - Installing phpunit/php-code-coverage (1.2.15)
    Loading from cache

  - Installing phpunit/phpunit (3.7.31)
    Loading from cache

  - Installing squizlabs/php_codesniffer (1.5.2)
    Downloading: 100%
```

```
PHPUnit 3.7.31 by Sebastian Bergmann.

Configuration read from /var/www/audiobookmart/vendor/solarium/solarium/phpunit.xml.dist

....................SSSSSSSSSSSSSSS..........................   61 / 1268 (  4%)
.............................................................  122 / 1268 (  9%)
...........................................................S.  183 / 1268 ( 14%)
.............................................................  244 / 1268 ( 19%)
.............................................................  305 / 1268 ( 24%)
.............................................................  366 / 1268 ( 28%)
.............................................................  427 / 1268 ( 33%)
.............................................................  488 / 1268 ( 38%)
.............................................................  549 / 1268 ( 43%)
.............................................................  610 / 1268 ( 48%)
.............................................................  671 / 1268 ( 52%)
.............................................................  732 / 1268 ( 57%)
.............................................................  793 / 1268 ( 62%)
.............................................................  854 / 1268 ( 67%)
.............................................................  915 / 1268 ( 72%)
.............................................................  976 / 1268 ( 76%)
............................................................. 1037 / 1268 ( 81%)
............................................................. 1098 / 1268 ( 86%)
............................................................. 1159 / 1268 ( 91%)
............................................................. 1220 / 1268 ( 96%)
```
