### PR TITLE
Make suggester query use suggest prefix

### DIFF
--- a/library/Solarium/QueryType/Suggester/RequestBuilder.php
+++ b/library/Solarium/QueryType/Suggester/RequestBuilder.php
@@ -59,12 +59,10 @@ class RequestBuilder extends BaseRequestBuilder
     public function build(QueryInterface $query)
     {
         $request = parent::build($query);
-        $request->addParam('spellcheck', 'true');
-        $request->addParam('q', $query->getQuery());
-        $request->addParam('spellcheck.dictionary', $query->getDictionary());
-        $request->addParam('spellcheck.count', $query->getCount());
-        $request->addParam('spellcheck.onlyMorePopular', $query->getOnlyMorePopular());
-        $request->addParam('spellcheck.collate', $query->getCollate());
+        $request->addParam('suggest', 'true');
+        $request->addParam('suggest.q', $query->getQuery());
+        $request->addParam('suggest.dictionary', $query->getDictionary());
+        $request->addParam('suggest.count', $query->getCount());
 
         return $request;
     }

--- a/tests/Solarium/Tests/QueryType/Suggester/RequestBuilderTest.php
+++ b/tests/Solarium/Tests/QueryType/Suggester/RequestBuilderTest.php
@@ -55,22 +55,18 @@ class RequestBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildParams()
     {
-        $this->query->setCollate(true);
         $this->query->setCount(13);
         $this->query->setDictionary('suggest');
         $this->query->setQuery('ap ip');
-        $this->query->setOnlyMorePopular(true);
 
         $request = $this->builder->build($this->query);
 
         $this->assertEquals(
             array(
-                'spellcheck' => 'true',
-                'q' => 'ap ip',
-                'spellcheck.dictionary' => 'suggest',
-                'spellcheck.count' => 13,
-                'spellcheck.onlyMorePopular' => 'true',
-                'spellcheck.collate' => 'true',
+                'suggest' => 'true',
+                'suggest.q' => 'ap ip',
+                'suggest.dictionary' => 'suggest',
+                'suggest.count' => 13,
                 'wt' => 'json',
                 'json.nl' => 'flat',
                 'omitHeader' => 'true',


### PR DESCRIPTION
This PR changes the behavior of the Suggester query that makes requests against `/suggest` to use the suggest prefixes and parameters described in [Suggester Apache Documentation](https://cwiki.apache.org/confluence/display/solr/Suggester).

The suggester query uses the spellcheck components although they should be used with the spell check endpoint. Right now my queries for anything other than the default suggester dicitonary get "redirected" to the default, because solr doesn't listen to `spellcheck.dictionary`. 

To use spell check requests the library should add a new query to meet that demand.

This may have worked with earlier versions of Solr, or I am completely missing the point on how to use a different dictionary with a suggester query in the solarium client.