### PR TITLE
add spatial component

### DIFF
--- a/library/Solarium/QueryType/Select/Query/Component/Spatial.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Spatial.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Solarium\QueryType\Select\Query\Component;
+
+use Solarium\QueryType\Select\Query\Query as SelectQuery;
+use Solarium\QueryType\Select\RequestBuilder\Component\Spatial as RequestBuilder;
+
+/**
+ * Spatial component.
+ *
+ * @link https://cwiki.apache.org/confluence/display/solr/Spatial+Search
+ */
+class Spatial extends AbstractComponent
+{
+    /**
+     * Get component type.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return SelectQuery::COMPONENT_SPATIAL;
+    }
+
+    /**
+     * Get a requestbuilder for this query.
+     *
+     * @return RequestBuilder
+     */
+    public function getRequestBuilder()
+    {
+        return new RequestBuilder();
+    }
+
+    /**
+     * This component has no response parser...
+     */
+    public function getResponseParser()
+    {
+        return;
+    }
+
+    /**
+     * @param string $sfield
+     */
+    public function setField($sfield)
+    {
+        $this->setOption('sfield', $sfield);
+    }
+
+    /**
+     * @param int $distance
+     */
+    public function setDistance($distance)
+    {
+        $this->setOption('d', $distance);
+    }
+
+    /**
+     * @param string $point
+     */
+    public function setPoint($point)
+    {
+        $this->setOption('pt', $point);
+    }
+
+    /**
+     * Get sfield option.
+     *
+     * @return string|null
+     */
+    public function getField()
+    {
+        return $this->getOption('sfield');
+    }
+
+    /**
+     * Get d option.
+     *
+     * @return int|null
+     */
+    public function getDistance()
+    {
+        return $this->getOption('d');
+    }
+
+    /**
+     * Get pt option.
+     *
+     * @return int|null
+     */
+    public function getPoint()
+    {
+        return $this->getOption('pt');
+    }
+}

--- a/library/Solarium/QueryType/Select/Query/Query.php
+++ b/library/Solarium/QueryType/Select/Query/Query.php
@@ -128,6 +128,11 @@ class Query extends BaseQuery
     const COMPONENT_DEBUG = 'debug';
 
     /**
+     * Query component spatial.
+     */
+    const COMPONENT_SPATIAL = 'spatial';
+
+    /**
      * Default options.
      *
      * @var array
@@ -166,6 +171,7 @@ class Query extends BaseQuery
         self::COMPONENT_DISTRIBUTEDSEARCH => 'Solarium\QueryType\Select\Query\Component\DistributedSearch',
         self::COMPONENT_STATS             => 'Solarium\QueryType\Select\Query\Component\Stats\Stats',
         self::COMPONENT_DEBUG             => 'Solarium\QueryType\Select\Query\Component\Debug',
+        self::COMPONENT_SPATIAL           => 'Solarium\QueryType\Select\Query\Component\Spatial',
     );
 
     /**
@@ -1055,6 +1061,18 @@ class Query extends BaseQuery
         $this->clearTags();
 
         return $this->addTags($tags);
+    }
+
+    /**
+     * Get a Spatial component instance.
+     *
+     * This is a convenience method that maps presets to getComponent
+     *
+     * @return \Solarium\QueryType\Select\Query\Component\Spatial
+     */
+    public function getSpatial()
+    {
+        return $this->getComponent(self::COMPONENT_SPATIAL, true);
     }
 
     /**

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/Spatial.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/Spatial.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Solarium\QueryType\Select\RequestBuilder\Component;
+
+use Solarium\QueryType\Select\Query\Component\Spatial as SpatialComponent;
+use Solarium\Core\Client\Request;
+
+/**
+ * Add select component spatial to the request.
+ */
+class Spatial implements ComponentRequestBuilderInterface
+{
+    /**
+     * Add request settings for Spatial.
+     *
+     * @param SpatialComponent $component
+     * @param Request         $request
+     *
+     * @return Request
+     */
+    public function buildComponent($component, $request)
+    {
+        $request->addParam('sfield', $component->getField());
+        $request->addParam('pt', $component->getPoint());
+        $request->addParam('d', $component->getDistance());
+
+        return $request;
+    }
+}

--- a/tests/Solarium/Tests/QueryType/Select/Query/AbstractQueryTest.php
+++ b/tests/Solarium/Tests/QueryType/Select/Query/AbstractQueryTest.php
@@ -708,4 +708,14 @@ abstract class AbstractQueryTest extends \PHPUnit_Framework_TestCase
         $this->query->setTags(array('t3', 't4'));
         $this->assertEquals(array('t3', 't4'), $this->query->getTags());
     }
+
+    public function testGetSpatial()
+    {
+        $spatial = $this->query->getSpatial();
+
+        $this->assertEquals(
+            'Solarium\QueryType\Select\Query\Component\Spatial',
+            get_class($spatial)
+        );
+    }
 }

--- a/tests/Solarium/Tests/QueryType/Select/Query/Component/SpatialTest.php
+++ b/tests/Solarium/Tests/QueryType/Select/Query/Component/SpatialTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Select\Query\Component;
+
+use Solarium\QueryType\Select\Query\Component\Spatial;
+use Solarium\QueryType\Select\Query\Query;
+
+class SpatialTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Spatial
+     */
+    protected $spatial;
+
+    public function setUp()
+    {
+        $this->spatial = new Spatial;
+    }
+
+    public function testConfigMode()
+    {
+        $options = array(
+            'sfield' => 'geo',
+            'd' => 50,
+            'pt' => '48.2233,16.3161',
+        );
+
+        $this->spatial->setOptions($options);
+
+        $this->assertEquals($options['sfield'], $this->spatial->getField());
+        $this->assertEquals($options['d'], $this->spatial->getDistance());
+        $this->assertEquals($options['pt'], $this->spatial->getPoint());
+    }
+
+    public function testGetType()
+    {
+        $this->assertEquals(
+            Query::COMPONENT_SPATIAL,
+            $this->spatial->getType()
+        );
+    }
+
+    public function testGetResponseParser()
+    {
+        $this->assertEquals(null, $this->spatial->getResponseParser());
+    }
+
+    public function testGetRequestBuilder()
+    {
+        $this->assertInstanceOf(
+            'Solarium\QueryType\Select\RequestBuilder\Component\Spatial',
+            $this->spatial->getRequestBuilder()
+        );
+    }
+
+    public function testSetAndGetField()
+    {
+        $value = 'geo';
+        $this->spatial->setField($value);
+
+        $this->assertEquals(
+            $value,
+            $this->spatial->getField()
+        );
+    }
+
+    public function testSetAndGetDistance()
+    {
+        $value = 'distance';
+        $this->spatial->setDistance($value);
+
+        $this->assertEquals(
+            $value,
+            $this->spatial->getDistance()
+        );
+    }
+
+    public function testSetAndGetPoint()
+    {
+        $value = '52,13';
+        $this->spatial->setPoint($value);
+
+        $this->assertEquals(
+            $value,
+            $this->spatial->getPoint()
+        );
+    }
+}

--- a/tests/Solarium/Tests/QueryType/Select/RequestBuilder/Component/SpatialTest.php
+++ b/tests/Solarium/Tests/QueryType/Select/RequestBuilder/Component/SpatialTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Select\RequestBuilder\Component;
+
+use Solarium\QueryType\Select\RequestBuilder\Component\Spatial as RequestBuilder;
+use Solarium\QueryType\Select\Query\Component\Spatial as Component;
+use Solarium\Core\Client\Request;
+
+class SpatialTest extends \PHPUnit_Framework_TestCase
+{
+    public function testBuildComponent()
+    {
+        $builder = new RequestBuilder();
+        $request = new Request();
+
+        $component = new Component();
+        $component->setField('geo');
+        $component->setDistance(50);
+        $component->setPoint('48.2233,16.3161');
+
+        $request = $builder->buildComponent($component, $request);
+
+        $this->assertEquals(
+            array(
+                'pt' => '48.2233,16.3161',
+                'sfield' => 'geo',
+                'd' => 50,
+            ),
+            $request->getParams()
+        );
+
+    }
+}


### PR DESCRIPTION
We added a spatial component in order to put solr spatial params ("pt", "d" and "sfield") onto the request.

```
// create a client instance
$client = new Solarium\Client($config);

// get a select query instance
$query = $client->createSelect();

// get the dismax component and set a boost query
$spatial = $query->getSpatial();
$spatial->setPoint('52,13');
$spatial->setField('geo');
$spatial->setDistance(50);

// this executes the query and returns the result
$resultset = $client->select($query);
```

Herewith you can use {!geofilt} as fq.
Also geodist() asc works out of the box for sorting without adding a field and calculating the score. 

Further reading:
https://cwiki.apache.org/confluence/display/solr/Spatial+Search