### PR TITLE
Fix: Cache dependencies installed with composer between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ env:
   - SYMFONY_VERSION=2.8.*
   - SYMFONY_VERSION=3.0.* # Does not work with php below 5.5
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_script:
   - bash -c "if [ $TRAVIS_PHP_VERSION != 'hhvm' ] && [ $TRAVIS_PHP_VERSION != '7.0' ] && [ $TRAVIS_PHP_VERSION != 'nightly' ]; then printf '\n\n\n\n' | pecl install pecl_http-1.7.6; fi"
   - composer require --prefer-source --dev symfony/event-dispatcher:${SYMFONY_VERSION}


### PR DESCRIPTION
This PR

* [x] caches dependencies installed with `composer` between builds on Travis

💁‍♂️ For reference, see https://docs.travis-ci.com/user/caching/#Arbitrary-directories.