### PR TITLE
Spellchecker: solr 5.0 format changes kills collations

### DIFF
--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Spellcheck.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Spellcheck.php
@@ -104,14 +104,8 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
             if (isset($data['spellcheck']['collations']) &&
                 is_array($data['spellcheck']['collations'])
             ) {
-              foreach ($data['spellcheck']['collations'] as $collationResult) {
-                if (is_array($collationResult)) {
-                  $collation = array();
-                  foreach ($collationResult as $key => $value) {
-                    $collation = array_merge($collation, array($key, $value));
-                  }
-                  $collations = array_merge($collations, $this->parseCollation($query, $collation ));
-                }
+              foreach ($this->convertToKeyValueArray($data['spellcheck']['collations']) as $collationResult) {
+                $collations = array_merge($collations, $this->parseCollation($query, $collationResult ));
               }
             }
 

--- a/tests/Solarium/Tests/QueryType/Select/ResponseParser/Component/SpellcheckTest.php
+++ b/tests/Solarium/Tests/QueryType/Select/ResponseParser/Component/SpellcheckTest.php
@@ -47,7 +47,8 @@ class SpellcheckTest extends \PHPUnit_Framework_TestCase
 
     public function testParseExtended()
     {
-        $data = array(
+        $data = array();
+        $data['solr4'] = array(
             'spellcheck' => array(
                 'suggestions' => array(
                     'delll',
@@ -123,24 +124,106 @@ class SpellcheckTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $result = $this->parser->parse($this->query, null, $data);
+        $data['solr5'] = array(
+            'spellcheck' => array(
+                'suggestions' => array(
+                    'delll',
+                    array (
+                        'numFound' => 1,
+                        'startOffset' => 0,
+                        'endOffset' => 5,
+                        'origFreq' => 0,
+                        'suggestion' => array (
+                            0 => array (
+                                'word' => 'dell',
+                                'freq' => 1,
+                            ),
+                        ),
+                    ),
+                    'ultrashar',
+                    array (
+                        'numFound' => 1,
+                        'startOffset' => 6,
+                        'endOffset' => 15,
+                        'origFreq' => 0,
+                        'suggestion' => array (
+                            0 => array (
+                                'word' => 'ultrasharp',
+                                'freq' => 1,
+                            ),
+                        ),
+                    ),
+                    'ultrashar',
+                    array (
+                        'numFound' => 1,
+                        'startOffset' => 16,
+                        'endOffset' => 25,
+                        'origFreq' => 0,
+                        'suggestion' => array (
+                            0 => array (
+                                'word' => 'ultrasharp',
+                                'freq' => 1,
+                            ),
+                        ),
+                    ),
+                ),
+                'correctlySpelled',
+                false,
+                'collations' => array(
+                    'collation',
+                    array (
+                        0 => 'collationQuery',
+                        1 => 'dell ultrasharp',
+                        2 => 'hits',
+                        3 => 0,
+                        4 => 'misspellingsAndCorrections',
+                        5 => array (
+                            0 => 'delll',
+                            1 => 'dell',
+                            2 => 'ultrashar',
+                            3 => 'ultrasharp',
+                        ),
+                    ),
+                    'collation',
+                    array (
+                        0 => 'collationQuery',
+                        1 => 'dell ultrasharp new',
+                        2 => 'hits',
+                        3 => 0,
+                        4 => 'misspellingsAndCorrections',
+                        5 => array (
+                            0 => 'delll',
+                            1 => 'dell',
+                            2 => 'ultrashar',
+                            3 => 'ultrasharp',
+                        ),
+                    ),
+                )
+            )
+        );
 
-        $suggestions = $result->getSuggestions();
-        $this->assertEquals(false, $result->getCorrectlySpelled());
-        $this->assertEquals('dell', $suggestions[0]->getWord());
-        $this->assertEquals('ultrasharp', $suggestions[1]->getWord());
-        $this->assertEquals(6, $suggestions[1]->getStartOffset());
-        $this->assertEquals('ultrasharp', $suggestions[2]->getWord());
-        $this->assertEquals(16, $suggestions[2]->getStartOffset());
-        $this->assertEquals('dell ultrasharp', $result->getCollation()->getQuery());
-        $collations = $result->getCollations();
-        $this->assertEquals('dell ultrasharp', $collations[0]->getQuery());
-        $this->assertEquals('dell ultrasharp new', $collations[1]->getQuery());
+        foreach ($data as $testData) {
+
+            $result = $this->parser->parse($this->query, null, $testData);
+
+            $suggestions = $result->getSuggestions();
+            $this->assertEquals(false, $result->getCorrectlySpelled());
+            $this->assertEquals('dell', $suggestions[0]->getWord());
+            $this->assertEquals('ultrasharp', $suggestions[1]->getWord());
+            $this->assertEquals(6, $suggestions[1]->getStartOffset());
+            $this->assertEquals('ultrasharp', $suggestions[2]->getWord());
+            $this->assertEquals(16, $suggestions[2]->getStartOffset());
+            $this->assertEquals('dell ultrasharp', $result->getCollation()->getQuery());
+            $collations = $result->getCollations();
+            $this->assertEquals('dell ultrasharp', $collations[0]->getQuery());
+            $this->assertEquals('dell ultrasharp new', $collations[1]->getQuery());
+        }
     }
 
     public function testParse()
     {
-        $data = array(
+        $data = array();
+        $data['solr4'] = array(
             'spellcheck' => array(
                 'suggestions' => array(
                     0 => 'delll',
@@ -176,21 +259,62 @@ class SpellcheckTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $result = $this->parser->parse($this->query, null, $data);
+        $data['solr5'] = array(
+            'spellcheck' => array(
+                'suggestions' => array(
+                    0 => 'delll',
+                    1 => array (
+                        'numFound' => 1,
+                        'startOffset' => 0,
+                        'endOffset' => 5,
+                        'origFreq' => 0,
+                        'suggestion' => array (
+                            0 => 'dell',
+                        ),
+                    ),
+                    2 => 'ultrashar',
+                    3 => array (
+                        'numFound' => 1,
+                        'startOffset' => 6,
+                        'endOffset' => 15,
+                        'origFreq' => 0,
+                        'suggestion' => array (
+                            0 => array (
+                                'word' => 'ultrasharp',
+                                'freq' => 1,
+                            ),
+                        ),
+                    ),
+                ),
+                'correctlySpelled',
+                false,
+                'collations' => array(
+                    'collation',
+                    'dell ultrasharp',
+                    'collation',
+                    'dell ultrasharp new',
+                )
+            )
+        );
 
-        $suggestions = $result->getSuggestions();
-        $this->assertEquals(false, $result->getCorrectlySpelled());
-        $this->assertEquals('dell', $suggestions[0]->getWord());
-        $this->assertEquals('dell ultrasharp', $result->getCollation()->getQuery());
-        $collations = $result->getCollations();
-        $this->assertEquals('dell ultrasharp', $collations[0]->getQuery());
-        $this->assertEquals('dell ultrasharp new', $collations[1]->getQuery());
+        foreach ($data as $testData) {
 
+            $result = $this->parser->parse($this->query, null, $testData);
+
+            $suggestions = $result->getSuggestions();
+            $this->assertEquals(false, $result->getCorrectlySpelled());
+            $this->assertEquals('dell', $suggestions[0]->getWord());
+            $this->assertEquals('dell ultrasharp', $result->getCollation()->getQuery());
+            $collations = $result->getCollations();
+            $this->assertEquals('dell ultrasharp', $collations[0]->getQuery());
+            $this->assertEquals('dell ultrasharp new', $collations[1]->getQuery());
+        }
     }
 
     public function testParseSingleCollation()
     {
-        $data = array(
+        $data = array();
+        $data['solr4'] = array(
             'spellcheck' => array(
                 'suggestions' => array(
                     0 => 'delll',
@@ -228,12 +352,55 @@ class SpellcheckTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $result = $this->parser->parse($this->query, null, $data);
-        $collations = $result->getCollations();
-        $this->assertEquals('dell ultrasharp', $collations[0]->getQuery());
+        $data['solr5'] = array(
+            'spellcheck' => array(
+                'suggestions' => array(
+                    0 => 'delll',
+                    1 => array (
+                        'numFound' => 1,
+                        'startOffset' => 0,
+                        'endOffset' => 5,
+                        'origFreq' => 0,
+                        'suggestion' => array (
+                            0 => 'dell',
+                        ),
+                    ),
+                    2 => 'ultrashar',
+                    3 => array (
+                        'numFound' => 1,
+                        'startOffset' => 6,
+                        'endOffset' => 15,
+                        'origFreq' => 0,
+                        'suggestion' => array (
+                            0 => array (
+                                'word' => 'ultrasharp',
+                                'freq' => 2,
+                            ),
+                            1 => array (
+                                'word' => 'ultrasharpy',
+                                'freq' => 1,
+                            ),
+                        ),
+                    ),
+                ),
+                'correctlySpelled',
+                false,
+                'collations' => array(
+                    'collation',
+                    'dell ultrasharp'
+                )
+            )
+        );
 
-        $words = $result->getSuggestion(1)->getWords();
-        $this->assertEquals(array('word' => 'ultrasharpy', 'freq' => 1), $words[1]);
+        foreach ($data as $testData) {
+
+            $result = $this->parser->parse($this->query, null, $testData);
+            $collations = $result->getCollations();
+            $this->assertEquals('dell ultrasharp', $collations[0]->getQuery());
+
+            $words = $result->getSuggestion(1)->getWords();
+            $this->assertEquals(array('word' => 'ultrasharpy', 'freq' => 1), $words[1]);
+        }
     }
 
     public function testParseNoData()


### PR DESCRIPTION
Hi,

the fix #320 doesnt work for me with solr 5.2.1 (may be solr 5.0 too). So I made this bugfix.

Hopefully everything is fine.