### PR TITLE
Fix: Remove useless override

### DIFF
--- a/tests/Solarium/Tests/QueryType/Select/Result/ResultTest.php
+++ b/tests/Solarium/Tests/QueryType/Select/Result/ResultTest.php
@@ -33,8 +33,4 @@ namespace Solarium\Tests\QueryType\Select\Result;
 
 class ResultTest extends AbstractResultTest
 {
-    public function setUp()
-    {
-        parent::setUp();
-    }
 }


### PR DESCRIPTION
This PR

* [x] removes a useless method override