### PR TITLE
Solarium bugs with Solr 5.1

### DIFF
--- a/library/Solarium/Core/Client/Adapter/Curl.php
+++ b/library/Solarium/Core/Client/Adapter/Curl.php
@@ -155,10 +155,6 @@ class Curl extends Configurable implements AdapterInterface
             curl_setopt($handler, CURLOPT_PROXY, $proxy);
         }
 
-        if (!isset($options['headers']['Content-Type'])) {
-            $options['headers']['Content-Type'] = 'text/xml; charset=utf-8';
-        }
-
         // Try endpoint authentication first, fallback to request for backwards compatibility
         $authData = $endpoint->getAuthentication();
         if (empty($authData['username'])) {

--- a/library/Solarium/Core/Client/Adapter/Http.php
+++ b/library/Solarium/Core/Client/Adapter/Http.php
@@ -121,8 +121,6 @@ class Http extends Configurable implements AdapterInterface
                         'content',
                         $data
                     );
-
-                    $request->addHeader('Content-Type: text/xml; charset=UTF-8');
                 }
             }
         }

--- a/library/Solarium/Core/Client/Adapter/PeclHttp.php
+++ b/library/Solarium/Core/Client/Adapter/PeclHttp.php
@@ -178,9 +178,6 @@ class PeclHttp extends Configurable implements AdapterInterface
                     );
                 } else {
                     $httpRequest->setBody($request->getRawData());
-                    if (!isset($headers['Content-Type'])) {
-                        $headers['Content-Type'] = 'text/xml; charset=utf-8';
-                    }
                 }
                 break;
             case Request::METHOD_HEAD:

--- a/library/Solarium/Core/Client/Adapter/ZendHttp.php
+++ b/library/Solarium/Core/Client/Adapter/ZendHttp.php
@@ -182,7 +182,6 @@ class ZendHttp extends Configurable implements AdapterInterface
                 } else {
                     $client->setParameterGet($request->getParams());
                     $client->setRawData($request->getRawData());
-                    $request->addHeader('Content-Type: text/xml; charset=UTF-8');
                 }
                 break;
             case Request::METHOD_HEAD:


### PR DESCRIPTION
Solr 5.1 now systematically returns a "Bad contentType for search handler :text/xml; charset=UTF-8" message.

It looks like a default content-type is hardcoded in Solarium library. Removing this settings solves the bug.

Not tested on former versions.