### PR TITLE
Fix: Move assignment of default values before condition

### DIFF
--- a/library/Solarium/Core/Client/Adapter/Http.php
+++ b/library/Solarium/Core/Client/Adapter/Http.php
@@ -183,10 +183,10 @@ class Http extends Configurable implements AdapterInterface
         // @codeCoverageIgnoreStart
         $data = @file_get_contents($uri, false, $context);
 
+        $headers = array();
+
         if (isset($http_response_header)) {
             $headers = $http_response_header;
-        } else {
-            $headers = array();
         }
 
         return array($data, $headers);

--- a/library/Solarium/Core/Query/Helper.php
+++ b/library/Solarium/Core/Query/Helper.php
@@ -460,10 +460,10 @@ class Helper
      */
     public function cacheControl($useCache, $cost = null)
     {
+        $cache = 'false';
+
         if ($useCache === true) {
             $cache = 'true';
-        } else {
-            $cache = 'false';
         }
 
         $result = '{!cache='.$cache;

--- a/library/Solarium/QueryType/Analysis/ResponseParser/Field.php
+++ b/library/Solarium/QueryType/Analysis/ResponseParser/Field.php
@@ -64,10 +64,10 @@ class Field extends ResponseParserAbstract implements ResponseParserInterface
     {
         $data = $result->getData();
 
+        $items = array();
+
         if (isset($data['analysis'])) {
             $items = $this->parseAnalysis($result, $data['analysis']);
-        } else {
-            $items = array();
         }
 
         return $this->addHeaderInfo($data, array('items' => $items));

--- a/library/Solarium/QueryType/Select/ResponseParser/ResponseParser.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/ResponseParser.php
@@ -95,16 +95,16 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
             }
         }
 
+        $numFound = null;
+
         if (isset($data['response']['numFound'])) {
             $numFound = $data['response']['numFound'];
-        } else {
-            $numFound = null;
         }
+
+        $maxScore = null;
 
         if (isset($data['response']['maxScore'])) {
             $maxScore = $data['response']['maxScore'];
-        } else {
-            $maxScore = null;
         }
 
         return $this->addHeaderInfo(


### PR DESCRIPTION
This PR

* [x] moves the assignment of default values from an `else` branch before the condition