### PR TITLE
Added 'contains' and 'containsignorecase' to FacetSet docs

### DIFF
--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
@@ -7,18 +7,18 @@ The options below can be set as query option values, but also by using the set/g
 
 Only the facet-type specific options are listed. See [Facetset component](V3:Facetset_component "wikilink") for the option shared by all facet types.
 
-| Name               | Type    | Default value | Description                                                                                                                |
-|--------------------|---------|---------------|----------------------------------------------------------------------------------------------------------------------------|
-| field              | string  | null          | The index field for the facet.                                                                                             |
-| prefix             | string  | null          | Limit the terms on which to facet to those starting with the given prefix. This does not limit the query, only the facets. |
-| contains           | string  | null          | Limit the terms on which to facet to those containing the given substring. This does not limit the query, only the facets. |
-| containsignorecase | boolean | null          | If 'contains' is used, causes case to be ignored when matching the given substring against candidate facet terms.          |
-| sort               | string  | null          | Sort order (sorted by count). Use one of the class constants.                                                              |
-| limit              | int     | null          | Limit the facet counts                                                                                                     |
-| offset             | int     | null          | Show facet count starting from this offset                                                                                 |
-| mincount           | int     | null          | Minimal term count to be included in facet count results.                                                                  |
-| missing            | boolean | null          | Also make a count of all document that have no value for the facet field.                                                  |
-| method             | string  | null          | Use one of the class constants as value. See <http://wiki.apache.org/solr/SimpleFacetParameters#facet.method> for details. |
+| Name               | Type    | Default value | Description                                                                                                                                          |
+|--------------------|---------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| field              | string  | null          | The index field for the facet.                                                                                                                       |
+| prefix             | string  | null          | Limit the terms on which to facet to those starting with the given prefix. This does not limit the query, only the facets.                           |
+| contains           | string  | null          | Limit the terms on which to facet to those containing the given substring. This does not limit the query, only the facets. Available since Solr 5.1. |
+| containsignorecase | boolean | null          | If 'contains' is used, causes case to be ignored when matching the given substring against candidate facet terms.                                    |
+| sort               | string  | null          | Sort order (sorted by count). Use one of the class constants.                                                                                        |
+| limit              | int     | null          | Limit the facet counts.                                                                                                                              |
+| offset             | int     | null          | Show facet count starting from this offset.                                                                                                          |
+| mincount           | int     | null          | Minimal term count to be included in facet count results.                                                                                            |
+| missing            | boolean | null          | Also make a count of all document that have no value for the facet field.                                                                            |
+| method             | string  | null          | Use one of the class constants as value. See <http://wiki.apache.org/solr/SimpleFacetParameters#facet.method> for details.                           |
 ||
 
 Example

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
@@ -1,4 +1,4 @@
-This facet type allows you to count the number of occurences of a term in a specific field.
+This facet type allows you to count the number of occurrences of a term in a specific field.
 
 Options
 -------
@@ -7,15 +7,18 @@ The options below can be set as query option values, but also by using the set/g
 
 Only the facet-type specific options are listed. See [Facetset component](V3:Facetset_component "wikilink") for the option shared by all facet types.
 
-| Name     | Type    | Default value | Description                                                                                                                |
-|----------|---------|---------------|----------------------------------------------------------------------------------------------------------------------------|
-| field    | string  | null          | The index field for the facet.                                                                                             |
-| sort     | string  | null          | Sort order (sorted by count). Use one of the class constants.                                                              |
-| limit    | int     | null          | Limit the facet counts                                                                                                     |
-| offset   | int     | null          | Show facet count starting from this offset                                                                                 |
-| mincount | int     | null          | Minimal term count to be included in facet count results.                                                                  |
-| missing  | boolean | null          | Also make a count of all document that have no value for the facet field.                                                  |
-| method   | string  | null          | Use one of the class constants as value. See <http://wiki.apache.org/solr/SimpleFacetParameters#facet.method> for details. |
+| Name               | Type    | Default value | Description                                                                                                                |
+|--------------------|---------|---------------|----------------------------------------------------------------------------------------------------------------------------|
+| field              | string  | null          | The index field for the facet.                                                                                             |
+| prefix             | string  | null          | Limit the terms on which to facet to those starting with the given prefix. This does not limit the query, only the facets. |
+| contains           | string  | null          | Limit the terms on which to facet to those containing the given substring. This does not limit the query, only the facets. |
+| containsignorecase | boolean | null          | If 'contains' is used, causes case to be ignored when matching the given substring against candidate facet terms.          |
+| sort               | string  | null          | Sort order (sorted by count). Use one of the class constants.                                                              |
+| limit              | int     | null          | Limit the facet counts                                                                                                     |
+| offset             | int     | null          | Show facet count starting from this offset                                                                                 |
+| mincount           | int     | null          | Minimal term count to be included in facet count results.                                                                  |
+| missing            | boolean | null          | Also make a count of all document that have no value for the facet field.                                                  |
+| method             | string  | null          | Use one of the class constants as value. See <http://wiki.apache.org/solr/SimpleFacetParameters#facet.method> for details. |
 ||
 
 Example

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facetset-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facetset-component.md
@@ -5,15 +5,15 @@ See the API docs for all methods. In the following sections facet types will be 
 Global facet options
 --------------------
 
-| Name               | Type    | Default value | Description                                 |
-|--------------------|---------|---------------|---------------------------------------------|
-| prefix             | string  | null          | Limit the terms for faceting by a prefix    |
-| contains           | string  | null          | Limit the terms for faceting by a substring |
-| containsignorecase | boolean | null          | Causes case to be ignored for 'contains'    |
-| sort               | string  | null          | Set the facet sort order                    |
-| limit              | int     | null          | Set the facet limit                         |
-| mincount           | int     | null          | Set the facet mincount                      |
-| missing            | boolean | null          | Set the 'count missing' option              |
+| Name               | Type    | Default value | Description                                                            |
+|--------------------|---------|---------------|------------------------------------------------------------------------|
+| prefix             | string  | null          | Limit the terms for faceting by a prefix                               |
+| contains           | string  | null          | Limit the terms for faceting by a substring (available since Solr 5.1) |
+| containsignorecase | boolean | null          | Causes case to be ignored for 'contains'                               |
+| sort               | string  | null          | Set the facet sort order                                               |
+| limit              | int     | null          | Set the facet limit                                                    |
+| mincount           | int     | null          | Set the facet mincount                                                 |
+| missing            | boolean | null          | Set the 'count missing' option                                         |
 ||
 
 Standard facet options

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facetset-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facetset-component.md
@@ -1,17 +1,19 @@
-The concept of a 'facetset' is doesn't exist in Solr. It was added to Solarium to have one central component for using facets of various type. You can use the facetset to create and manage facets, and also to set global facet options.
+The concept of a 'facetset' doesn't exist in Solr. It was added to Solarium to have one central component for using facets of various type. You can use the facetset to create and manage facets, and also to set global facet options.
 
 See the API docs for all methods. In the following sections facet types will be detailed. The examples used on those pages will also show the usage of the facetset component.
 
 Global facet options
 --------------------
 
-| Name     | Type    | Default value | Description                              |
-|----------|---------|---------------|------------------------------------------|
-| prefix   | string  | null          | Limit the terms for faceting by a prefix |
-| sort     | string  | null          | Set the facet sort order                 |
-| limit    | int     | null          | Set the facet limit                      |
-| mincount | int     | null          | Set the facet mincount                   |
-| missing  | boolean | null          | Set the 'count missing' option           |
+| Name               | Type    | Default value | Description                                 |
+|--------------------|---------|---------------|---------------------------------------------|
+| prefix             | string  | null          | Limit the terms for faceting by a prefix    |
+| contains           | string  | null          | Limit the terms for faceting by a substring |
+| containsignorecase | boolean | null          | Causes case to be ignored for 'contains'    |
+| sort               | string  | null          | Set the facet sort order                    |
+| limit              | int     | null          | Set the facet limit                         |
+| mincount           | int     | null          | Set the facet mincount                      |
+| missing            | boolean | null          | Set the 'count missing' option              |
 ||
 
 Standard facet options

--- a/src/Component/Facet/Field.php
+++ b/src/Component/Facet/Field.php
@@ -119,7 +119,7 @@ class Field extends AbstractFacet
     }
 
     /**
-     * Limit the terms for faceting by a string they must contain.
+     * Limit the terms for faceting by a string they must contain. Since Solr 5.1.
      *
      * This is a global value for all facets in this facetset
      *
@@ -145,7 +145,7 @@ class Field extends AbstractFacet
     }
 
     /**
-     * Case sensitivity of matching string that facet terms must contain.
+     * Case sensitivity of matching string that facet terms must contain. Since Solr 5.1.
      *
      * This is a global value for all facets in this facetset
      *

--- a/src/Component/Facet/Field.php
+++ b/src/Component/Facet/Field.php
@@ -121,8 +121,6 @@ class Field extends AbstractFacet
     /**
      * Limit the terms for faceting by a string they must contain. Since Solr 5.1.
      *
-     * This is a global value for all facets in this facetset
-     *
      * @param string $contains
      *
      * @return self Provides fluent interface
@@ -135,8 +133,6 @@ class Field extends AbstractFacet
     /**
      * Get the facet contains.
      *
-     * This is a global value for all facets in this facetset
-     *
      * @return string
      */
     public function getContains()
@@ -146,8 +142,6 @@ class Field extends AbstractFacet
 
     /**
      * Case sensitivity of matching string that facet terms must contain. Since Solr 5.1.
-     *
-     * This is a global value for all facets in this facetset
      *
      * @param bool $containsIgnoreCase
      *
@@ -160,8 +154,6 @@ class Field extends AbstractFacet
 
     /**
      * Get the case sensitivity of facet contains.
-     *
-     * This is a global value for all facets in this facetset
      *
      * @return bool
      */

--- a/src/Component/FacetSet.php
+++ b/src/Component/FacetSet.php
@@ -153,7 +153,7 @@ class FacetSet extends AbstractComponent
     }
 
     /**
-     * Limit the terms for faceting by a string they must contain.
+     * Limit the terms for faceting by a string they must contain. Since Solr 5.1.
      *
      * This is a global value for all facets in this facetset
      *
@@ -179,7 +179,7 @@ class FacetSet extends AbstractComponent
     }
 
     /**
-     * Case sensitivity of matching string that facet terms must contain.
+     * Case sensitivity of matching string that facet terms must contain. Since Solr 5.1.
      *
      * This is a global value for all facets in this facetset
      *

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -40,7 +40,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
             $request->addParam('facet.sort', $component->getSort());
             $request->addParam('facet.prefix', $component->getPrefix());
             $request->addParam('facet.contains', $component->getContains());
-            $request->addParam('facet.contains.ignoreCase', null === ($ignoreCase = $component->getContainsIgnoreCase()) ? null : ($ignoreCase ? 'true' : 'false'));
+            $request->addParam('facet.contains.ignoreCase', $component->getContainsIgnoreCase());
             $request->addParam('facet.missing', $component->getMissing());
             $request->addParam('facet.mincount', $component->getMinCount());
             $request->addParam('facet.limit', $component->getLimit());
@@ -96,7 +96,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
         $request->addParam("f.$field.facet.sort", $facet->getSort());
         $request->addParam("f.$field.facet.prefix", $facet->getPrefix());
         $request->addParam("f.$field.facet.contains", $facet->getContains());
-        $request->addParam("f.$field.facet.contains.ignoreCase", null === ($ignoreCase = $facet->getContainsIgnoreCase()) ? null : ($ignoreCase ? 'true' : 'false'));
+        $request->addParam("f.$field.facet.contains.ignoreCase", $facet->getContainsIgnoreCase());
         $request->addParam("f.$field.facet.offset", $facet->getOffset());
         $request->addParam("f.$field.facet.mincount", $facet->getMinCount());
         $request->addParam("f.$field.facet.missing", $facet->getMissing());


### PR DESCRIPTION
Added basic documentation for 'contains' and 'containsignorecase' to the docs. Added 'prefix' for fields, it was only documented for facetsets.

Also did a minor refactoring on the code that adds the facet.contains.ignoreCase param to the request. I put in a redundant check back when I added it.