### PR TITLE
Escape the phrases in a range query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Isolated search components from the select query type and made them re-usable
 - BC break: Suggester component is now compatible to Solr v6/7 (the existing one was renamed to Spellcheck)
 - BC break: Suggester query type is now compatible to Solr v6/7 (the existing one was renamed to Spellcheck)
+- Prevented query injection inside range queries
 - Lots of source code re-structuring and clean-up
 
 ### Removed

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -180,6 +180,9 @@ class Helper
             $to = '*';
         }
 
+        $from = $this->escapePhrase($from);
+        $to = $this->escapePhrase($to);
+
         if ($inclusive) {
             return $field.':['.$from.' TO '.$to.']';
         }

--- a/tests/Core/Query/HelperTest.php
+++ b/tests/Core/Query/HelperTest.php
@@ -28,12 +28,12 @@ class HelperTest extends TestCase
     public function testRangeQueryInclusive()
     {
         $this->assertEquals(
-            'field:[1 TO 2]',
+            'field:["1" TO "2"]',
             $this->helper->rangeQuery('field', 1, 2)
         );
 
         $this->assertSame(
-            'store:[45,-94 TO 46,-93]',
+            'store:["45,-94" TO "46,-93"]',
             $this->helper->rangeQuery('store', '45,-94', '46,-93')
         );
     }
@@ -41,12 +41,12 @@ class HelperTest extends TestCase
     public function testRangeQueryExclusive()
     {
         $this->assertSame(
-            'field:{1 TO 2}',
+            'field:{"1" TO "2"}',
             $this->helper->rangeQuery('field', 1, 2, false)
         );
 
         $this->assertSame(
-            'store:{45,-94 TO 46,-93}',
+            'store:{"45,-94" TO "46,-93"}',
             $this->helper->rangeQuery('store', '45,-94', '46,-93', false)
         );
     }
@@ -54,12 +54,12 @@ class HelperTest extends TestCase
     public function testRangeQueryInclusiveNullValues()
     {
         $this->assertSame(
-            'field:[1 TO *]',
+            'field:["1" TO "*"]',
             $this->helper->rangeQuery('field', 1, null)
         );
 
         $this->assertSame(
-            'store:[* TO 46,-93]',
+            'store:["*" TO "46,-93"]',
             $this->helper->rangeQuery('store', null, '46,-93')
         );
     }
@@ -67,12 +67,12 @@ class HelperTest extends TestCase
     public function testRangeQueryExclusiveNullValues()
     {
         $this->assertSame(
-            'field:{1 TO *}',
+            'field:{"1" TO "*"}',
             $this->helper->rangeQuery('field', 1, null, false)
         );
 
         $this->assertSame(
-            'store:{* TO 46,-93}',
+            'store:{"*" TO "46,-93"}',
             $this->helper->rangeQuery('store', null, '46,-93', false)
         );
     }


### PR DESCRIPTION
In order to prevent query injection, the helper methods should escape the phrases.  Otherwise you could end up with something like rangeQuery('1', '2] someOtherField:[* TO *') and leak information, etc.

See #273 for prior discussion on an old branch.