### PR TITLE
Update composer version specifications

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
     ],
     "require": {
         "php": ">=5.6",
-        "symfony/event-dispatcher": "~2.3|~3.0|~4.0"
+        "symfony/event-dispatcher": "^2.7 || ^3.0 || ^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7",
-        "squizlabs/php_codesniffer": "~1.4",
-        "zendframework/zendframework1": "~1.12",
-        "satooshi/php-coveralls": "~1.0",
+        "phpunit/phpunit": "^3.7",
+        "squizlabs/php_codesniffer": "^1.4",
+        "zendframework/zendframework1": "^1.12",
+        "satooshi/php-coveralls": "^1.0",
         "guzzlehttp/guzzle": "^3.8 || ^6.2"
     },
     "suggest": {


### PR DESCRIPTION
- [x] Use `||` as version separator
- [x] Use LTS release of symfony/event-dispatcher version 2.7