### PR TITLE
Solarium 3.x: Fix for #618 DateTime is not set to UTC when using Extract in v3.x

### DIFF
--- a/library/Solarium/QueryType/Extract/RequestBuilder.php
+++ b/library/Solarium/QueryType/Extract/RequestBuilder.php
@@ -87,6 +87,9 @@ class RequestBuilder extends BaseRequestBuilder
 
             // literal.*
             foreach ($doc->getFields() as $name => $value) {
+                if ($value instanceof \DateTime) {
+                    $value = $query->getHelper()->formatDate($value);
+                }
                 $value = (array) $value;
                 foreach ($value as $multival) {
                     $request->addParam('literal.'.$name, $multival);

--- a/tests/Solarium/Tests/QueryType/Extract/RequestBuilderTest.php
+++ b/tests/Solarium/Tests/QueryType/Extract/RequestBuilderTest.php
@@ -139,4 +139,26 @@ class RequestBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($headers,
                             $request->getHeaders());
     }
+
+    public function testDocumentDateTimeField()
+    {
+        $timezone = new \DateTimeZone('Europe/London');
+        $date = new \DateTime('2013-01-15 14:41:58', $timezone);
+        $document = $this->query->createDocument(array('date' => $date));
+        $this->query->setDocument($document);
+        $request = $this->builder->build($this->query);
+        $this->assertEquals(
+            array(
+                'fmap.from-field' => 'to-field',
+                'literal.date' => '2013-01-15T14:41:58Z',
+                'omitHeader' => 'true',
+                'extractOnly' => 'false',
+                'param1' => 'value1',
+                'resource.name' => 'RequestBuilderTest.php',
+                'wt' => 'json',
+                'json.nl' => 'flat',
+            ),
+            $request->getParams()
+        );
+    }
 }


### PR DESCRIPTION
Fix for https://github.com/solariumphp/solarium/issues/618