### PR TITLE
fix for PHP 5.3

### DIFF
--- a/library/Solarium/Client.php
+++ b/library/Solarium/Client.php
@@ -72,7 +72,7 @@ class Client extends CoreClient
      *
      * @var string
      */
-    const VERSION = '3.7.0';
+    const VERSION = '3.8.0';
 
     /**
      * Check for an exact version.

--- a/library/Solarium/Core/Client/Adapter/Guzzle3.php
+++ b/library/Solarium/Core/Client/Adapter/Guzzle3.php
@@ -74,10 +74,10 @@ class Guzzle3 extends Configurable implements AdapterInterface
             $endpoint->getBaseUri() . $request->getUri(),
             $this->getRequestHeaders($request),
             $this->getRequestBody($request),
-            [
+            array(
                 'timeout' => $endpoint->getTimeout(),
                 'connecttimeout' => $endpoint->getTimeout(),
-            ]
+            )
         );
 
         // Try endpoint authentication first, fallback to request for backwards compatibility
@@ -96,7 +96,7 @@ class Guzzle3 extends Configurable implements AdapterInterface
             $guzzleResponse = $guzzleRequest->getResponse();
 
             $responseHeaders = array_merge(
-                ["HTTP/1.1 {$guzzleResponse->getStatusCode()} {$guzzleResponse->getReasonPhrase()}"],
+                array("HTTP/1.1 {$guzzleResponse->getStatusCode()} {$guzzleResponse->getReasonPhrase()}"),
                 $guzzleResponse->getHeaderLines()
             );
 
@@ -155,7 +155,7 @@ class Guzzle3 extends Configurable implements AdapterInterface
      */
     private function getRequestHeaders(Request $request)
     {
-        $headers = [];
+        $headers = array();
         foreach ($request->getHeaders() as $headerLine) {
             list($header, $value) = explode(':', $headerLine);
             if ($header = trim($header)) {

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Grouping.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Grouping.php
@@ -82,7 +82,7 @@ class Grouping implements ComponentParserInterface
             $matches = (isset($result['matches'])) ? $result['matches'] : null;
             $groupCount = (isset($result['ngroups'])) ? $result['ngroups'] : null;
             if ($grouping->getFormat() === GroupingComponent::FORMAT_SIMPLE) {
-                $valueGroups = [$this->extractValueGroup($valueResultClass, $documentClass, $result, $query)];
+                $valueGroups = array($this->extractValueGroup($valueResultClass, $documentClass, $result, $query));
                 $groups[$field] = new FieldGroup($matches, $groupCount, $valueGroups);
                 continue;
             }

--- a/tests/Solarium/Tests/Core/Client/Adapter/Guzzle3Test.php
+++ b/tests/Solarium/Tests/Core/Client/Adapter/Guzzle3Test.php
@@ -91,11 +91,11 @@ final class Guzzle3Test extends \PHPUnit_Framework_TestCase
         $this->assertSame('OK', $response->getStatusMessage());
         $this->assertSame('200', $response->getStatusCode());
         $this->assertSame(
-            [
+            array(
                 'HTTP/1.1 200 OK',
                 'Content-Type: application/json',
                 'X-PHPUnit: response value',
-            ],
+            ),
             $response->getHeaders()
         );
         $this->assertSame($guzzleResponse->getBody(true), $response->getBody());
@@ -138,11 +138,11 @@ final class Guzzle3Test extends \PHPUnit_Framework_TestCase
         $this->assertSame('OK', $response->getStatusMessage());
         $this->assertSame('200', $response->getStatusCode());
         $this->assertSame(
-            [
+            array(
                 'HTTP/1.1 200 OK',
                 'Content-Type: application/json',
                 'X-PHPUnit: response value',
-            ],
+            ),
             $response->getHeaders()
         );
         $this->assertSame($guzzleResponse->getBody(true), $response->getBody());
@@ -187,11 +187,11 @@ final class Guzzle3Test extends \PHPUnit_Framework_TestCase
         $this->assertSame('OK', $response->getStatusMessage());
         $this->assertSame('200', $response->getStatusCode());
         $this->assertSame(
-            [
+            array(
                 'HTTP/1.1 200 OK',
                 'Content-Type: application/json',
                 'X-PHPUnit: response value',
-            ],
+            ),
             $response->getHeaders()
         );
         $this->assertSame($guzzleResponse->getBody(true), $response->getBody());
@@ -239,11 +239,11 @@ final class Guzzle3Test extends \PHPUnit_Framework_TestCase
         $this->assertSame('OK', $response->getStatusMessage());
         $this->assertSame('200', $response->getStatusCode());
         $this->assertSame(
-            [
+            array(
                 'HTTP/1.1 200 OK',
                 'Content-Type: application/json',
                 'X-PHPUnit: response value',
-            ],
+            ),
             $response->getHeaders()
         );
         $this->assertSame($guzzleResponse->getBody(true), $response->getBody());
@@ -280,9 +280,9 @@ final class Guzzle3Test extends \PHPUnit_Framework_TestCase
         $request->setMethod(Request::METHOD_GET);
 
         $endpoint = new Endpoint(
-            [
+            array(
                 'scheme'  => 'silly', //invalid protocol
-            ]
+            )
         );
 
         $this->adapter->execute($request, $endpoint);
@@ -296,12 +296,12 @@ final class Guzzle3Test extends \PHPUnit_Framework_TestCase
     private function getValidResponse()
     {
         $body = json_encode(
-            [
-                'response' => [
+            array(
+                'response' => array(
                     'numFound' => 10,
                     'start' => 0,
-                    'docs' => [
-                        [
+                    'docs' => array(
+                        array(
                             'id' => '58339e95d5200',
                             'author' => 'Gambardella, Matthew',
                             'title' => "XML Developer's Guide",
@@ -309,13 +309,13 @@ final class Guzzle3Test extends \PHPUnit_Framework_TestCase
                             'price' => 44.95,
                             'published' => 970372800,
                             'description' => 'An in-depth look at creating applications with XML.',
-                        ],
-                    ],
-                ],
-            ]
+                        ),
+                    ),
+                ),
+            )
         );
 
-        $headers = ['Content-Type' => 'application/json', 'X-PHPUnit' => 'response value'];
+        $headers = array('Content-Type' => 'application/json', 'X-PHPUnit' => 'response value');
         return new Response(200, $headers, $body);
     }
 }

--- a/tests/Solarium/Tests/Core/Client/Adapter/GuzzleTest.php
+++ b/tests/Solarium/Tests/Core/Client/Adapter/GuzzleTest.php
@@ -75,15 +75,15 @@ final class GuzzleAdapterTest extends \PHPUnit_Framework_TestCase
     public function executeGet()
     {
         $guzzleResponse = $this->getValidResponse();
-        $mockHandler = new MockHandler([$guzzleResponse]);
+        $mockHandler = new MockHandler(array($guzzleResponse));
 
-        $container = [];
+        $container = array();
         $history = Middleware::history($container);
 
         $stack = HandlerStack::create($mockHandler);
         $stack->push($history);
 
-        $adapter = new GuzzleAdapter(['handler' => $stack]);
+        $adapter = new GuzzleAdapter(array('handler' => $stack));
 
         $request = new Request();
         $request->setMethod(Request::METHOD_GET);
@@ -96,11 +96,11 @@ final class GuzzleAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('OK', $response->getStatusMessage());
         $this->assertSame('200', $response->getStatusCode());
         $this->assertSame(
-            [
+            array(
                 'HTTP/1.1 200 OK',
                 'Content-Type: application/json',
                 'X-PHPUnit: response value',
-            ],
+            ),
             $response->getHeaders()
         );
         $this->assertSame((string)$guzzleResponse->getBody(), $response->getBody());
@@ -121,15 +121,15 @@ final class GuzzleAdapterTest extends \PHPUnit_Framework_TestCase
     public function executePostWithFile()
     {
         $guzzleResponse = $this->getValidResponse();
-        $mockHandler = new MockHandler([$guzzleResponse]);
+        $mockHandler = new MockHandler(array($guzzleResponse));
 
-        $container = [];
+        $container = array();
         $history = Middleware::history($container);
 
         $stack = HandlerStack::create($mockHandler);
         $stack->push($history);
 
-        $adapter = new GuzzleAdapter(['handler' => $stack]);
+        $adapter = new GuzzleAdapter(array('handler' => $stack));
 
         $request = new Request();
         $request->setMethod(Request::METHOD_POST);
@@ -143,11 +143,11 @@ final class GuzzleAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('OK', $response->getStatusMessage());
         $this->assertSame('200', $response->getStatusCode());
         $this->assertSame(
-            [
+            array(
                 'HTTP/1.1 200 OK',
                 'Content-Type: application/json',
                 'X-PHPUnit: response value',
-            ],
+            ),
             $response->getHeaders()
         );
         $this->assertSame((string)$guzzleResponse->getBody(), $response->getBody());
@@ -169,15 +169,15 @@ final class GuzzleAdapterTest extends \PHPUnit_Framework_TestCase
     public function executePostWithRawBody()
     {
         $guzzleResponse = $this->getValidResponse();
-        $mockHandler = new MockHandler([$guzzleResponse]);
+        $mockHandler = new MockHandler(array($guzzleResponse));
 
-        $container = [];
+        $container = array();
         $history = Middleware::history($container);
 
         $stack = HandlerStack::create($mockHandler);
         $stack->push($history);
 
-        $adapter = new GuzzleAdapter(['handler' => $stack]);
+        $adapter = new GuzzleAdapter(array('handler' => $stack));
 
         $request = new Request();
         $request->setMethod(Request::METHOD_POST);
@@ -192,11 +192,11 @@ final class GuzzleAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('OK', $response->getStatusMessage());
         $this->assertSame('200', $response->getStatusCode());
         $this->assertSame(
-            [
+            array(
                 'HTTP/1.1 200 OK',
                 'Content-Type: application/json',
                 'X-PHPUnit: response value',
-            ],
+            ),
             $response->getHeaders()
         );
         $this->assertSame((string)$guzzleResponse->getBody(), $response->getBody());
@@ -219,15 +219,15 @@ final class GuzzleAdapterTest extends \PHPUnit_Framework_TestCase
     public function executeGetWithAuthentication()
     {
         $guzzleResponse = $this->getValidResponse();
-        $mockHandler = new MockHandler([$guzzleResponse]);
+        $mockHandler = new MockHandler(array($guzzleResponse));
 
-        $container = [];
+        $container = array();
         $history = Middleware::history($container);
 
         $stack = HandlerStack::create($mockHandler);
         $stack->push($history);
 
-        $adapter = new GuzzleAdapter(['handler' => $stack]);
+        $adapter = new GuzzleAdapter(array('handler' => $stack));
 
         $request = new Request();
         $request->setMethod(Request::METHOD_GET);
@@ -241,11 +241,11 @@ final class GuzzleAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('OK', $response->getStatusMessage());
         $this->assertSame('200', $response->getStatusCode());
         $this->assertSame(
-            [
+            array(
                 'HTTP/1.1 200 OK',
                 'Content-Type: application/json',
                 'X-PHPUnit: response value',
-            ],
+            ),
             $response->getHeaders()
         );
         $this->assertSame((string)$guzzleResponse->getBody(), $response->getBody());
@@ -277,9 +277,9 @@ final class GuzzleAdapterTest extends \PHPUnit_Framework_TestCase
         $request->setMethod(Request::METHOD_GET);
 
         $endpoint = new Endpoint(
-            [
+            array(
                 'scheme'  => 'silly', //invalid protocol
-            ]
+            )
         );
         $endpoint->setTimeout(10);
 
@@ -294,12 +294,12 @@ final class GuzzleAdapterTest extends \PHPUnit_Framework_TestCase
     private function getValidResponse()
     {
         $body = json_encode(
-            [
-                'response' => [
+            array(
+                'response' => array(
                     'numFound' => 10,
                     'start' => 0,
-                    'docs' => [
-                        [
+                    'docs' => array(
+                        array(
                             'id' => '58339e95d5200',
                             'author' => 'Gambardella, Matthew',
                             'title' => "XML Developer's Guide",
@@ -307,13 +307,13 @@ final class GuzzleAdapterTest extends \PHPUnit_Framework_TestCase
                             'price' => 44.95,
                             'published' => 970372800,
                             'description' => 'An in-depth look at creating applications with XML.',
-                        ],
-                    ],
-                ],
-            ]
+                        ),
+                    ),
+                ),
+            )
         );
 
-        $headers = ['Content-Type' => 'application/json', 'X-PHPUnit' => 'response value'];
+        $headers = array('Content-Type' => 'application/json', 'X-PHPUnit' => 'response value');
         return new Response(200, $headers, $body);
     }
 }


### PR DESCRIPTION
From composer.json:

```
    "require": {
        "php": ">=5.3.2",
```

Testing on RHEL-6 with PHP 5.3 and Guzzle 3.9.3

I haven't touch the Guzzle adapter (as Guzzle v6 requires PHP 5.5)