### PR TITLE
Added support for deep paging with a cursor

### DIFF
--- a/library/Solarium/QueryType/Select/Query/Query.php
+++ b/library/Solarium/QueryType/Select/Query/Query.php
@@ -1058,6 +1058,40 @@ class Query extends BaseQuery
     }
 
     /**
+     * Set the cursor mark to fetch.
+     * 
+     * Cursor functionality requires a sort containing a uniqueKey field tie breaker
+     *
+     * @param string $cursormark
+     *
+     * @return self Provides fluent interface
+     */
+    public function setCursormark($cursormark)
+    {
+        return $this->setOption('cursormark', $cursormark);
+    }
+
+    /**
+     * Get the cursor mark.
+     *
+     * @return string|null
+     */
+    public function getCursormark()
+    {
+        return $this->getOption('cursormark');
+    }
+
+    /**
+     * Remove the cursor mark.
+     *
+     * @return self Provides fluent interface
+     */
+    public function clearCursormark()
+    {
+        return $this->setOption('cursormark', null);
+    }
+
+    /**
      * Initialize options.
      *
      * Several options need some extra checks or setup work, for these options
@@ -1093,6 +1127,9 @@ class Query extends BaseQuery
                         $value = array($value);
                     }
                     $this->addTags($value);
+                    break;
+                case 'cursormark':
+                    $this->setCursormark($value);
                     break;
             }
         }

--- a/library/Solarium/QueryType/Select/RequestBuilder/RequestBuilder.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/RequestBuilder.php
@@ -74,6 +74,7 @@ class RequestBuilder extends BaseRequestBuilder
         $request->addParam('fl', implode(',', $query->getFields()));
         $request->addParam('q.op', $query->getQueryDefaultOperator());
         $request->addParam('df', $query->getQueryDefaultField());
+        $request->addParam('cursorMark', $query->getCursormark());
 
         // add sort fields to request
         $sort = array();

--- a/library/Solarium/QueryType/Select/ResponseParser/ResponseParser.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/ResponseParser.php
@@ -107,6 +107,12 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
             $maxScore = null;
         }
 
+        if (isset($data['nextCursorMark'])) {
+            $nextCursorMark = $data['nextCursorMark'];
+        } else {
+            $nextCursorMark = null;
+        }
+
         return $this->addHeaderInfo(
             $data,
             array(
@@ -114,6 +120,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
                 'maxscore' => $maxScore,
                 'documents' => $documents,
                 'components' => $components,
+                'nextcursormark' => $nextCursorMark,
             )
         );
     }

--- a/library/Solarium/QueryType/Select/Result/Result.php
+++ b/library/Solarium/QueryType/Select/Result/Result.php
@@ -84,6 +84,15 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     protected $maxscore;
 
     /**
+     * Solr nextcursormark.
+     *
+     * Will only be available if 'cursormark' was set for your query
+     *
+     * @var string
+     */
+    protected $nextcursormark;
+
+    /**
      * Document instances array.
      *
      * @var array
@@ -169,6 +178,21 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
         $this->parseResponse();
 
         return $this->maxscore;
+    }
+
+    /**
+     * get Solr nextcursormark.
+     *
+     * Returns the next cursor mark for deep paging
+     * Will only be available if 'cursormark' was set for your query
+     *
+     * @return string
+     */
+    public function getNextCursorMark()
+    {
+        $this->parseResponse();
+
+        return $this->nextcursormark;
     }
 
     /**


### PR DESCRIPTION
I've added the possibility to use Solr's cursor functionality for efficient deep paging. PrefetchIterator makes use of this implementation if a cursorMark is set for the query.
