### PR TITLE
Update coveralls settings

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,1 @@
 service_name: travis-ci
-
-src_dir: library

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ before_script:
 
 script: vendor/bin/phpunit -c phpunit.xml.travis -v
 
-after_script: vendor/bin/coveralls -v
+after_success:
+  - travis_retry php vendor/bin/coveralls -v
 
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "phpunit/phpunit": "~3.7",
         "squizlabs/php_codesniffer": "~1.4",
         "zendframework/zendframework1": "~1.12",
-        "satooshi/php-coveralls": "~0.6"
+        "satooshi/php-coveralls": "~1.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
php-coveralls [has dropped](https://github.com/satooshi/php-coveralls/issues/126) `src_dir` settings and complains with deprecated error:
https://travis-ci.org/solariumphp/solarium/jobs/114613279#L551