### PR TITLE
Add support for grouping result using a function

### DIFF
--- a/library/Solarium/Client.php
+++ b/library/Solarium/Client.php
@@ -72,7 +72,7 @@ class Client extends CoreClient
      *
      * @var string
      */
-    const VERSION = '3.4.0';
+    const VERSION = '3.6.0';
 
     /**
      * Check for an exact version.

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Grouping.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Grouping.php
@@ -67,7 +67,9 @@ class Grouping implements ComponentParserInterface
             // parse field groups
             $valueResultClass = $grouping->getOption('resultvaluegroupclass');
             $documentClass = $query->getOption('documentclass');
-            foreach ($grouping->getFields() as $field) {
+
+            // check grouping fields as well as the grouping function (either can be used in the query)
+            foreach (array_merge($grouping->getFields(), array($grouping->getFunction())) as $field) {
                 if (isset($data['grouped'][$field])) {
                     $result = $data['grouped'][$field];
 

--- a/tests/Solarium/Tests/QueryType/Select/ResponseParser/Component/GroupingTest.php
+++ b/tests/Solarium/Tests/QueryType/Select/ResponseParser/Component/GroupingTest.php
@@ -64,6 +64,7 @@ class GroupingTest extends \PHPUnit_Framework_TestCase
         $this->query = new Query();
         $this->grouping = $this->query->getGrouping();
         $this->grouping->addField('fieldA');
+        $this->grouping->setFunction('functionF');
         $this->grouping->addQuery('cat:1');
 
         $data = array(
@@ -78,6 +79,21 @@ class GroupingTest extends \PHPUnit_Framework_TestCase
                                 'numFound' => 13,
                                 'docs' => array(
                                     array('id' => 1, 'name' => 'test')
+                                )
+                            )
+                        )
+                    )
+                ),
+                'functionF' => array(
+                    'matches' =>  8,
+                    'ngroups' => 3,
+                    'groups' => array(
+                        array(
+                            'groupValue' => true,
+                            'doclist' => array(
+                                'numFound' => 5,
+                                'docs' => array(
+                                    array('id' => 3, 'name' => 'fun')
                                 )
                             )
                         )
@@ -101,13 +117,15 @@ class GroupingTest extends \PHPUnit_Framework_TestCase
 
     public function testGroupParsing()
     {
-        $this->assertEquals(2, count($this->result->getGroups()));
+        $this->assertEquals(3, count($this->result->getGroups()));
 
         $fieldGroup = $this->result->getGroup('fieldA');
         $queryGroup = $this->result->getGroup('cat:1');
+        $functionGroup = $this->result->getGroup('functionF');
 
         $this->assertEquals('Solarium\QueryType\Select\Result\Grouping\FieldGroup', get_class($fieldGroup));
         $this->assertEquals('Solarium\QueryType\Select\Result\Grouping\QueryGroup', get_class($queryGroup));
+        $this->assertEquals('Solarium\QueryType\Select\Result\Grouping\FieldGroup', get_class($functionGroup));
     }
 
     public function testFieldGroupParsing()
@@ -141,5 +159,21 @@ class GroupingTest extends \PHPUnit_Framework_TestCase
     {
         $result = $this->parser->parse($this->query, $this->grouping, array());
         $this->assertEquals(array(), $result->getGroups());
+    }
+
+    public function testFunctionGroupParsing()
+    {
+        $fieldGroup = $this->result->getGroup('functionF');
+        $valueGroups = $fieldGroup->getValueGroups();
+
+        $this->assertEquals(8, $fieldGroup->getMatches());
+        $this->assertEquals(3, $fieldGroup->getNumberOfGroups());
+        $this->assertEquals(1, count($valueGroups));
+
+        $valueGroup = $valueGroups[0];
+        $this->assertEquals(5, $valueGroup->getNumFound());
+
+        $docs = $valueGroup->getDocuments();
+        $this->assertEquals('fun', $docs[0]->name);
     }
 }


### PR DESCRIPTION
Add functionality that checks whether the result data in
ResponseParser\Component\Grouping contain groups created by
solr parameter `group.func` (an arbitrary Solr-supported
function).

When such field is found, apply the same parsing logic
which is usually used for field-grouping, in order to ensure
the function-grouping is recognized and added to the FieldGroup
result object.

This should add a new functionality requested in ticket #440 