### PR TITLE
Enable Simple Group Format

### DIFF
--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Grouping.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Grouping.php
@@ -81,6 +81,12 @@ class Grouping implements ComponentParserInterface
 
             $matches = (isset($result['matches'])) ? $result['matches'] : null;
             $groupCount = (isset($result['ngroups'])) ? $result['ngroups'] : null;
+            if ($grouping->getFormat() === GroupingComponent::FORMAT_SIMPLE) {
+                $valueGroups = [$this->extractValueGroup($valueResultClass, $documentClass, $result, $query)];
+                $groups[$field] = new FieldGroup($matches, $groupCount, $valueGroups);
+                continue;
+            }
+
             $valueGroups = array();
             foreach ($result['groups'] as $valueGroupResult) {
                 $valueGroups[] = $this->extractValueGroup($valueResultClass, $documentClass, $valueGroupResult, $query);

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Grouping.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Grouping.php
@@ -73,39 +73,41 @@ class Grouping implements ComponentParserInterface
 
         // check grouping fields as well as the grouping function (either can be used in the query)
         foreach (array_merge($grouping->getFields(), array($grouping->getFunction())) as $field) {
-            if (isset($data['grouped'][$field])) {
-                $result = $data['grouped'][$field];
+            if (!isset($data['grouped'][$field])) {
+                continue;
+            }
 
-                $matches = (isset($result['matches'])) ? $result['matches'] : null;
-                $groupCount = (isset($result['ngroups'])) ? $result['ngroups'] : null;
-                $valueGroups = array();
-                foreach ($result['groups'] as $valueGroupResult) {
-                    $value = (isset($valueGroupResult['groupValue'])) ?
-                            $valueGroupResult['groupValue'] : null;
+            $result = $data['grouped'][$field];
 
-                    $numFound = (isset($valueGroupResult['doclist']['numFound'])) ?
-                            $valueGroupResult['doclist']['numFound'] : null;
+            $matches = (isset($result['matches'])) ? $result['matches'] : null;
+            $groupCount = (isset($result['ngroups'])) ? $result['ngroups'] : null;
+            $valueGroups = array();
+            foreach ($result['groups'] as $valueGroupResult) {
+                $value = (isset($valueGroupResult['groupValue'])) ?
+                        $valueGroupResult['groupValue'] : null;
 
-                    $start = (isset($valueGroupResult['doclist']['start'])) ?
-                            $valueGroupResult['doclist']['start'] : null;
+                $numFound = (isset($valueGroupResult['doclist']['numFound'])) ?
+                        $valueGroupResult['doclist']['numFound'] : null;
 
-                    $maxScore = (isset($valueGroupResult['doclist']['maxScore'])) ?
-                            $valueGroupResult['doclist']['maxScore'] : null;
+                $start = (isset($valueGroupResult['doclist']['start'])) ?
+                        $valueGroupResult['doclist']['start'] : null;
 
-                    // create document instances
-                    $documents = array();
-                    if (isset($valueGroupResult['doclist']['docs']) &&
-                        is_array($valueGroupResult['doclist']['docs'])) {
-                        foreach ($valueGroupResult['doclist']['docs'] as $doc) {
-                            $documents[] = new $documentClass($doc);
-                        }
+                $maxScore = (isset($valueGroupResult['doclist']['maxScore'])) ?
+                        $valueGroupResult['doclist']['maxScore'] : null;
+
+                // create document instances
+                $documents = array();
+                if (isset($valueGroupResult['doclist']['docs']) &&
+                    is_array($valueGroupResult['doclist']['docs'])) {
+                    foreach ($valueGroupResult['doclist']['docs'] as $doc) {
+                        $documents[] = new $documentClass($doc);
                     }
-
-                    $valueGroups[] = new $valueResultClass($value, $numFound, $start, $documents, $maxScore, $query);
                 }
 
-                $groups[$field] = new FieldGroup($matches, $groupCount, $valueGroups);
+                $valueGroups[] = new $valueResultClass($value, $numFound, $start, $documents, $maxScore, $query);
             }
+
+            $groups[$field] = new FieldGroup($matches, $groupCount, $valueGroups);
         }
 
         // parse query groups

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Grouping.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Grouping.php
@@ -83,28 +83,7 @@ class Grouping implements ComponentParserInterface
             $groupCount = (isset($result['ngroups'])) ? $result['ngroups'] : null;
             $valueGroups = array();
             foreach ($result['groups'] as $valueGroupResult) {
-                $value = (isset($valueGroupResult['groupValue'])) ?
-                        $valueGroupResult['groupValue'] : null;
-
-                $numFound = (isset($valueGroupResult['doclist']['numFound'])) ?
-                        $valueGroupResult['doclist']['numFound'] : null;
-
-                $start = (isset($valueGroupResult['doclist']['start'])) ?
-                        $valueGroupResult['doclist']['start'] : null;
-
-                $maxScore = (isset($valueGroupResult['doclist']['maxScore'])) ?
-                        $valueGroupResult['doclist']['maxScore'] : null;
-
-                // create document instances
-                $documents = array();
-                if (isset($valueGroupResult['doclist']['docs']) &&
-                    is_array($valueGroupResult['doclist']['docs'])) {
-                    foreach ($valueGroupResult['doclist']['docs'] as $doc) {
-                        $documents[] = new $documentClass($doc);
-                    }
-                }
-
-                $valueGroups[] = new $valueResultClass($value, $numFound, $start, $documents, $maxScore, $query);
+                $valueGroups[] = $this->extractValueGroup($valueResultClass, $documentClass, $valueGroupResult, $query);
             }
 
             $groups[$field] = new FieldGroup($matches, $groupCount, $valueGroups);
@@ -138,5 +117,41 @@ class Grouping implements ComponentParserInterface
         }
 
         return new Result($groups);
+    }
+
+    /**
+     * Helper method to extract a ValueGroup object from the given value group result array.
+     *
+     * @param string $valueResultClass The grouping resultvaluegroupclass option.
+     * @param string $documentClass    The name of the solr document class to use.
+     * @param array  $valueGroupResult The group result from the solr response.
+     * @param Query  $query            The current solr query.
+     *
+     * @return object
+     */
+    private function extractValueGroup($valueResultClass, $documentClass, $valueGroupResult, $query)
+    {
+        $value = (isset($valueGroupResult['groupValue'])) ?
+                $valueGroupResult['groupValue'] : null;
+
+        $numFound = (isset($valueGroupResult['doclist']['numFound'])) ?
+                $valueGroupResult['doclist']['numFound'] : null;
+
+        $start = (isset($valueGroupResult['doclist']['start'])) ?
+                $valueGroupResult['doclist']['start'] : null;
+
+        $maxScore = (isset($valueGroupResult['doclist']['maxScore'])) ?
+                $valueGroupResult['doclist']['maxScore'] : null;
+
+        // create document instances
+        $documents = array();
+        if (isset($valueGroupResult['doclist']['docs']) &&
+            is_array($valueGroupResult['doclist']['docs'])) {
+            foreach ($valueGroupResult['doclist']['docs'] as $doc) {
+                $documents[] = new $documentClass($doc);
+            }
+        }
+
+        return new $valueResultClass($value, $numFound, $start, $documents, $maxScore, $query);
     }
 }

--- a/tests/Solarium/Tests/QueryType/Select/ResponseParser/Component/GroupingTest.php
+++ b/tests/Solarium/Tests/QueryType/Select/ResponseParser/Component/GroupingTest.php
@@ -161,6 +161,43 @@ class GroupingTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $result->getGroups());
     }
 
+    public function testParseMissingGroupField()
+    {
+        //data does not contain 'fieldA'
+        $data = array(
+            'grouped' => array(
+                'functionF' => array(
+                    'matches' =>  8,
+                    'ngroups' => 3,
+                    'groups' => array(
+                        array(
+                            'groupValue' => true,
+                            'doclist' => array(
+                                'numFound' => 5,
+                                'docs' => array(
+                                    array('id' => 3, 'name' => 'fun'),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                'cat:1' => array(
+                    'matches' =>  40,
+                    'doclist' => array(
+                        'numFound' => 22,
+                        'docs' => array(
+                            array('id' => 2, 'name' => 'dummy2'),
+                            array('id' => 5, 'name' => 'dummy5'),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $result = $this->parser->parse($this->query, $this->grouping, $data);
+        $this->assertNull($result->getGroup('fieldA'));
+    }
+
     public function testFunctionGroupParsing()
     {
         $fieldGroup = $this->result->getGroup('functionF');
@@ -175,5 +212,41 @@ class GroupingTest extends \PHPUnit_Framework_TestCase
 
         $docs = $valueGroup->getDocuments();
         $this->assertEquals('fun', $docs[0]->name);
+    }
+
+    public function testsParseWithSimpleFormat()
+    {
+        $data = array(
+            'grouped' => array(
+                'fieldA' => array(
+                    'matches' =>  25,
+                    'ngroups' => 12,
+                    'doclist' => array(
+                        'numFound' => 13,
+                        'docs' => array(
+                            array('id' => 1, 'name' => 'test'),
+                            array('id' => 2, 'name' => 'test2'),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->grouping->setFormat(Component::FORMAT_SIMPLE);
+
+        $result = $this->parser->parse($this->query, $this->grouping, $data);
+
+        $fieldGroup = $result->getGroup('fieldA');
+        $valueGroups = $fieldGroup->getValueGroups();
+
+        $this->assertEquals(25, $fieldGroup->getMatches());
+        $this->assertEquals(12, $fieldGroup->getNumberOfGroups());
+        $this->assertEquals(1, count($valueGroups));
+
+        $valueGroup = $valueGroups[0];
+        $this->assertEquals(13, $valueGroup->getNumFound());
+
+        $docs = $valueGroup->getDocuments();
+        $this->assertEquals('test2', $docs[1]->name);
     }
 }


### PR DESCRIPTION
Currently you must use `$groupComponent->setMainResult(true);` in order to use the `simple` group format.  This pull request allows the simple format to be used with out specifying the main result setting.

Related to #260 

You can see the difference between the response types below.

## Solr Response with `simple` group format
`?rows=2&q=*%3A*&wt=json&indent=true&group=true&group.field=STATE_CODE&group.format=simple&group.ngroups=true`
```json
{
  "responseHeader":{
    "status":0,
    "QTime":33,
    "params":{
      "group.format":"simple",
      "group.ngroups":"true",
      "indent":"true",
      "q":"*:*",
      "group.field":"STATE_CODE",
      "group":"true",
      "wt":"json",
      "rows":"2"}},
  "grouped":{
    "STATE_CODE":{
      "matches":893638,
      "ngroups":65,
      "doclist":{"numFound":893638,"start":0,"docs":[
          {
            "ZIP_ID":"US:85332",
            "ZIP_CODE":"85332",
            "STATE_NAME":"Arizona",
            "CITY_NAME":"Congress",
            "COUNTRY_CODE":"US",
            "AREA_CODE":"928",
            "STATE_CODE":"AZ",
            "LONGITUDE":-112.8044,
            "LATLONG_1_COORDINATE":-112.8044,
            "COUNTRY_NAME":"United States",
            "LATITUDE":34.1734,
            "LATLONG_0_COORDINATE":34.1734,
            "_version_":1525713107556499456},
          {
            "ZIP_ID":"US:72670",
            "ZIP_CODE":"72670",
            "STATE_NAME":"Arkansas",
            "CITY_NAME":"Ponca",
            "COUNTRY_CODE":"US",
            "AREA_CODE":"870",
            "STATE_CODE":"AR",
            "LONGITUDE":-93.4014,
            "LATLONG_1_COORDINATE":-93.4014,
            "COUNTRY_NAME":"United States",
            "LATITUDE":36.0667,
            "LATLONG_0_COORDINATE":36.0667,
            "_version_":1525713107558596608}]
      }}}}
```

## Solr Response with `group.main=true`
`?rows=2&q=*%3A*&wt=json&indent=true&group=true&group.field=STATE_CODE&group.format=simple&group.main=true&group.ngroups=true`
```json
{
  "responseHeader":{
    "status":0,
    "QTime":60,
    "params":{
      "group.format":"simple",
      "group.ngroups":"true",
      "indent":"true",
      "q":"*:*",
      "group.field":"STATE_CODE",
      "group.main":"true",
      "group":"true",
      "wt":"json",
      "rows":"2"}},
  "response":{"numFound":893638,"start":0,"docs":[
      {
        "ZIP_ID":"US:85332",
        "ZIP_CODE":"85332",
        "STATE_NAME":"Arizona",
        "CITY_NAME":"Congress",
        "COUNTRY_CODE":"US",
        "AREA_CODE":"928",
        "STATE_CODE":"AZ",
        "LONGITUDE":-112.8044,
        "LATLONG_1_COORDINATE":-112.8044,
        "COUNTRY_NAME":"United States",
        "LATITUDE":34.1734,
        "LATLONG_0_COORDINATE":34.1734,
        "_version_":1525713107556499456},
      {
        "ZIP_ID":"US:72670",
        "ZIP_CODE":"72670",
        "STATE_NAME":"Arkansas",
        "CITY_NAME":"Ponca",
        "COUNTRY_CODE":"US",
        "AREA_CODE":"870",
        "STATE_CODE":"AR",
        "LONGITUDE":-93.4014,
        "LATLONG_1_COORDINATE":-93.4014,
        "COUNTRY_NAME":"United States",
        "LATITUDE":36.0667,
        "LATLONG_0_COORDINATE":36.0667,
        "_version_":1525713107558596608}]
  }}
```