### PR TITLE
Fix and improve PHAR generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /composer.phar
 /composer.lock
 /vendor
+/phar/solarium.phar

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-build
-phpunit.xml
-composer.phar
-composer.lock
-vendor
+/build
+/phpunit.xml
+/composer.phar
+/composer.lock
+/vendor

--- a/phar/buildphar.php
+++ b/phar/buildphar.php
@@ -88,4 +88,4 @@ if ($compress) {
 }
 
 $time = round(microtime(true)-$start, 5);
-echo "\nDONE ($time seconds)\nsolarium.php has been created.\n\n";
+echo "\nDONE ($time seconds)\nsolarium.phar has been created.\n\n";

--- a/phar/buildphar.php
+++ b/phar/buildphar.php
@@ -49,27 +49,36 @@ $strip = (isset($options['s']) && $options['s'] == '1');
 
 $start = microtime(true);
 
-// Create a new Solarium phar file
+// Create a new Solarium PHAR file.
 @unlink('solarium.phar');
 $phar = new Phar('solarium.phar', 0, 'solarium.phar');
-$phar->setStub(file_get_contents("stub.php"));
+$phar->setStub(file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'stub.php'));
 $phar->setSignatureAlgorithm(Phar::SHA1);
 
-// Add files to the phar
-$basePath = realpath(__DIR__."/../library/Solarium");
-if ($strip) {
-    $directoryIterator = new RecursiveIteratorIterator(
-        new RecursiveDirectoryIterator($basePath),
+// Add files to the PHAR.
+$basePath = dirname(__DIR__);
+$directoryIterator = new AppendIterator();
+$directoryIterator->append(
+    new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($basePath . DIRECTORY_SEPARATOR . 'library'),
         RecursiveIteratorIterator::SELF_FIRST
-    );
+    )
+);
+$directoryIterator->append(
+    new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($basePath . DIRECTORY_SEPARATOR . 'vendor'),
+        RecursiveIteratorIterator::SELF_FIRST
+    )
+);
 
+if ($strip) {
     foreach ($directoryIterator as $file) {
-        if (preg_match('/\\.php$/i', $file)) {
+        if (0 !== preg_match('/\\.php$/i', $file)) {
             $phar->addFromString(substr($file, strlen($basePath) + 1), php_strip_whitespace($file));
         }
     }
 } else {
-    $phar->buildFromDirectory($basePath, '/\.php$/');
+    $phar->buildFromIterator($directoryIterator, $basePath);
 }
 
 // Create compressed versions
@@ -79,4 +88,4 @@ if ($compress) {
 }
 
 $time = round(microtime(true)-$start, 5);
-echo "\nDONE ($time seconds)\n\n";
+echo "\nDONE ($time seconds)\nsolarium.php has been created.\n\n";

--- a/phar/stub.php
+++ b/phar/stub.php
@@ -34,7 +34,7 @@
  */
 
 Phar::mapPhar("solarium.phar");
-require_once 'phar://solarium.phar/Autoloader.php';
+require_once 'phar://solarium.phar/library/Solarium/Autoloader.php';
 Solarium\Autoloader::register();
 
 if ('cli' === php_sapi_name() && basename(__FILE__) === basename($_SERVER['argv'][0]) && isset($_SERVER['argv'][1])) {

--- a/phar/stub.php
+++ b/phar/stub.php
@@ -35,18 +35,18 @@
 
 Phar::mapPhar("solarium.phar");
 require_once 'phar://solarium.phar/Autoloader.php';
-Solarium_Autoloader::register();
+Solarium\Autoloader::register();
 
 if ('cli' === php_sapi_name() && basename(__FILE__) === basename($_SERVER['argv'][0]) && isset($_SERVER['argv'][1])) {
 
     switch ($_SERVER['argv'][1]) {
 
         case 'version':
-            echo "Solarium version " . Solarium_Version::VERSION ."\n";
+            echo 'Solarium version ' . Solarium\Client::VERSION . "\n";
             break;
 
         default:
-            echo "Unknown command '" . $_SERVER['argv'][1] . "' (Supported commands: version)\n";
+            echo 'Unknown command \'' . $_SERVER['argv'][1] . '\' (Supported commands: version)' . "\n";
     }
 
     exit(0);

--- a/phar/stub.php
+++ b/phar/stub.php
@@ -34,7 +34,7 @@
  */
 
 Phar::mapPhar("solarium.phar");
-require_once 'phar://solarium.phar/library/Solarium/Autoloader.php';
+require_once 'phar://solarium.phar/vendor/autoload.php';
 Solarium\Autoloader::register();
 
 if ('cli' === php_sapi_name() && basename(__FILE__) === basename($_SERVER['argv'][0]) && isset($_SERVER['argv'][1])) {

--- a/phar/stub.php
+++ b/phar/stub.php
@@ -52,5 +52,4 @@ if ('cli' === php_sapi_name() && basename(__FILE__) === basename($_SERVER['argv'
     exit(0);
 }
 
-__halt_compiler();
-?>
+__HALT_COMPILER();


### PR DESCRIPTION
Hello :-),

A lot of different commits here:
1. The stub is outdated (https://github.com/solariumphp/solarium/commit/c3fbad09cf86d1d98ce3afb855c6e5fe5cc3f9e8),
2. Moving to PSR-2 introduced a syntax error in the stub (https://github.com/solariumphp/solarium/commit/976c5b19e516bb0f9f943ee436fdce049a7a6d89),
3. Since we have vendors/dependencies, they must be included inside the PHAR (https://github.com/solariumphp/solarium/commit/0ea2603f16603dd7c15964035640cf865a0aa317),
4. Instead of using Solarium's autoloader, we use Composer's one to support vendors (https://github.com/solariumphp/solarium/commit/a29043342a7450b5de33fd863125d23d38e2646d),
5. Finally, the `.gitignore` file is updated (https://github.com/solariumphp/solarium/commit/bd358d8a34d31ce2c7be36956643088fa5b32690 and https://github.com/solariumphp/solarium/commit/4b810f6337473b9841cf65164c7dba4b18135206).

Now it works great :-].