### PR TITLE
Remove duplicated word

### DIFF
--- a/docs/queries/update-query/building-an-update-query/commit-command.md
+++ b/docs/queries/update-query/building-an-update-query/commit-command.md
@@ -2,7 +2,7 @@ This command commits any buffered commands to the index. This buffering is done 
 
 If you use the autoCommit feature on the Solr core you probably don't want to use the commit command, because that would trigger a commit in between the autoCommit interval. In all other cases it makes sense to add a commit to your update (or at least to the last update request if you issue multiple) to apply your update to the Solr index.
 
-This command command starts the commit process on the server, bit the actual commit process might take a while. If your update command with a commit returns successfully this only means Solr received the commands and is processing them, the result might not be visible for a while. The time this takes depends on many factors: hardware, index size, number of index segments, the commands to execute, the search load, etcetera. It can vary between milliseconds and minutes.
+This command starts the commit process on the server, bit the actual commit process might take a while. If your update command with a commit returns successfully this only means Solr received the commands and is processing them, the result might not be visible for a while. The time this takes depends on many factors: hardware, index size, number of index segments, the commands to execute, the search load, etcetera. It can vary between milliseconds and minutes.
 
 Options
 -------


### PR DESCRIPTION
## Overview

- The word "command" is duplicated.
    - This is not necessary, maybe.
