### PR TITLE
Fix interface typehint in docblock

### DIFF
--- a/library/Solarium/Plugin/BufferedAdd/BufferedAdd.php
+++ b/library/Solarium/Plugin/BufferedAdd/BufferedAdd.php
@@ -43,7 +43,7 @@ namespace Solarium\Plugin\BufferedAdd;
 use Solarium\Core\Plugin\AbstractPlugin;
 use Solarium\QueryType\Update\Result as UpdateResult;
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;
-use Solarium\QueryType\Select\Result\DocumentInterface;
+use Solarium\QueryType\Update\Query\Document\DocumentInterface;
 use Solarium\Plugin\BufferedAdd\Event\Events;
 use Solarium\Plugin\BufferedAdd\Event\PreFlush as PreFlushEvent;
 use Solarium\Plugin\BufferedAdd\Event\PostFlush as PostFlushEvent;

--- a/library/Solarium/Plugin/BufferedAdd/Event/AddDocument.php
+++ b/library/Solarium/Plugin/BufferedAdd/Event/AddDocument.php
@@ -41,7 +41,7 @@
 namespace Solarium\Plugin\BufferedAdd\Event;
 
 use Symfony\Component\EventDispatcher\Event;
-use Solarium\QueryType\Select\Result\DocumentInterface;
+use Solarium\QueryType\Update\Query\Document\DocumentInterface;
 
 /**
  * AddDocument event, see Events for details.


### PR DESCRIPTION
Update document interface should be considered instead of select documents for the BufferedAdd plugin