### PR TITLE
add php 7.0 to travis manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.0
   - 5.6
   - 5.5
   - 5.4


### PR DESCRIPTION
PHP 7.0 final is expected to be released in the coming days - so there should be non-failing tests against it.