### PR TITLE
[Proposal] solr query-builder

### DIFF
--- a/library/Solarium/Core/Query/QueryBuilder.php
+++ b/library/Solarium/Core/Query/QueryBuilder.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Solarium\Core\Query;
+
+use Solarium\Client;
+use Solarium\QueryType\Select\Query\Query;
+
+class QueryBuilder
+{
+    /**
+     * @var array
+     */
+    private $queryParts = array();
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @var array
+     */
+    private $selectFields;
+
+    /**
+     * @var AbstractQuery
+     */
+    private $query;
+
+    /**
+     * @var bool
+     */
+    private $buildingWhere;
+
+    /**
+     * @param Client $client
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param string $field
+     *
+     * @return QueryBuilder
+     */
+    public function where($field)
+    {
+        $this->queryParts[] = $field . ':';
+
+        $this->buildingWhere = true;
+
+        return $this;
+    }
+
+    /**
+     * @param array $select
+     *
+     * @return QueryBuilder
+     */
+    public function select($select)
+    {
+        $this->selectFields = is_array($select) ? $select : func_get_args();
+
+        $this->query = $this->client->createSelect();
+
+        return $this;
+    }
+
+    /**
+     * @param float $lat
+     * @param float $long
+     * @param float $distance
+     *
+     * @return QueryBuilder
+     */
+    public function inDistance($lat, $long, $distance)
+    {
+        $this->ensureIsBuildingWhere();
+
+        $parts = count($this->queryParts);
+        $fieldName = $this->queryParts[$parts-1];
+
+        $geoQuery = $this->query->getHelper()->geofilt($fieldName, $lat, $long, $distance);
+
+        $this->queryParts[] = $geoQuery;
+
+        $this->buildingWhere = false;
+
+        return $this;
+    }
+
+    /**
+     * @param array $collection
+     *
+     * @return QueryBuilder
+     */
+    public function inSet($collection)
+    {
+        $this->ensureIsBuildingWhere();
+
+        $in = '(' . join(', ', $collection) . ')';
+
+        $this->queryParts[] = $in;
+
+        $this->buildingWhere = false;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $rangeStart
+     * @param mixed $rangeEnd
+     *
+     * @return QueryBuilder
+     */
+    public function inRange($rangeStart, $rangeEnd)
+    {
+        $this->ensureIsBuildingWhere();
+
+        $range = sprintf('[%s TO %s]', $rangeStart, $rangeEnd);
+
+        $this->queryParts[] = $range;
+
+        $this->buildingWhere = false;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return QueryBuilder
+     */
+    public function equals($value)
+    {
+        $this->ensureIsBuildingWhere();
+
+        $this->queryParts[] = $value;
+
+        $this->buildingWhere = false;
+
+        return $this;
+    }
+
+    /**
+     * @param string $field
+     *
+     * @return QueryBuilder
+     */
+    public function andWhere($field)
+    {
+        $this->queryParts[] = ' AND ' . $field . ':';
+
+        $this->buildingWhere = true;
+
+        return $this;
+    }
+
+    /**
+     * @param string $field
+     *
+     * @return QueryBuilder
+     */
+    public function orWhere($field)
+    {
+        $this->queryParts[] = ' OR ' . $field . ':';
+
+        $this->buildingWhere = true;
+
+        return $this;
+    }
+
+    /**
+     * @return AbstractQuery
+     */
+    public function getQuery()
+    {
+        $selectQuery = new Query();
+
+        foreach ($this->selectFields as $field) {
+            $selectQuery->addField($field);
+        }
+
+        $query = '';
+
+        foreach ($this->queryParts as $queryPart) {
+            $query .= $queryPart;
+        }
+
+        $selectQuery->setQuery($query);
+
+        return $selectQuery;
+    }
+
+    /**
+     * @throws \RuntimeException if no where is build
+     */
+    private function ensureIsBuildingWhere()
+    {
+        if ($this->buildingWhere === false) {
+            throw new \RuntimeException('No where statement is currently build');
+        }
+    }
+}

--- a/tests/Solarium/Tests/Core/Query/QueryBuilderTest.php
+++ b/tests/Solarium/Tests/Core/Query/QueryBuilderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Solarium\Tests\Core\Query;
+
+use Solarium\Client;
+use Solarium\Core\Query\AbstractQuery;
+use Solarium\Core\Query\QueryBuilder;
+
+class QueryBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function usage()
+    {
+        $client = new Client();
+
+        $builder = new QueryBuilder($client);
+        $builder
+            ->select('title', 'content')
+            ->where('id')
+                ->equals('id_prefix_*')
+            ->andWhere('title_s')
+                ->equals('a title')
+            ->orWhere('tags_ss')
+                ->inSet(array('solr', 'symfony'))
+            ->andWhere('latlong')
+                ->inDistance(10, 10, 10);
+
+        $query = $builder->getQuery();
+
+        $this->assertInstanceOf(AbstractQuery::class, $query);
+
+        $expected = 'id:id_prefix_* AND title_s:a title OR tags_ss:(solr, symfony) AND latlong:{!geofilt pt=10,10 sfield= AND latlong: d=10}';
+
+        $this->assertEquals($expected, $query->getQuery());
+    }
+}


### PR DESCRIPTION
Related issue #420 

QueryBuilder allows to define queries programmatically.

```php
$builder
    ->select('title', 'content')
    ->where('id')
        ->equals('id_prefix_*')
    ->andWhere('title_s')
        ->equals('a title')
    ->orWhere('tags_ss')
        ->inSet(array('solr', 'symfony'));
```

A condition starts always with `where` / `andWhere` / `orWhere`, followed by `equals($value)`/ `inSet($values)`/ `inRange($start, $end)`/ `inDistance($lat, $long, $distance)`.

I have also implemented a test-class to show the usage.

The implementation and featureset is very basic and should only start a discussion.