### PR TITLE
 Added Query Elevation Component

### DIFF
--- a/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
@@ -1,4 +1,4 @@
-Query Elevation is a Solr component that lets you configure the top results for a given query regardless of the normal Lucene scoring. For more info see <https://lucene.apache.org/solr/guide/the-query-elevation-component.html>.
+Query Elevation is a Solr component that lets you configure the top results for a given query regardless of the normal Lucene scoring. Elevated query results can be configured in an external XML file or at request time. For more info see <https://lucene.apache.org/solr/guide/the-query-elevation-component.html>.
 
 Options
 -------
@@ -7,12 +7,12 @@ Options
 |-----------------|---------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | handler         | string  | elevate       | Path to the request handler as configured in Solr.                                                                                                     |
 | transformers    | string  | [elevated]    | Comma separated list of transformers to annotate each document. The [elevated] transformer tells whether or not the document was elevated.             |
-| enableElevation | boolean | null          | For debugging it may be useful to see results with and without the elevated documents. To hide results, use false.                                     |
+| enableElevation | boolean | null          | For debugging it may be useful to see results with and without elevation applied. To get results without elevation, use false.                         |
 | forceElevation  | boolean | null          | By default, this component respects the requested sort parameter. To return elevated documents first, use true.                                        |
-| exclusive       | boolean | null          | You can force Solr to return only the results specified in the elevation configuration by using true.                                                  |
+| exclusive       | boolean | null          | You can force Solr to return only the results specified in the elevation file by using true.                                                           |
 | markExcludes    | boolean | null          | You can include documents that the elevation configuration would normally exclude by using true. The [excluded] transformer is added to each document. |
-| elevateIds      | string  | null          | Comma separated list of documents to elevate. This overrides the elevations _and_ exclusions that are configured for the query in `elevate.xml`.       |
-| excludeIds      | string  | null          | Comma separated list of documents to exclude. This overrides the elevations _and_ exclusions that are configured for the query in `elevate.xml`.       |
+| elevateIds      | string  | null          | Comma separated list of documents to elevate. This overrides the elevations _and_ exclusions that are configured for the query in the elevation file.  |
+| excludeIds      | string  | null          | Comma separated list of documents to exclude. This overrides the elevations _and_ exclusions that are configured for the query in the elevation file.  |
 ||
 
 Example
@@ -37,7 +37,7 @@ $elevate = $query->getQueryElevation();
 // return elevated documents first
 $elevate->setForceElevation(true);
 
-// specify documents to elevate and/or exclude if you don't use elevate.xml or want to override it at runtime
+// specify documents to elevate and/or exclude if you don't use an elevation file or want to override it at request time
 $elevate->setElevateIds(array('doc1', 'doc2'));
 $elevate->setExcludeIds(array('doc3', 'doc4'));
 

--- a/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
@@ -5,7 +5,6 @@ Options
 
 | Name            | Type    | Default value | Description                                                                                                                                            |
 |-----------------|---------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| handler         | string  | elevate       | Path to the request handler as configured in Solr.                                                                                                     |
 | transformers    | string  | [elevated]    | Comma separated list of transformers to annotate each document. The [elevated] transformer tells whether or not the document was elevated.             |
 | enableElevation | boolean | null          | For debugging it may be useful to see results with and without elevation applied. To get results without elevation, use false.                         |
 | forceElevation  | boolean | null          | By default, this component respects the requested sort parameter. To return elevated documents first, use true.                                        |
@@ -29,7 +28,10 @@ $client = new Solarium\Client($config);
 
 // get a select query instance
 $query = $client->createSelect();
-$query->setQuery('ipod');
+$query->setQuery('electronics');
+
+// set a handler that is configured with an elevator component in solrconfig.xml (or add it to your default handler)
+$query->setHandler('elevate');
 
 // get query elevation component
 $elevate = $query->getQueryElevation();
@@ -38,8 +40,8 @@ $elevate = $query->getQueryElevation();
 $elevate->setForceElevation(true);
 
 // specify documents to elevate and/or exclude if you don't use an elevation file or want to override it at request time
-$elevate->setElevateIds(array('doc1', 'doc2'));
-$elevate->setExcludeIds(array('doc3', 'doc4'));
+$elevate->setElevateIds(array('VS1GB400C3', 'VDBDB1A16'));
+$elevate->setExcludeIds(array('SP2514N', '6H500F0'));
 
 // document transformers can be omitted from the results
 //$elevate->clearTransformers();

--- a/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
@@ -1,0 +1,71 @@
+Query Elevation is a Solr component that lets you configure the top results for a given query regardless of the normal Lucene scoring. For more info see <https://lucene.apache.org/solr/guide/the-query-elevation-component.html>.
+
+Options
+-------
+
+| Name            | Type    | Default value | Description                                                                                                                                            |
+|-----------------|---------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| handler         | string  | elevate       | Path to the request handler as configured in Solr.                                                                                                     |
+| transformers    | string  | [elevated]    | Comma separated list of transformers to annotate each document. The [elevated] transformer tells whether or not the document was elevated.             |
+| enableElevation | boolean | null          | For debugging it may be useful to see results with and without the elevated documents. To hide results, use false.                                     |
+| forceElevation  | boolean | null          | By default, this component respects the requested sort parameter. To return elevated documents first, use true.                                        |
+| exclusive       | boolean | null          | You can force Solr to return only the results specified in the elevation configuration by using true.                                                  |
+| markExcludes    | boolean | null          | You can include documents that the elevation configuration would normally exclude by using true. The [excluded] transformer is added to each document. |
+| elevateIds      | string  | null          | Comma separated list of documents to elevate. This overrides the elevations _and_ exclusions that are configured for the query in `elevate.xml`.       |
+| excludeIds      | string  | null          | Comma separated list of documents to exclude. This overrides the elevations _and_ exclusions that are configured for the query in `elevate.xml`.       |
+||
+
+Example
+-------
+
+```php
+<?php
+
+require(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($config);
+
+// get a select query instance
+$query = $client->createSelect();
+$query->setQuery('ipod');
+
+// get query elevation component
+$elevate = $query->getQueryElevation();
+
+// return elevated documents first
+$elevate->setForceElevation(true);
+
+// specify documents to elevate and/or exclude if you don't use elevate.xml or want to override it at runtime
+$elevate->setElevateIds(array('doc1', 'doc2'));
+$elevate->setExcludeIds(array('doc3', 'doc4'));
+
+// document transformers can be omitted from the results
+//$elevate->clearTransformers();
+
+// this executes the query and returns the result
+$resultset = $client->select($query);
+// display the total number of documents found by solr
+echo 'NumFound: '.$resultset->getNumFound();
+
+// show documents using the resultset iterator
+foreach ($resultset as $document) {
+
+    echo '<hr/><table>';
+
+    // the documents are also iterable, to get all fields
+    foreach ($document as $field => $value) {
+        // this converts multivalue fields to a comma-separated string
+        if (is_array($value)) {
+            $value = implode(', ', $value);
+        }
+
+        echo '<tr><th>' . $field . '</th><td>' . $value . '</td></tr>';
+    }
+
+}
+
+htmlFooter();
+
+```

--- a/examples/2.1.5.12-queryelevation.php
+++ b/examples/2.1.5.12-queryelevation.php
@@ -8,7 +8,10 @@ $client = new Solarium\Client($config);
 
 // get a select query instance
 $query = $client->createSelect();
-$query->setQuery('ipod');
+$query->setQuery('electronics');
+
+// set a handler that is configured with an elevator component in solrconfig.xml (or add it to your default handler)
+$query->setHandler('elevate');
 
 // get query elevation component
 $elevate = $query->getQueryElevation();
@@ -17,8 +20,8 @@ $elevate = $query->getQueryElevation();
 $elevate->setForceElevation(true);
 
 // specify documents to elevate and/or exclude if you don't use an elevation file or want to override it at request time
-$elevate->setElevateIds(array('doc1', 'doc2'));
-$elevate->setExcludeIds(array('doc3', 'doc4'));
+$elevate->setElevateIds(array('VS1GB400C3', 'VDBDB1A16'));
+$elevate->setExcludeIds(array('SP2514N', '6H500F0'));
 
 // document transformers can be omitted from the results
 //$elevate->clearTransformers();

--- a/examples/2.1.5.12-queryelevation.php
+++ b/examples/2.1.5.12-queryelevation.php
@@ -1,0 +1,48 @@
+<?php
+
+require(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($config);
+
+// get a select query instance
+$query = $client->createSelect();
+$query->setQuery('ipod');
+
+// get query elevation component
+$elevate = $query->getQueryElevation();
+
+// return elevated documents first
+$elevate->setForceElevation(true);
+
+// specify documents to elevate and/or exclude if you don't use elevate.xml or want to override it at runtime
+$elevate->setElevateIds(array('doc1', 'doc2'));
+$elevate->setExcludeIds(array('doc3', 'doc4'));
+
+// document transformers can be omitted from the results
+//$elevate->clearTransformers();
+
+// this executes the query and returns the result
+$resultset = $client->select($query);
+// display the total number of documents found by solr
+echo 'NumFound: '.$resultset->getNumFound();
+
+// show documents using the resultset iterator
+foreach ($resultset as $document) {
+
+    echo '<hr/><table>';
+
+    // the documents are also iterable, to get all fields
+    foreach ($document as $field => $value) {
+        // this converts multivalue fields to a comma-separated string
+        if (is_array($value)) {
+            $value = implode(', ', $value);
+        }
+
+        echo '<tr><th>' . $field . '</th><td>' . $value . '</td></tr>';
+    }
+
+}
+
+htmlFooter();

--- a/examples/2.1.5.12-queryelevation.php
+++ b/examples/2.1.5.12-queryelevation.php
@@ -16,7 +16,7 @@ $elevate = $query->getQueryElevation();
 // return elevated documents first
 $elevate->setForceElevation(true);
 
-// specify documents to elevate and/or exclude if you don't use elevate.xml or want to override it at runtime
+// specify documents to elevate and/or exclude if you don't use an elevation file or want to override it at request time
 $elevate->setElevateIds(array('doc1', 'doc2'));
 $elevate->setExcludeIds(array('doc3', 'doc4'));
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -58,6 +58,7 @@
                         <li><a href="2.1.5.9-spellcheck.php">2.1.5.9 Spellcheck</a></li>
                         <li><a href="2.1.5.10-stats.php">2.1.5.10 Stats</a></li>
                         <li><a href="2.1.5.11-debug.php">2.1.5.11 Debug (DebugQuery)</a></li>
+                        <li><a href="2.1.5.12-queryelevation.php">2.1.5.12 Query Elevation</a></li>
                     </ul>
                     <li><a href="2.1.6-helper-functions.php">2.1.6 Helper functions</a></li>
                     <li><a href="2.1.7-query-reuse.php">2.1.7 Query re-use</a></li>

--- a/src/Component/ComponentAwareQueryInterface.php
+++ b/src/Component/ComponentAwareQueryInterface.php
@@ -73,6 +73,11 @@ interface ComponentAwareQueryInterface
     const COMPONENT_TERMS = 'terms';
 
     /**
+     * Query component queryelevation.
+     */
+    const COMPONENT_QUERYELEVATION = 'queryelevation';
+
+    /**
      * Get all registered component types.
      *
      * @return array

--- a/src/Component/QueryElevation.php
+++ b/src/Component/QueryElevation.php
@@ -17,7 +17,6 @@ class QueryElevation extends AbstractComponent
      * @var array
      */
     protected $options = [
-        'handler' => 'elevate',
         'transformers' => '[elevated]',
     ];
 
@@ -53,28 +52,6 @@ class QueryElevation extends AbstractComponent
      */
     public function getResponseParser()
     {
-    }
-
-    /**
-     * Set handler option.
-     *
-     * @param string $handler
-     *
-     * @return self Provides fluent interface
-     */
-    public function setHandler($handler)
-    {
-        return $this->setOption('handler', $handler);
-    }
-
-    /**
-     * Get handler option.
-     *
-     * @return string
-     */
-    public function getHandler()
-    {
-        return $this->getOption('handler');
     }
 
     /**

--- a/src/Component/QueryElevation.php
+++ b/src/Component/QueryElevation.php
@@ -328,7 +328,7 @@ class QueryElevation extends AbstractComponent
         foreach ($this->options as $name => $value) {
             switch ($name) {
                 case 'transformers':
-                    $this->addTransformers($value);
+                    $this->setTransformers($value);
                     break;
                 case 'markExcludes':
                     $this->setMarkExcludes($value);

--- a/src/Component/QueryElevation.php
+++ b/src/Component/QueryElevation.php
@@ -246,8 +246,7 @@ class QueryElevation extends AbstractComponent
     {
         if (true === $mark || 'true' === $mark) {
             $this->addTransformer('[excluded]');
-        }
-        else {
+        } else {
             $this->removeTransformer('[excluded]');
         }
 

--- a/src/Component/QueryElevation.php
+++ b/src/Component/QueryElevation.php
@@ -1,0 +1,346 @@
+<?php
+
+namespace Solarium\Component;
+
+use Solarium\Component\RequestBuilder\QueryElevation as RequestBuilder;
+
+/**
+ * QueryElevation component.
+ *
+ * @see https://lucene.apache.org/solr/guide/the-query-elevation-component.html
+ */
+class QueryElevation extends AbstractComponent
+{
+    /**
+     * Default options.
+     *
+     * @var array
+     */
+    protected $options = [
+        'handler' => 'elevate',
+        'transformers' => '[elevated]',
+    ];
+
+    /**
+     * Document transformers.
+     *
+     * @var array
+     */
+    protected $transformers = [];
+
+    /**
+     * Get component type.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return ComponentAwareQueryInterface::COMPONENT_QUERYELEVATION;
+    }
+
+    /**
+     * Get a requestbuilder for this query.
+     *
+     * @return RequestBuilder
+     */
+    public function getRequestBuilder()
+    {
+        return new RequestBuilder();
+    }
+
+    /**
+     * This component has no response parser...
+     */
+    public function getResponseParser()
+    {
+    }
+
+    /**
+     * Set handler option.
+     *
+     * @param string $handler
+     *
+     * @return self Provides fluent interface
+     */
+    public function setHandler($handler)
+    {
+        return $this->setOption('handler', $handler);
+    }
+
+    /**
+     * Get handler option.
+     *
+     * @return string
+     */
+    public function getHandler()
+    {
+        return $this->getOption('handler');
+    }
+
+    /**
+     * Add a document transformer.
+     *
+     * @param string $transformer
+     *
+     * @return self fluent interface
+     */
+    public function addTransformer($transformer)
+    {
+        $this->transformers[$transformer] = true;
+
+        return $this;
+    }
+
+    /**
+     * Add multiple document transformers.
+     *
+     * You can use an array or a comma separated string as input
+     *
+     * @param array|string $transformers
+     *
+     * @return self Provides fluent interface
+     */
+    public function addTransformers($transformers)
+    {
+        if (is_string($transformers)) {
+            $transformers = explode(',', $transformers);
+            $transformers = array_map('trim', $transformers);
+        }
+
+        foreach ($transformers as $transformer) {
+            $this->addTransformer($transformer);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove a document transformer.
+     *
+     * @param string $transformer
+     *
+     * @return self Provides fluent interface
+     */
+    public function removeTransformer($transformer)
+    {
+        if (isset($this->transformers[$transformer])) {
+            unset($this->transformers[$transformer]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove all document transformers.
+     *
+     * @return self fluent interface
+     */
+    public function clearTransformers()
+    {
+        $this->transformers = [];
+
+        return $this;
+    }
+
+    /**
+     * Get all document transformers.
+     *
+     * @return array
+     */
+    public function getTransformers()
+    {
+        return array_keys($this->transformers);
+    }
+
+    /**
+     * Set multiple document transformers.
+     *
+     * This overwrites any existing transformers
+     *
+     * @param array|string $transformers
+     *
+     * @return self Provides fluent interface
+     */
+    public function setTransformers($transformers)
+    {
+        $this->clearTransformers();
+        $this->addTransformers($transformers);
+
+        return $this;
+    }
+
+    /**
+     * Set enable elevation.
+     *
+     * @param bool $enable
+     *
+     * @return self Provides fluent interface
+     */
+    public function setEnableElevation($enable)
+    {
+        return $this->setOption('enableElevation', $enable);
+    }
+
+    /**
+     * Get enable elevation.
+     *
+     * @return bool
+     */
+    public function getEnableElevation()
+    {
+        return $this->getOption('enableElevation');
+    }
+
+    /**
+     * Set force elevation.
+     *
+     * @param bool $force
+     *
+     * @return self Provides fluent interface
+     */
+    public function setForceElevation($force)
+    {
+        return $this->setOption('forceElevation', $force);
+    }
+
+    /**
+     * Get force elevation.
+     *
+     * @return bool
+     */
+    public function getForceElevation()
+    {
+        return $this->getOption('forceElevation');
+    }
+
+    /**
+     * Set exclusive.
+     *
+     * @param bool $exclusive
+     *
+     * @return self Provides fluent interface
+     */
+    public function setExclusive($exclusive)
+    {
+        return $this->setOption('exclusive', $exclusive);
+    }
+
+    /**
+     * Get exclusive.
+     *
+     * @return bool
+     */
+    public function getExclusive()
+    {
+        return $this->getOption('exclusive');
+    }
+
+    /**
+     * Set mark excludes.
+     *
+     * @param bool $mark
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMarkExcludes($mark)
+    {
+        if (true === $mark || 'true' === $mark) {
+            $this->addTransformer('[excluded]');
+        }
+        else {
+            $this->removeTransformer('[excluded]');
+        }
+
+        return $this->setOption('markExcludes', $mark);
+    }
+
+    /**
+     * Get mark excludes.
+     *
+     * @return bool
+     */
+    public function getMarkExcludes()
+    {
+        return $this->getOption('markExcludes');
+    }
+
+    /**
+     * Set elevated document ids.
+     *
+     * @param string|array $ids can be an array or string with comma separated ids
+     *
+     * @return self Provides fluent interface
+     */
+    public function setElevateIds($ids)
+    {
+        if (is_string($ids)) {
+            $ids = explode(',', $ids);
+            $ids = array_map('trim', $ids);
+        }
+
+        return $this->setOption('elevateIds', $ids);
+    }
+
+    /**
+     * Get elevated document ids.
+     *
+     * @return null|array
+     */
+    public function getElevateIds()
+    {
+        return $this->getOption('elevateIds');
+    }
+
+    /**
+     * Set excluded document ids.
+     *
+     * @param string|array $ids can be an array or string with comma separated ids
+     *
+     * @return self Provides fluent interface
+     */
+    public function setExcludeIds($ids)
+    {
+        if (is_string($ids)) {
+            $ids = explode(',', $ids);
+            $ids = array_map('trim', $ids);
+        }
+
+        return $this->setOption('excludeIds', $ids);
+    }
+
+    /**
+     * Get excluded document ids.
+     *
+     * @return null|array
+     */
+    public function getExcludeIds()
+    {
+        return $this->getOption('excludeIds');
+    }
+
+    /**
+     * Initialize options.
+     *
+     * Several options need some extra checks or setup work, for these options
+     * the setters are called.
+     */
+    protected function init()
+    {
+        foreach ($this->options as $name => $value) {
+            switch ($name) {
+                case 'transformers':
+                    $this->addTransformers($value);
+                    break;
+                case 'markExcludes':
+                    $this->setMarkExcludes($value);
+                    break;
+                case 'elevateIds':
+                    $this->setElevateIds($value);
+                    break;
+                case 'excludeIds':
+                    $this->setExcludeIds($value);
+                    break;
+            }
+        }
+    }
+}

--- a/src/Component/QueryTraits/QueryElevationTrait.php
+++ b/src/Component/QueryTraits/QueryElevationTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Solarium\Component\QueryTraits;
+
+use Solarium\Component\ComponentAwareQueryInterface;
+
+/**
+ * Trait query types supporting components.
+ */
+trait QueryElevationTrait
+{
+    /**
+     * Get a QueryElevation component instance.
+     *
+     * This is a convenience method that maps presets to getComponent
+     *
+     * @return \Solarium\Component\QueryElevation
+     */
+    public function getQueryElevation()
+    {
+        return $this->getComponent(ComponentAwareQueryInterface::COMPONENT_QUERYELEVATION, true);
+    }
+}

--- a/src/Component/RequestBuilder/QueryElevation.php
+++ b/src/Component/RequestBuilder/QueryElevation.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Solarium\Component\RequestBuilder;
+
+use Solarium\Component\QueryElevation as QueryelevationComponent;
+use Solarium\Core\Client\Request;
+
+/**
+ * Add select component queryelevation to the request.
+ */
+class QueryElevation implements ComponentRequestBuilderInterface
+{
+    /**
+     * Add request settings for QueryelevationComponent.
+     *
+     * @param QueryelevationComponent $component
+     * @param Request                 $request
+     *
+     * @return Request
+     */
+    public function buildComponent($component, $request)
+    {
+        // switch request handler
+        $request->setHandler($component->getHandler());
+
+        // add document transformers to request field list
+        if (null !== ($transformers = $component->getTransformers())) {
+            $fl = $request->getParam('fl');
+            $fields = implode(',', null === $fl ? $transformers : array_merge([$fl], $transformers));
+            $request->addParam('fl', $fields, true);
+        }
+
+        // add basic params to request
+        $request->addParam('enableElevation', $component->getEnableElevation());
+        $request->addParam('forceElevation', $component->getForceElevation());
+        $request->addParam('exclusive', $component->getExclusive());
+        $request->addParam('markExcludes', $component->getMarkExcludes());
+
+        // add overrides for pre-configured elevations
+        $request->addParam('elevateIds', null === ($ids = $component->getElevateIds()) ? null : implode(',', $ids));
+        $request->addParam('excludeIds', null === ($ids = $component->getExcludeIds()) ? null : implode(',', $ids));
+
+        return $request;
+    }
+}

--- a/src/Component/RequestBuilder/QueryElevation.php
+++ b/src/Component/RequestBuilder/QueryElevation.php
@@ -20,9 +20,6 @@ class QueryElevation implements ComponentRequestBuilderInterface
      */
     public function buildComponent($component, $request)
     {
-        // switch request handler
-        $request->setHandler($component->getHandler());
-
         // add document transformers to request field list
         if (null !== ($transformers = $component->getTransformers())) {
             $fl = $request->getParam('fl');

--- a/src/QueryType/Select/Query/Query.php
+++ b/src/QueryType/Select/Query/Query.php
@@ -12,6 +12,7 @@ use Solarium\Component\QueryTraits\FacetSetTrait;
 use Solarium\Component\QueryTraits\GroupingTrait;
 use Solarium\Component\QueryTraits\HighlightingTrait;
 use Solarium\Component\QueryTraits\MoreLikeThisTrait;
+use Solarium\Component\QueryTraits\QueryElevationTrait;
 use Solarium\Component\QueryTraits\SpatialTrait;
 use Solarium\Component\QueryTraits\SpellcheckTrait;
 use Solarium\Component\QueryTraits\StatsTrait;
@@ -44,6 +45,7 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface
     use GroupingTrait;
     use DistributedSearchTrait;
     use StatsTrait;
+    use QueryElevationTrait;
 
     /**
      * Solr sort mode descending.
@@ -124,6 +126,7 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface
             ComponentAwareQueryInterface::COMPONENT_GROUPING => 'Solarium\Component\Grouping',
             ComponentAwareQueryInterface::COMPONENT_DISTRIBUTEDSEARCH => 'Solarium\Component\DistributedSearch',
             ComponentAwareQueryInterface::COMPONENT_STATS => 'Solarium\Component\Stats\Stats',
+            ComponentAwareQueryInterface::COMPONENT_QUERYELEVATION => 'Solarium\Component\QueryElevation',
         ];
 
         parent::__construct($options);

--- a/tests/Component/QueryElevationTest.php
+++ b/tests/Component/QueryElevationTest.php
@@ -21,7 +21,6 @@ class QueryElevationTest extends TestCase
     public function testConfigMode()
     {
         $options = [
-            'handler' => 'myhandler',
             'transformers' => '[transformer]',
             'enableElevation' => false,
             'forceElevation' => true,
@@ -33,7 +32,6 @@ class QueryElevationTest extends TestCase
 
         $this->queryelevation->setOptions($options);
 
-        $this->assertSame('myhandler', $this->queryelevation->getHandler());
         $this->assertSame(['[transformer]'], $this->queryelevation->getTransformers());
         $this->assertFalse($this->queryelevation->getEnableElevation());
         $this->assertTrue($this->queryelevation->getForceElevation());
@@ -59,12 +57,6 @@ class QueryElevationTest extends TestCase
             'Solarium\Component\RequestBuilder\QueryElevation',
             $this->queryelevation->getRequestBuilder()
         );
-    }
-
-    public function testSetAndGetHandler()
-    {
-        $this->queryelevation->setHandler('myhandler');
-        $this->assertSame('myhandler', $this->queryelevation->getHandler());
     }
 
     public function testAddTransformer()

--- a/tests/Component/QueryElevationTest.php
+++ b/tests/Component/QueryElevationTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Solarium\Tests\Component;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Component\ComponentAwareQueryInterface;
+use Solarium\Component\QueryElevation;
+
+class QueryElevationTest extends TestCase
+{
+    /**
+     * @var QueryElevation
+     */
+    protected $queryelevation;
+
+    public function setUp()
+    {
+        $this->queryelevation = new QueryElevation();
+    }
+
+    public function testConfigMode()
+    {
+        $options = [
+            'handler' => 'myhandler',
+            'transformers' => '[transformer]',
+            'enableElevation' => false,
+            'forceElevation' => true,
+            'exclusive' => true,
+            'markExcludes' => false,
+            'elevateIds' => 'doc1,doc2',
+            'excludeIds' => 'doc3,doc4',
+        ];
+
+        $this->queryelevation->setOptions($options);
+
+        $this->assertSame('myhandler', $this->queryelevation->getHandler());
+        $this->assertSame(['[transformer]'], $this->queryelevation->getTransformers());
+        $this->assertFalse($this->queryelevation->getEnableElevation());
+        $this->assertTrue($this->queryelevation->getForceElevation());
+        $this->assertTrue($this->queryelevation->getExclusive());
+        $this->assertFalse($this->queryelevation->getMarkExcludes());
+        $this->assertSame(['doc1', 'doc2'], $this->queryelevation->getElevateIds());
+        $this->assertSame(['doc3', 'doc4'], $this->queryelevation->getExcludeIds());
+    }
+
+    public function testGetType()
+    {
+        $this->assertEquals(ComponentAwareQueryInterface::COMPONENT_QUERYELEVATION, $this->queryelevation->getType());
+    }
+
+    public function testGetResponseParser()
+    {
+        $this->assertNull($this->queryelevation->getResponseParser());
+    }
+
+    public function testGetRequestBuilder()
+    {
+        $this->assertInstanceOf(
+            'Solarium\Component\RequestBuilder\QueryElevation',
+            $this->queryelevation->getRequestBuilder()
+        );
+    }
+
+    public function testSetAndGetHandler()
+    {
+        $this->queryelevation->setHandler('myhandler');
+        $this->assertSame('myhandler', $this->queryelevation->getHandler());
+    }
+
+    public function testAddTransformer()
+    {
+        $expectedTrans = $this->queryelevation->getTransformers();
+        $expectedTrans[] = '[newtrans]';
+        $this->queryelevation->addTransformer('[newtrans]');
+        $this->assertSame($expectedTrans, $this->queryelevation->getTransformers());
+    }
+
+    public function testClearTransformers()
+    {
+        $this->queryelevation->addTransformer('[newtrans]');
+        $this->queryelevation->clearTransformers();
+        $this->assertSame([], $this->queryelevation->getTransformers());
+    }
+
+    public function testAddTransformers()
+    {
+        $transformers = ['[trans1]', '[trans2]'];
+
+        $this->queryelevation->clearTransformers();
+        $this->queryelevation->addTransformers($transformers);
+        $this->assertSame($transformers, $this->queryelevation->getTransformers());
+    }
+
+    public function testAddTransformersAsStringWithTrim()
+    {
+        $this->queryelevation->clearTransformers();
+        $this->queryelevation->addTransformers('[trans1], [trans2]');
+        $this->assertSame(['[trans1]', '[trans2]'], $this->queryelevation->getTransformers());
+    }
+
+    public function testRemoveTransformer()
+    {
+        $this->queryelevation->clearTransformers();
+        $this->queryelevation->addTransformers(['[trans1]', '[trans2]']);
+        $this->queryelevation->removeTransformer('[trans1]');
+        $this->assertSame(['[trans2]'], $this->queryelevation->getTransformers());
+    }
+
+    public function testSetTransformers()
+    {
+        $this->queryelevation->clearTransformers();
+        $this->queryelevation->addTransformers(['[trans1]', '[trans2]']);
+        $this->queryelevation->setTransformers(['[trans3]', '[trans4]']);
+        $this->assertSame(['[trans3]', '[trans4]'], $this->queryelevation->getTransformers());
+    }
+
+    public function testSetAndGetEnableElevation()
+    {
+        $this->queryelevation->setEnableElevation(false);
+        $this->assertFalse($this->queryelevation->getEnableElevation());
+    }
+
+    public function testSetAndGetForceElevation()
+    {
+        $this->queryelevation->setForceElevation(true);
+        $this->assertTrue($this->queryelevation->getForceElevation());
+    }
+
+    public function testSetAndGetExclusive()
+    {
+        $this->queryelevation->setExclusive(true);
+        $this->assertTrue($this->queryelevation->getExclusive());
+    }
+
+    public function testSetMarkExcludesTrue()
+    {
+        $this->queryelevation->removeTransformer('[excluded]');
+        $this->queryelevation->setMarkExcludes(true);
+        $this->assertTrue($this->queryelevation->getMarkExcludes());
+        $this->assertContains('[excluded]', $this->queryelevation->getTransformers());
+    }
+
+    public function testSetMarkExcludesTrueAsString()
+    {
+        $this->queryelevation->removeTransformer('[excluded]');
+        $this->queryelevation->setMarkExcludes('true');
+        $this->assertSame('true', $this->queryelevation->getMarkExcludes());
+        $this->assertContains('[excluded]', $this->queryelevation->getTransformers());
+    }
+
+    public function testSetMarkExcludesFalse()
+    {
+        $this->queryelevation->addTransformer('[excluded]');
+        $this->queryelevation->setMarkExcludes(false);
+        $this->assertFalse($this->queryelevation->getMarkExcludes());
+        $this->assertNotContains('[excluded]', $this->queryelevation->getTransformers());
+    }
+
+    public function testSetMarkExcludesFalseAsString()
+    {
+        $this->queryelevation->addTransformer('[excluded]');
+        $this->queryelevation->setMarkExcludes('false');
+        $this->assertSame('false', $this->queryelevation->getMarkExcludes());
+        $this->assertNotContains('[excluded]', $this->queryelevation->getTransformers());
+    }
+
+    public function testSetMarkExcludesNull()
+    {
+        $this->queryelevation->addTransformer('[excluded]');
+        $this->queryelevation->setMarkExcludes(null);
+        $this->assertNull($this->queryelevation->getMarkExcludes());
+        $this->assertNotContains('[excluded]', $this->queryelevation->getTransformers());
+    }
+
+    public function testSetAndGetElevateIds()
+    {
+        $ids = ['doc1', 'doc2'];
+
+        $this->queryelevation->setElevateIds($ids);
+        $this->assertSame($ids, $this->queryelevation->getElevateIds());
+    }
+
+    public function testSetElevateIdsAsStringWithTrim()
+    {
+        $this->queryelevation->setElevateIds('doc1, doc2');
+        $this->assertSame(['doc1', 'doc2'], $this->queryelevation->getElevateIds());
+    }
+
+    public function testSetAndGetExcludeIds()
+    {
+        $ids = ['doc3', 'doc4'];
+
+        $this->queryelevation->setExcludeIds($ids);
+        $this->assertSame($ids, $this->queryelevation->getExcludeIds());
+    }
+
+    public function testSetExcludeIdsAsStringWithTrim()
+    {
+        $this->queryelevation->setExcludeIds('doc3, doc4');
+        $this->assertSame(['doc3', 'doc4'], $this->queryelevation->getExcludeIds());
+    }
+}

--- a/tests/Component/RequestBuilder/QueryElevationTest.php
+++ b/tests/Component/RequestBuilder/QueryElevationTest.php
@@ -24,8 +24,6 @@ class QueryElevationTest extends TestCase
 
         $request = $builder->buildComponent($component, $request);
 
-        $this->assertSame($component->getHandler(), $request->getHandler());
-
         $this->assertEquals(
             [
                 'fl' => '[elevated],[excluded]',

--- a/tests/Component/RequestBuilder/QueryElevationTest.php
+++ b/tests/Component/RequestBuilder/QueryElevationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Solarium\Tests\Component\RequestBuilder;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Component\QueryElevation as Component;
+use Solarium\Component\RequestBuilder\QueryElevation as RequestBuilder;
+use Solarium\Core\Client\Request;
+
+class QueryElevationTest extends TestCase
+{
+    public function testBuildComponent()
+    {
+        $builder = new RequestBuilder();
+        $request = new Request();
+
+        $component = new Component();
+        $component->setEnableElevation(false);
+        $component->setForceElevation(true);
+        $component->setExclusive(true);
+        $component->setMarkExcludes(true);
+        $component->setElevateIds(['doc1', 'doc2']);
+        $component->setExcludeIds(['doc3', 'doc4']);
+
+        $request = $builder->buildComponent($component, $request);
+
+        $this->assertSame($component->getHandler(), $request->getHandler());
+
+        $this->assertEquals(
+            [
+                'fl' => '[elevated],[excluded]',
+                'enableElevation' => 'false',
+                'forceElevation' => 'true',
+                'exclusive' => 'true',
+                'markExcludes' => 'true',
+                'elevateIds' => 'doc1,doc2',
+                'excludeIds' => 'doc3,doc4',
+            ],
+            $request->getParams()
+        );
+    }
+}

--- a/tests/QueryType/Select/Query/AbstractQueryTest.php
+++ b/tests/QueryType/Select/Query/AbstractQueryTest.php
@@ -577,6 +577,16 @@ abstract class AbstractQueryTest extends TestCase
         );
     }
 
+    public function testGetQueryElevation()
+    {
+        $queryelevation = $this->query->getQueryElevation();
+
+        $this->assertSame(
+            'Solarium\Component\QueryElevation',
+            get_class($queryelevation)
+        );
+    }
+
     public function testRegisterComponentType()
     {
         $components = $this->query->getComponentTypes();


### PR DESCRIPTION
I've added support for Solr's [Query Elevation Component](https://lucene.apache.org/solr/guide/the-query-elevation-component.html).

The solarium component does three things:

1. Override the request handler (`elevate` by default).
2. Add document transformers to the existing `fl` parameter.
3. Add optional additional parameters to the request.

Test coverage and documentation is included.