### PR TITLE
fix(client): set the connection_timeout for Guzzle v3

### DIFF
--- a/library/Solarium/Core/Client/Adapter/Guzzle3.php
+++ b/library/Solarium/Core/Client/Adapter/Guzzle3.php
@@ -76,7 +76,7 @@ class Guzzle3 extends Configurable implements AdapterInterface
             $this->getRequestBody($request),
             array(
                 'timeout' => $endpoint->getTimeout(),
-                'connecttimeout' => $endpoint->getTimeout(),
+                'connect_timeout' => $endpoint->getTimeout(),
             )
         );
 


### PR DESCRIPTION
From what I see on the Guzzle v3 documentation its `connection_timeout` 
https://guzzle3.readthedocs.io/http-client/client.html?highlight=timeout#timeout-connect-timeout