### PR TITLE
Fixed examples for registerQueryType arguments.

### DIFF
--- a/examples/5.3.2-plugin-solarium-presets.php
+++ b/examples/5.3.2-plugin-solarium-presets.php
@@ -17,9 +17,7 @@ class QueryCustomizer extends Plugin
     {
         $client->registerQueryType(
             Client::QUERY_SELECT,
-            'MyQuery',
-            'Solarium\QueryType\Select\RequestBuilder\RequestBuilder',
-            'Solarium\QueryType\Select\ResponseParser\ResponseParser'
+            'MyQuery'
         );
     }
 }


### PR DESCRIPTION
[registerQueryType](https://github.com/basdenooijer/solarium/blob/develop/library/Solarium/Core/Client/Client.php#L525)
