### PR TITLE
Make sure floats use "." decimal separator

### DIFF
--- a/library/Solarium/QueryType/Update/RequestBuilder.php
+++ b/library/Solarium/QueryType/Update/RequestBuilder.php
@@ -125,7 +125,7 @@ class RequestBuilder extends BaseRequestBuilder
 
         foreach ($command->getDocuments() as $doc) {
             $xml .= '<doc';
-            $xml .= $this->attrib('boost', $doc->getBoost());
+            $xml .= $this->attrib('boost', number_format($doc->getBoost(), 5, '.', ''));
             $xml .= '>';
 
             foreach ($doc->getFields() as $name => $value) {


### PR DESCRIPTION
The current locale applies when casting floats to strings. For example, with the `de_DE` locale, a boost value of 12.34 will be case to `"12,34"`. This causes a downstream exception in Solr because it does not understand this format.

`number_format` is a bit hacky but is independent of the current locale.
