### PR TITLE
range pivot

### DIFF
--- a/library/Solarium/QueryType/Select/Query/Component/Facet/Range.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Facet/Range.php
@@ -319,6 +319,42 @@ class Range extends AbstractFacet
     }
 
     /**
+     * @param string $tag
+     *
+     * @return \Solarium\Core\Configurable
+     */
+    public function setTag($tag)
+    {
+        return $this->setOption('tag', $tag);
+    }
+
+    /**
+     * @return string
+     */
+    public function getTag()
+    {
+        return $this->getOption('tag');
+    }
+
+    /**
+     * @param mixed $pivot
+     *
+     * @return \Solarium\Core\Configurable
+     */
+    public function setPivot($pivot)
+    {
+        return $this->setOption('pivot', $pivot);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPivot()
+    {
+        return $this->getOption('pivot');
+    }
+
+    /**
      * Initialize options.
      *
      * Several options need some extra checks or setup work, for these options

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/FacetSet.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/FacetSet.php
@@ -179,12 +179,13 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
     public function addFacetRange($request, $facet)
     {
         $field = $facet->getField();
+        $key = (null !== $facet->getTag()) ? array('tag' => $facet->getTag(), 'key' => $facet->getKey()) : array('key' => $facet->getKey());
 
         $request->addParam(
             'facet.range',
             $this->renderLocalParams(
                 $field,
-                array('key' => $facet->getKey(), 'ex' => $facet->getExcludes())
+                array_merge($key, array('ex' => $facet->getExcludes()))
             )
         );
 
@@ -200,6 +201,22 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
 
         foreach ($facet->getInclude() as $includeValue) {
             $request->addParam("f.$field.facet.range.include", $includeValue);
+        }
+
+        if (null !== $pivot = $facet->getPivot()) {
+            $link = $facet->getTag() ?: $facet->getKey();
+
+            if (!is_array($pivot)) {
+                $pivot = array($pivot);
+            }
+
+            $request->addParam(
+                'facet.pivot',
+                $this->renderLocalParams(
+                    implode(',', $pivot),
+                    array(FacetsetComponent::FACET_RANGE => $link)
+                )
+            );
         }
     }
 

--- a/library/Solarium/QueryType/Select/Result/Facet/Pivot/PivotItem.php
+++ b/library/Solarium/QueryType/Select/Result/Facet/Pivot/PivotItem.php
@@ -40,6 +40,7 @@
 
 namespace Solarium\QueryType\Select\Result\Facet\Pivot;
 
+use Solarium\QueryType\Select\Result\Facet\Range;
 use Solarium\QueryType\Select\Result\Stats\Stats;
 
 /**
@@ -76,6 +77,11 @@ class PivotItem extends Pivot
     protected $stats;
 
     /**
+     * @var \Solarium\QueryType\Select\Result\Facet\Range[]
+     */
+    protected $ranges;
+
+    /**
      * Constructor
      *
      * @param array $data
@@ -94,6 +100,19 @@ class PivotItem extends Pivot
 
         if (isset($data['stats'])) {
             $this->stats = new Stats($data['stats']);
+        }
+
+        if (isset($data['ranges'])) {
+            foreach ($data['ranges'] as $range) {
+                $before = (isset($range['before'])) ? $range['before'] : null;
+                $after = (isset($range['after'])) ? $range['after'] : null;
+                $between = (isset($range['between'])) ? $range['between'] : null;
+                $start = (isset($range['start'])) ? $range['start'] : null;
+                $end = (isset($range['end'])) ? $range['end'] : null;
+                $gap = (isset($range['gap'])) ? $range['gap'] : null;
+
+                $this->ranges[] = new Range($range['counts'], $before, $after, $between, $start, $end, $gap);
+            }
         }
     }
 
@@ -135,5 +154,15 @@ class PivotItem extends Pivot
     public function getStats()
     {
         return $this->stats;
+    }
+
+    /**
+     * Get ranges.
+     *
+     * @return \Solarium\QueryType\Select\Result\Facet\Range[]
+     */
+    public function getRanges()
+    {
+        return $this->ranges;
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Facet/Range.php
+++ b/library/Solarium/QueryType/Select/Result/Facet/Range.php
@@ -95,6 +95,11 @@ class Range extends Field
     protected $gap;
 
     /**
+     * @var \Solarium\QueryType\Select\Result\Facet\Pivot\Pivot
+     */
+    protected $pivot;
+
+    /**
      * Constructor.
      *
      * @param array $values
@@ -104,8 +109,9 @@ class Range extends Field
      * @param int   $start
      * @param int   $end
      * @param int   $gap
+     * @param null  $pivot
      */
-    public function __construct($values, $before, $after, $between, $start, $end, $gap)
+    public function __construct($values, $before, $after, $between, $start, $end, $gap, $pivot = null)
     {
         $this->values = $values;
         $this->before = $before;
@@ -114,6 +120,7 @@ class Range extends Field
         $this->start = $start;
         $this->end = $end;
         $this->gap = $gap;
+        $this->pivot = $pivot;
     }
 
     /**
@@ -189,5 +196,13 @@ class Range extends Field
     public function getGap()
     {
         return $this->gap;
+    }
+
+    /**
+     * @return \Solarium\QueryType\Select\Result\Facet\Pivot\Pivot|null
+     */
+    public function getPivot()
+    {
+        return $this->pivot;
     }
 }


### PR DESCRIPTION
hi thre,

i needed to implement a [range pivot](https://lucene.apache.org/solr/guide/6_6/faceting.html#Faceting-CombiningFacetQueriesAndFacetRangesWithPivotFacets) and could not find a way to implement this using solarium so i made some changes to be able to.

as you can see this pr is targeting the 3.x branch as that's the one we're currently usinng.

i'm willing to target the 4.x branch and write some unittests for this feature, but
- are you interested in this feature at all?
- will it be available in the 3.x branch as i donn't know when we've got time to upgrade

the givenn example can now be achieved by:
```php
$facetSet = $query->getFacetSet();
$facet = $facetSet->createFacetRange(['key' => 'manufacturedate_dt', 'tag' => 'r1']);

$facet->setField('manufacturedate_dt');
$facet->setStart('2006-01-01T00:00:00Z');
$facet->setEnd('NOW/YEAR'));
$facet->setGap('+1YEAR');
$facet->setPivot(['cat', 'inStock']);
```