### PR TITLE
Remove Client dependency from Result

### DIFF
--- a/library/Solarium/Core/Client/Client.php
+++ b/library/Solarium/Core/Client/Client.php
@@ -739,7 +739,7 @@ class Client extends Configurable implements ClientInterface
         }
 
         $resultClass = $query->getResultClass();
-        $result = new $resultClass($this, $query, $response);
+        $result = new $resultClass($query, $response);
 
         if (!($result instanceof ResultInterface)) {
             throw new UnexpectedValueException('Result class must implement the ResultInterface');

--- a/library/Solarium/Core/Query/Result/Result.php
+++ b/library/Solarium/Core/Query/Result/Result.php
@@ -79,24 +79,15 @@ class Result implements ResultInterface
     protected $query;
 
     /**
-     * Solarium client instance.
-     *
-     * @var Client
-     */
-    protected $client;
-
-    /**
      * Constructor.
      *
      * @throws HttpException
      *
-     * @param Client        $client
      * @param AbstractQuery $query
      * @param Response      $response
      */
-    public function __construct($client, $query, $response)
+    public function __construct($query, $response)
     {
-        $this->client = $client;
         $this->query = $query;
         $this->response = $response;
 

--- a/tests/Solarium/Tests/Core/Client/ClientTest.php
+++ b/tests/Solarium/Tests/Core/Client/ClientTest.php
@@ -712,7 +712,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             $expectedEvent->setDispatcher($this->client->getEventDispatcher());
             $expectedEvent->setName(Events::PRE_CREATE_RESULT);
         }
-        $expectedResult = new Result($this->client, $query, $response);
+        $expectedResult = new Result($query, $response);
 
         $test = $this;
         $this->client->getEventDispatcher()->addListener(
@@ -749,7 +749,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $query = new PingQuery();
         $response = new Response('', array('HTTP 1.0 200 OK'));
-        $result = new Result($this->client, $query, $response);
+        $result = new Result($query, $response);
 
         $observer = $this->getMock(
             'Solarium\Core\Client\Client',
@@ -778,7 +778,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $query = new PingQuery();
         $response = new Response('', array('HTTP 1.0 200 OK'));
-        $result = new Result($this->client, $query, $response);
+        $result = new Result($query, $response);
         $expectedEvent = new PreExecuteEvent($query);
 
 
@@ -815,7 +815,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $query = new PingQuery();
         $response = new Response('', array('HTTP 1.0 200 OK'));
-        $result = new Result($this->client, $query, $response);
+        $result = new Result($query, $response);
         $expectedEvent = new PostExecuteEvent($query, $result);
 
         $mock = $this->getMock('Solarium\Core\Client\Client', array('createRequest', 'executeRequest', 'createResult'));
@@ -851,7 +851,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $query = new PingQuery();
         $response = new Response('', array('HTTP 1.0 200 OK'));
-        $expectedResult = new Result($this->client, $query, $response);
+        $expectedResult = new Result($query, $response);
         $expectedEvent = new PreExecuteEvent($query);
         if (method_exists($expectedEvent, 'setDispatcher')) {
             $expectedEvent->setDispatcher($this->client->getEventDispatcher());

--- a/tests/Solarium/Tests/Core/Event/PostCreateResultTest.php
+++ b/tests/Solarium/Tests/Core/Event/PostCreateResultTest.php
@@ -45,7 +45,7 @@ class PostCreateResultTest extends \PHPUnit_Framework_TestCase
         $query = $client->createSelect();
         $query->setQuery('test123');
         $response = new Response('', array('HTTP 1.0 200 OK'));
-        $result = new Result($client, $query, $response);
+        $result = new Result($query, $response);
 
         $event = new PostCreateResult($query, $response, $result);
 

--- a/tests/Solarium/Tests/Core/Event/PostExecuteTest.php
+++ b/tests/Solarium/Tests/Core/Event/PostExecuteTest.php
@@ -45,7 +45,7 @@ class PostExecuteTest extends \PHPUnit_Framework_TestCase
         $query = $client->createSelect();
         $query->setQuery('test123');
         $response = new Response('', array('HTTP 1.0 200 OK'));
-        $result = new Result($client, $query, $response);
+        $result = new Result($query, $response);
 
         $event = new PostExecute($query, $result);
 

--- a/tests/Solarium/Tests/Core/Event/PreCreateResultTest.php
+++ b/tests/Solarium/Tests/Core/Event/PreCreateResultTest.php
@@ -66,7 +66,7 @@ class PreCreateResultTest extends \PHPUnit_Framework_TestCase
         $query->setQuery('test123');
         $response = new Response('', array('HTTP 1.0 200 OK'));
 
-        $result = new Result($client, $query, $response);
+        $result = new Result($query, $response);
         $event->setResult($result);
 
         $this->assertEquals($result, $event->getResult());

--- a/tests/Solarium/Tests/Core/Event/PreExecuteTest.php
+++ b/tests/Solarium/Tests/Core/Event/PreExecuteTest.php
@@ -63,7 +63,7 @@ class PreExecuteTest extends \PHPUnit_Framework_TestCase
         $query = $client->createSelect();
         $query->setQuery('test123');
         $response = new Response('', array('HTTP 1.0 200 OK'));
-        $result = new Result($client, $query, $response);
+        $result = new Result($query, $response);
 
         $event->setResult($result);
         $this->assertEquals($result, $event->getResult());

--- a/tests/Solarium/Tests/Core/Query/Result/QueryTypeTest.php
+++ b/tests/Solarium/Tests/Core/Query/Result/QueryTypeTest.php
@@ -49,7 +49,7 @@ class QueryTypeTest extends \PHPUnit_Framework_TestCase
         $client = new Client;
         $query = new UpdateQuery;
         $response = new Response('{"responseHeader":{"status":1,"QTime":12}}', array('HTTP 1.1 200 OK'));
-        $this->result = new QueryTypeDummy($client, $query, $response);
+        $this->result = new QueryTypeDummy($query, $response);
     }
 
     public function testParseResponse()
@@ -57,7 +57,7 @@ class QueryTypeTest extends \PHPUnit_Framework_TestCase
         $client = new Client;
         $query = new QueryDummyTest;
         $response = new Response('{"responseHeader":{"status":1,"QTime":12}}', array('HTTP 1.1 200 OK'));
-        $result = new QueryTypeDummy($client, $query, $response);
+        $result = new QueryTypeDummy($query, $response);
 
         $this->setExpectedException('Solarium\Exception\UnexpectedValueException');
         $result->parse();

--- a/tests/Solarium/Tests/Core/Query/Result/ResultTest.php
+++ b/tests/Solarium/Tests/Core/Query/Result/ResultTest.php
@@ -58,7 +58,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
             '"response":{"numFound":0,"start":0,"docs":[]}}';
         $this->response = new Response($data, $this->headers);
 
-        $this->result = new Result($this->client, $this->query, $this->response);
+        $this->result = new Result($this->query, $this->response);
     }
 
     public function testResultWithErrorResponse()
@@ -67,7 +67,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
         $response = new Response('Error message', $headers);
 
         $this->setExpectedException('Solarium\Exception\HttpException');
-        new Result($this->client, $this->query, $response);
+        new Result($this->query, $response);
     }
 
     public function testExceptionGetBody()
@@ -76,7 +76,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
         $response = new Response('Error message', $headers);
 
         try {
-            new Result($this->client, $this->query, $response);
+            new Result($this->query, $response);
         } catch (HttpException $e) {
             $this->assertEquals('Error message', $e->getBody());
         }
@@ -126,7 +126,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
         );
 
         $response = new Response($phpsData, $this->headers);
-        $result = new Result($this->client, $this->query, $response);
+        $result = new Result($this->query, $response);
 
         $this->assertEquals($resultData, $result->getData());
     }
@@ -134,7 +134,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
     public function testGetDataWithUnkownResponseWriter()
     {
         $this->query->setResponseWriter('asdf');
-        $result = new Result($this->client, $this->query, $this->response);
+        $result = new Result($this->query, $this->response);
 
         $this->setExpectedException('Solarium\Exception\RuntimeException');
         $result->getData();
@@ -144,9 +144,10 @@ class ResultTest extends \PHPUnit_Framework_TestCase
     {
         $data = 'invalid';
         $this->response = new Response($data, $this->headers);
-        $this->result = new Result($this->client, $this->query, $this->response);
+        $this->result = new Result($this->query, $this->response);
 
         $this->setExpectedException('Solarium\Exception\UnexpectedValueException');
         $this->result->getData();
     }
+
 }

--- a/tests/Solarium/Tests/Plugin/BufferedAdd/Event/PostCommitTest.php
+++ b/tests/Solarium/Tests/Plugin/BufferedAdd/Event/PostCommitTest.php
@@ -45,7 +45,7 @@ class PostCommitTest extends \PHPUnit_Framework_TestCase
         $query = $client->createSelect();
         $query->setQuery('test123');
         $response = new Response('', array('HTTP 1.0 200 OK'));
-        $result = new Result($client, $query, $response);
+        $result = new Result($query, $response);
 
         $event = new PostCommit($result);
 

--- a/tests/Solarium/Tests/Plugin/BufferedAdd/Event/PostFlushTest.php
+++ b/tests/Solarium/Tests/Plugin/BufferedAdd/Event/PostFlushTest.php
@@ -45,7 +45,7 @@ class PostFlushTest extends \PHPUnit_Framework_TestCase
         $query = $client->createSelect();
         $query->setQuery('test123');
         $response = new Response('', array('HTTP 1.0 200 OK'));
-        $result = new Result($client, $query, $response);
+        $result = new Result($query, $response);
 
         $event = new PostFlush($result);
 

--- a/tests/Solarium/Tests/QueryType/MoreLikeThis/ResultTest.php
+++ b/tests/Solarium/Tests/QueryType/MoreLikeThis/ResultTest.php
@@ -102,7 +102,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
         $query = new Query;
         $response = new Response('{"responseHeader":{"status":1,"QTime":12}}', array('HTTP 1.1 200 OK'));
 
-        $ping = new Result($client, $query, $response);
+        $ping = new Result($query, $response);
         $this->assertEquals(
             $query,
             $ping->getQuery()

--- a/tests/Solarium/Tests/QueryType/Ping/ResultTest.php
+++ b/tests/Solarium/Tests/QueryType/Ping/ResultTest.php
@@ -44,7 +44,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
         $query = new Query;
         $response = new Response('{"responseHeader":{"status":1,"QTime":12}}', array('HTTP 1.1 200 OK'));
 
-        $ping = new Result($client, $query, $response);
+        $ping = new Result($query, $response);
         $this->assertEquals(
             0,
             $ping->getStatus()

--- a/tests/Solarium/Tests/QueryType/Update/ResponseParserTest.php
+++ b/tests/Solarium/Tests/QueryType/Update/ResponseParserTest.php
@@ -43,7 +43,7 @@ class ResponseParserTest extends \PHPUnit_Framework_TestCase
         $data = '{"responseHeader" : {"status":1,"QTime":15}}';
 
         $response = new Response($data, array('HTTP 1.1 200 OK'));
-        $result = new Result(null, new SelectQuery, $response);
+        $result = new Result(new SelectQuery, $response);
         $parser = new ResponseParser;
         $parsed = $parser->parse($result);
 


### PR DESCRIPTION
I'm using the library and caching the Solr Result for some cases and I had some errors regarding serializing the Result object. The serialize problem itself is related to the Event Dispatcher dependency on Client https://github.com/solariumphp/solarium/blob/master/library/Solarium/Core/Client/Client.php#L551.

Anyway, the Client dependency on Result doesn't make much sense for me, and it's not used. That's the reason for the PR.
