### PR TITLE
Spellcheck solr5

### DIFF
--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Spellcheck.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Spellcheck.php
@@ -96,6 +96,32 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
                 }
             }
 
+            /*
+             * https://issues.apache.org/jira/browse/SOLR-3029
+             * Solr5 has moved collations and correctlySpelled
+             * directly under spellcheck.
+             */
+            if (isset($data['spellcheck']['collations']) &&
+                !isset($collations) &&
+                is_array($data['spellcheck']['collations'])
+            ) {
+              foreach ($data['spellcheck']['collations'] as $collationResult) {
+                if (is_array($collationResult)) {
+                  $collation = array();
+                  foreach ($collationResult as $key => $value) {
+                    $collation = array_merge($collation, array($key, $value));
+                  }
+                  $collations = array_merge($collations, $this->parseCollation($query, $collation ));
+                }
+              }
+            }
+
+            if (isset($data['spellcheck']['correctlySpelled']) &&
+                !isset($correctlySpelled)
+            ) {
+              $correctlySpelled = $data['spellcheck']['correctlySpelled'];
+            }
+          
             return new SpellcheckResult\Result($suggestions, $collations, $correctlySpelled);
         } else {
             return null;

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Spellcheck.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Spellcheck.php
@@ -102,7 +102,6 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
              * directly under spellcheck.
              */
             if (isset($data['spellcheck']['collations']) &&
-                !isset($collations) &&
                 is_array($data['spellcheck']['collations'])
             ) {
               foreach ($data['spellcheck']['collations'] as $collationResult) {
@@ -116,12 +115,11 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
               }
             }
 
-            if (isset($data['spellcheck']['correctlySpelled']) &&
-                !isset($correctlySpelled)
+            if (isset($data['spellcheck']['correctlySpelled'])
             ) {
               $correctlySpelled = $data['spellcheck']['correctlySpelled'];
             }
-          
+
             return new SpellcheckResult\Result($suggestions, $collations, $correctlySpelled);
         } else {
             return null;


### PR DESCRIPTION
Fix for Solr5 changes to collations and correctlySpelled. Neither are currently working in Solarium and Solr5.

The code to parse Solr4 responses was untouched. This simply comes along afterwords and checks for the Solr5 locations and processes them.

#320 