### PR TITLE
Fix: Remove unused parameters

### DIFF
--- a/tests/Solarium/Tests/Core/Client/ClientTest.php
+++ b/tests/Solarium/Tests/Core/Client/ClientTest.php
@@ -551,7 +551,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
              ->method('getRequestBuilder')
              ->will($this->returnValue($observer));
 
-        $this->client->registerQueryType('testquerytype', 'Solarium\QueryType\Select\Query\Query', $observer, '');
+        $this->client->registerQueryType('testquerytype', 'Solarium\QueryType\Select\Query\Query');
         $this->client->createRequest($queryStub);
     }
 

--- a/tests/Solarium/Tests/QueryType/Select/Query/AbstractQueryTest.php
+++ b/tests/Solarium/Tests/QueryType/Select/Query/AbstractQueryTest.php
@@ -262,7 +262,7 @@ abstract class AbstractQueryTest extends \PHPUnit_Framework_TestCase
     {
         $key = 'fq1';
 
-        $fq = $this->query->createFilterQuery($key, true);
+        $fq = $this->query->createFilterQuery($key);
         $fq->setQuery('category:1');
 
         $this->assertEquals(
@@ -612,7 +612,7 @@ abstract class AbstractQueryTest extends \PHPUnit_Framework_TestCase
         $components = $this->query->getComponentTypes();
         $components['mykey'] = 'mycomponent';
 
-        $this->query->registerComponentType('mykey', 'mycomponent', 'mybuilder', 'myparser');
+        $this->query->registerComponentType('mykey', 'mycomponent');
 
         $this->assertEquals(
             $components,

--- a/tests/Solarium/Tests/QueryType/Select/Query/Component/Stats/StatsTest.php
+++ b/tests/Solarium/Tests/QueryType/Select/Query/Component/Stats/StatsTest.php
@@ -139,7 +139,7 @@ class StatsTest extends \PHPUnit_Framework_TestCase
     {
         $key = 'f1';
 
-        $fld = $this->stats->createField($key, true);
+        $fld = $this->stats->createField($key);
 
         $this->assertEquals(
             $key,

--- a/tests/Solarium/Tests/QueryType/Update/RequestBuilderTest.php
+++ b/tests/Solarium/Tests/QueryType/Update/RequestBuilderTest.php
@@ -437,11 +437,9 @@ class RequestBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildRollbackXml()
     {
-        $command = new RollbackCommand;
-
         $this->assertEquals(
             '<rollback/>',
-            $this->builder->buildRollbackXml($command)
+            $this->builder->buildRollbackXml()
         );
     }
 


### PR DESCRIPTION
This PR

* [x] removes unused parameters
