### PR TITLE
Added support for NOW and TZ

### DIFF
--- a/src/Core/Query/AbstractQuery.php
+++ b/src/Core/Query/AbstractQuery.php
@@ -198,4 +198,54 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
 
         return $responseWriter;
     }
+
+    /**
+     * Set now option.
+     * 
+     * Instructs Solr to use an arbitrary moment in time (past or future) to override NOW for date math expressions.
+     * 
+     * Make sure to pass a string instead of an int if the code has to run on a 32-bit PHP installation.
+     * 
+     * @param string $timestamp Milliseconds since epoch
+     *
+     * @return self Provides fluent interface
+     */
+    public function setNow($timestamp)
+    {
+        return $this->setOption('now', $timestamp);
+    }
+
+    /**
+     * Get now option.
+     * 
+     * @return string Milliseconds since epoch
+     */
+    public function getNow()
+    {
+        return $this->getOption('now');
+    }
+
+    /**
+     * Set timezone option.
+     * 
+     * Forces all date based addition and rounding to be relative to the specified time zone instead of UTC.
+     * 
+     * @param string $timezone Java TimeZone ID
+     *
+     * @return self Provides fluent interface
+     */
+    public function setTimeZone($timezone)
+    {
+        return $this->setOption('timezone', $timezone);
+    }
+
+    /**
+     * Get timezone option.
+     * 
+     * @return string Java TimeZone ID
+     */
+    public function getTimeZone()
+    {
+        return $this->getOption('timezone');
+    }
 }

--- a/src/Core/Query/AbstractQuery.php
+++ b/src/Core/Query/AbstractQuery.php
@@ -201,11 +201,11 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
 
     /**
      * Set now option.
-     * 
+     *
      * Instructs Solr to use an arbitrary moment in time (past or future) to override NOW for date math expressions.
-     * 
+     *
      * Make sure to pass a string instead of an int if the code has to run on a 32-bit PHP installation.
-     * 
+     *
      * @param string $timestamp Milliseconds since epoch
      *
      * @return self Provides fluent interface
@@ -217,7 +217,7 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
 
     /**
      * Get now option.
-     * 
+     *
      * @return string Milliseconds since epoch
      */
     public function getNow()
@@ -227,9 +227,9 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
 
     /**
      * Set timezone option.
-     * 
+     *
      * Forces all date based addition and rounding to be relative to the specified time zone instead of UTC.
-     * 
+     *
      * @param string $timezone Java TimeZone ID
      *
      * @return self Provides fluent interface
@@ -241,7 +241,7 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
 
     /**
      * Get timezone option.
-     * 
+     *
      * @return string Java TimeZone ID
      */
     public function getTimeZone()

--- a/src/Core/Query/AbstractRequestBuilder.php
+++ b/src/Core/Query/AbstractRequestBuilder.php
@@ -22,6 +22,8 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
         $request->setHandler($query->getHandler());
         $request->addParam('omitHeader', $query->getOmitHeader());
         $request->addParam('timeAllowed', $query->getTimeAllowed());
+        $request->addParam('NOW', $query->getNow());
+        $request->addParam('TZ', $query->getTimeZone());
         $request->addParams($query->getParams());
 
         $request->addParam('wt', $query->getResponseWriter());

--- a/tests/Core/Query/QueryTest.php
+++ b/tests/Core/Query/QueryTest.php
@@ -70,6 +70,20 @@ class QueryTest extends TestCase
         $query->setTimeAllowed(1200);
         $this->assertSame(1200, $query->getTimeAllowed());
     }
+
+    public function testSetAndGetNow()
+    {
+        $query = new TestQuery();
+        $query->setNow('1520997255000');
+        $this->assertSame('1520997255000', $query->getNow());
+    }
+
+    public function testSetAndGetTimeZone()
+    {
+        $query = new TestQuery();
+        $query->setTimeZone('Europe/Brussels');
+        $this->assertSame('Europe/Brussels', $query->getTimeZone());
+    }
 }
 
 class TestQuery extends AbstractQuery

--- a/tests/Core/Query/RequestBuilderTest.php
+++ b/tests/Core/Query/RequestBuilderTest.php
@@ -60,6 +60,34 @@ class RequestBuilderTest extends TestCase
         );
     }
 
+    public function testBuildWithNow()
+    {
+        $query = new SelectQuery();
+        $query->addParam('p1', 'v1');
+        $query->addParam('p2', 'v2');
+        $query->setNow('1520997255000');
+        $request = $this->builder->build($query);
+
+        $this->assertSame(
+            'select?omitHeader=true&NOW=1520997255000&p1=v1&p2=v2&wt=json&json.nl=flat',
+            urldecode($request->getUri())
+        );
+    }
+
+    public function testBuildWithTimeZone()
+    {
+        $query = new SelectQuery();
+        $query->addParam('p1', 'v1');
+        $query->addParam('p2', 'v2');
+        $query->setTimeZone('Europe/Brussels');
+        $request = $this->builder->build($query);
+
+        $this->assertSame(
+            'select?omitHeader=true&TZ=Europe/Brussels&p1=v1&p2=v2&wt=json&json.nl=flat',
+            urldecode($request->getUri())
+        );
+    }
+
     public function testRenderLocalParams()
     {
         $myParams = ['tag' => 'mytag', 'ex' => ['exclude1', 'exclude2']];


### PR DESCRIPTION
I've added support for the NOW and TZ [request parameters that affect date math](https://lucene.apache.org/solr/guide/7_1/working-with-dates.html#request-parameters-that-affect-date-math).

According to this [older wiki page](https://wiki.apache.org/solr/CoreQueryParameters), the parameters can be used for all requests. There doesn't seem to be a place in the docs yet to document these.

Test coverage is included.