### PR TITLE
Update path to autoload.php for examples/ini.php

### DIFF
--- a/examples/init.php
+++ b/examples/init.php
@@ -3,7 +3,7 @@
 error_reporting(E_ALL);
 ini_set('display_errors', true);
 
-require __DIR__.'/../vendor/autoload.php';
+require __DIR__.'/../../../../vendor/autoload.php';
 
 if (file_exists('config.php')) {
     require('config.php');


### PR DESCRIPTION
Hi,
The examples in example folder use ini.php that includes the autoload file, but the path for it is not accurate no more.
