### PR TITLE
Do not parse collation array for Solr 5+; values are already in name/…

### DIFF
--- a/docs/customizing-solarium.md
+++ b/docs/customizing-solarium.md
@@ -97,7 +97,8 @@ By combining these options you can achieve almost any type of customization with
 
 Solarium uses a separate library (included using Composer) for events. For more info on the Event Dispatcher take a look at [http://symfony.com/doc/2.0/components/event\_dispatcher/introduction.html the docs](http://symfony.com/doc/2.0/components/event_dispatcher/introduction.html_the_docs)
 
-This example shows all available events and how to use the events to create a very basic debugger: ```php
+This example shows all available events and how to use the events to create a very basic debugger: 
+```php
 <?php
 require(__DIR__.'/init.php');
 use Solarium\Core\Event\Events;
@@ -230,7 +231,8 @@ htmlFooter();
 
 ```
 
-The second example shows how to replace the built-in select querytype with a custom implementation: ```php
+The second example shows how to replace the built-in select querytype with a custom implementation: 
+```php
 <?php
 require(__DIR__.'/init.php');
 use Solarium\Client;

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Spellcheck.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Spellcheck.php
@@ -141,10 +141,18 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
             if ($queryObject->getResponseWriter() == $queryObject::WT_JSON) {
                 if (is_array(current($values))) {
                     foreach ($values as $key => $value) {
-                        $values[$key] = $this->convertToKeyValueArray($value);
+                        if (array_key_exists('collationQuery', $value)) {
+                            $values[$key] = $value;
+                        } else {
+                            $values[$key] = $this->convertToKeyValueArray($value);
+                        }
                     }
                 } else {
-                    $values = array($this->convertToKeyValueArray($values));
+                    if (array_key_exists('collationQuery', $values)) {
+                        $values = array($values);
+                    } else {
+                        $values = array($this->convertToKeyValueArray($values));
+                    }
                 }
             }
 

--- a/tests/Solarium/Tests/QueryType/Select/ResponseParser/Component/SpellcheckTest.php
+++ b/tests/Solarium/Tests/QueryType/Select/ResponseParser/Component/SpellcheckTest.php
@@ -194,12 +194,9 @@ class SpellcheckTest extends \PHPUnit_Framework_TestCase
                         'collations' => array(
                             'collation',
                             array(
-                                0 => 'collationQuery',
-                                1 => 'dell ultrasharp',
-                                2 => 'hits',
-                                3 => 0,
-                                4 => 'misspellingsAndCorrections',
-                                5 => array(
+                                'collationQuery' => 'dell ultrasharp',
+                                'hits' => 0,
+                                'misspellingsAndCorrections' => array(
                                     0 => 'delll',
                                     1 => 'dell',
                                     2 => 'ultrashar',
@@ -208,12 +205,9 @@ class SpellcheckTest extends \PHPUnit_Framework_TestCase
                             ),
                             'collation',
                             array(
-                                0 => 'collationQuery',
-                                1 => 'dell ultrasharp new',
-                                2 => 'hits',
-                                3 => 0,
-                                4 => 'misspellingsAndCorrections',
-                                5 => array(
+                                'collationQuery' => 'dell ultrasharp new',
+                                'hits' => 0,
+                                'misspellingsAndCorrections' => array(
                                     0 => 'delll',
                                     1 => 'dell',
                                     2 => 'ultrashar',


### PR DESCRIPTION
…value pairs. Change unit test to match the collation data structure returned by Solr.