### PR TITLE
Fix: bufferAdd only allowed commitWithin/overwrite values to be set w…

### DIFF
--- a/library/Solarium/Plugin/BufferedAdd/BufferedAdd.php
+++ b/library/Solarium/Plugin/BufferedAdd/BufferedAdd.php
@@ -127,6 +127,50 @@ class BufferedAdd extends AbstractPlugin
     }
 
     /**
+     * Set commitWithin time option.
+     *
+     * @param int $time
+     *
+     * @return self
+     */
+    public function setCommitWithin($time)
+    {
+        return $this->setOption('commitwithin', $time);
+    }
+
+    /**
+     * Get commitWithin time option value.
+     *
+     * @return int
+     */
+    public function getCommitWithin()
+    {
+        return $this->getOption('commitwithin');
+    }
+
+    /**
+     * Set overwrite boolean option.
+     *
+     * @param boolean $value
+     *
+     * @return self
+     */
+    public function setOverwrite($value)
+    {
+        return $this->setOption('overwrite', $value);
+    }
+
+    /**
+     * Get overwrite boolean option value.
+     *
+     * @return boolean
+     */
+    public function getOverwrite()
+    {
+        return $this->getOption('overwrite');
+    }
+
+    /**
      * Create a document object instance and add it to the buffer.
      *
      * @param array $fields
@@ -218,6 +262,9 @@ class BufferedAdd extends AbstractPlugin
             // nothing to do
             return false;
         }
+
+		$overwrite = is_null($overwrite) ? $this->getOverwrite() : $overwrite;
+		$commitWithin = is_null($commitWithin) ? $this->getCommitWithin() : $commitWithin;
 
         $event = new PreFlushEvent($this->buffer, $overwrite, $commitWithin);
         $this->client->getEventDispatcher()->dispatch(Events::PRE_FLUSH, $event);

--- a/tests/Solarium/Tests/Plugin/BufferedAdd/BufferedAddTest.php
+++ b/tests/Solarium/Tests/Plugin/BufferedAdd/BufferedAddTest.php
@@ -57,6 +57,18 @@ class BufferedAddTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(500, $this->plugin->getBufferSize());
     }
 
+    public function testSetAndGetOverwrite()
+    {
+        $this->plugin->setOverwrite(true);
+        $this->assertTrue($this->plugin->getOverwrite());
+	}
+
+    public function testSetAndGetCommitWithin()
+    {
+        $this->plugin->setCommitWithin(500);
+        $this->assertEquals(500, $this->plugin->getCommitWithin());
+	}
+
     public function testAddDocument()
     {
         $doc = new Document();


### PR DESCRIPTION
…hen flush

is manually called and would not set these values when the flush method automatically triggered due to reaching the buffersize.
Getter/setter methods were provided similar to bufferSize to allow these values to be preset so that automatic calls to flush
would still provide these values.