### PR TITLE
Define composer test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - bash -c "if [ $TRAVIS_PHP_VERSION != 'hhvm' ] && [ $TRAVIS_PHP_VERSION != 'hhvm-nightly' ] && [ $TRAVIS_PHP_VERSION != '5.3' ]; then printf '\n\n\n\n' | pecl install pecl_http-1.7.6; fi"
   - composer require --prefer-source --dev symfony/event-dispatcher:${SYMFONY_VERSION}
 
-script: vendor/bin/phpunit -c phpunit.xml.travis -v
+script: composer test
 
 after_script: vendor/bin/coveralls -v
 

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
             "dev-develop": "3.3.x-dev"
         }
     },
+    "scripts": {
+        "test": "phpunit -c phpunit.xml.travis -v"
+    },
     "autoload": {
         "psr-0": { "Solarium\\": "library/" }
     }


### PR DESCRIPTION
The composer test script is an easy and convenient way to define your unit
testing scripts. It makes testing your library as easy as just running
`composer test`.

For more information about the `scripts` field check out [the manual](https://getcomposer.org/doc/articles/scripts.md) and [this blog post](http://maxgfeller.com/blog/2014/07/22/composer-test/).
