### PR TITLE
Do not parse collation array for Solr 5+; values are already in name/value pairs. Change unit test to match the collation data structure returned by Solr.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 
-## 3.6.0
+## 3.6.0 - 2016-05-03
 
 - improvement: no longer allow failures for HHVM in continuous integration
 - improvement: added Symfony 3.x components to CI tests for PHP 5.5+

--- a/library/Solarium/Client.php
+++ b/library/Solarium/Client.php
@@ -72,7 +72,7 @@ class Client extends CoreClient
      *
      * @var string
      */
-    const VERSION = '3.4.0';
+    const VERSION = '3.6.0';
 
     /**
      * Check for an exact version.

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Spellcheck.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Spellcheck.php
@@ -141,10 +141,18 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
             if ($queryObject->getResponseWriter() == $queryObject::WT_JSON) {
                 if (is_array(current($values))) {
                     foreach ($values as $key => $value) {
-                        $values[$key] = $this->convertToKeyValueArray($value);
+                        if (array_key_exists('collationQuery', $value)) {
+                            $values[$key] = $value;
+                        } else {
+                            $values[$key] = $this->convertToKeyValueArray($value);
+                        }
                     }
                 } else {
-                    $values = array($this->convertToKeyValueArray($values));
+                    if (array_key_exists('collationQuery', $values)) {
+                        $values = array($values);
+                    } else {
+                        $values = array($this->convertToKeyValueArray($values));
+                    }
                 }
             }
 

--- a/tests/Solarium/Tests/QueryType/Select/ResponseParser/Component/SpellcheckTest.php
+++ b/tests/Solarium/Tests/QueryType/Select/ResponseParser/Component/SpellcheckTest.php
@@ -194,12 +194,9 @@ class SpellcheckTest extends \PHPUnit_Framework_TestCase
                         'collations' => array(
                             'collation',
                             array(
-                                0 => 'collationQuery',
-                                1 => 'dell ultrasharp',
-                                2 => 'hits',
-                                3 => 0,
-                                4 => 'misspellingsAndCorrections',
-                                5 => array(
+                                'collationQuery' => 'dell ultrasharp',
+                                'hits' => 0,
+                                'misspellingsAndCorrections' => array(
                                     0 => 'delll',
                                     1 => 'dell',
                                     2 => 'ultrashar',
@@ -208,12 +205,9 @@ class SpellcheckTest extends \PHPUnit_Framework_TestCase
                             ),
                             'collation',
                             array(
-                                0 => 'collationQuery',
-                                1 => 'dell ultrasharp new',
-                                2 => 'hits',
-                                3 => 0,
-                                4 => 'misspellingsAndCorrections',
-                                5 => array(
+                                'collationQuery' => 'dell ultrasharp new',
+                                'hits' => 0,
+                                'misspellingsAndCorrections' => array(
                                     0 => 'delll',
                                     1 => 'dell',
                                     2 => 'ultrashar',


### PR DESCRIPTION
@basdenooijer No problem. PR against develop branch. Replaces #438.