### PR TITLE
Added option to add multiple boostqueries to dismax parser

### DIFF
--- a/library/Solarium/QueryType/Select/Query/Component/BoostQuery.php
+++ b/library/Solarium/QueryType/Select/Query/Component/BoostQuery.php
@@ -38,47 +38,93 @@
  * @namespace
  */
 
-namespace Solarium\QueryType\Select\RequestBuilder\Component;
+namespace Solarium\QueryType\Select\Query\Component;
 
-use Solarium\QueryType\Select\Query\Component\Dismax as DismaxComponent;
-use Solarium\Core\Client\Request;
+use Solarium\Core\Configurable;
+use Solarium\Core\Query\Helper;
 
 /**
- * Add select component dismax to the request.
+ * Filterquery.
+ *
+ * @link http://wiki.apache.org/solr/CommonQueryParameters#fq
  */
-class DisMax implements ComponentRequestBuilderInterface
+class BoostQuery extends Configurable
 {
     /**
-     * Add request settings for Dismax.
+     * Query.
      *
-     * @param DismaxComponent $component
-     * @param Request         $request
-     *
-     * @return Request
+     * @var string
      */
-    public function buildComponent($component, $request)
+    protected $query;
+
+    /**
+     * Get key value.
+     *
+     * @return string
+     */
+    public function getKey()
     {
-        // enable dismax
-        $request->addParam('defType', $component->getQueryParser());
+        return $this->getOption('key');
+    }
 
-        $request->addParam('q.alt', $component->getQueryAlternative());
-        $request->addParam('qf', $component->getQueryFields());
-        $request->addParam('mm', $component->getMinimumMatch());
-        $request->addParam('pf', $component->getPhraseFields());
-        $request->addParam('ps', $component->getPhraseSlop());
-        $request->addParam('qs', $component->getQueryPhraseSlop());
-        $request->addParam('tie', $component->getTie());
+    /**
+     * Set key value.
+     *
+     * @param string $value
+     *
+     * @return self Provides fluent interface
+     */
+    public function setKey($value)
+    {
+        return $this->setOption('key', $value);
+    }
 
-        // add boostqueries to request
-        $boostQueries = $component->getBoostQueries();
-        if (count($boostQueries) !== 0) {
-            foreach ($boostQueries as $boostQuery) {
-                $request->addParam('bq', $boostQuery->getQuery());
-            }
+    /**
+     * Set the query string.
+     *
+     * This overwrites the current value
+     *
+     * @param string $query
+     * @param array  $bind  Bind values for placeholders in the query string
+     *
+     * @return self Provides fluent interface
+     */
+    public function setQuery($query, $bind = null)
+    {
+        if (!is_null($bind)) {
+            $helper = new Helper();
+            $query = $helper->assemble($query, $bind);
         }
 
-        $request->addParam('bf', $component->getBoostFunctions());
+        $this->query = trim($query);
 
-        return $request;
+        return $this;
+    }
+
+    /**
+     * Get the query string.
+     *
+     * @return string
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    /**
+     * Initialize options.
+     */
+    protected function init()
+    {
+        foreach ($this->options as $name => $value) {
+            switch ($name) {
+                case 'key':
+                    $this->setKey($value);
+                    break;
+                case 'query':
+                    $this->setQuery($value);
+                    break;
+            }
+        }
     }
 }

--- a/library/Solarium/QueryType/Select/Query/Component/DisMax.php
+++ b/library/Solarium/QueryType/Select/Query/Component/DisMax.php
@@ -338,12 +338,12 @@ class DisMax extends AbstractComponent
         $key = $boostQuery->getKey();
 
         if (0 === strlen($key)) {
-            throw new InvalidArgumentException('A filterquery must have a key value');
+            throw new InvalidArgumentException('A boostquery must have a key value');
         }
 
         //double add calls for the same BQ are ignored, but non-unique keys cause an exception
         if (array_key_exists($key, $this->boostQueries) && $this->boostQueries[$key] !== $boostQuery) {
-            throw new InvalidArgumentException('A filterquery must have a unique key value within a query');
+            throw new InvalidArgumentException('A boostquery must have a unique key value within a query');
         } else {
             $this->boostQueries[$key] = $boostQuery;
         }
@@ -383,9 +383,9 @@ class DisMax extends AbstractComponent
     }
 
     /**
-     * Remove a single filterquery.
+     * Remove a single boostquery.
      *
-     * You can remove a filterquery by passing its key, or by passing the filterquery instance
+     * You can remove a boostquery by passing its key, or by passing the boostquery instance
      *
      * @param string|BoostQuery $boostQuery
      *
@@ -405,7 +405,7 @@ class DisMax extends AbstractComponent
     }
 
     /**
-     * Remove all filterqueries.
+     * Remove all boostqueries.
      *
      * @return self Provides fluent interface
      */
@@ -417,9 +417,9 @@ class DisMax extends AbstractComponent
     }
 
     /**
-     * Set multiple filterqueries.
+     * Set multiple boostqueries.
      *
-     * This overwrites any existing filterqueries
+     * This overwrites any existing boostqueries
      *
      * @param array $boostQueries
      */

--- a/library/Solarium/QueryType/Select/Query/Component/DisMax.php
+++ b/library/Solarium/QueryType/Select/Query/Component/DisMax.php
@@ -40,6 +40,7 @@
 
 namespace Solarium\QueryType\Select\Query\Component;
 
+use Solarium\Exception\InvalidArgumentException;
 use Solarium\QueryType\Select\Query\Query as SelectQuery;
 use Solarium\QueryType\Select\RequestBuilder\Component\DisMax as RequestBuilder;
 
@@ -58,6 +59,13 @@ class DisMax extends AbstractComponent
     protected $options = array(
         'queryparser' => 'dismax',
     );
+
+    /**
+     * Boostqueries.
+     *
+     * @var BoostQuery[]
+     */
+    protected $boostQueries = array();
 
     /**
      * Get component type.
@@ -278,17 +286,147 @@ class DisMax extends AbstractComponent
      */
     public function setBoostQuery($boostQuery)
     {
-        return $this->setOption('boostquery', $boostQuery);
+        $this->clearBoostQueries();
+        $this->addBoostQuery(array('key' => 0, 'query' => $boostQuery));
+
+        return $this;
     }
 
     /**
      * Get BoostQuery option.
      *
+     * @param string $key
+     *
      * @return string|null
      */
-    public function getBoostQuery()
+    public function getBoostQuery($key = null)
     {
-        return $this->getOption('boostquery');
+        if ($key !== null) {
+            if (array_key_exists($key, $this->boostQueries)) {
+                return $this->boostQueries[$key]->getQuery();
+            }
+        } else if (!empty($this->boostQueries)) {
+            /** @var BoostQuery[] $boostQueries */
+            $boostQueries = array_values($this->boostQueries);
+
+            return $boostQueries[0]->getQuery();
+        } else if (array_key_exists('boostquery', $this->options)) {
+            return $this->options['boostquery'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Add a boost query.
+     *
+     * Supports a boostquery instance or a config array, in that case a new
+     * boostquery instance wil be created based on the options.
+     *
+     * @throws InvalidArgumentException
+     *
+     * @param BoostQuery|array $boostQuery
+     *
+     * @return self Provides fluent interface
+     */
+    public function addBoostQuery($boostQuery)
+    {
+        if (is_array($boostQuery)) {
+            $boostQuery = new BoostQuery($boostQuery);
+        }
+
+        $key = $boostQuery->getKey();
+
+        if (0 === strlen($key)) {
+            throw new InvalidArgumentException('A filterquery must have a key value');
+        }
+
+        //double add calls for the same BQ are ignored, but non-unique keys cause an exception
+        if (array_key_exists($key, $this->boostQueries) && $this->boostQueries[$key] !== $boostQuery) {
+            throw new InvalidArgumentException('A filterquery must have a unique key value within a query');
+        } else {
+            $this->boostQueries[$key] = $boostQuery;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add multiple boostqueries.
+     *
+     * @param array $boostQueries
+     *
+     * @return self Provides fluent interface
+     */
+    public function addBoostQueries(array $boostQueries)
+    {
+        foreach ($boostQueries as $key => $boostQuery) {
+            // in case of a config array: add key to config
+            if (is_array($boostQuery) && !isset($boostQuery['key'])) {
+                $boostQuery['key'] = $key;
+            }
+
+            $this->addBoostQuery($boostQuery);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get all boostqueries.
+     *
+     * @return BoostQuery[]
+     */
+    public function getBoostQueries()
+    {
+        return $this->boostQueries;
+    }
+
+    /**
+     * Remove a single filterquery.
+     *
+     * You can remove a filterquery by passing its key, or by passing the filterquery instance
+     *
+     * @param string|BoostQuery $boostQuery
+     *
+     * @return self Provides fluent interface
+     */
+    public function removeBoostQuery($boostQuery)
+    {
+        if (is_object($boostQuery)) {
+            $boostQuery = $boostQuery->getKey();
+        }
+
+        if (isset($this->boostQueries[$boostQuery])) {
+            unset($this->boostQueries[$boostQuery]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove all filterqueries.
+     *
+     * @return self Provides fluent interface
+     */
+    public function clearBoostQueries()
+    {
+        $this->boostQueries = array();
+
+        return $this;
+    }
+
+    /**
+     * Set multiple filterqueries.
+     *
+     * This overwrites any existing filterqueries
+     *
+     * @param array $boostQueries
+     */
+    public function setBoostQueries($boostQueries)
+    {
+        $this->clearBoostQueries();
+        $this->addBoostQueries($boostQueries);
     }
 
     /**

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/EdisMax.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/EdisMax.php
@@ -72,7 +72,15 @@ class EdisMax implements ComponentRequestBuilderInterface
         $request->addParam('ps3', $component->getPhraseTrigramSlop());
         $request->addParam('qs', $component->getQueryPhraseSlop());
         $request->addParam('tie', $component->getTie());
-        $request->addParam('bq', $component->getBoostQuery());
+
+        // add boostqueries to request
+        $boostQueries = $component->getBoostQueries();
+        if (count($boostQueries) !== 0) {
+            foreach ($boostQueries as $boostQuery) {
+                $request->addParam('bq', $boostQuery->getQuery());
+            }
+        }
+
         $request->addParam('bf', $component->getBoostFunctions());
         $request->addParam('boost', $component->getBoostFunctionsMult());
         $request->addParam('uf', $component->getUserFields());

--- a/tests/Solarium/Tests/QueryType/Select/Query/Component/BoostQueryTest.php
+++ b/tests/Solarium/Tests/QueryType/Select/Query/Component/BoostQueryTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright 2011 Bas de Nooijer. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this listof conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of the copyright holder.
+ */
+
+namespace Solarium\Tests\QueryType\Select\Query\Component;
+
+use Solarium\QueryType\Select\Query\Component\BoostQuery;
+
+class BoostQueryTest extends \PHPUnit_Framework_TestCase
+{
+    protected $boostQuery;
+
+    public function setUp()
+    {
+        $this->boostQuery = new BoostQuery;
+    }
+
+    public function testConfigMode()
+    {
+        $fq = new BoostQuery(array('key' => 'k1', 'query'=> 'id:[10 TO 20]'));
+
+        $this->assertEquals('k1', $fq->getKey());
+        $this->assertEquals('id:[10 TO 20]', $fq->getQuery());
+    }
+
+    public function testSetAndGetKey()
+    {
+        $this->boostQuery->setKey('testkey');
+        $this->assertEquals('testkey', $this->boostQuery->getKey());
+    }
+
+    public function testSetAndGetQuery()
+    {
+        $this->boostQuery->setQuery('category:1');
+        $this->assertEquals('category:1', $this->boostQuery->getQuery());
+    }
+
+    public function testSetAndGetQueryWithBind()
+    {
+        $this->boostQuery->setQuery('id:%1%', array(678));
+        $this->assertEquals('id:678', $this->boostQuery->getQuery());
+    }
+}


### PR DESCRIPTION
Inspired by https://github.com/solariumphp/solarium/pull/314

Work derived from query filter management

Methods setBoostQuery et getBoostQuery have been written to be as backward compatible as possible.