### PR TITLE
fix(client): set the connection timeout as the timeout (like Guzzlev3)

### DIFF
--- a/library/Solarium/Core/Client/Adapter/Guzzle.php
+++ b/library/Solarium/Core/Client/Adapter/Guzzle.php
@@ -74,6 +74,7 @@ class Guzzle extends Configurable implements AdapterInterface
             RequestOptions::HEADERS => $this->getRequestHeaders($request),
             RequestOptions::BODY => $this->getRequestBody($request),
             RequestOptions::TIMEOUT => $endpoint->getTimeout(),
+            RequestOptions::CONNECT_TIMEOUT => $endpoint->getTimeout()
         ];
 
         // Try endpoint authentication first, fallback to request for backwards compatibility

--- a/library/Solarium/Core/Client/Adapter/Guzzle.php
+++ b/library/Solarium/Core/Client/Adapter/Guzzle.php
@@ -74,7 +74,7 @@ class Guzzle extends Configurable implements AdapterInterface
             RequestOptions::HEADERS => $this->getRequestHeaders($request),
             RequestOptions::BODY => $this->getRequestBody($request),
             RequestOptions::TIMEOUT => $endpoint->getTimeout(),
-            RequestOptions::CONNECT_TIMEOUT => $endpoint->getTimeout()
+            RequestOptions::CONNECT_TIMEOUT => $endpoint->getTimeout(),
         ];
 
         // Try endpoint authentication first, fallback to request for backwards compatibility


### PR DESCRIPTION
The Guzzle3 client sets the connection_timeout.. therefore seems fitting the Guzzle client also follows.. 

Although its less than ideal to use the same method for both connection timeout & timeout as the numbers would be different ideally. 