### PR TITLE
Fix: Remove useless else

### DIFF
--- a/library/Component/DisMax.php
+++ b/library/Component/DisMax.php
@@ -306,9 +306,9 @@ class DisMax extends AbstractComponent
         //double add calls for the same BQ are ignored, but non-unique keys cause an exception
         if (array_key_exists($key, $this->boostQueries) && $this->boostQueries[$key] !== $boostQuery) {
             throw new InvalidArgumentException('A boostquery must have a unique key value within a query');
-        } else {
-            $this->boostQueries[$key] = $boostQuery;
         }
+
+        $this->boostQueries[$key] = $boostQuery;
 
         return $this;
     }

--- a/library/Component/Facet/MultiQuery.php
+++ b/library/Component/Facet/MultiQuery.php
@@ -124,8 +124,6 @@ class MultiQuery extends AbstractFacet
     {
         if (isset($this->facetQueries[$key])) {
             return $this->facetQueries[$key];
-        } else {
-            return;
         }
     }
 

--- a/library/Component/FacetSet.php
+++ b/library/Component/FacetSet.php
@@ -335,9 +335,9 @@ class FacetSet extends AbstractComponent
         //double add calls for the same facet are ignored, but non-unique keys cause an exception
         if (array_key_exists($key, $this->facets) && $this->facets[$key] !== $facet) {
             throw new InvalidArgumentException('A facet must have a unique key value within a query');
-        } else {
-            $this->facets[$key] = $facet;
         }
+
+        $this->facets[$key] = $facet;
 
         return $this;
     }
@@ -374,8 +374,6 @@ class FacetSet extends AbstractComponent
     {
         if (isset($this->facets[$key])) {
             return $this->facets[$key];
-        } else {
-            return;
         }
     }
 

--- a/library/Component/Highlighting/Highlighting.php
+++ b/library/Component/Highlighting/Highlighting.php
@@ -98,8 +98,6 @@ class Highlighting extends AbstractComponent
             $this->addField($name);
 
             return $this->fields[$name];
-        } else {
-            return;
         }
     }
 

--- a/library/Component/Result/Debug/DocumentSet.php
+++ b/library/Component/Result/Debug/DocumentSet.php
@@ -73,9 +73,7 @@ class DocumentSet implements \IteratorAggregate, \Countable
     {
         if (isset($this->docs[$key])) {
             return $this->docs[$key];
-        } else {
-            return;
-        }
+        }  
     }
 
     /**

--- a/library/Component/Result/Debug/Timing.php
+++ b/library/Component/Result/Debug/Timing.php
@@ -92,8 +92,6 @@ class Timing implements \IteratorAggregate, \Countable
     {
         if (isset($this->phases[$key])) {
             return $this->phases[$key];
-        } else {
-            return;
         }
     }
 

--- a/library/Component/Result/Debug/TimingPhase.php
+++ b/library/Component/Result/Debug/TimingPhase.php
@@ -101,8 +101,6 @@ class TimingPhase implements \IteratorAggregate, \Countable
     {
         if (isset($this->timings[$key])) {
             return $this->timings[$key];
-        } else {
-            return;
         }
     }
 

--- a/library/Component/Result/FacetSet.php
+++ b/library/Component/Result/FacetSet.php
@@ -73,9 +73,7 @@ class FacetSet implements \IteratorAggregate, \Countable
     {
         if (isset($this->facets[$key])) {
             return $this->facets[$key];
-        } else {
-            return;
-        }
+        }  
     }
 
     /**

--- a/library/Component/Result/Grouping/Result.php
+++ b/library/Component/Result/Grouping/Result.php
@@ -85,8 +85,6 @@ class Result implements \IteratorAggregate, \Countable
     {
         if (isset($this->groups[$key])) {
             return $this->groups[$key];
-        } else {
-            return;
         }
     }
 

--- a/library/Component/Result/Highlighting/Highlighting.php
+++ b/library/Component/Result/Highlighting/Highlighting.php
@@ -73,8 +73,6 @@ class Highlighting implements \IteratorAggregate, \Countable
     {
         if (isset($this->results[$key])) {
             return $this->results[$key];
-        } else {
-            return;
         }
     }
 

--- a/library/Component/Result/Highlighting/Result.php
+++ b/library/Component/Result/Highlighting/Result.php
@@ -83,9 +83,9 @@ class Result implements \IteratorAggregate, \Countable
     {
         if (isset($this->fields[$key])) {
             return $this->fields[$key];
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**

--- a/library/Component/Result/MoreLikeThis/MoreLikeThis.php
+++ b/library/Component/Result/MoreLikeThis/MoreLikeThis.php
@@ -73,8 +73,6 @@ class MoreLikeThis implements \IteratorAggregate, \Countable
     {
         if (isset($this->results[$key])) {
             return $this->results[$key];
-        } else {
-            return;
         }
     }
 

--- a/library/Component/Result/Spellcheck/Result.php
+++ b/library/Component/Result/Spellcheck/Result.php
@@ -92,13 +92,13 @@ class Result implements \IteratorAggregate, \Countable
         $nrOfCollations = count($this->collations);
         if ($nrOfCollations == 0) {
             return;
-        } else {
-            if ($key === null) {
-                return reset($this->collations);
-            }
-
-            return $this->collations[$key];
         }
+
+        if ($key === null) {
+            return reset($this->collations);
+        }
+
+        return $this->collations[$key];
     }
 
     /**
@@ -134,8 +134,6 @@ class Result implements \IteratorAggregate, \Countable
     {
         if (isset($this->suggestions[$key])) {
             return $this->suggestions[$key];
-        } else {
-            return;
         }
     }
 

--- a/library/Component/Result/Spellcheck/Suggestion.php
+++ b/library/Component/Result/Spellcheck/Suggestion.php
@@ -115,9 +115,9 @@ class Suggestion
         $word = reset($this->words);
         if (isset($word['word'])) {
             return $word['word'];
-        } else {
-            return $word;
         }
+
+        return $word;
     }
 
     /**
@@ -142,8 +142,6 @@ class Suggestion
         $word = reset($this->words);
         if (isset($word['freq'])) {
             return $word['freq'];
-        } else {
-            return;
         }
     }
 }

--- a/library/Component/Result/Stats/Stats.php
+++ b/library/Component/Result/Stats/Stats.php
@@ -73,8 +73,6 @@ class Stats implements \IteratorAggregate, \Countable
     {
         if (isset($this->results[$key])) {
             return $this->results[$key];
-        } else {
-            return;
         }
     }
 

--- a/library/Component/Result/Suggester/Result.php
+++ b/library/Component/Result/Suggester/Result.php
@@ -66,9 +66,9 @@ class Result implements \IteratorAggregate, \Countable
     {
         if (isset($this->results[$dictionary])) {
             return $this->results[$dictionary];
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**

--- a/library/Component/Result/Terms/Field.php
+++ b/library/Component/Result/Terms/Field.php
@@ -45,9 +45,9 @@ class Field implements \IteratorAggregate, \Countable
     {
         if (isset($this->terms[$field])) {
             return $this->terms[$field];
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**

--- a/library/Component/Result/Terms/Result.php
+++ b/library/Component/Result/Terms/Result.php
@@ -65,9 +65,9 @@ class Result implements \IteratorAggregate, \Countable
     {
         if (isset($this->results[$field])) {
             return $this->results[$field];
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**

--- a/library/Component/Stats/Stats.php
+++ b/library/Component/Stats/Stats.php
@@ -116,9 +116,9 @@ class Stats extends AbstractComponent
         //double add calls for the same field are ignored, but non-unique keys cause an exception
         if (array_key_exists($key, $this->fields) && $this->fields[$key] !== $field) {
             throw new InvalidArgumentException('A field must have a unique key value');
-        } else {
-            $this->fields[$key] = $field;
         }
+
+        $this->fields[$key] = $field;
 
         return $this;
     }
@@ -155,8 +155,6 @@ class Stats extends AbstractComponent
     {
         if (isset($this->fields[$key])) {
             return $this->fields[$key];
-        } else {
-            return;
         }
     }
 

--- a/library/Core/Client/Client.php
+++ b/library/Core/Client/Client.php
@@ -301,13 +301,13 @@ class Client extends Configurable implements ClientInterface
         //double add calls for the same endpoint are ignored, but non-unique keys cause an exception
         if (array_key_exists($key, $this->endpoints) && $this->endpoints[$key] !== $endpoint) {
             throw new InvalidArgumentException('An endpoint must have a unique key');
-        } else {
-            $this->endpoints[$key] = $endpoint;
+        }  
 
-            // if no default endpoint is set do so now
-            if (null === $this->defaultEndpoint) {
-                $this->defaultEndpoint = $key;
-            }
+        $this->endpoints[$key] = $endpoint;
+
+        // if no default endpoint is set do so now
+        if (null === $this->defaultEndpoint) {
+            $this->defaultEndpoint = $key;
         }
 
         return $this;
@@ -474,9 +474,9 @@ class Client extends Configurable implements ClientInterface
             $this->adapter = $adapter;
 
             return $this;
-        } else {
-            throw new InvalidArgumentException('Invalid adapter input for setAdapter');
         }
+
+        throw new InvalidArgumentException('Invalid adapter input for setAdapter');
     }
 
     /**
@@ -659,11 +659,9 @@ class Client extends Configurable implements ClientInterface
                 $this->registerPlugin($key, $this->pluginTypes[$key]);
 
                 return $this->pluginInstances[$key];
-            } else {
-                throw new OutOfBoundsException('Cannot autoload plugin of unknown type: '.$key);
-            }
-        } else {
-            return;
+            }  
+
+            throw new OutOfBoundsException('Cannot autoload plugin of unknown type: '.$key);
         }
     }
 

--- a/library/Core/Client/Request.php
+++ b/library/Core/Client/Request.php
@@ -155,8 +155,6 @@ class Request extends Configurable
     {
         if (isset($this->params[$key])) {
             return $this->params[$key];
-        } else {
-            return;
         }
     }
 

--- a/library/Core/Configurable.php
+++ b/library/Core/Configurable.php
@@ -132,9 +132,7 @@ class Configurable implements ConfigurableInterface
     {
         if (isset($this->options[$name])) {
             return $this->options[$name];
-        } else {
-            return;
-        }
+        }  
     }
 
     /**

--- a/library/Core/Query/AbstractRequestBuilder.php
+++ b/library/Core/Query/AbstractRequestBuilder.php
@@ -121,9 +121,9 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
             $value = (true === (bool)$value) ? 'true' : 'false';
 
             return $this->attrib($name, $value);
-        } else {
-            return '';
         }
+
+        return '';
     }
 
     /**
@@ -140,8 +140,8 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
     {
         if (null !== $value) {
             return ' '.$name.'="'.$value.'"';
-        } else {
-            return '';
         }
+
+        return '';
     }
 }

--- a/library/Core/Query/Helper.php
+++ b/library/Core/Query/Helper.php
@@ -186,10 +186,10 @@ class Helper
             $iso8601 .= 'Z';
 
             return $iso8601;
-        } else {
-            // unsupported input
-            return false;
         }
+
+        // unsupported input
+        return false;
     }
 
     /**
@@ -223,9 +223,9 @@ class Helper
 
         if ($inclusive) {
             return $field.':['.$from.' TO '.$to.']';
-        } else {
-            return $field.':{'.$from.' TO '.$to.'}';
         }
+
+        return $field.':{'.$from.' TO '.$to.'}';
     }
 
     /**
@@ -369,9 +369,9 @@ class Helper
             }
 
             return $name.'()';
-        } else {
-            return $name.'('.implode($params, ',').')';
         }
+
+        return $name.'('.implode($params, ',').')';
     }
 
     /**

--- a/library/Plugin/CustomizeRequest/CustomizeRequest.php
+++ b/library/Plugin/CustomizeRequest/CustomizeRequest.php
@@ -161,9 +161,7 @@ class CustomizeRequest extends AbstractPlugin
     {
         if (isset($this->customizations[$key])) {
             return $this->customizations[$key];
-        } else {
-            return;
-        }
+        }  
     }
 
     /**

--- a/library/Plugin/Loadbalancer/Loadbalancer.php
+++ b/library/Plugin/Loadbalancer/Loadbalancer.php
@@ -205,9 +205,9 @@ class Loadbalancer extends AbstractPlugin
 
         if (array_key_exists($endpoint, $this->endpoints)) {
             throw new InvalidArgumentException('An endpoint for the loadbalancer plugin must have a unique key');
-        } else {
-            $this->endpoints[$endpoint] = $weight;
         }
+
+        $this->endpoints[$endpoint] = $weight;
 
         // reset the randomizer as soon as a new endpoint is added
         $this->randomizer = null;
@@ -487,12 +487,12 @@ class Loadbalancer extends AbstractPlugin
 
             // if we get here no more retries available, throw exception
             throw new RuntimeException('Maximum number of loadbalancer retries reached');
-        } else {
-            // no failover retries, just execute and let an exception bubble upwards
-            $endpoint = $this->getRandomEndpoint();
-
-            return $adapter->execute($request, $endpoint);
         }
+
+        // no failover retries, just execute and let an exception bubble upwards
+        $endpoint = $this->getRandomEndpoint();
+
+        return $adapter->execute($request, $endpoint);
     }
 
     /**

--- a/library/Plugin/Loadbalancer/WeightedRandomChoice.php
+++ b/library/Plugin/Loadbalancer/WeightedRandomChoice.php
@@ -145,8 +145,8 @@ class WeightedRandomChoice
 
         if ($this->lookup[$low] >= $random) {
             return $low;
-        } else {
-            return $low+1;
         }
+
+        return $low+1;
     }
 }

--- a/library/QueryType/Analysis/Result/Document.php
+++ b/library/QueryType/Analysis/Result/Document.php
@@ -149,8 +149,6 @@ class Document extends BaseResult implements \IteratorAggregate, \Countable
 
         if (isset($this->items[$key])) {
             return $this->items[$key];
-        } else {
-            return;
-        }
+        }  
     }
 }

--- a/library/QueryType/Analysis/Result/Item.php
+++ b/library/QueryType/Analysis/Result/Item.php
@@ -185,9 +185,9 @@ class Item
     {
         if (is_array($this->positionHistory)) {
             return $this->positionHistory;
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**

--- a/library/QueryType/Select/Query/Query.php
+++ b/library/QueryType/Select/Query/Query.php
@@ -607,9 +607,9 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface
         //double add calls for the same FQ are ignored, but non-unique keys cause an exception
         if (array_key_exists($key, $this->filterQueries) && $this->filterQueries[$key] !== $filterQuery) {
             throw new InvalidArgumentException('A filterquery must have a unique key value within a query');
-        } else {
-            $this->filterQueries[$key] = $filterQuery;
         }
+
+        $this->filterQueries[$key] = $filterQuery;
 
         return $this;
     }
@@ -646,8 +646,6 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface
     {
         if (isset($this->filterQueries[$key])) {
             return $this->filterQueries[$key];
-        } else {
-            return;
         }
     }
 

--- a/library/QueryType/Select/Result/Result.php
+++ b/library/QueryType/Select/Result/Result.php
@@ -262,9 +262,9 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
         if (isset($this->components[$key])) {
             return $this->components[$key];
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**

--- a/library/QueryType/Spellcheck/Result/Result.php
+++ b/library/QueryType/Spellcheck/Result/Result.php
@@ -153,9 +153,9 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
         if (isset($this->results[$term])) {
             return $this->results[$term];
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**

--- a/library/QueryType/Suggester/Result/Dictionary.php
+++ b/library/QueryType/Suggester/Result/Dictionary.php
@@ -83,9 +83,9 @@ class Dictionary implements \IteratorAggregate, \Countable
     {
         if (isset($this->terms[$term])) {
             return $this->terms[$term];
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**

--- a/library/QueryType/Suggester/Result/Result.php
+++ b/library/QueryType/Suggester/Result/Result.php
@@ -144,9 +144,9 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
         if (isset($this->results[$dictionary])) {
             return $this->results[$dictionary];
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**

--- a/library/QueryType/Terms/Result.php
+++ b/library/QueryType/Terms/Result.php
@@ -125,9 +125,9 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
         if (isset($this->results[$field])) {
             return $this->results[$field];
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**

--- a/library/QueryType/Update/Query/Document/Document.php
+++ b/library/QueryType/Update/Query/Document/Document.php
@@ -273,9 +273,7 @@ class Document extends AbstractDocument implements DocumentInterface
     {
         if (isset($this->fieldBoosts[$key])) {
             return $this->fieldBoosts[$key];
-        } else {
-            return;
-        }
+        }  
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] removes useless `else` statements

Replaces #511.

💁‍♂️ Looks like the referenced PR got closed because the `develop` branch it proposed to make a change to got deleted.