### PR TITLE
only check type for added documents to add query if provided as an array

### DIFF
--- a/library/Solarium/QueryType/Update/Query/Command/Add.php
+++ b/library/Solarium/QueryType/Update/Query/Command/Add.php
@@ -89,9 +89,12 @@ class Add extends Command
      */
     public function addDocuments($documents)
     {
-        foreach ($documents as $document) {
-            if (!($document instanceof DocumentInterface)) {
-                throw new RuntimeException('Documents must implement DocumentInterface.');
+        //only check documents for type if in an array (iterating a Traversable may do unnecessary work)
+        if (is_array($documents)) {
+            foreach ($documents as $document) {
+                if (!($document instanceof DocumentInterface)) {
+                    throw new RuntimeException('Documents must implement DocumentInterface.');
+                }
             }
         }
 


### PR DESCRIPTION
The purpose of adding support for traversables was so that it enabled large numbers of documents to be added in a manner that was as light as possible.  Checking for the type of documents means that the traversable is evaluated, doing any work that happens at this point.  As any update that is given bad data will fail anyway, I'd argue the type check should only be retained when arrays of documents are passed in, passing the responsibility of ensuring documents only are passed in away from the library (when traversables are used) - otherwise it almost defeats the purpose of supporting a traversable.
