### PR TITLE
Check ini_get is not disabled before using it

### DIFF
--- a/library/Solarium/Core/Client/Adapter/Curl.php
+++ b/library/Solarium/Core/Client/Adapter/Curl.php
@@ -116,7 +116,7 @@ class Curl extends Configurable implements AdapterInterface
         $handler = curl_init();
         curl_setopt($handler, CURLOPT_URL, $uri);
         curl_setopt($handler, CURLOPT_RETURNTRANSFER, true);
-        if (!ini_get('open_basedir')) {
+        if (!(function_exists('ini_get') && ini_get('open_basedir'))) {
             curl_setopt($handler, CURLOPT_FOLLOWLOCATION, true);
         }
         curl_setopt($handler, CURLOPT_TIMEOUT, $options['timeout']);


### PR DESCRIPTION
As described in #492, ini_get may often be disabled in production environments, causing warnings to be generated (and NULL) to be returned. This change checks that ini_get is usable (otherwise function_exists will return FALSE) before using it, preventing the warnings while introducing no functional change.