### PR TITLE
Fix: Use trusty dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 7.0
   - 5.6


### PR DESCRIPTION
❗️ Blocks a range of PRs, starting with https://github.com/solariumphp/solarium/pull/503.

This PR

* [x] uses trusty dist

💁‍♂️ For reference, see https://travis-ci.org/solariumphp/solarium/jobs/241417639#L134:

> HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.