### PR TITLE
Updated composer to use latest Symfony event dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/event-dispatcher": "^2.7 || ^3.0"
+        "symfony/event-dispatcher": "^2.7 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^3.7",


### PR DESCRIPTION
I have updated composer.json to use v4 of Symfony event dispatcher.

I have run this through phpunit running on php7.1 (unable to do so on php7.2 due to a bug within this version of phpunit) and all checks pass, excepting 8 which were skipped.