### PR TITLE
[TASK] Allow to pass http DELETE requests

### DIFF
--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -130,6 +130,8 @@ class Curl extends Configurable implements AdapterInterface
             curl_setopt($handler, CURLOPT_HTTPGET, true);
         } elseif (Request::METHOD_HEAD == $method) {
             curl_setopt($handler, CURLOPT_CUSTOMREQUEST, 'HEAD');
+        } elseif (Request::METHOD_DELETE == $method) {
+            curl_setopt($handler, CURLOPT_CUSTOMREQUEST, 'DELETE');
         } else {
             throw new InvalidArgumentException("unsupported method: $method");
         }

--- a/src/Core/Client/Adapter/PeclHttp.php
+++ b/src/Core/Client/Adapter/PeclHttp.php
@@ -106,6 +106,9 @@ class PeclHttp extends Configurable implements AdapterInterface
             case Request::METHOD_HEAD:
                 $method = HTTP_METH_HEAD;
                 break;
+            case Request::METHOD_DELETE:
+                $method = HTTP_METH_DELETE;
+                break;
             default:
                 throw new InvalidArgumentException(
                     'Unsupported method: '.$request->getMethod()

--- a/src/Core/Client/Adapter/Zend2Http.php
+++ b/src/Core/Client/Adapter/Zend2Http.php
@@ -154,6 +154,10 @@ class Zend2Http extends Configurable implements AdapterInterface
                 $client->setMethod('HEAD');
                 $client->setParameterGet($request->getParams());
                 break;
+            case Request::METHOD_DELETE:
+                $client->setMethod('DELETE');
+                $client->setParameterGet($request->getParams());
+                break;
             default:
                 throw new OutOfBoundsException('Unsupported method: '.$request->getMethod());
                 break;

--- a/src/Core/Client/Adapter/ZendHttp.php
+++ b/src/Core/Client/Adapter/ZendHttp.php
@@ -155,6 +155,10 @@ class ZendHttp extends Configurable implements AdapterInterface
                 $client->setMethod(\Zend_Http_Client::HEAD);
                 $client->setParameterGet($request->getParams());
                 break;
+            case Request::METHOD_DELETE:
+                $client->setMethod(\Zend_Http_Client::DELETE);
+                $client->setParameterGet($request->getParams());
+                break;
             default:
                 throw new OutOfBoundsException('Unsupported method: '.$request->getMethod());
                 break;

--- a/src/Core/Client/Request.php
+++ b/src/Core/Client/Request.php
@@ -30,6 +30,11 @@ class Request extends Configurable implements RequestParamsInterface
     const METHOD_HEAD = 'HEAD';
 
     /**
+     * Request DELETE method.
+     */
+    const METHOD_DELETE = 'DELETE';
+
+    /**
      * Default options.
      *
      * @var array

--- a/tests/Core/Client/Adapter/CurlTest.php
+++ b/tests/Core/Client/Adapter/CurlTest.php
@@ -2,6 +2,7 @@
 
 namespace Solarium\Tests\Core\Client\Adapter;
 
+use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Solarium\Core\Client\Adapter\Curl;
@@ -65,5 +66,18 @@ class CurlTest extends TestCase
         $response = $mock->execute($request, $endpoint);
 
         $this->assertSame($data, $response);
+    }
+
+    public function testCanCreateHandleForDeleteRequest()
+    {
+        $request = new Request();
+        $request->setMethod(Request::METHOD_DELETE);
+        $endpoint = new Endpoint();
+
+        $curlAdapter = new Curl();
+        $handler = $curlAdapter->createHandle($request, $endpoint);
+
+        $this->assertInternalType(IsType::TYPE_RESOURCE, $handler);
+        curl_close($handler);
     }
 }

--- a/tests/Core/Client/Adapter/HttpTest.php
+++ b/tests/Core/Client/Adapter/HttpTest.php
@@ -203,4 +203,27 @@ class HttpTest extends TestCase
             stream_context_get_options($context)
         );
     }
+
+    public function testCreateContextForDeleteRequest()
+    {
+        $timeout = 22;
+        $method = Request::METHOD_DELETE;
+
+        $request = new Request();
+        $request->setMethod($method);
+        $endpoint = new Endpoint();
+        $endpoint->setTimeout($timeout);
+
+        $context = $this->adapter->createContext($request, $endpoint);
+
+        $this->assertSame(
+            [
+                'http' => [
+                    'method' => $method,
+                    'timeout' => $timeout,
+                ],
+            ],
+            stream_context_get_options($context)
+        );
+    }
 }

--- a/tests/Core/Client/Adapter/Zend2HttpTest.php
+++ b/tests/Core/Client/Adapter/Zend2HttpTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Solarium\Tests\Core\Client\Adapter;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Adapter\Zend2Http;
+use Solarium\Core\Client\Endpoint;
+use Solarium\Core\Client\Request;
+use Zend\Http\Client as ZendClient;
+use Zend\Http\Response as ZendResponse;
+
+class Zend2HttpTest extends TestCase
+{
+    /**
+     * @var Zend2Http
+     */
+    protected $adapter;
+
+    /**
+     * @var ZendClient
+     */
+    protected $zendClientMock;
+
+    /**
+     * @var ZendResponse
+     */
+    protected $zendResponseMock;
+
+    public function setUp()
+    {
+        $this->adapter = new Zend2Http();
+        $this->zendClientMock = $this->getMockBuilder(ZendClient::class)->setMethods([])->disableOriginalConstructor()->getMock();
+        $this->zendResponseMock = $this->getMockBuilder(ZendResponse::class)->setMethods([])->disableOriginalConstructor()->getMock();
+        $this->zendClientMock->expects($this->any())->method('send')->willReturn($this->zendResponseMock);
+        $this->adapter->setZendHttp($this->zendClientMock);
+    }
+
+    protected function fakeValidResponseHeader()
+    {
+        $this->zendResponseMock->expects($this->any())->method('renderStatusLine')->willReturn('HTTP/1.1 200 OK');
+    }
+
+    public function getAllowedHttpMethods()
+    {
+        return [
+            'get' => [Request::METHOD_GET, 'GET', ['foo' => 'bar']],
+            'post' => [Request::METHOD_POST, 'POST', ['foo' => 'bar']],
+            'head' => [Request::METHOD_HEAD, 'HEAD', ['foo' => 'bar']],
+            'delete' => [Request::METHOD_DELETE, 'DELETE', ['foo' => 'bar']],
+        ];
+    }
+
+    /**
+     * @param string $requestMethod
+     * @param string $passedHttpMethodString
+     * @param array  $passedGetParameters
+     * @dataProvider getAllowedHttpMethods
+     */
+    public function testExecute($requestMethod, $passedHttpMethodString, $passedGetParameters)
+    {
+        $this->fakeValidResponseHeader();
+
+        $request = new Request();
+        $request->setMethod($requestMethod);
+        $request->addParams($passedGetParameters);
+
+        $endpoint = new Endpoint();
+
+        $this->zendClientMock->expects($this->once())->method('setMethod')->with($passedHttpMethodString);
+        $this->zendClientMock->expects($this->once())->method('setParameterGet')->with($passedGetParameters);
+
+        $this->adapter->execute($request, $endpoint);
+    }
+}


### PR DESCRIPTION
This pr:

* Allows to pass DELETE requests to the underlying HttpAdapter
* This allows an application that uses solarium to execute thos requests, e.g. to delete managed resources
* Add's testcases

Fixes: #616