### PR TITLE
Additional tests for cursormark

### DIFF
--- a/examples/7.6-plugin-prefetchiterator.php
+++ b/examples/7.6-plugin-prefetchiterator.php
@@ -10,15 +10,15 @@ $client = new Solarium\Client($config);
 $query = $client->createSelect();
 $query->setFields(array('id'));
 
-// get a plugin instance and apply settings
-$prefetch = $client->getPlugin('prefetchiterator');
-$prefetch->setPrefetch(2); //fetch 2 rows per query (for real world use this can be way higher)
-$prefetch->setQuery($query);
-
 // cursor functionality can be used for efficient deep paging (since Solr 4.7)
 $query->setCursormark('*');
 // cursor functionality requires a sort containing a uniqueKey field as tie breaker on top of your desired sorts for the query
 $query->addSort('id', $query::SORT_ASC);
+
+// get a plugin instance and apply settings
+$prefetch = $client->getPlugin('prefetchiterator');
+$prefetch->setPrefetch(2); //fetch 2 rows per query (for real world use this can be way higher)
+$prefetch->setQuery($query);
 
 // display the total number of documents found by solr
 echo 'NumFound: ' . count($prefetch);

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -358,12 +358,12 @@ abstract class AbstractTechproductsTest extends TestCase
         $prefetch = $this->client->getPlugin('prefetchiterator');
         $prefetch->setPrefetch(2);
         $prefetch->setQuery($select);
-        
+
         // count() uses getNumFound() on the result set and wouldn't actually test if all results are iterated
         for ($i = 0; $prefetch->valid(); ++$i) {
             $prefetch->next();
         }
-        
+
         $this->assertSame(32, $i);
     }
 
@@ -375,12 +375,12 @@ abstract class AbstractTechproductsTest extends TestCase
         $prefetch = $this->client->getPlugin('prefetchiterator');
         $prefetch->setPrefetch(2);
         $prefetch->setQuery($select);
-        
+
         // count() uses getNumFound() on the result set and wouldn't actually test if all results are iterated
         for ($i = 0; $prefetch->valid(); ++$i) {
             $prefetch->next();
         }
-        
+
         $this->assertSame(32, $i);
     }
 
@@ -391,22 +391,22 @@ abstract class AbstractTechproductsTest extends TestCase
         $prefetch = $this->client->getPlugin('prefetchiterator');
         $prefetch->setPrefetch(2);
         $prefetch->setQuery($select);
-        
+
         $without = [];
         foreach ($prefetch as $document) {
             $without = $document->id;
         }
-        
+
         $select = $this->client->createSelect();
         $select->setCursormark('*');
         $select->addSort('id', SelectQuery::SORT_ASC);
         $prefetch->setQuery($select);
-        
+
         $with = [];
         foreach ($prefetch as $document) {
             $with = $document->id;
         }
-        
+
         $this->assertSame($without, $with);
     }
 }

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -351,6 +351,64 @@ abstract class AbstractTechproductsTest extends TestCase
             'pc' => 3,
         ], $terms);
     }
+
+    public function testPrefetchIterator()
+    {
+        $select = $this->client->createSelect();
+        $prefetch = $this->client->getPlugin('prefetchiterator');
+        $prefetch->setPrefetch(2);
+        $prefetch->setQuery($select);
+        
+        // count() uses getNumFound() on the result set and wouldn't actually test if all results are iterated
+        for ($i = 0; $prefetch->valid(); ++$i) {
+            $prefetch->next();
+        }
+        
+        $this->assertSame(32, $i);
+    }
+
+    public function testPrefetchIteratorWithCursormark()
+    {
+        $select = $this->client->createSelect();
+        $select->setCursormark('*');
+        $select->addSort('id', SelectQuery::SORT_ASC);
+        $prefetch = $this->client->getPlugin('prefetchiterator');
+        $prefetch->setPrefetch(2);
+        $prefetch->setQuery($select);
+        
+        // count() uses getNumFound() on the result set and wouldn't actually test if all results are iterated
+        for ($i = 0; $prefetch->valid(); ++$i) {
+            $prefetch->next();
+        }
+        
+        $this->assertSame(32, $i);
+    }
+
+    public function testPrefetchIteratorWithoutAndWithCursormark()
+    {
+        $select = $this->client->createSelect();
+        $select->addSort('id', SelectQuery::SORT_ASC);
+        $prefetch = $this->client->getPlugin('prefetchiterator');
+        $prefetch->setPrefetch(2);
+        $prefetch->setQuery($select);
+        
+        $without = [];
+        foreach ($prefetch as $document) {
+            $without = $document->id;
+        }
+        
+        $select = $this->client->createSelect();
+        $select->setCursormark('*');
+        $select->addSort('id', SelectQuery::SORT_ASC);
+        $prefetch->setQuery($select);
+        
+        $with = [];
+        foreach ($prefetch as $document) {
+            $with = $document->id;
+        }
+        
+        $this->assertSame($without, $with);
+    }
 }
 
 class TestQuery extends SelectQuery

--- a/tests/QueryType/Select/Query/AbstractQueryTest.php
+++ b/tests/QueryType/Select/Query/AbstractQueryTest.php
@@ -417,6 +417,8 @@ abstract class AbstractQueryTest extends TestCase
             'resultclass' => 'MyResultClass',
             'documentclass' => 'MyDocumentClass',
             'tag' => ['t1', 't2'],
+            'cursormark' => '*',
+            'splitonwhitespace' => false,
         ];
         $query = new Query($config);
 
@@ -427,6 +429,8 @@ abstract class AbstractQueryTest extends TestCase
         $this->assertSame($config['start'], $query->getStart());
         $this->assertSame($config['documentclass'], $query->getDocumentClass());
         $this->assertSame($config['resultclass'], $query->getResultClass());
+        $this->assertSame($config['cursormark'], $query->getCursormark());
+        $this->assertSame($config['splitonwhitespace'], $query->getSplitOnWhitespace());
         $this->assertSame('published:true', $query->getFilterQuery('pub')->getQuery());
         $this->assertSame('online:true', $query->getFilterQuery('online')->getQuery());
 

--- a/tests/QueryType/Select/RequestBuilderTest.php
+++ b/tests/QueryType/Select/RequestBuilderTest.php
@@ -128,6 +128,14 @@ class RequestBuilderTest extends TestCase
         $this->assertSame('{!tag=t1,t2}cat:1', $request->getParam('q'));
     }
 
+    public function testWithCursormark()
+    {
+        $this->query->setCursormark('*');
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame('*', $request->getParam('cursorMark'));
+    }
+
     public function testWithSplitOnWhitespace()
     {
         $this->query->setSplitOnWhitespace(false);


### PR DESCRIPTION
Added tests for config mode and request building. More interestingly, I wrote integration tests against techproducts to test if the results of `prefetchiterator` without and with `cursormark` are actually the same.

Also changed the code order in the example. Although not wrong, it could be confusing.