### PR TITLE
raise timeout in integration tests for curl adapter

### DIFF
--- a/tests/Integration/TechproductsAdapters/TechproductsCurlTest.php
+++ b/tests/Integration/TechproductsAdapters/TechproductsCurlTest.php
@@ -9,4 +9,12 @@ use Solarium\Tests\Integration\AbstractTechproductsTest;
  */
 class TechproductsCurlTest extends AbstractTechproductsTest
 {
+    public function setUp()
+    {
+        parent::setUp();
+        // The default timeout of solarium of 5s seems to be too aggressive on travis and causes random test failures.
+        // Set it to the PHP default of 13s.
+        $this->client->getEndpoint()->setTimeout(CURLOPT_TIMEOUT);
+    }
+
 }

--- a/tests/Integration/TechproductsAdapters/TechproductsCurlTest.php
+++ b/tests/Integration/TechproductsAdapters/TechproductsCurlTest.php
@@ -16,5 +16,4 @@ class TechproductsCurlTest extends AbstractTechproductsTest
         // Set it to the PHP default of 13s.
         $this->client->getEndpoint()->setTimeout(CURLOPT_TIMEOUT);
     }
-
 }


### PR DESCRIPTION
The default timeout of solarium of 5s seems to be too aggressive on travis and causes random test failures. Set it to the PHP default of 13s.