### PR TITLE
Fix: Remove useless return statements

### DIFF
--- a/library/Solarium/QueryType/Analysis/Result/Types.php
+++ b/library/Solarium/QueryType/Analysis/Result/Types.php
@@ -64,8 +64,6 @@ class Types extends ResultList
                 return $item;
             }
         }
-
-        return;
     }
 
     /**
@@ -80,7 +78,5 @@ class Types extends ResultList
                 return $item;
             }
         }
-
-        return;
     }
 }

--- a/library/Solarium/QueryType/Ping/Query.php
+++ b/library/Solarium/QueryType/Ping/Query.php
@@ -88,6 +88,5 @@ class Query extends BaseQuery
      */
     public function getResponseParser()
     {
-        return;
     }
 }

--- a/library/Solarium/QueryType/Select/Query/Component/DisMax.php
+++ b/library/Solarium/QueryType/Select/Query/Component/DisMax.php
@@ -92,7 +92,6 @@ class DisMax extends AbstractComponent
      */
     public function getResponseParser()
     {
-        return;
     }
 
     /**

--- a/library/Solarium/QueryType/Select/Query/Component/DistributedSearch.php
+++ b/library/Solarium/QueryType/Select/Query/Component/DistributedSearch.php
@@ -97,7 +97,6 @@ class DistributedSearch extends AbstractComponent
      */
     public function getResponseParser()
     {
-        return;
     }
 
     /**

--- a/library/Solarium/QueryType/Select/Query/Component/Spatial.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Spatial.php
@@ -37,7 +37,6 @@ class Spatial extends AbstractComponent
      */
     public function getResponseParser()
     {
-        return;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] removes useless `return` statements