### PR TITLE
usleep after curl_multi_select -1

### DIFF
--- a/library/Solarium/Plugin/ParallelExecution/ParallelExecution.php
+++ b/library/Solarium/Plugin/ParallelExecution/ParallelExecution.php
@@ -156,11 +156,13 @@ class ParallelExecution extends AbstractPlugin
 
         $timeout = $this->getOption('curlmultiselecttimeout');
         while ($active && $mrc == CURLM_OK) {
-            if (curl_multi_select($multiHandle, $timeout) != -1) {
-                do {
-                    $mrc = curl_multi_exec($multiHandle, $active);
-                } while ($mrc == CURLM_CALL_MULTI_PERFORM);
+            if (curl_multi_select($multiHandle, $timeout) == -1) {
+                usleep(100);
             }
+
+            do {
+                $mrc = curl_multi_exec($multiHandle, $active);
+            } while ($mrc == CURLM_CALL_MULTI_PERFORM);
         }
 
         $this->client->getEventDispatcher()->dispatch(Events::EXECUTE_END, new ExecuteEndEvent());


### PR DESCRIPTION
According to these php bugs:

* https://bugs.php.net/bug.php?id=61141
* https://bugs.php.net/bug.php?id=63842

thats what we should do.

I came across this issue when trying to make the ParallelExecution
working on my CentOS 7.3 box. It spinlooped inside the changed loop.

Also guzzle is doing the same thing:

https://github.com/guzzle/guzzle/blob/master/src/Handler/CurlMultiHandler.php#L103

I am not sure if the timeout needs to be configurable and if the choosen
value (100) is good.


Thank you very much for looking into the change. I do no think we can add a test for this. :/