### PR TITLE
Accept DateTimeImmutable objects in helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.6",
         "symfony/event-dispatcher": "~2.3|~3.0"
     },
     "require-dev": {

--- a/library/Solarium/Core/Query/Helper.php
+++ b/library/Solarium/Core/Query/Helper.php
@@ -139,7 +139,7 @@ class Helper
      *
      * @see http://lucene.apache.org/solr/api/org/apache/solr/schema/DateField.html
      *
-     * @param int|string|\DateTime $input accepted formats: timestamp, date string or DateTime
+     * @param int|string|\DateTimeInterface $input accepted formats: timestamp, date string or DateTime / DateTimeImmutable
      *
      * @return string|boolean false is returned in case of invalid input
      */
@@ -148,7 +148,7 @@ class Helper
         switch (true) {
 
             // input of datetime object
-            case $input instanceof \DateTime:
+            case $input instanceof \DateTimeInterface:
                 // no work needed
                 break;
 
@@ -180,7 +180,7 @@ class Helper
         // handle the filtered input
         if ($input) {
             // when we get here the input is always a datetime object
-            $input->setTimezone(new \DateTimeZone('UTC'));
+            $input = $input->setTimezone(new \DateTimeZone('UTC'));
             $iso8601 = $input->format(\DateTime::ISO8601);
             $iso8601 = strstr($iso8601, '+', true); //strip timezone
             $iso8601 .= 'Z';

--- a/tests/Solarium/Tests/Core/Query/HelperTest.php
+++ b/tests/Solarium/Tests/Core/Query/HelperTest.php
@@ -321,6 +321,22 @@ class HelperTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testFormatDateInputDateTimeImmutable()
+    {
+        date_default_timezone_set("UTC"); // prevent timezone differences
+
+        $this->assertFalse(
+            $this->helper->formatDate(new \stdClass()),
+            'Expect any other object not to be accepted'
+        );
+
+        $this->assertEquals(
+            $this->mockFormatDateOutput(strtotime('2011-10-01')),
+            $this->helper->formatDate(new \DateTimeImmutable('2011-10-01')),
+            'Expects formatDate with DateTimeImmutable input to output ISO8601 with stripped timezone'
+        );
+    }
+
     public function testFormatDate()
     {
         //check if timezone is stripped


### PR DESCRIPTION
This pull request aims at accepting any `DateTimeInterface` / `DateTimeImmutable` objects in the query helper that transform date objects to Solr UTC ISO8601 date format.

Since these native PHP interface / object have been introduced in PHP 5.5, `composer.json` needs to be modified.

The whole library shouldn't force PHP version upgrade just for that small feature, so there's no emergency at all.  It's just for getting it in the pipe for the next major version.
