### PR TITLE
Fix: Remove invalid configuration from phpunit.xml

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
     syntaxCheck="false"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,10 +4,8 @@
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
-    syntaxCheck="false"
     colors="true"
 >
-
     <testsuites>
        <testsuite name="Solarium">
          <directory suffix="Test.php">tests</directory>
@@ -15,11 +13,9 @@
     </testsuites>
 
     <logging>
-      <log type="coverage-html" target="build/coverage" title="Solarium"
-       charset="UTF-8" yui="true" highlight="true"
-       lowUpperBound="35" highLowerBound="70"/>
+      <log type="coverage-html" target="build/coverage" lowUpperBound="35" highLowerBound="70"/>
       <log type="coverage-clover" target="build/logs/clover.xml"/>
-      <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+      <log type="junit" target="build/logs/junit.xml"/>
     </logging>
 
     <filter>

--- a/phpunit.xml.travis
+++ b/phpunit.xml.travis
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
-    syntaxCheck="false"
+    colors="true"
 >
     <testsuites>
        <testsuite name="Solarium">


### PR DESCRIPTION
This PR

* [x] references `phpunit.xsd` in `phpunit.xml`
* [x] removes invalid configuration items

### Before

<img width="1000" alt="screen shot 2018-01-24 at 21 51 37" src="https://user-images.githubusercontent.com/605483/35356498-ec8582e8-0150-11e8-9157-f8b05744bc2a.png">

### After

<img width="1000" alt="screen shot 2018-01-24 at 21 51 54" src="https://user-images.githubusercontent.com/605483/35356506-f194dbd0-0150-11e8-9fd7-a96c9d53ac24.png">


