### PR TITLE
Fix suggester parser with duplicates

### DIFF
--- a/library/Solarium/QueryType/Suggester/ResponseParser.php
+++ b/library/Solarium/QueryType/Suggester/ResponseParser.php
@@ -60,6 +60,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         $query = $result->getQuery();
 
         $suggestions = array();
+        $allSuggestions = array();
         $collation = null;
 
         if (isset($data['spellcheck']['suggestions']) && is_array($data['spellcheck']['suggestions'])) {
@@ -74,12 +75,17 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
                 if ($term == 'collation') {
                     $collation = $termData;
                 } else {
-                    $suggestions[$term] = new $termClass(
-                        $termData['numFound'],
-                        $termData['startOffset'],
-                        $termData['endOffset'],
-                        $termData['suggestion']
-                    );
+                    if (!array_key_exists(0, $termData)) {
+                        $termData = array($termData);
+                    }
+
+                    foreach ($termData as $currentTermData) {
+                        $allSuggestions[] = $this->createTerm($termClass, $currentTermData);
+
+                        if (!array_key_exists($term, $suggestions)) {
+                            $suggestions[$term] = $this->createTerm($termClass, $currentTermData);
+                        }
+                    }
                 }
             }
         }
@@ -88,8 +94,19 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
             $data,
             array(
                 'results' => $suggestions,
+                'all' => $allSuggestions,
                 'collation' => $collation,
             )
+        );
+    }
+
+    private function createTerm($termClass, array $termData)
+    {
+        return new $termClass(
+            $termData['numFound'],
+            $termData['startOffset'],
+            $termData['endOffset'],
+            $termData['suggestion']
         );
     }
 }

--- a/library/Solarium/QueryType/Suggester/Result/Result.php
+++ b/library/Solarium/QueryType/Suggester/Result/Result.php
@@ -70,6 +70,13 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     protected $results;
 
     /**
+     * Suggester flat results
+     *
+     * @var array
+     */
+    protected $all;
+
+    /**
      * Collation result
      *
      * Only available when collate is enabled in the suggester query
@@ -117,6 +124,18 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
         $this->parseResponse();
 
         return $this->results;
+    }
+
+    /**
+     * Get flat results
+     *
+     * @return array
+     */
+    public function getAll()
+    {
+        $this->parseResponse();
+
+        return $this->all;
     }
 
     /**

--- a/tests/Solarium/Tests/QueryType/Suggester/ResponseParserTest.php
+++ b/tests/Solarium/Tests/QueryType/Suggester/ResponseParserTest.php
@@ -65,6 +65,15 @@ class ResponseParserTest extends \PHPUnit_Framework_TestCase
                             'video',
                         )
                     ),
+                    'vid',
+                    array(
+                        'numFound' => 1,
+                        'startOffset' => 6,
+                        'endOffset' => 9,
+                        'suggestion' => array(
+                            'video',
+                        )
+                    ),
                     'collation',
                     'disk video'
                 ),
@@ -88,8 +97,14 @@ class ResponseParserTest extends \PHPUnit_Framework_TestCase
             'd' => new Term(2, 3, 7, array('disk', 'ddr')),
             'vid' => new Term(1, 2, 5, array('video'))
         );
+        $allExpected = array(
+            new Term(2, 3, 7, array('disk', 'ddr')),
+            new Term(1, 2, 5, array('video')),
+            new Term(1, 6, 9, array('video')),
+        );
 
         $this->assertEquals($expected, $result['results']);
+        $this->assertEquals($allExpected, $result['all']);
         $this->assertEquals('disk video', $result['collation']);
     }
 }

--- a/tests/Solarium/Tests/QueryType/Suggester/Result/ResultTest.php
+++ b/tests/Solarium/Tests/QueryType/Suggester/Result/ResultTest.php
@@ -46,6 +46,11 @@ class ResultTest extends \PHPUnit_Framework_TestCase
     protected $data;
 
     /**
+     * @var array
+     */
+    protected $allData;
+
+    /**
      * @var string
      */
     protected $collation;
@@ -56,8 +61,9 @@ class ResultTest extends \PHPUnit_Framework_TestCase
             'term1' => 'data1',
             'term2' => 'data2',
         );
+        $this->allData = array_values($this->data);
         $this->collation = 'collation result';
-        $this->result = new SuggesterDummy($this->data, $this->collation);
+        $this->result = new SuggesterDummy($this->data, $this->allData, $this->collation);
     }
 
     public function testGetStatus()
@@ -79,6 +85,11 @@ class ResultTest extends \PHPUnit_Framework_TestCase
     public function testGetResults()
     {
         $this->assertEquals($this->data, $this->result->getResults());
+    }
+
+    public function testGetAll()
+    {
+        $this->assertEquals($this->allData, $this->result->getAll());
     }
 
     public function testGetTerm()
@@ -116,9 +127,10 @@ class SuggesterDummy extends Result
 {
     protected $parsed = true;
 
-    public function __construct($results, $collation)
+    public function __construct($results, $all, $collation)
     {
         $this->results = $results;
+        $this->all = $all;
         $this->collation = $collation;
         $this->status = 1;
         $this->queryTime = 12;


### PR DESCRIPTION
When asking for a suggestion of something like "blac blac", solr will return the blac suggestion 2 times.

I tried to keep the format BC, so that's why I added a new key for the flat format.
