### PR TITLE
Backward compatibility

### DIFF
--- a/src/Core/Client/Adapter/AdapterHelper.php
+++ b/src/Core/Client/Adapter/AdapterHelper.php
@@ -4,22 +4,39 @@ namespace Solarium\Core\Client\Adapter;
 
 use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
+use Solarium\Exception\HttpException;
+use Solarium\Exception\UnexpectedValueException;
 
 /**
  * Helper class for shared adapter functionality.
  */
 class AdapterHelper
 {
+    /**
+     * @param Request  $request
+     * @param Endpoint $endpoint
+     *
+     * @return string
+     *
+     * @throws HttpException
+     */
     public static function buildUri(Request $request, Endpoint $endpoint): string
     {
-        if (Request::API_V2 == $request->getApi()) {
-            $baseUri = $endpoint->getV2BaseUri();
-        } elseif ($request->getIsServerRequest()) {
-            $baseUri = $endpoint->getV1BaseUri();
-        } else {
-            $baseUri = $endpoint->getBaseUri();
+        try {
+            if (Request::API_V2 == $request->getApi()) {
+                $baseUri = $endpoint->getV2BaseUri();
+            } elseif ($request->getIsServerRequest()) {
+                $baseUri = $endpoint->getV1BaseUri();
+            } else {
+                $baseUri = $endpoint->getBaseUri();
+            }
+            return $baseUri . $request->getUri();
         }
-        return $baseUri.$request->getUri();
+        catch (UnexpectedValueException $e) {
+            // Backward compatibility: getBaseUri() now throws an UnexpectedValueException and we don't send a request.
+            // In previous version we sent the request which resulted in HttpException.
+            throw new HttpException($e->getMessage(), 404, $e->getTraceAsString());
+        }
     }
 
     /**

--- a/src/Core/Client/Adapter/AdapterHelper.php
+++ b/src/Core/Client/Adapter/AdapterHelper.php
@@ -31,8 +31,7 @@ class AdapterHelper
                 $baseUri = $endpoint->getBaseUri();
             }
             return $baseUri . $request->getUri();
-        }
-        catch (UnexpectedValueException $e) {
+        } catch (UnexpectedValueException $e) {
             // Backward compatibility: getBaseUri() now throws an UnexpectedValueException and we don't send a request.
             // In previous version we sent the request which resulted in HttpException.
             throw new HttpException($e->getMessage(), 404, $e->getTraceAsString());

--- a/src/Core/Client/Adapter/AdapterHelper.php
+++ b/src/Core/Client/Adapter/AdapterHelper.php
@@ -30,7 +30,7 @@ class AdapterHelper
             } else {
                 $baseUri = $endpoint->getBaseUri();
             }
-            return $baseUri . $request->getUri();
+            return $baseUri.$request->getUri();
         } catch (UnexpectedValueException $e) {
             // Backward compatibility: getBaseUri() now throws an UnexpectedValueException and we don't send a request.
             // In previous version we sent the request which resulted in HttpException.

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -39,7 +39,7 @@ class HttpException extends \RuntimeException implements ExceptionInterface
      * Exception constructor.
      *
      * The input message is a HTTP status message. Because an exception with the
-     * message 'Not Found' is not very clear it this message is tranformed to a
+     * message 'Not Found' is not very clear this message is transformed to a
      * more descriptive text. The original message is available using the
      * {@link getStatusMessage} method.
      *


### PR DESCRIPTION
getBaseUri() now throws an UnexpectedValueException and we don't send a request. In previous version we sent the request which resulted in HttpException.