### PR TITLE
Add wildcard behavior for null endpoints in rangeQuery.

### DIFF
--- a/library/Solarium/Core/Query/Helper.php
+++ b/library/Solarium/Core/Query/Helper.php
@@ -192,9 +192,13 @@ class Helper
      * Render a range query
      *
      * From and to can be any type of data. For instance int, string or point.
+     * If they are null, then '*' will be used.
      *
      * Example: rangeQuery('store', '45,-94', '46,-93')
      * Returns: store:[45,-94 TO 46,-93]
+     *
+     * Example: rangeQuery('store', '5', '*', false)
+     * Returns: store:{5 TO *}
      *
      * @param  string  $field
      * @param  string  $from
@@ -204,6 +208,14 @@ class Helper
      */
     public function rangeQuery($field, $from, $to, $inclusive = true)
     {
+        if ($from === null) {
+            $from = '*';
+        }
+
+        if ($to === null) {
+            $to = '*';
+        }
+
         if ($inclusive) {
             return $field . ':[' . $from . ' TO ' . $to . ']';
         } else {

--- a/tests/Solarium/Tests/Core/Query/HelperTest.php
+++ b/tests/Solarium/Tests/Core/Query/HelperTest.php
@@ -78,6 +78,32 @@ class HelperTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testRangeQueryInclusiveNullValues()
+    {
+        $this->assertEquals(
+            'field:[1 TO *]',
+            $this->helper->rangeQuery('field', 1, null)
+        );
+
+        $this->assertEquals(
+            'store:[* TO 46,-93]',
+            $this->helper->rangeQuery('store', null, '46,-93')
+        );
+    }
+
+    public function testRangeQueryExclusiveNullValues()
+    {
+        $this->assertEquals(
+            'field:{1 TO *}',
+            $this->helper->rangeQuery('field', 1, null, false)
+        );
+
+        $this->assertEquals(
+            'store:{* TO 46,-93}',
+            $this->helper->rangeQuery('store', null, '46,-93', false)
+        );
+    }
+
     public function testGeofilt()
     {
         $this->assertEquals(


### PR DESCRIPTION
I believe the '_' range feature is a pretty common usecase of range queries.  Right now, passing null to this function generates an invalid SOLR phrase like 'field:[5 TO ]'.  Users can of course pass '_' to the helper, but supporting null makes this common usecase easier to handle.

For example,

``` php
$minValue = $request->get('min'); // returns null if min not specified
$maxValue = $request->get('max'); // returns null if max not specified
$range = $helper->rangeQuery('value', $minValue, $maxValue);
```
