### PR TITLE
Solarium 3.x: ci failure fixes

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,37 @@
+<?php
+
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+       '@PHP56Migration' => true,
+       '@Symfony' => true,
+       '@Symfony:risky' => true,
+       'class_attributes_separation' => ['elements' => ['const', 'method', 'property']],
+       'combine_consecutive_unsets' => true,
+       // one should use PHPUnit methods to set up expected exception instead of annotations
+       'general_phpdoc_annotation_remove' => ['expectedException', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp'],
+       'heredoc_to_nowdoc' => true,
+       'list_syntax' => ['syntax' => 'long'],
+       'method_argument_space' => ['keep_multiple_spaces_after_comma' => false],
+       'no_extra_consecutive_blank_lines' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block'],
+       'no_short_echo_tag' => true,
+       'no_unreachable_default_argument_value' => true,
+       'no_useless_else' => true,
+       'no_useless_return' => true,
+       'ordered_class_elements' => true,
+       'ordered_imports' => true,
+       // 'php_unit_strict' => true,
+       // 'php_unit_test_class_requires_covers' => true,
+       'phpdoc_add_missing_param_annotation' => true,
+       'phpdoc_order' => true,
+       'semicolon_after_instruction' => true,
+       // 'strict_comparison' => true,
+       'strict_param' => true,
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->exclude('vendor/')
+            ->in('library')
+    )
+;
+

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,13 @@
+preset: symfony
+
+finder:
+    path:
+        - "library"
+
+disabled:
+    - blank_line_before_break
+    - blank_line_before_continue
+    - blank_line_before_declare
+    - blank_line_before_return
+    - blank_line_before_throw
+    - blank_line_before_try

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 7.1
   - 7.0
   - 5.6
-  - hhvm
+  - hhvm-3.3
   - nightly
 
 env:
@@ -26,8 +26,8 @@ before_install:
   - tar -xzf solr-${SOLR_VERSION}.tgz
 
 before_script:
-#  - pecl install pecl_http
-  - composer require --prefer-source --dev symfony/event-dispatcher:${SYMFONY_VERSION}
+  #  - pecl install pecl_http
+  - COMPOSER_MEMORY_LIMIT=-1 composer require --prefer-source symfony/event-dispatcher:${SYMFONY_VERSION}
   - solr-${SOLR_VERSION}/bin/solr start -e techproducts
 
 script: vendor/bin/phpunit -c phpunit.xml.travis -v
@@ -37,13 +37,13 @@ after_success:
 
 matrix:
   exclude:
-      - php: 7.0
-        env: SYMFONY_VERSION=4.0.* SOLR_VERSION=6.6.2
-      - php: 5.6
-        env: SYMFONY_VERSION=4.0.* SOLR_VERSION=6.6.2
-      - php: hhvm
-        env: SYMFONY_VERSION=4.0.* SOLR_VERSION=6.6.2
+    - php: 7.0
+      env: SYMFONY_VERSION=4.0.* SOLR_VERSION=6.6.2
+    - php: 5.6
+      env: SYMFONY_VERSION=4.0.* SOLR_VERSION=6.6.2
+    - php: hhvm-3.3
+      env: SYMFONY_VERSION=4.0.* SOLR_VERSION=6.6.2
   allow_failures:
-      - php: nightly
+    - php: nightly
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/event-dispatcher": "^2.7 || ^3.0 || ^4.0"
+        "symfony/event-dispatcher": "^2.1 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^3.7",
         "squizlabs/php_codesniffer": "^1.4",
         "zendframework/zendframework1": "^1.12",
-        "satooshi/php-coveralls": "^1.0",
-        "guzzlehttp/guzzle": "^3.8 || ^6.2"
+        "satooshi/php-coveralls": "^1.1",
+        "guzzlehttp/guzzle": "^3.8.1 || ^6.2"
     },
     "suggest": {
         "minimalcode/search": "Query builder compatible with Solarium, allows simplified solr-query handling"

--- a/library/Solarium/Autoloader.php
+++ b/library/Solarium/Autoloader.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -81,14 +81,14 @@ class Autoloader
      */
     public static function load($class)
     {
-        if (substr($class, 0, 8) == 'Solarium') {
+        if ('Solarium' == substr($class, 0, 8)) {
             $class = str_replace(
                 array('Solarium', '\\'),
                 array('', '/'),
                 $class
             );
 
-            $file = dirname(__FILE__).$class.'.php';
+            $file = __DIR__.$class.'.php';
 
             require $file;
         }

--- a/library/Solarium/Client.php
+++ b/library/Solarium/Client.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -100,11 +100,11 @@ class Client extends CoreClient
      *
      * @param string $version
      *
-     * @return boolean
+     * @return bool
      */
     public static function checkExact($version)
     {
-        return (substr(self::VERSION, 0, strlen($version)) == $version);
+        return substr(self::VERSION, 0, \strlen($version)) == $version;
     }
 
     /**
@@ -128,7 +128,7 @@ class Client extends CoreClient
      *
      * @param string $version
      *
-     * @return boolean
+     * @return bool
      */
     public static function checkMinimal($version)
     {

--- a/library/Solarium/Core/Client/Adapter/AdapterInterface.php
+++ b/library/Solarium/Core/Client/Adapter/AdapterInterface.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,10 +40,10 @@
 
 namespace Solarium\Core\Client\Adapter;
 
-use Solarium\Core\ConfigurableInterface;
+use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Core\Client\Endpoint;
+use Solarium\Core\ConfigurableInterface;
 
 /**
  * Interface for client adapters.

--- a/library/Solarium/Core/Client/Adapter/Curl.php
+++ b/library/Solarium/Core/Client/Adapter/Curl.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,13 +40,13 @@
 
 namespace Solarium\Core\Client\Adapter;
 
-use Solarium\Core\Configurable;
+use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Core\Client\Endpoint;
+use Solarium\Core\Configurable;
+use Solarium\Exception\HttpException;
 use Solarium\Exception\InvalidArgumentException;
 use Solarium\Exception\RuntimeException;
-use Solarium\Exception\HttpException;
 
 /**
  * cURL HTTP adapter.
@@ -79,7 +79,7 @@ class Curl extends Configurable implements AdapterInterface
     public function getResponse($handle, $httpResponse)
     {
         // @codeCoverageIgnoreStart
-        if ($httpResponse !== false && $httpResponse !== null) {
+        if (false !== $httpResponse && null !== $httpResponse) {
             $data = $httpResponse;
             $info = curl_getinfo($handle);
             $headers = array();
@@ -99,10 +99,11 @@ class Curl extends Configurable implements AdapterInterface
     /**
      * Create curl handle for a request.
      *
-     * @throws InvalidArgumentException
      *
      * @param Request  $request
      * @param Endpoint $endpoint
+     *
+     * @throws InvalidArgumentException
      *
      * @return resource
      */
@@ -116,7 +117,7 @@ class Curl extends Configurable implements AdapterInterface
         $handler = curl_init();
         curl_setopt($handler, CURLOPT_URL, $uri);
         curl_setopt($handler, CURLOPT_RETURNTRANSFER, true);
-        if (!(function_exists('ini_get') && ini_get('open_basedir'))) {
+        if (!(\function_exists('ini_get') && ini_get('open_basedir'))) {
             curl_setopt($handler, CURLOPT_FOLLOWLOCATION, true);
         }
         curl_setopt($handler, CURLOPT_TIMEOUT, $options['timeout']);
@@ -127,7 +128,7 @@ class Curl extends Configurable implements AdapterInterface
         }
 
         if (!isset($options['headers']['Content-Type'])) {
-            if($method == Request::METHOD_GET){
+            if (Request::METHOD_GET == $method) {
                 $options['headers']['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
             } else {
                 $options['headers']['Content-Type'] = 'application/xml; charset=utf-8';
@@ -145,15 +146,15 @@ class Curl extends Configurable implements AdapterInterface
             curl_setopt($handler, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
         }
 
-        if (count($options['headers'])) {
+        if (\count($options['headers'])) {
             $headers = array();
             foreach ($options['headers'] as $key => $value) {
-                $headers[] = $key.": ".$value;
+                $headers[] = $key.': '.$value;
             }
             curl_setopt($handler, CURLOPT_HTTPHEADER, $headers);
         }
 
-        if ($method == Request::METHOD_POST) {
+        if (Request::METHOD_POST == $method) {
             curl_setopt($handler, CURLOPT_POST, true);
 
             if ($request->getFileUpload()) {
@@ -166,9 +167,9 @@ class Curl extends Configurable implements AdapterInterface
             } else {
                 curl_setopt($handler, CURLOPT_POSTFIELDS, $request->getRawData());
             }
-        } elseif ($method == Request::METHOD_GET) {
+        } elseif (Request::METHOD_GET == $method) {
             curl_setopt($handler, CURLOPT_HTTPGET, true);
-        } elseif ($method == Request::METHOD_HEAD) {
+        } elseif (Request::METHOD_HEAD == $method) {
             curl_setopt($handler, CURLOPT_CUSTOMREQUEST, 'HEAD');
         } else {
             throw new InvalidArgumentException("unsupported method: $method");
@@ -181,17 +182,18 @@ class Curl extends Configurable implements AdapterInterface
     /**
      * Check result of a request.
      *
-     * @throws HttpException
      *
      * @param string   $data
      * @param array    $headers
      * @param resource $handle
+     *
+     * @throws HttpException
      */
     public function check($data, $headers, $handle)
     {
         // if there is no data and there are no headers it's a total failure,
         // a connection to the host was impossible.
-        if (empty($data) && count($headers) == 0) {
+        if (empty($data) && 0 == \count($headers)) {
             throw new HttpException('HTTP request failed, '.curl_error($handle));
         }
     }
@@ -224,7 +226,7 @@ class Curl extends Configurable implements AdapterInterface
     protected function init()
     {
         // @codeCoverageIgnoreStart
-        if (!function_exists('curl_init')) {
+        if (!\function_exists('curl_init')) {
             throw new RuntimeException('cURL is not available, install it to use the CurlHttp adapter');
         }
 

--- a/library/Solarium/Core/Client/Adapter/Guzzle.php
+++ b/library/Solarium/Core/Client/Adapter/Guzzle.php
@@ -2,7 +2,7 @@
 /**
  * Copyright 2011 Bas de Nooijer. All rights reserved.
  * * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * modification, are permitted provided that the following conditions are met:.
  *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
@@ -30,17 +30,17 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 namespace Solarium\Core\Client\Adapter;
 
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\RequestOptions;
-use Solarium\Core\Configurable;
+use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Core\Client\Endpoint;
+use Solarium\Core\Configurable;
 use Solarium\Exception\HttpException;
 
 /**
@@ -58,12 +58,13 @@ class Guzzle extends Configurable implements AdapterInterface
     /**
      * Execute a Solr request using the cURL Http.
      *
-     * @param Request  $request  The incoming Solr request.
-     * @param Endpoint $endpoint The configured Solr endpoint.
+     * @param Request  $request  the incoming Solr request
+     * @param Endpoint $endpoint the configured Solr endpoint
+     *
+     * @throws HttpException thrown if solr request connot be made
      *
      * @return Response
      *
-     * @throws HttpException Thrown if solr request connot be made.
      *
      * @codingStandardsIgnoreStart AdapterInterface does not declare type-hints
      */
@@ -90,20 +91,20 @@ class Guzzle extends Configurable implements AdapterInterface
         try {
             $guzzleResponse = $this->getGuzzleClient()->request(
                 $request->getMethod(),
-                $endpoint->getBaseUri() . $request->getUri(),
+                $endpoint->getBaseUri().$request->getUri(),
                 $requestOptions
             );
 
             $responseHeaders = [
                 "HTTP/{$guzzleResponse->getProtocolVersion()} {$guzzleResponse->getStatusCode()} "
-                . $guzzleResponse->getReasonPhrase(),
+                .$guzzleResponse->getReasonPhrase(),
             ];
 
             foreach ($guzzleResponse->getHeaders() as $key => $value) {
-                $responseHeaders[] = "{$key}: " . implode(', ', $value);
+                $responseHeaders[] = "{$key}: ".implode(', ', $value);
             }
 
-            return new Response((string)$guzzleResponse->getBody(), $responseHeaders);
+            return new Response((string) $guzzleResponse->getBody(), $responseHeaders);
         } catch (\GuzzleHttp\Exception\RequestException $e) {
             $error = $e->getMessage();
             throw new HttpException("HTTP request failed, {$error}");
@@ -117,7 +118,7 @@ class Guzzle extends Configurable implements AdapterInterface
      */
     public function getGuzzleClient()
     {
-        if ($this->guzzleClient === null) {
+        if (null === $this->guzzleClient) {
             $this->guzzleClient = new GuzzleClient($this->options);
         }
 
@@ -127,13 +128,13 @@ class Guzzle extends Configurable implements AdapterInterface
     /**
      * Helper method to create a request body suitable for a guzzle 3 request.
      *
-     * @param Request $request The incoming solarium request.
+     * @param Request $request the incoming solarium request
      *
-     * @return null|resource|string
+     * @return resource|string|null
      */
     private function getRequestBody(Request $request)
     {
-        if ($request->getMethod() !== Request::METHOD_POST) {
+        if (Request::METHOD_POST !== $request->getMethod()) {
             return null;
         }
 
@@ -148,7 +149,7 @@ class Guzzle extends Configurable implements AdapterInterface
      * Helper method to extract headers from the incoming solarium request and put them in a format
      * suitable for a guzzle 3 request.
      *
-     * @param Request $request The incoming solarium request.
+     * @param Request $request the incoming solarium request
      *
      * @return array
      */
@@ -163,7 +164,7 @@ class Guzzle extends Configurable implements AdapterInterface
         }
 
         if (!isset($headers['Content-Type'])) {
-            if ($request->getMethod() == Request::METHOD_GET) {
+            if (Request::METHOD_GET == $request->getMethod()) {
                 $headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
             } else {
                 $headers['Content-Type'] = 'application/xml; charset=utf-8';

--- a/library/Solarium/Core/Client/Adapter/Guzzle3.php
+++ b/library/Solarium/Core/Client/Adapter/Guzzle3.php
@@ -2,7 +2,7 @@
 /**
  * Copyright 2011 Bas de Nooijer. All rights reserved.
  * * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * modification, are permitted provided that the following conditions are met:.
  *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
@@ -30,7 +30,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,10 +40,10 @@
 namespace Solarium\Core\Client\Adapter;
 
 use Guzzle\Http\Client as GuzzleClient;
-use Solarium\Core\Configurable;
+use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Core\Client\Endpoint;
+use Solarium\Core\Configurable;
 use Solarium\Exception\HttpException;
 
 /**
@@ -70,7 +70,7 @@ class Guzzle3 extends Configurable implements AdapterInterface
     {
         $guzzleRequest = $this->getGuzzleClient()->createRequest(
             $request->getMethod(),
-            $endpoint->getBaseUri() . $request->getUri(),
+            $endpoint->getBaseUri().$request->getUri(),
             $this->getRequestHeaders($request),
             $this->getRequestBody($request),
             array(
@@ -99,7 +99,7 @@ class Guzzle3 extends Configurable implements AdapterInterface
                 $guzzleResponse->getHeaderLines()
             );
 
-             return new Response($guzzleResponse->getBody(true), $responseHeaders);
+            return new Response($guzzleResponse->getBody(true), $responseHeaders);
         } catch (\Guzzle\Http\Exception\RequestException $e) {
             $error = $e->getMessage();
             if ($e instanceof \Guzzle\Http\Exception\CurlException) {
@@ -117,7 +117,7 @@ class Guzzle3 extends Configurable implements AdapterInterface
      */
     public function getGuzzleClient()
     {
-        if ($this->guzzleClient === null) {
+        if (null === $this->guzzleClient) {
             $this->guzzleClient = new GuzzleClient(null, $this->options);
         }
 
@@ -127,13 +127,13 @@ class Guzzle3 extends Configurable implements AdapterInterface
     /**
      * Helper method to create a request body suitable for a guzzle 3 request.
      *
-     * @param Request $request The incoming solarium request.
+     * @param Request $request the incoming solarium request
      *
-     * @return null|resource|string
+     * @return resource|string|null
      */
     private function getRequestBody(Request $request)
     {
-        if ($request->getMethod() !== Request::METHOD_POST) {
+        if (Request::METHOD_POST !== $request->getMethod()) {
             return null;
         }
 
@@ -148,7 +148,7 @@ class Guzzle3 extends Configurable implements AdapterInterface
      * Helper method to extract headers from the incoming solarium request and put them in a format
      * suitable for a guzzle 3 request.
      *
-     * @param Request $request The incoming solarium request.
+     * @param Request $request the incoming solarium request
      *
      * @return array
      */
@@ -163,7 +163,7 @@ class Guzzle3 extends Configurable implements AdapterInterface
         }
 
         if (!isset($headers['Content-Type'])) {
-            if ($request->getMethod() == Request::METHOD_GET) {
+            if (Request::METHOD_GET == $request->getMethod()) {
                 $headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
             } else {
                 $headers['Content-Type'] = 'application/xml; charset=utf-8';

--- a/library/Solarium/Core/Client/Adapter/Http.php
+++ b/library/Solarium/Core/Client/Adapter/Http.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,10 +40,10 @@
 
 namespace Solarium\Core\Client\Adapter;
 
-use Solarium\Core\Configurable;
+use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Core\Client\Endpoint;
+use Solarium\Core\Configurable;
 use Solarium\Exception\HttpException;
 
 /**
@@ -54,10 +54,11 @@ class Http extends Configurable implements AdapterInterface
     /**
      * Handle Solr communication.
      *
-     * @throws HttpException
      *
      * @param Request  $request
      * @param Endpoint $endpoint
+     *
+     * @throws HttpException
      *
      * @return Response
      */
@@ -76,17 +77,18 @@ class Http extends Configurable implements AdapterInterface
     /**
      * Check result of a request.
      *
-     * @throws HttpException
      *
      * @param string $data
      * @param array  $headers
+     *
+     * @throws HttpException
      */
     public function check($data, $headers)
     {
         // if there is no data and there are no headers it's a total failure,
         // a connection to the host was impossible.
-        if (false === $data && count($headers) == 0) {
-            throw new HttpException("HTTP request failed");
+        if (false === $data && 0 == \count($headers)) {
+            throw new HttpException('HTTP request failed');
         }
     }
 
@@ -108,25 +110,25 @@ class Http extends Configurable implements AdapterInterface
             ),
         ));
 
-        if ($method == Request::METHOD_POST) {
+        if (Request::METHOD_POST == $method) {
             if ($request->getFileUpload()) {
-                $boundary = '----------' . md5(time());
+                $boundary = '----------'.md5(time());
                 $CRLF = "\r\n";
                 $file = $request->getFileUpload();
                 // Add the proper boundary to the Content-Type header
                 $headers = $request->getHeaders();
                 // Remove the Content-Type header, because we will replace it with something else.
-                if (($key = array_search("Content-Type: multipart/form-data", $headers)) !== false) {
+                if (false !== ($key = array_search('Content-Type: multipart/form-data', $headers, true))) {
                     unset($headers[$key]);
                 }
                 $request->setHeaders($headers);
                 $request->addHeader("Content-Type: multipart/form-data; boundary={$boundary}");
-                $data =  "--{$boundary}" . $CRLF;
-                $data .= 'Content-Disposition: form-data; name="upload"; filename=' . $file . $CRLF;
-                $data .= 'Content-Type: application/octet-stream' . $CRLF . $CRLF;
-                $data .= file_get_contents($file) . $CRLF;
-                $data .= '--' . $boundary . '--';
-                $content_length = strlen($data);
+                $data = "--{$boundary}".$CRLF;
+                $data .= 'Content-Disposition: form-data; name="upload"; filename='.$file.$CRLF;
+                $data .= 'Content-Type: application/octet-stream'.$CRLF.$CRLF;
+                $data .= file_get_contents($file).$CRLF;
+                $data .= '--'.$boundary.'--';
+                $content_length = \strlen($data);
                 $request->addHeader("Content-Length: $content_length\r\n");
                 stream_context_set_option(
                     $context,
@@ -162,7 +164,7 @@ class Http extends Configurable implements AdapterInterface
         }
 
         $headers = $request->getHeaders();
-        if (count($headers) > 0) {
+        if (\count($headers) > 0) {
             stream_context_set_option(
                 $context,
                 'http',

--- a/library/Solarium/Core/Client/Adapter/PeclHttp.php
+++ b/library/Solarium/Core/Client/Adapter/PeclHttp.php
@@ -32,7 +32,7 @@
  * @copyright Copyright 2011 Gasol Wu <gasol.wu@gmail.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -41,13 +41,13 @@
 
 namespace Solarium\Core\Client\Adapter;
 
-use Solarium\Core\Configurable;
+use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Core\Client\Endpoint;
-use Solarium\Exception\RuntimeException;
+use Solarium\Core\Configurable;
 use Solarium\Exception\HttpException;
 use Solarium\Exception\InvalidArgumentException;
+use Solarium\Exception\RuntimeException;
 
 /**
  * Pecl HTTP adapter.
@@ -59,10 +59,11 @@ class PeclHttp extends Configurable implements AdapterInterface
     /**
      * Execute a Solr request using the Pecl Http.
      *
-     * @throws HttpException
      *
      * @param Request  $request
      * @param Endpoint $endpoint
+     *
+     * @throws HttpException
      *
      * @return Response
      */
@@ -91,10 +92,11 @@ class PeclHttp extends Configurable implements AdapterInterface
      * {@link http://us.php.net/manual/en/http.request.options.php
      *  HttpRequest options}
      *
-     * @throws InvalidArgumentException
      *
      * @param Request  $request
      * @param Endpoint $endpoint
+     *
+     * @throws InvalidArgumentException
      *
      * @return \HttpRequest
      */

--- a/library/Solarium/Core/Client/Adapter/Zend2Http.php
+++ b/library/Solarium/Core/Client/Adapter/Zend2Http.php
@@ -33,24 +33,26 @@
  * @copyright Copyright 2012 Alexander Brausewetter <alex@helpdeskhq.com>
  * @copyright Copyright 2014 Marin Purgar <marin.purgar@gmail.com.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
- * @link http://www.solarium-project.org/
+ *
+ * @see http://www.solarium-project.org/
  */
 
 /**
  * @namespace
  */
+
 namespace Solarium\Core\Client\Adapter;
 
-use Solarium\Core\Configurable;
 use Solarium\Core\Client;
+use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Core\Client\Endpoint;
+use Solarium\Core\Configurable;
 use Solarium\Exception\HttpException;
 use Solarium\Exception\OutOfBoundsException;
 
 /**
- * Adapter that uses a ZF2 Zend\Http\Client
+ * Adapter that uses a ZF2 Zend\Http\Client.
  *
  * The Zend Framework HTTP client has many great features and has lots of
  * configuration options. For more info see the manual at
@@ -61,7 +63,7 @@ use Solarium\Exception\OutOfBoundsException;
 class Zend2Http extends Configurable implements AdapterInterface
 {
     /**
-     * Zend Http instance for communication with Solr
+     * Zend Http instance for communication with Solr.
      *
      * @var \Zend\Http\Client
      */
@@ -73,7 +75,7 @@ class Zend2Http extends Configurable implements AdapterInterface
     protected $timeout;
 
     /**
-     * Set options
+     * Set options.
      *
      * Overrides any existing values.
      *
@@ -84,9 +86,10 @@ class Zend2Http extends Configurable implements AdapterInterface
      * The $options param should be an array or an object that has a toArray
      * method, like Zend_Config
      *
-     * @param  array|object $options
-     * @param  boolean      $overwrite
-     * @return self         Provides fluent interface
+     * @param array|object $options
+     * @param bool         $overwrite
+     *
+     * @return self Provides fluent interface
      */
     public function setOptions($options, $overwrite = false)
     {
@@ -94,7 +97,6 @@ class Zend2Http extends Configurable implements AdapterInterface
 
         // forward options to zendHttp instance
         if (null !== $this->zendHttp) {
-
             // forward timeout setting
             $adapterOptions = array();
 
@@ -110,14 +112,15 @@ class Zend2Http extends Configurable implements AdapterInterface
     }
 
     /**
-     * Set the Zend\Http\Client instance
+     * Set the Zend\Http\Client instance.
      *
      * This method is optional, if you don't set a client it will be created
      * upon first use, using default and/or custom options (the most common use
      * case)
      *
-     * @param  \Zend\Http\Client $zendHttp
-     * @return self              Provides fluent interface
+     * @param \Zend\Http\Client $zendHttp
+     *
+     * @return self Provides fluent interface
      */
     public function setZendHttp($zendHttp)
     {
@@ -127,7 +130,7 @@ class Zend2Http extends Configurable implements AdapterInterface
     }
 
     /**
-     * Get the Zend\Http\Client instance
+     * Get the Zend\Http\Client instance.
      *
      * If no instance is available yet it will be created automatically based on
      * options.
@@ -158,12 +161,14 @@ class Zend2Http extends Configurable implements AdapterInterface
     }
 
     /**
-     * Execute a Solr request using the Zend\Http\Client instance
+     * Execute a Solr request using the Zend\Http\Client instance.
+     *
+     * @param Request  $request
+     * @param Endpoint $endpoint
      *
      * @throws HttpException
      * @throws OutOfBoundsException
-     * @param  Request              $request
-     * @param  Endpoint             $endpoint
+     *
      * @return Response
      */
     public function execute($request, $endpoint)
@@ -191,11 +196,11 @@ class Zend2Http extends Configurable implements AdapterInterface
                 $client->setParameterGet($request->getParams());
                 break;
             default:
-                throw new OutOfBoundsException('Unsupported method: ' . $request->getMethod());
+                throw new OutOfBoundsException('Unsupported method: '.$request->getMethod());
                 break;
         }
 
-        $client->setUri($endpoint->getBaseUri() . $request->getHandler());
+        $client->setUri($endpoint->getBaseUri().$request->getHandler());
         $client->setHeaders($request->getHeaders());
         $this->timeout = $endpoint->getTimeout();
 
@@ -209,11 +214,13 @@ class Zend2Http extends Configurable implements AdapterInterface
 
     /**
      * Prepare a solarium response from the given request and client
-     * response
+     * response.
+     *
+     * @param Request             $request
+     * @param \Zend\Http\Response $response
      *
      * @throws HttpException
-     * @param  Request             $request
-     * @param  \Zend\Http\Response $response
+     *
      * @return Response
      */
     protected function prepareResponse($request, $response)
@@ -225,7 +232,7 @@ class Zend2Http extends Configurable implements AdapterInterface
             );
         }
 
-        if ($request->getMethod() == Request::METHOD_HEAD) {
+        if (Request::METHOD_HEAD == $request->getMethod()) {
             $data = '';
         } else {
             $data = $response->getBody();
@@ -238,11 +245,10 @@ class Zend2Http extends Configurable implements AdapterInterface
     }
 
     /**
-     * Prepare the client to send the file and params in request
+     * Prepare the client to send the file and params in request.
      *
-     * @param  \Zend\Http\Client $client
-     * @param  Request           $request
-     * @return void
+     * @param \Zend\Http\Client $client
+     * @param Request           $request
      */
     protected function prepareFileUpload($client, $request)
     {

--- a/library/Solarium/Core/Client/Adapter/ZendHttp.php
+++ b/library/Solarium/Core/Client/Adapter/ZendHttp.php
@@ -33,7 +33,7 @@
  * @copyright Copyright 2012 Alexander Brausewetter <alex@helpdeskhq.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -42,11 +42,11 @@
 
 namespace Solarium\Core\Client\Adapter;
 
-use Solarium\Core\Configurable;
 use Solarium\Core\Client;
+use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Core\Client\Endpoint;
+use Solarium\Core\Configurable;
 use Solarium\Exception\HttpException;
 use Solarium\Exception\OutOfBoundsException;
 
@@ -86,7 +86,7 @@ class ZendHttp extends Configurable implements AdapterInterface
      * method, like Zend_Config
      *
      * @param array|object $options
-     * @param boolean      $overwrite
+     * @param bool         $overwrite
      *
      * @return self Provides fluent interface
      */
@@ -162,11 +162,12 @@ class ZendHttp extends Configurable implements AdapterInterface
     /**
      * Execute a Solr request using the Zend_Http_Client instance.
      *
-     * @throws HttpException
-     * @throws OutOfBoundsException
      *
      * @param Request  $request
      * @param Endpoint $endpoint
+     *
+     * @throws HttpException
+     * @throws OutOfBoundsException
      *
      * @return Response
      */
@@ -215,10 +216,11 @@ class ZendHttp extends Configurable implements AdapterInterface
      * Prepare a solarium response from the given request and client
      * response.
      *
-     * @throws HttpException
      *
      * @param Request             $request
      * @param \Zend_Http_Response $response
+     *
+     * @throws HttpException
      *
      * @return Response
      */
@@ -231,7 +233,7 @@ class ZendHttp extends Configurable implements AdapterInterface
             );
         }
 
-        if ($request->getMethod() == Request::METHOD_HEAD) {
+        if (Request::METHOD_HEAD == $request->getMethod()) {
             $data = '';
         } else {
             $data = $response->getBody();

--- a/library/Solarium/Core/Client/Client.php
+++ b/library/Solarium/Core/Client/Client.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,27 +40,27 @@
 
 namespace Solarium\Core\Client;
 
+use Solarium\Core\Client\Adapter\AdapterInterface;
 use Solarium\Core\Configurable;
+use Solarium\Core\Event\Events;
+use Solarium\Core\Event\PostCreateQuery as PostCreateQueryEvent;
+use Solarium\Core\Event\PostCreateRequest as PostCreateRequestEvent;
+use Solarium\Core\Event\PostCreateResult as PostCreateResultEvent;
+use Solarium\Core\Event\PostExecute as PostExecuteEvent;
+use Solarium\Core\Event\PostExecuteRequest as PostExecuteRequestEvent;
+use Solarium\Core\Event\PreCreateQuery as PreCreateQueryEvent;
+use Solarium\Core\Event\PreCreateRequest as PreCreateRequestEvent;
+use Solarium\Core\Event\PreCreateResult as PreCreateResultEvent;
+use Solarium\Core\Event\PreExecute as PreExecuteEvent;
+use Solarium\Core\Event\PreExecuteRequest as PreExecuteRequestEvent;
 use Solarium\Core\Plugin\PluginInterface;
 use Solarium\Core\Query\QueryInterface;
-use Solarium\Core\Query\Result\ResultInterface;
-use Solarium\Core\Client\Adapter\AdapterInterface;
 use Solarium\Core\Query\RequestBuilderInterface;
+use Solarium\Core\Query\Result\ResultInterface;
 use Solarium\Exception\InvalidArgumentException;
 use Solarium\Exception\OutOfBoundsException;
 use Solarium\Exception\UnexpectedValueException;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Solarium\Core\Event\Events;
-use Solarium\Core\Event\PreCreateRequest as PreCreateRequestEvent;
-use Solarium\Core\Event\PostCreateRequest as PostCreateRequestEvent;
-use Solarium\Core\Event\PreCreateQuery as PreCreateQueryEvent;
-use Solarium\Core\Event\PostCreateQuery as PostCreateQueryEvent;
-use Solarium\Core\Event\PreCreateResult as PreCreateResultEvent;
-use Solarium\Core\Event\PostCreateResult as PostCreateResultEvent;
-use Solarium\Core\Event\PreExecute as PreExecuteEvent;
-use Solarium\Core\Event\PostExecute as PostExecuteEvent;
-use Solarium\Core\Event\PreExecuteRequest as PreExecuteRequestEvent;
-use Solarium\Core\Event\PostExecuteRequest as PostExecuteRequestEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -226,7 +226,7 @@ class Client extends Configurable implements ClientInterface
      * If an EventDispatcher instance is provided this will be used instead of creating a new instance
      *
      * @param array|\Zend_Config $options
-     * @param EventDispatcher $eventDispatcher
+     * @param EventDispatcher    $eventDispatcher
      */
     public function __construct($options = null, $eventDispatcher = null)
     {
@@ -244,23 +244,23 @@ class Client extends Configurable implements ClientInterface
      * When no key is supplied the endpoint cannot be registered, in that case you will need to do this manually
      * after setting the key, by using the addEndpoint method.
      *
-     * @param mixed   $options
-     * @param boolean $setAsDefault
+     * @param mixed $options
+     * @param bool  $setAsDefault
      *
      * @return Endpoint
      */
     public function createEndpoint($options = null, $setAsDefault = false)
     {
-        if (is_string($options)) {
+        if (\is_string($options)) {
             $endpoint = new Endpoint();
             $endpoint->setKey($options);
         } else {
             $endpoint = new Endpoint($options);
         }
 
-        if ($endpoint->getKey() !== null) {
+        if (null !== $endpoint->getKey()) {
             $this->addEndpoint($endpoint);
-            if ($setAsDefault === true) {
+            if (true === $setAsDefault) {
                 $this->setDefaultEndpoint($endpoint);
             }
         }
@@ -274,34 +274,34 @@ class Client extends Configurable implements ClientInterface
      * Supports a endpoint instance or a config array as input.
      * In case of options a new endpoint instance wil be created based on the options.
      *
-     * @throws InvalidArgumentException
      *
      * @param Endpoint|array $endpoint
+     *
+     * @throws InvalidArgumentException
      *
      * @return self Provides fluent interface
      */
     public function addEndpoint($endpoint)
     {
-        if (is_array($endpoint)) {
+        if (\is_array($endpoint)) {
             $endpoint = new Endpoint($endpoint);
         }
 
         $key = $endpoint->getKey();
 
-        if (0 === strlen($key)) {
+        if (0 === \strlen($key)) {
             throw new InvalidArgumentException('An endpoint must have a key value');
         }
 
         //double add calls for the same endpoint are ignored, but non-unique keys cause an exception
-        if (array_key_exists($key, $this->endpoints) && $this->endpoints[$key] !== $endpoint) {
+        if (\array_key_exists($key, $this->endpoints) && $this->endpoints[$key] !== $endpoint) {
             throw new InvalidArgumentException('An endpoint must have a unique key');
-        } else {
-            $this->endpoints[$key] = $endpoint;
+        }
+        $this->endpoints[$key] = $endpoint;
 
-            // if no default endpoint is set do so now
-            if (null === $this->defaultEndpoint) {
-                $this->defaultEndpoint = $key;
-            }
+        // if no default endpoint is set do so now
+        if (null === $this->defaultEndpoint) {
+            $this->defaultEndpoint = $key;
         }
 
         return $this;
@@ -318,7 +318,7 @@ class Client extends Configurable implements ClientInterface
     {
         foreach ($endpoints as $key => $endpoint) {
             // in case of a config array: add key to config
-            if (is_array($endpoint) && !isset($endpoint['key'])) {
+            if (\is_array($endpoint) && !isset($endpoint['key'])) {
                 $endpoint['key'] = $key;
             }
 
@@ -331,9 +331,10 @@ class Client extends Configurable implements ClientInterface
     /**
      * Get an endpoint by key.
      *
-     * @throws OutOfBoundsException
      *
      * @param string $key
+     *
+     * @throws OutOfBoundsException
      *
      * @return Endpoint
      */
@@ -371,7 +372,7 @@ class Client extends Configurable implements ClientInterface
      */
     public function removeEndpoint($endpoint)
     {
-        if (is_object($endpoint)) {
+        if (\is_object($endpoint)) {
             $endpoint = $endpoint->getKey();
         }
 
@@ -415,13 +416,13 @@ class Client extends Configurable implements ClientInterface
      *
      * @param string|Endpoint $endpoint
      *
-     * @return self Provides fluent interface
-     *
      * @throws OutOfBoundsException
+     *
+     * @return self Provides fluent interface
      */
     public function setDefaultEndpoint($endpoint)
     {
-        if (is_object($endpoint)) {
+        if (\is_object($endpoint)) {
             $endpoint = $endpoint->getKey();
         }
 
@@ -449,15 +450,16 @@ class Client extends Configurable implements ClientInterface
      * If an adapter instance is passed it will replace the current adapter
      * immediately, bypassing the lazy loading.
      *
-     * @throws InvalidArgumentException
      *
      * @param string|Adapter\AdapterInterface $adapter
+     *
+     * @throws InvalidArgumentException
      *
      * @return self Provides fluent interface
      */
     public function setAdapter($adapter)
     {
-        if (is_string($adapter)) {
+        if (\is_string($adapter)) {
             $this->adapter = null;
 
             return $this->setOption('adapter', $adapter);
@@ -468,9 +470,8 @@ class Client extends Configurable implements ClientInterface
             $this->adapter = $adapter;
 
             return $this;
-        } else {
-            throw new InvalidArgumentException('Invalid adapter input for setAdapter');
         }
+        throw new InvalidArgumentException('Invalid adapter input for setAdapter');
     }
 
     /**
@@ -479,7 +480,7 @@ class Client extends Configurable implements ClientInterface
      * If {@see $adapter} doesn't hold an instance a new one will be created by
      * calling {@see createAdapter()}
      *
-     * @param boolean $autoload
+     * @param bool $autoload
      *
      * @return AdapterInterface
      */
@@ -522,7 +523,7 @@ class Client extends Configurable implements ClientInterface
     {
         foreach ($queryTypes as $type => $class) {
             // support both "key=>value" and "(no-key) => array(key=>x,query=>y)" formats
-            if (is_array($class)) {
+            if (\is_array($class)) {
                 if (isset($class['type'])) {
                     $type = $class['type'];
                 }
@@ -574,17 +575,18 @@ class Client extends Configurable implements ClientInterface
      * This requires the availability of the class through autoloading
      * or a manual require.
      *
-     * @throws InvalidArgumentException
      *
      * @param string                 $key
      * @param string|PluginInterface $plugin
      * @param array                  $options
      *
+     * @throws InvalidArgumentException
+     *
      * @return self Provides fluent interface
      */
     public function registerPlugin($key, $plugin, $options = array())
     {
-        if (is_string($plugin)) {
+        if (\is_string($plugin)) {
             $plugin = class_exists($plugin) ? $plugin : $plugin.strrchr($plugin, '\\');
             $plugin = new $plugin();
         }
@@ -637,10 +639,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Get a plugin instance.
      *
-     * @throws OutOfBoundsException
      *
-     * @param string  $key
-     * @param boolean $autocreate
+     * @param string $key
+     * @param bool   $autocreate
+     *
+     * @throws OutOfBoundsException
      *
      * @return PluginInterface|null
      */
@@ -649,15 +652,12 @@ class Client extends Configurable implements ClientInterface
         if (isset($this->pluginInstances[$key])) {
             return $this->pluginInstances[$key];
         } elseif ($autocreate) {
-            if (array_key_exists($key, $this->pluginTypes)) {
+            if (\array_key_exists($key, $this->pluginTypes)) {
                 $this->registerPlugin($key, $this->pluginTypes[$key]);
 
                 return $this->pluginInstances[$key];
-            } else {
-                throw new OutOfBoundsException('Cannot autoload plugin of unknown type: '.$key);
             }
-        } else {
-            return;
+            throw new OutOfBoundsException('Cannot autoload plugin of unknown type: '.$key);
         }
     }
 
@@ -672,7 +672,7 @@ class Client extends Configurable implements ClientInterface
      */
     public function removePlugin($plugin)
     {
-        if (is_object($plugin)) {
+        if (\is_object($plugin)) {
             foreach ($this->pluginInstances as $key => $instance) {
                 if ($instance === $plugin) {
                     unset($this->pluginInstances[$key]);
@@ -691,9 +691,10 @@ class Client extends Configurable implements ClientInterface
     /**
      * Creates a request based on a query instance.
      *
-     * @throws UnexpectedValueException
      *
      * @param QueryInterface $query
+     *
+     * @throws UnexpectedValueException
      *
      * @return Request
      */
@@ -701,7 +702,7 @@ class Client extends Configurable implements ClientInterface
     {
         $event = new PreCreateRequestEvent($query);
         $this->eventDispatcher->dispatch(Events::PRE_CREATE_REQUEST, $event);
-        if ($event->getRequest() !== null) {
+        if (null !== $event->getRequest()) {
             return $event->getRequest();
         }
 
@@ -723,10 +724,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Creates a result object.
      *
-     * @throws UnexpectedValueException;
      *
      * @param QueryInterface $query
      * @param array Response $response
+     *
+     * @throws UnexpectedValueException;
      *
      * @return ResultInterface
      */
@@ -734,7 +736,7 @@ class Client extends Configurable implements ClientInterface
     {
         $event = new PreCreateResultEvent($query, $response);
         $this->eventDispatcher->dispatch(Events::PRE_CREATE_RESULT, $event);
-        if ($event->getResult() !== null) {
+        if (null !== $event->getResult()) {
             return $event->getResult();
         }
 
@@ -765,7 +767,7 @@ class Client extends Configurable implements ClientInterface
     {
         $event = new PreExecuteEvent($query);
         $this->eventDispatcher->dispatch(Events::PRE_EXECUTE, $event);
-        if ($event->getResult() !== null) {
+        if (null !== $event->getResult()) {
             return $event->getResult();
         }
 
@@ -798,7 +800,7 @@ class Client extends Configurable implements ClientInterface
 
         $event = new PreExecuteRequestEvent($request, $endpoint);
         $this->eventDispatcher->dispatch(Events::PRE_EXECUTE_REQUEST, $event);
-        if ($event->getResponse() !== null) {
+        if (null !== $event->getResponse()) {
             $response = $event->getResponse(); //a plugin result overrules the standard execution result
         } else {
             $response = $this->getAdapter()->execute($request, $endpoint);
@@ -999,10 +1001,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a query instance.
      *
-     * @throws InvalidArgumentException|UnexpectedValueException
      *
      * @param string $type
      * @param array  $options
+     *
+     * @throws InvalidArgumentException|UnexpectedValueException
      *
      * @return \Solarium\Core\Query\AbstractQuery
      */
@@ -1012,7 +1015,7 @@ class Client extends Configurable implements ClientInterface
 
         $event = new PreCreateQueryEvent($type, $options);
         $this->eventDispatcher->dispatch(Events::PRE_CREATE_QUERY, $event);
-        if ($event->getQuery() !== null) {
+        if (null !== $event->getQuery()) {
             return $event->getQuery();
         }
 
@@ -1160,7 +1163,7 @@ class Client extends Configurable implements ClientInterface
      */
     protected function init()
     {
-        if ($this->eventDispatcher === null) {
+        if (null === $this->eventDispatcher) {
             $this->eventDispatcher = new EventDispatcher();
         }
 

--- a/library/Solarium/Core/Client/ClientInterface.php
+++ b/library/Solarium/Core/Client/ClientInterface.php
@@ -30,19 +30,21 @@
  *
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
- * @link http://www.solarium-project.org/
+ *
+ * @see http://www.solarium-project.org/
  */
 
 /**
  * @namespace
  */
+
 namespace Solarium\Core\Client;
 
 use Solarium\Core\Query\QueryInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
- * Main interface for interaction with Solr
+ * Main interface for interaction with Solr.
  *
  * The client is the main interface for usage of the Solarium library.
  * You can use it to get query instances and to execute them.
@@ -59,7 +61,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 interface ClientInterface
 {
     /**
-     * Create a endpoint instance
+     * Create a endpoint instance.
      *
      * If you supply a string as the first arguments ($options) it will be used as the key for the endpoint
      * and it will be registered.
@@ -68,67 +70,74 @@ interface ClientInterface
      * When no key is supplied the endpoint cannot be registered, in that case you will need to do this manually
      * after setting the key, by using the addEndpoint method.
      *
-     * @param  mixed    $options
-     * @param  boolean  $setAsDefault
+     * @param mixed $options
+     * @param bool  $setAsDefault
+     *
      * @return Endpoint
      */
     public function createEndpoint($options = null, $setAsDefault = false);
 
     /**
-     * Add an endpoint
+     * Add an endpoint.
      *
      * Supports a endpoint instance or a config array as input.
      * In case of options a new endpoint instance wil be created based on the options.
      *
+     * @param Endpoint|array $endpoint
+     *
      * @throws InvalidArgumentException
-     * @param  Endpoint|array           $endpoint
-     * @return self                     Provides fluent interface
+     *
+     * @return self Provides fluent interface
      */
     public function addEndpoint($endpoint);
 
     /**
-     * Add multiple endpoints
+     * Add multiple endpoints.
      *
-     * @param  array $endpoints
-     * @return self  Provides fluent interface
+     * @param array $endpoints
+     *
+     * @return self Provides fluent interface
      */
     public function addEndpoints(array $endpoints);
 
     /**
-     * Get an endpoint by key
+     * Get an endpoint by key.
+     *
+     * @param string $key
      *
      * @throws OutOfBoundsException
-     * @param  string               $key
+     *
      * @return Endpoint
      */
     public function getEndpoint($key = null);
 
     /**
-     * Get all endpoints
+     * Get all endpoints.
      *
      * @return Endpoint[]
      */
     public function getEndpoints();
 
     /**
-     * Remove a single endpoint
+     * Remove a single endpoint.
      *
      * You can remove a endpoint by passing it's key, or by passing the endpoint instance
      *
-     * @param  string|Endpoint $endpoint
+     * @param string|Endpoint $endpoint
+     *
      * @return ClientInterface Provides fluent interface
      */
     public function removeEndpoint($endpoint);
 
     /**
-     * Remove all endpoints
+     * Remove all endpoints.
      *
      * @return self Provides fluent interface
      */
     public function clearEndpoints();
 
     /**
-     * Set multiple endpoints
+     * Set multiple endpoints.
      *
      * This overwrites any existing endpoints
      *
@@ -137,18 +146,20 @@ interface ClientInterface
     public function setEndpoints($endpoints);
 
     /**
-     * Set a default endpoint
+     * Set a default endpoint.
      *
      * All queries executed without a specific endpoint will use this default endpoint.
      *
-     * @param  string|Endpoint      $endpoint
-     * @return ClientInterface      Provides fluent interface
+     * @param string|Endpoint $endpoint
+     *
      * @throws OutOfBoundsException
+     *
+     * @return ClientInterface Provides fluent interface
      */
     public function setDefaultEndpoint($endpoint);
 
     /**
-     * Set the adapter
+     * Set the adapter.
      *
      * The adapter has to be a class that implements the AdapterInterface
      *
@@ -162,46 +173,51 @@ interface ClientInterface
      * If an adapter instance is passed it will replace the current adapter
      * immediately, bypassing the lazy loading.
      *
+     * @param string|Adapter\AdapterInterface $adapter
+     *
      * @throws InvalidArgumentException
-     * @param  string|Adapter\AdapterInterface $adapter
-     * @return ClientInterface                 Provides fluent interface
+     *
+     * @return ClientInterface Provides fluent interface
      */
     public function setAdapter($adapter);
 
     /**
-     * Get the adapter instance
+     * Get the adapter instance.
      *
      * If {@see $adapter} doesn't hold an instance a new one will be created by
      * calling {@see createAdapter()}
      *
-     * @param  boolean          $autoload
+     * @param bool $autoload
+     *
      * @return AdapterInterface
      */
     public function getAdapter($autoload = true);
 
     /**
-     * Register a querytype
+     * Register a querytype.
      *
      * You can also use this method to override any existing querytype with a new mapping.
      * This requires the availability of the classes through autoloading or a manual
      * require before calling this method.
      *
-     * @param  string $type
-     * @param  string $queryClass
-     * @return self   Provides fluent interface
+     * @param string $type
+     * @param string $queryClass
+     *
+     * @return self Provides fluent interface
      */
     public function registerQueryType($type, $queryClass);
 
     /**
-     * Register multiple querytypes
+     * Register multiple querytypes.
      *
-     * @param  array $queryTypes
-     * @return self  Provides fluent interface
+     * @param array $queryTypes
+     *
+     * @return self Provides fluent interface
      */
     public function registerQueryTypes($queryTypes);
 
     /**
-     * Get all registered querytypes
+     * Get all registered querytypes.
      *
      * @return array
      */
@@ -224,94 +240,108 @@ interface ClientInterface
     public function setEventDispatcher(EventDispatcherInterface $eventDispatcher);
 
     /**
-     * Register a plugin
+     * Register a plugin.
      *
      * You can supply a plugin instance or a plugin classname as string.
      * This requires the availability of the class through autoloading
      * or a manual require.
      *
+     * @param string                 $key
+     * @param string|PluginInterface $plugin
+     * @param array                  $options
+     *
      * @throws InvalidArgumentException
-     * @param  string                   $key
-     * @param  string|PluginInterface   $plugin
-     * @param  array                    $options
-     * @return self                     Provides fluent interface
+     *
+     * @return self Provides fluent interface
      */
     public function registerPlugin($key, $plugin, $options = array());
 
     /**
-     * Register multiple plugins
+     * Register multiple plugins.
      *
-     * @param  array $plugins
-     * @return self  Provides fluent interface
+     * @param array $plugins
+     *
+     * @return self Provides fluent interface
      */
     public function registerPlugins($plugins);
 
     /**
-     * Get all registered plugins
+     * Get all registered plugins.
      *
      * @return PluginInterface[]
      */
     public function getPlugins();
 
     /**
-     * Get a plugin instance
+     * Get a plugin instance.
+     *
+     * @param string $key
+     * @param bool   $autocreate
      *
      * @throws OutOfBoundsException
-     * @param  string               $key
-     * @param  boolean              $autocreate
+     *
      * @return PluginInterface|null
      */
     public function getPlugin($key, $autocreate = true);
 
     /**
-     * Remove a plugin instance
+     * Remove a plugin instance.
      *
      * You can remove a plugin by passing the plugin key, or the plugin instance
      *
-     * @param  string|PluginInterface $plugin
-     * @return ClientInterface        Provides fluent interface
+     * @param string|PluginInterface $plugin
+     *
+     * @return ClientInterface Provides fluent interface
      */
     public function removePlugin($plugin);
 
     /**
-     * Creates a request based on a query instance
+     * Creates a request based on a query instance.
+     *
+     * @param QueryInterface $query
      *
      * @throws UnexpectedValueException
-     * @param  QueryInterface           $query
+     *
      * @return Request
      */
     public function createRequest(QueryInterface $query);
 
     /**
-     * Creates a result object
+     * Creates a result object.
+     *
+     * @param QueryInterface $query
+     * @param array Response $response
      *
      * @throws UnexpectedValueException;
-     * @param  QueryInterface            $query
-     * @param  array Response            $response
+     *
      * @return ResultInterface
      */
     public function createResult(QueryInterface $query, $response);
 
     /**
-     * Execute a query
+     * Execute a query.
      *
-     * @param  QueryInterface       $query
-     * @param  Endpoint|string|null $endpoint
+     * @param QueryInterface       $query
+     * @param Endpoint|string|null $endpoint
+     *
      * @return ResultInterface
      */
     public function execute(QueryInterface $query, $endpoint = null);
 
     /**
-     * Execute a request and return the response
+     * Execute a request and return the response.
      *
      * @param Request
      * @param Endpoint|string|null
+     * @param mixed      $request
+     * @param mixed|null $endpoint
+     *
      * @return Response
      */
     public function executeRequest($request, $endpoint = null);
 
     /**
-     * Execute a ping query
+     * Execute a ping query.
      *
      * Example usage:
      * <code>
@@ -322,17 +352,18 @@ interface ClientInterface
      *
      * @see Solarium\QueryType\Ping
      *
-     * @internal This is a convenience method that forwards the query to the
-     *  execute method, thus allowing for an easy to use and clean API.
+     * @internal this is a convenience method that forwards the query to the
+     *  execute method, thus allowing for an easy to use and clean API
      *
-     * @param  QueryInterface|\Solarium\QueryType\Ping\Query $query
-     * @param  Endpoint|string|null                          $endpoint
+     * @param QueryInterface|\Solarium\QueryType\Ping\Query $query
+     * @param Endpoint|string|null                          $endpoint
+     *
      * @return \Solarium\QueryType\Ping\Result
      */
     public function ping(QueryInterface $query, $endpoint = null);
 
     /**
-     * Execute an update query
+     * Execute an update query.
      *
      * Example usage:
      * <code>
@@ -345,17 +376,18 @@ interface ClientInterface
      * @see Solarium\QueryType\Update
      * @see Solarium\Result\Update
      *
-     * @internal This is a convenience method that forwards the query to the
-     *  execute method, thus allowing for an easy to use and clean API.
+     * @internal this is a convenience method that forwards the query to the
+     *  execute method, thus allowing for an easy to use and clean API
      *
-     * @param  QueryInterface|\Solarium\QueryType\Update\Query\Query $query
-     * @param  Endpoint|string|null                                  $endpoint
+     * @param QueryInterface|\Solarium\QueryType\Update\Query\Query $query
+     * @param Endpoint|string|null                                  $endpoint
+     *
      * @return \Solarium\QueryType\Update\Result
      */
     public function update(QueryInterface $query, $endpoint = null);
 
     /**
-     * Execute a select query
+     * Execute a select query.
      *
      * Example usage:
      * <code>
@@ -367,17 +399,18 @@ interface ClientInterface
      * @see Solarium\QueryType\Select
      * @see Solarium\Result\Select
      *
-     * @internal This is a convenience method that forwards the query to the
-     *  execute method, thus allowing for an easy to use and clean API.
+     * @internal this is a convenience method that forwards the query to the
+     *  execute method, thus allowing for an easy to use and clean API
      *
-     * @param  QueryInterface|\Solarium\QueryType\Select\Query\Query $query
-     * @param  Endpoint|string|null                                  $endpoint
+     * @param QueryInterface|\Solarium\QueryType\Select\Query\Query $query
+     * @param Endpoint|string|null                                  $endpoint
+     *
      * @return \Solarium\QueryType\Select\Result\Result
      */
     public function select(QueryInterface $query, $endpoint = null);
 
     /**
-     * Execute a MoreLikeThis query
+     * Execute a MoreLikeThis query.
      *
      * Example usage:
      * <code>
@@ -389,161 +422,179 @@ interface ClientInterface
      * @see Solarium\QueryType\MoreLikeThis
      * @see Solarium\Result\MoreLikeThis
      *
-     * @internal This is a convenience method that forwards the query to the
-     *  execute method, thus allowing for an easy to use and clean API.
+     * @internal this is a convenience method that forwards the query to the
+     *  execute method, thus allowing for an easy to use and clean API
      *
-     * @param  QueryInterface|\Solarium\QueryType\MoreLikeThis\Query $query
-     * @param  Endpoint|string|null                                  $endpoint
+     * @param QueryInterface|\Solarium\QueryType\MoreLikeThis\Query $query
+     * @param Endpoint|string|null                                  $endpoint
+     *
      * @return \Solarium\QueryType\MoreLikeThis\Result
      */
     public function moreLikeThis(QueryInterface $query, $endpoint = null);
 
     /**
-     * Execute an analysis query
+     * Execute an analysis query.
      *
-     * @internal This is a convenience method that forwards the query to the
-     *  execute method, thus allowing for an easy to use and clean API.
+     * @internal this is a convenience method that forwards the query to the
+     *  execute method, thus allowing for an easy to use and clean API
      *
-     * @param  QueryInterface|\Solarium\QueryType\Analysis\Query\Document|\Solarium\QueryType\Analysis\Query\Field $query
-     * @param  Endpoint|string|null                                                                                $endpoint
+     * @param QueryInterface|\Solarium\QueryType\Analysis\Query\Document|\Solarium\QueryType\Analysis\Query\Field $query
+     * @param Endpoint|string|null                                                                                $endpoint
+     *
      * @return \Solarium\QueryType\Analysis\Result\Document|\Solarium\QueryType\Analysis\Result\Field
      */
     public function analyze(QueryInterface $query, $endpoint = null);
 
     /**
-     * Execute a terms query
+     * Execute a terms query.
      *
-     * @internal This is a convenience method that forwards the query to the
-     *  execute method, thus allowing for an easy to use and clean API.
+     * @internal this is a convenience method that forwards the query to the
+     *  execute method, thus allowing for an easy to use and clean API
      *
-     * @param  QueryInterface|\Solarium\QueryType\Terms\Query $query
-     * @param  Endpoint|string|null                           $endpoint
+     * @param QueryInterface|\Solarium\QueryType\Terms\Query $query
+     * @param Endpoint|string|null                           $endpoint
+     *
      * @return \Solarium\QueryType\Terms\Result
      */
     public function terms(QueryInterface $query, $endpoint = null);
 
     /**
-     * Execute a suggester query
+     * Execute a suggester query.
      *
-     * @internal This is a convenience method that forwards the query to the
-     *  execute method, thus allowing for an easy to use and clean API.
+     * @internal this is a convenience method that forwards the query to the
+     *  execute method, thus allowing for an easy to use and clean API
      *
-     * @param  QueryInterface|\Solarium\QueryType\Suggester\Query $query
-     * @param  Endpoint|string|null                               $endpoint
+     * @param QueryInterface|\Solarium\QueryType\Suggester\Query $query
+     * @param Endpoint|string|null                               $endpoint
+     *
      * @return \Solarium\QueryType\Suggester\Result\Result
      */
     public function suggester(QueryInterface $query, $endpoint = null);
 
     /**
-     * Execute an extract query
+     * Execute an extract query.
      *
-     * @internal This is a convenience method that forwards the query to the
-     *  execute method, thus allowing for an easy to use and clean API.
+     * @internal this is a convenience method that forwards the query to the
+     *  execute method, thus allowing for an easy to use and clean API
      *
-     * @param  QueryInterface|\Solarium\QueryType\Extract\Query $query
-     * @param  Endpoint|string|null                             $endpoint
+     * @param QueryInterface|\Solarium\QueryType\Extract\Query $query
+     * @param Endpoint|string|null                             $endpoint
+     *
      * @return \Solarium\QueryType\Extract\Result
      */
     public function extract(QueryInterface $query, $endpoint = null);
 
     /**
-     * Execute a RealtimeGet query
+     * Execute a RealtimeGet query.
      *
-     * @internal This is a convenience method that forwards the query to the
-     *  execute method, thus allowing for an easy to use and clean API.
+     * @internal this is a convenience method that forwards the query to the
+     *  execute method, thus allowing for an easy to use and clean API
      *
-     * @param  QueryInterface|\Solarium\QueryType\RealtimeGet\Query $query
-     * @param  Endpoint|string|null                                 $endpoint
+     * @param QueryInterface|\Solarium\QueryType\RealtimeGet\Query $query
+     * @param Endpoint|string|null                                 $endpoint
+     *
      * @return \Solarium\QueryType\RealtimeGet\Result
      */
     public function realtimeGet(QueryInterface $query, $endpoint = null);
 
     /**
-     * Create a query instance
+     * Create a query instance.
+     *
+     * @param string $type
+     * @param array  $options
      *
      * @throws InvalidArgumentException|UnexpectedValueException
-     * @param  string                                            $type
-     * @param  array                                             $options
+     *
      * @return \Solarium\Core\Query\Query
      */
     public function createQuery($type, $options = null);
 
     /**
-     * Create a select query instance
+     * Create a select query instance.
      *
-     * @param  mixed                                  $options
+     * @param mixed $options
+     *
      * @return \Solarium\QueryType\Select\Query\Query
      */
     public function createSelect($options = null);
 
     /**
-     * Create a MoreLikeThis query instance
+     * Create a MoreLikeThis query instance.
      *
-     * @param  mixed                                  $options
+     * @param mixed $options
+     *
      * @return \Solarium\QueryType\MorelikeThis\Query
      */
     public function createMoreLikeThis($options = null);
 
     /**
-     * Create an update query instance
+     * Create an update query instance.
      *
-     * @param  mixed                                  $options
+     * @param mixed $options
+     *
      * @return \Solarium\QueryType\Update\Query\Query
      */
     public function createUpdate($options = null);
 
     /**
-     * Create a ping query instance
+     * Create a ping query instance.
      *
-     * @param  mixed                          $options
+     * @param mixed $options
+     *
      * @return \Solarium\QueryType\Ping\Query
      */
     public function createPing($options = null);
 
     /**
-     * Create an analysis field query instance
+     * Create an analysis field query instance.
      *
-     * @param  mixed                                    $options
+     * @param mixed $options
+     *
      * @return \Solarium\QueryType\Analysis\Query\Field
      */
     public function createAnalysisField($options = null);
 
     /**
-     * Create an analysis document query instance
+     * Create an analysis document query instance.
      *
-     * @param  mixed                                       $options
+     * @param mixed $options
+     *
      * @return \Solarium\QueryType\Analysis\Query\Document
      */
     public function createAnalysisDocument($options = null);
 
     /**
-     * Create a terms query instance
+     * Create a terms query instance.
      *
-     * @param  mixed                           $options
+     * @param mixed $options
+     *
      * @return \Solarium\QueryType\Terms\Query
      */
     public function createTerms($options = null);
 
     /**
-     * Create a suggester query instance
+     * Create a suggester query instance.
      *
-     * @param  mixed                               $options
+     * @param mixed $options
+     *
      * @return \Solarium\QueryType\Suggester\Query
      */
     public function createSuggester($options = null);
 
     /**
-     * Create an extract query instance
+     * Create an extract query instance.
      *
-     * @param  mixed                             $options
+     * @param mixed $options
+     *
      * @return \Solarium\QueryType\Extract\Query
      */
     public function createExtract($options = null);
 
     /**
-     * Create a RealtimeGet query instance
+     * Create a RealtimeGet query instance.
      *
-     * @param  mixed                                 $options
+     * @param mixed $options
+     *
      * @return \Solarium\QueryType\RealtimeGet\Query
      */
     public function createRealtimeGet($options = null);

--- a/library/Solarium/Core/Client/Endpoint.php
+++ b/library/Solarium/Core/Client/Endpoint.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -56,13 +56,28 @@ class Endpoint extends Configurable
      * @var array
      */
     protected $options = array(
-        'scheme'  => 'http',
-        'host'    => '127.0.0.1',
-        'port'    => 8983,
-        'path'    => '/solr',
-        'core'    => null,
+        'scheme' => 'http',
+        'host' => '127.0.0.1',
+        'port' => 8983,
+        'path' => '/solr',
+        'core' => null,
         'timeout' => 5,
     );
+
+    /**
+     * Magic method enables a object to be transformed to a string.
+     *
+     * Get a summary showing significant variables in the object
+     * note: uri resource is decoded for readability
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $output = __CLASS__.'::__toString'."\n".'base uri: '.$this->getBaseUri()."\n".'host: '.$this->getHost()."\n".'port: '.$this->getPort()."\n".'path: '.$this->getPath()."\n".'core: '.$this->getCore()."\n".'timeout: '.$this->getTimeout()."\n".'authentication: '.print_r($this->getAuthentication(), 1);
+
+        return $output;
+    }
 
     /**
      * Get key value.
@@ -141,7 +156,7 @@ class Endpoint extends Configurable
      */
     public function setPath($path)
     {
-        if (substr($path, -1) == '/') {
+        if ('/' == substr($path, -1)) {
             $path = substr($path, 0, -1);
         }
 
@@ -272,21 +287,6 @@ class Endpoint extends Configurable
             'username' => $this->getOption('username'),
             'password' => $this->getOption('password'),
         );
-    }
-
-    /**
-     * Magic method enables a object to be transformed to a string.
-     *
-     * Get a summary showing significant variables in the object
-     * note: uri resource is decoded for readability
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        $output = __CLASS__.'::__toString'."\n".'base uri: '.$this->getBaseUri()."\n".'host: '.$this->getHost()."\n".'port: '.$this->getPort()."\n".'path: '.$this->getPath()."\n".'core: '.$this->getCore()."\n".'timeout: '.$this->getTimeout()."\n".'authentication: '.print_r($this->getAuthentication(), 1);
-
-        return $output;
     }
 
     /**

--- a/library/Solarium/Core/Client/Request.php
+++ b/library/Solarium/Core/Client/Request.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -51,17 +51,17 @@ class Request extends Configurable
     /**
      * Request GET method.
      */
-    const METHOD_GET     = 'GET';
+    const METHOD_GET = 'GET';
 
     /**
      * Request POST method.
      */
-    const METHOD_POST    = 'POST';
+    const METHOD_POST = 'POST';
 
     /**
      * Request HEAD method.
      */
-    const METHOD_HEAD    = 'HEAD';
+    const METHOD_HEAD = 'HEAD';
 
     /**
      * Default options.
@@ -93,6 +93,21 @@ class Request extends Configurable
      * @var string
      */
     protected $rawData;
+
+    /**
+     * Magic method enables a object to be transformed to a string.
+     *
+     * Get a summary showing significant variables in the object
+     * note: uri resource is decoded for readability
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $output = __CLASS__.'::__toString'."\n".'method: '.$this->getMethod()."\n".'header: '.print_r($this->getHeaders(), 1).'authentication: '.print_r($this->getAuthentication(), 1).'resource: '.$this->getUri()."\n".'resource urldecoded: '.urldecode($this->getUri())."\n".'raw data: '.$this->getRawData()."\n".'file upload: '.$this->getFileUpload()."\n";
+
+        return $output;
+    }
 
     /**
      * Set request handler.
@@ -155,8 +170,6 @@ class Request extends Configurable
     {
         if (isset($this->params[$key])) {
             return $this->params[$key];
-        } else {
-            return;
         }
     }
 
@@ -196,23 +209,23 @@ class Request extends Configurable
      *
      * @param string       $key
      * @param string|array $value
-     * @param boolean      $overwrite
+     * @param bool         $overwrite
      *
      * @return self Provides fluent interface
      */
     public function addParam($key, $value, $overwrite = false)
     {
-        if ($value !== null) {
+        if (null !== $value) {
             if (!$overwrite && isset($this->params[$key])) {
-                if (!is_array($this->params[$key])) {
+                if (!\is_array($this->params[$key])) {
                     $this->params[$key] = array($this->params[$key]);
                 }
                 $this->params[$key][] = $value;
             } else {
                 // not all solr handlers support 0/1 as boolean values...
-                if ($value === true) {
+                if (true === $value) {
                     $value = 'true';
-                } elseif ($value === false) {
+                } elseif (false === $value) {
                     $value = 'false';
                 }
 
@@ -226,8 +239,8 @@ class Request extends Configurable
     /**
      * Add multiple params to the request.
      *
-     * @param array   $params
-     * @param boolean $overwrite
+     * @param array $params
+     * @param bool  $overwrite
      *
      * @return self Provides fluent interface
      */
@@ -307,9 +320,10 @@ class Request extends Configurable
     /**
      * Set the file to upload via "multipart/form-data" POST request.
      *
-     * @throws RuntimeException
      *
      * @param string $filename Name of file to upload
+     *
+     * @throws RuntimeException
      *
      * @return self
      */
@@ -409,7 +423,7 @@ class Request extends Configurable
     public function getQueryString()
     {
         $queryString = '';
-        if (count($this->params) > 0) {
+        if (\count($this->params) > 0) {
             $queryString = http_build_query($this->params, null, '&');
             $queryString = preg_replace(
                 '/%5B(?:[0-9]|[1-9][0-9]+)%5D=/',
@@ -419,21 +433,6 @@ class Request extends Configurable
         }
 
         return $queryString;
-    }
-
-    /**
-     * Magic method enables a object to be transformed to a string.
-     *
-     * Get a summary showing significant variables in the object
-     * note: uri resource is decoded for readability
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        $output = __CLASS__.'::__toString'."\n".'method: '.$this->getMethod()."\n".'header: '.print_r($this->getHeaders(), 1).'authentication: '.print_r($this->getAuthentication(), 1).'resource: '.$this->getUri()."\n".'resource urldecoded: '.urldecode($this->getUri())."\n".'raw data: '.$this->getRawData()."\n".'file upload: '.$this->getFileUpload()."\n";
-
-        return $output;
     }
 
     /**

--- a/library/Solarium/Core/Client/Response.php
+++ b/library/Solarium/Core/Client/Response.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -132,9 +132,10 @@ class Response
     /**
      * Set headers.
      *
-     * @throws HttpException
      *
      * @param array $headers
+     *
+     * @throws HttpException
      */
     public function setHeaders($headers)
     {
@@ -143,14 +144,14 @@ class Response
         // get the status header
         $statusHeader = null;
         foreach ($headers as $header) {
-            if (substr($header, 0, 4) == 'HTTP') {
+            if ('HTTP' == substr($header, 0, 4)) {
                 $statusHeader = $header;
                 break;
             }
         }
 
         if (null === $statusHeader) {
-            throw new HttpException("No HTTP status found");
+            throw new HttpException('No HTTP status found');
         }
 
         // parse header like "$statusInfo[1]" into code and message

--- a/library/Solarium/Core/Configurable.php
+++ b/library/Solarium/Core/Configurable.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -66,9 +66,10 @@ class Configurable implements ConfigurableInterface
      *
      * After handling the options the {@link _init()} method is called.
      *
-     * @throws InvalidArgumentException
      *
      * @param array|\Zend_Config $options
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($options = null)
     {
@@ -88,19 +89,20 @@ class Configurable implements ConfigurableInterface
      * If $options does not have the toArray method, the internal method will
      * be used instead.
      *
-     * @throws InvalidArgumentException
      *
      * @param array|\Zend_Config $options
-     * @param boolean            $overwrite True for overwriting existing options, false
+     * @param bool               $overwrite True for overwriting existing options, false
      *                                      for merging (new values overwrite old ones if needed)
+     *
+     * @throws InvalidArgumentException
      */
     public function setOptions($options, $overwrite = false)
     {
         if (null !== $options) {
             // first convert to array if needed
-            if (!is_array($options)) {
-                if (is_object($options)) {
-                    $options = (! method_exists($options, 'toArray') ? $this->toArray($options) : $options->toArray());
+            if (!\is_array($options)) {
+                if (\is_object($options)) {
+                    $options = (!method_exists($options, 'toArray') ? $this->toArray($options) : $options->toArray());
                 } else {
                     throw new InvalidArgumentException(
                         'Options value given to the setOptions() method must be an array or a Zend_Config object'
@@ -132,8 +134,6 @@ class Configurable implements ConfigurableInterface
     {
         if (isset($this->options[$name])) {
             return $this->options[$name];
-        } else {
-            return;
         }
     }
 
@@ -189,10 +189,10 @@ class Configurable implements ConfigurableInterface
      */
     protected function toArray($object)
     {
-        if (is_object($object)) {
+        if (\is_object($object)) {
             // get_object_vars() does not handle recursive objects well,
             // so use set-type without scope operator instead
-            settype($object, 'array');
+            $object = (array) $object;
         }
 
         /*
@@ -200,7 +200,7 @@ class Configurable implements ConfigurableInterface
         * Using __METHOD__ (Magic constant)
         * for recursive call
         */
-        if (is_array($object)) {
+        if (\is_array($object)) {
             return array_map(__METHOD__, $object);
         }
 

--- a/library/Solarium/Core/ConfigurableInterface.php
+++ b/library/Solarium/Core/ConfigurableInterface.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -58,11 +58,12 @@ interface ConfigurableInterface
      * it's toArray method. This is compatible with the Zend_Config classes in
      * Zend Framework, but can also easily be implemented in any other object.
      *
-     * @throws InvalidArgumentException
      *
      * @param array|\Zend_Config $options
-     * @param boolean            $overwrite True for overwriting existing options, false
+     * @param bool               $overwrite True for overwriting existing options, false
      *                                      for merging (new values overwrite old ones if needed)
+     *
+     * @throws InvalidArgumentException
      */
     public function setOptions($options, $overwrite = false);
 

--- a/library/Solarium/Core/Event/Events.php
+++ b/library/Solarium/Core/Event/Events.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Core/Event/PostCreateQuery.php
+++ b/library/Solarium/Core/Event/PostCreateQuery.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\Core\Event;
 
-use Symfony\Component\EventDispatcher\Event;
 use Solarium\Core\Query\QueryInterface;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PostCreateQuery event, see Events for details.

--- a/library/Solarium/Core/Event/PostCreateRequest.php
+++ b/library/Solarium/Core/Event/PostCreateRequest.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,9 +40,9 @@
 
 namespace Solarium\Core\Event;
 
-use Symfony\Component\EventDispatcher\Event;
-use Solarium\Core\Query\QueryInterface;
 use Solarium\Core\Client\Request;
+use Solarium\Core\Query\QueryInterface;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PostCreateRequest event, see Events for details.

--- a/library/Solarium/Core/Event/PostCreateResult.php
+++ b/library/Solarium/Core/Event/PostCreateResult.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,10 +40,10 @@
 
 namespace Solarium\Core\Event;
 
-use Symfony\Component\EventDispatcher\Event;
-use Solarium\Core\Query\QueryInterface;
 use Solarium\Core\Client\Response;
+use Solarium\Core\Query\QueryInterface;
 use Solarium\Core\Query\Result\ResultInterface;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PostCreateResult event, see Events for details.

--- a/library/Solarium/Core/Event/PostExecute.php
+++ b/library/Solarium/Core/Event/PostExecute.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,9 +40,9 @@
 
 namespace Solarium\Core\Event;
 
-use Symfony\Component\EventDispatcher\Event;
 use Solarium\Core\Query\QueryInterface;
 use Solarium\Core\Query\Result\ResultInterface;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PostExecute event, see Events for details.

--- a/library/Solarium/Core/Event/PostExecuteRequest.php
+++ b/library/Solarium/Core/Event/PostExecuteRequest.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,10 +40,10 @@
 
 namespace Solarium\Core\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Core\Client\Endpoint;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PostExecuteRequest event, see Events for details.

--- a/library/Solarium/Core/Event/PreCreateQuery.php
+++ b/library/Solarium/Core/Event/PreCreateQuery.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\Core\Event;
 
-use Symfony\Component\EventDispatcher\Event;
 use Solarium\Core\Query\QueryInterface;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PreCreateQuery event, see Events for details.
@@ -49,7 +49,7 @@ use Solarium\Core\Query\QueryInterface;
 class PreCreateQuery extends Event
 {
     /**
-     * @var null|QueryInterface
+     * @var QueryInterface|null
      */
     protected $query;
 

--- a/library/Solarium/Core/Event/PreCreateRequest.php
+++ b/library/Solarium/Core/Event/PreCreateRequest.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,9 +40,9 @@
 
 namespace Solarium\Core\Event;
 
-use Symfony\Component\EventDispatcher\Event;
-use Solarium\Core\Query\QueryInterface;
 use Solarium\Core\Client\Request;
+use Solarium\Core\Query\QueryInterface;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PreCreateRequest event, see Events for details.
@@ -94,7 +94,7 @@ class PreCreateRequest extends Event
     /**
      * Get the result.
      *
-     * @return null|Request
+     * @return Request|null
      */
     public function getRequest()
     {

--- a/library/Solarium/Core/Event/PreCreateResult.php
+++ b/library/Solarium/Core/Event/PreCreateResult.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,10 +40,10 @@
 
 namespace Solarium\Core\Event;
 
-use Symfony\Component\EventDispatcher\Event;
-use Solarium\Core\Query\QueryInterface;
 use Solarium\Core\Client\Response;
+use Solarium\Core\Query\QueryInterface;
 use Solarium\Core\Query\Result\ResultInterface;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PreCreateResult event, see Events for details.

--- a/library/Solarium/Core/Event/PreExecute.php
+++ b/library/Solarium/Core/Event/PreExecute.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,9 +40,9 @@
 
 namespace Solarium\Core\Event;
 
-use Symfony\Component\EventDispatcher\Event;
 use Solarium\Core\Query\QueryInterface;
 use Solarium\Core\Query\Result\ResultInterface;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PostExecute event, see Events for details.

--- a/library/Solarium/Core/Event/PreExecuteRequest.php
+++ b/library/Solarium/Core/Event/PreExecuteRequest.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,10 +40,10 @@
 
 namespace Solarium\Core\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Core\Client\Endpoint;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PreExecuteRequest event, see Events for details.

--- a/library/Solarium/Core/Plugin/AbstractPlugin.php
+++ b/library/Solarium/Core/Plugin/AbstractPlugin.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Core/Plugin/Plugin.php
+++ b/library/Solarium/Core/Plugin/Plugin.php
@@ -31,13 +31,13 @@
  * @copyright Copyright 2015 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 namespace Solarium\Core\Plugin;
 
 /**
- * This class is for backwards compatibility, will be removed in 4.x releases in favor of AbstractPlugin
+ * This class is for backwards compatibility, will be removed in 4.x releases in favor of AbstractPlugin.
  *
  * @deprecated
  */

--- a/library/Solarium/Core/Plugin/PluginInterface.php
+++ b/library/Solarium/Core/Plugin/PluginInterface.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\Core\Plugin;
 
-use Solarium\Core\ConfigurableInterface;
 use Solarium\Core\Client\Client;
+use Solarium\Core\ConfigurableInterface;
 
 /**
  * Interface for plugins.

--- a/library/Solarium/Core/Query/AbstractQuery.php
+++ b/library/Solarium/Core/Query/AbstractQuery.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -48,6 +48,7 @@ use Solarium\Core\Configurable;
 abstract class AbstractQuery extends Configurable implements QueryInterface
 {
     const WT_JSON = 'json';
+
     const WT_PHPS = 'phps';
 
     /**
@@ -140,7 +141,7 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
     /**
      * Set omitHeader option.
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return self Provides fluent interface
      */
@@ -152,7 +153,7 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
     /**
      * Get omitHeader option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getOmitHeader()
     {
@@ -229,7 +230,7 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
     public function getResponseWriter()
     {
         $responseWriter = $this->getOption('responsewriter');
-        if ($responseWriter === null) {
+        if (null === $responseWriter) {
             $responseWriter = self::WT_JSON;
         }
 

--- a/library/Solarium/Core/Query/AbstractRequestBuilder.php
+++ b/library/Solarium/Core/Query/AbstractRequestBuilder.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -76,7 +76,7 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
      *
      * LocalParams can be use in various Solr GET params.
      *
-     * @link http://wiki.apache.org/solr/LocalParams
+     * @see http://wiki.apache.org/solr/LocalParams
      *
      * @param string $value
      * @param array  $localParams in key => value format
@@ -91,14 +91,14 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
                 continue;
             }
 
-            if (is_array($paramValue)) {
-                $paramValue = implode($paramValue, ',');
+            if (\is_array($paramValue)) {
+                $paramValue = implode(',', $paramValue);
             }
 
             $params .= $paramName.'='.$paramValue.' ';
         }
 
-        if ($params !== '') {
+        if ('' !== $params) {
             $value = '{!'.trim($params).'}'.$value;
         }
 
@@ -110,20 +110,20 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
      *
      * For use in building XML messages
      *
-     * @param string  $name
-     * @param boolean $value
+     * @param string $name
+     * @param bool   $value
      *
      * @return string
      */
     public function boolAttrib($name, $value)
     {
         if (null !== $value) {
-            $value = (true === (bool)$value) ? 'true' : 'false';
+            $value = (true === (bool) $value) ? 'true' : 'false';
 
             return $this->attrib($name, $value);
-        } else {
-            return '';
         }
+
+        return '';
     }
 
     /**
@@ -140,8 +140,8 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
     {
         if (null !== $value) {
             return ' '.$name.'="'.$value.'"';
-        } else {
-            return '';
         }
+
+        return '';
     }
 }

--- a/library/Solarium/Core/Query/AbstractResponseParser.php
+++ b/library/Solarium/Core/Query/AbstractResponseParser.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -59,17 +59,17 @@ abstract class AbstractResponseParser
         // key counter to convert values to arrays when keys are re-used
         $keys = array();
 
-        $dataCount = count($data);
+        $dataCount = \count($data);
         $result = array();
         for ($i = 0; $i < $dataCount; $i += 2) {
-            $key  = $data[$i];
-            $value = $data[$i+1];
-            if (array_key_exists($key, $keys)) {
-                if ($keys[$key] == 1) {
+            $key = $data[$i];
+            $value = $data[$i + 1];
+            if (\array_key_exists($key, $keys)) {
+                if (1 == $keys[$key]) {
                     $result[$key] = array($result[$key]);
                 }
                 $result[$key][] = $value;
-                $keys[$key]++;
+                ++$keys[$key];
             } else {
                 $keys[$key] = 1;
                 $result[$key] = $value;

--- a/library/Solarium/Core/Query/Helper.php
+++ b/library/Solarium/Core/Query/Helper.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -97,7 +97,7 @@ class Helper
      * If you want to use the input as a phrase please use the {@link phrase()}
      * method, because a phrase requires much less escaping.\
      *
-     * @link http://lucene.apache.org/java/docs/queryparsersyntax.html#Escaping%20Special%20Characters
+     * @see http://lucene.apache.org/java/docs/queryparsersyntax.html#Escaping%20Special%20Characters
      *
      * @param string $input
      *
@@ -141,22 +141,20 @@ class Helper
      *
      * @param int|string|\DateTime $input accepted formats: timestamp, date string or DateTime
      *
-     * @return string|boolean false is returned in case of invalid input
+     * @return string|bool false is returned in case of invalid input
      */
     public function formatDate($input)
     {
         switch (true) {
-
             // input of datetime object
             case $input instanceof \DateTime:
                 // no work needed
                 break;
-
             // input of timestamp or date/time string
-            case is_string($input) || is_numeric($input):
+            case \is_string($input) || is_numeric($input):
 
                 // if date/time string: convert to timestamp first
-                if (is_string($input)) {
+                if (\is_string($input)) {
                     $input = strtotime($input);
                 }
 
@@ -167,7 +165,6 @@ class Helper
                     $input = false;
                 }
                 break;
-
             // any other input formats can be added in additional cases here...
             // case $input instanceof Zend_Date:
 
@@ -186,10 +183,9 @@ class Helper
             $iso8601 .= 'Z';
 
             return $iso8601;
-        } else {
-            // unsupported input
-            return false;
         }
+        // unsupported input
+        return false;
     }
 
     /**
@@ -204,28 +200,28 @@ class Helper
      * Example: rangeQuery('store', '5', '*', false)
      * Returns: store:{5 TO *}
      *
-     * @param string  $field
-     * @param string  $from
-     * @param string  $to
-     * @param boolean $inclusive
+     * @param string $field
+     * @param string $from
+     * @param string $to
+     * @param bool   $inclusive
      *
      * @return string
      */
     public function rangeQuery($field, $from, $to, $inclusive = true)
     {
-        if ($from === null) {
+        if (null === $from) {
             $from = '*';
         }
 
-        if ($to === null) {
+        if (null === $to) {
             $to = '*';
         }
 
         if ($inclusive) {
             return $field.':['.$from.' TO '.$to.']';
-        } else {
-            return $field.':{'.$from.' TO '.$to.'}';
         }
+
+        return $field.':{'.$from.' TO '.$to.'}';
     }
 
     /**
@@ -233,11 +229,11 @@ class Helper
      *
      * Find all entries within the distance of a certain point.
      *
-     * @param string  $field
-     * @param string  $pointX
-     * @param string  $pointY
-     * @param string  $distance
-     * @param boolean $dereferenced
+     * @param string $field
+     * @param string $pointX
+     * @param string $pointY
+     * @param string $distance
+     * @param bool   $dereferenced
      *
      * @return string
      */
@@ -262,11 +258,11 @@ class Helper
      * guaranteed to encompass all of the points of interest, but it may also
      * include other points that are slightly outside of the required distance.
      *
-     * @param string  $field
-     * @param string  $pointX
-     * @param string  $pointY
-     * @param string  $distance
-     * @param boolean $dereferenced
+     * @param string $field
+     * @param string $pointX
+     * @param string $pointY
+     * @param string $distance
+     * @param bool   $dereferenced
      *
      * @return string
      */
@@ -292,10 +288,10 @@ class Helper
      * or combining the distance with the relevancy score,
      * such as boosting by the inverse of the distance.
      *
-     * @param string  $field
-     * @param string  $pointX
-     * @param string  $pointY
-     * @param boolean $dereferenced
+     * @param string $field
+     * @param string $pointX
+     * @param string $pointY
+     * @param bool   $dereferenced
      *
      * @return string
      */
@@ -311,12 +307,13 @@ class Helper
     /**
      * Render a qparser plugin call.
      *
-     * @throws InvalidArgumentException
      *
-     * @param string  $name
-     * @param array   $params
-     * @param boolean $dereferenced
-     * @param boolean $forceKeys
+     * @param string $name
+     * @param array  $params
+     * @param bool   $dereferenced
+     * @param bool   $forceKeys
+     *
+     * @throws InvalidArgumentException
      *
      * @return string
      */
@@ -330,8 +327,8 @@ class Helper
             }
 
             foreach ($params as $paramKey => $paramValue) {
-                if (is_int($paramKey) || $forceKeys) {
-                    $this->derefencedParamsLastKey++;
+                if (\is_int($paramKey) || $forceKeys) {
+                    ++$this->derefencedParamsLastKey;
                     $derefKey = 'deref_'.$this->derefencedParamsLastKey;
                 } else {
                     $derefKey = $paramKey;
@@ -343,7 +340,7 @@ class Helper
 
         $output = '{!'.$name;
         foreach ($params as $key => $value) {
-            if (!$dereferenced || $forceKeys || is_int($key)) {
+            if (!$dereferenced || $forceKeys || \is_int($key)) {
                 $output .= ' '.$key.'='.$value;
             }
         }
@@ -355,9 +352,9 @@ class Helper
     /**
      * Render a functionCall.
      *
-     * @param string  $name
-     * @param array   $params
-     * @param boolean $dereferenced
+     * @param string $name
+     * @param array  $params
+     * @param bool   $dereferenced
      *
      * @return string
      */
@@ -369,9 +366,9 @@ class Helper
             }
 
             return $name.'()';
-        } else {
-            return $name.'('.implode($params, ',').')';
         }
+
+        return $name.'('.implode(',', $params).')';
     }
 
     /**
@@ -415,9 +412,9 @@ class Helper
      * @see http://wiki.apache.org/solr/Join
      * @since 2.4.0
      *
-     * @param string  $from
-     * @param string  $to
-     * @param boolean $dereferenced
+     * @param string $from
+     * @param string $to
+     * @param bool   $dereferenced
      *
      * @return string
      */
@@ -453,7 +450,7 @@ class Helper
      *
      * @see http://wiki.apache.org/solr/CommonQueryParameters#Caching_of_filters
      *
-     * @param boolean    $useCache
+     * @param bool       $useCache
      * @param float|null $cost
      *
      * @return string
@@ -462,7 +459,7 @@ class Helper
     {
         $cache = 'false';
 
-        if ($useCache === true) {
+        if (true === $useCache) {
             $cache = 'true';
         }
 
@@ -492,9 +489,10 @@ class Helper
     /**
      * Render placeholders in a querystring.
      *
-     * @throws InvalidArgumentException
      *
      * @param array $matches
+     *
+     * @throws InvalidArgumentException
      *
      * @return string
      */
@@ -503,8 +501,8 @@ class Helper
         $partNumber = $matches[2];
         $partMode = strtoupper($matches[1]);
 
-        if (isset($this->assembleParts[$partNumber-1])) {
-            $value = $this->assembleParts[$partNumber-1];
+        if (isset($this->assembleParts[$partNumber - 1])) {
+            $value = $this->assembleParts[$partNumber - 1];
         } else {
             throw new InvalidArgumentException('No value supplied for part #'.$partNumber.' in query assembler');
         }

--- a/library/Solarium/Core/Query/Query.php
+++ b/library/Solarium/Core/Query/Query.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2015 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -41,7 +41,7 @@
 namespace Solarium\Core\Query;
 
 /**
- * This class is for backwards compatibility, will be removed in 4.x releases in favor of AbstractQuery
+ * This class is for backwards compatibility, will be removed in 4.x releases in favor of AbstractQuery.
  *
  * @deprecated
  */

--- a/library/Solarium/Core/Query/QueryInterface.php
+++ b/library/Solarium/Core/Query/QueryInterface.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Core/Query/RequestBuilder.php
+++ b/library/Solarium/Core/Query/RequestBuilder.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2015 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -41,7 +41,7 @@
 namespace Solarium\Core\Query;
 
 /**
- * This class is for backwards compatibility, will be removed in 4.x releases in favor of AbstractRequestBuilder
+ * This class is for backwards compatibility, will be removed in 4.x releases in favor of AbstractRequestBuilder.
  *
  * @deprecated
  */

--- a/library/Solarium/Core/Query/RequestBuilderInterface.php
+++ b/library/Solarium/Core/Query/RequestBuilderInterface.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Core/Query/ResponseParser.php
+++ b/library/Solarium/Core/Query/ResponseParser.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2015 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -41,7 +41,7 @@
 namespace Solarium\Core\Query;
 
 /**
- * This class is for backwards compatibility, will be removed in 4.x releases in favor of AbstractResponseParser
+ * This class is for backwards compatibility, will be removed in 4.x releases in favor of AbstractResponseParser.
  *
  * @deprecated
  */

--- a/library/Solarium/Core/Query/ResponseParserInterface.php
+++ b/library/Solarium/Core/Query/ResponseParserInterface.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Core/Query/Result/QueryType.php
+++ b/library/Solarium/Core/Query/Result/QueryType.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Core/Query/Result/Result.php
+++ b/library/Solarium/Core/Query/Result/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -42,10 +42,10 @@ namespace Solarium\Core\Query\Result;
 
 use Solarium\Core\Client\Client;
 use Solarium\Core\Client\Response;
-use Solarium\Exception\HttpException;
 use Solarium\Core\Query\AbstractQuery;
-use Solarium\Exception\UnexpectedValueException;
+use Solarium\Exception\HttpException;
 use Solarium\Exception\RuntimeException;
+use Solarium\Exception\UnexpectedValueException;
 
 /**
  * Query result.
@@ -88,11 +88,12 @@ class Result implements ResultInterface
     /**
      * Constructor.
      *
-     * @throws HttpException
      *
      * @param Client        $client
      * @param AbstractQuery $query
      * @param Response      $response
+     *
+     * @throws HttpException
      */
     public function __construct($client, $query, $response)
     {
@@ -102,7 +103,7 @@ class Result implements ResultInterface
 
         // check status for error (range of 400 and 500)
         $statusNum = floor($response->getStatusCode() / 100);
-        if ($statusNum == 4 || $statusNum == 5) {
+        if (4 == $statusNum || 5 == $statusNum) {
             throw new HttpException(
                 $response->getStatusMessage(),
                 $response->getStatusCode(),

--- a/library/Solarium/Core/Query/Result/ResultInterface.php
+++ b/library/Solarium/Core/Query/Result/ResultInterface.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Exception/ExceptionInterface.php
+++ b/library/Solarium/Exception/ExceptionInterface.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Exception/HttpException.php
+++ b/library/Solarium/Exception/HttpException.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Exception/InvalidArgumentException.php
+++ b/library/Solarium/Exception/InvalidArgumentException.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Exception/OutOfBoundsException.php
+++ b/library/Solarium/Exception/OutOfBoundsException.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Exception/RuntimeException.php
+++ b/library/Solarium/Exception/RuntimeException.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Exception/UnexpectedValueException.php
+++ b/library/Solarium/Exception/UnexpectedValueException.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Plugin/BufferedAdd/BufferedAdd.php
+++ b/library/Solarium/Plugin/BufferedAdd/BufferedAdd.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -41,15 +41,15 @@
 namespace Solarium\Plugin\BufferedAdd;
 
 use Solarium\Core\Plugin\AbstractPlugin;
-use Solarium\QueryType\Update\Result as UpdateResult;
-use Solarium\QueryType\Update\Query\Query as UpdateQuery;
-use Solarium\QueryType\Select\Result\DocumentInterface;
+use Solarium\Plugin\BufferedAdd\Event\AddDocument as AddDocumentEvent;
 use Solarium\Plugin\BufferedAdd\Event\Events;
-use Solarium\Plugin\BufferedAdd\Event\PreFlush as PreFlushEvent;
+use Solarium\Plugin\BufferedAdd\Event\PostCommit as PostCommitEvent;
 use Solarium\Plugin\BufferedAdd\Event\PostFlush as PostFlushEvent;
 use Solarium\Plugin\BufferedAdd\Event\PreCommit as PreCommitEvent;
-use Solarium\Plugin\BufferedAdd\Event\PostCommit as PostCommitEvent;
-use Solarium\Plugin\BufferedAdd\Event\AddDocument as AddDocumentEvent;
+use Solarium\Plugin\BufferedAdd\Event\PreFlush as PreFlushEvent;
+use Solarium\QueryType\Select\Result\DocumentInterface;
+use Solarium\QueryType\Update\Query\Query as UpdateQuery;
+use Solarium\QueryType\Update\Result as UpdateResult;
 
 /**
  * Buffered add plugin.
@@ -156,7 +156,7 @@ class BufferedAdd extends AbstractPlugin
         $event = new AddDocumentEvent($document);
         $this->client->getEventDispatcher()->dispatch(Events::ADD_DOCUMENT, $event);
 
-        if (count($this->buffer) == $this->options['buffersize']) {
+        if (\count($this->buffer) == $this->options['buffersize']) {
             $this->flush();
         }
 
@@ -207,14 +207,14 @@ class BufferedAdd extends AbstractPlugin
     /**
      * Flush any buffered documents to Solr.
      *
-     * @param boolean $overwrite
-     * @param int     $commitWithin
+     * @param bool $overwrite
+     * @param int  $commitWithin
      *
-     * @return boolean|UpdateResult
+     * @return bool|UpdateResult
      */
     public function flush($overwrite = null, $commitWithin = null)
     {
-        if (count($this->buffer) == 0) {
+        if (0 == \count($this->buffer)) {
             // nothing to do
             return false;
         }
@@ -237,10 +237,10 @@ class BufferedAdd extends AbstractPlugin
      *
      * Any remaining documents in the buffer will also be flushed
      *
-     * @param boolean $overwrite
-     * @param boolean $softCommit
-     * @param boolean $waitSearcher
-     * @param boolean $expungeDeletes
+     * @param bool $overwrite
+     * @param bool $softCommit
+     * @param bool $waitSearcher
+     * @param bool $expungeDeletes
      *
      * @return UpdateResult
      */

--- a/library/Solarium/Plugin/BufferedAdd/Event/AddDocument.php
+++ b/library/Solarium/Plugin/BufferedAdd/Event/AddDocument.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\Plugin\BufferedAdd\Event;
 
-use Symfony\Component\EventDispatcher\Event;
 use Solarium\QueryType\Select\Result\DocumentInterface;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * AddDocument event, see Events for details.

--- a/library/Solarium/Plugin/BufferedAdd/Event/Events.php
+++ b/library/Solarium/Plugin/BufferedAdd/Event/Events.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Plugin/BufferedAdd/Event/PostCommit.php
+++ b/library/Solarium/Plugin/BufferedAdd/Event/PostCommit.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,9 +40,9 @@
 
 namespace Solarium\Plugin\BufferedAdd\Event;
 
-use Symfony\Component\EventDispatcher\Event;
-use Solarium\QueryType\Update\Result;
 use Solarium\QueryType\Select\Result\DocumentInterface;
+use Solarium\QueryType\Update\Result;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PostCommit event, see Events for details.

--- a/library/Solarium/Plugin/BufferedAdd/Event/PostFlush.php
+++ b/library/Solarium/Plugin/BufferedAdd/Event/PostFlush.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,9 +40,9 @@
 
 namespace Solarium\Plugin\BufferedAdd\Event;
 
-use Symfony\Component\EventDispatcher\Event;
-use Solarium\QueryType\Update\Result;
 use Solarium\QueryType\Select\Result\DocumentInterface;
+use Solarium\QueryType\Update\Result;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PostFlush event, see Events for details.

--- a/library/Solarium/Plugin/BufferedAdd/Event/PreCommit.php
+++ b/library/Solarium/Plugin/BufferedAdd/Event/PreCommit.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\Plugin\BufferedAdd\Event;
 
-use Symfony\Component\EventDispatcher\Event;
 use Solarium\QueryType\Select\Result\DocumentInterface;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PreCommit event, see Events for details.
@@ -54,33 +54,33 @@ class PreCommit extends Event
     protected $buffer;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $overwrite;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $softCommit;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $waitSearcher;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $expungeDeletes;
 
     /**
      * Event constructor.
      *
-     * @param array   $buffer
-     * @param boolean $overwrite
-     * @param boolean $softCommit
-     * @param boolean $waitSearcher
-     * @param boolean $expungeDeletes
+     * @param array $buffer
+     * @param bool  $overwrite
+     * @param bool  $softCommit
+     * @param bool  $waitSearcher
+     * @param bool  $expungeDeletes
      */
     public function __construct($buffer, $overwrite, $softCommit, $waitSearcher, $expungeDeletes)
     {
@@ -114,7 +114,7 @@ class PreCommit extends Event
     /**
      * Optionally override the value.
      *
-     * @param boolean $expungeDeletes
+     * @param bool $expungeDeletes
      */
     public function setExpungeDeletes($expungeDeletes)
     {
@@ -122,7 +122,7 @@ class PreCommit extends Event
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function getExpungeDeletes()
     {
@@ -132,7 +132,7 @@ class PreCommit extends Event
     /**
      * Optionally override the value.
      *
-     * @param boolean $overwrite
+     * @param bool $overwrite
      */
     public function setOverwrite($overwrite)
     {
@@ -140,7 +140,7 @@ class PreCommit extends Event
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function getOverwrite()
     {
@@ -150,7 +150,7 @@ class PreCommit extends Event
     /**
      * Optionally override the value.
      *
-     * @param boolean $softCommit
+     * @param bool $softCommit
      */
     public function setSoftCommit($softCommit)
     {
@@ -158,7 +158,7 @@ class PreCommit extends Event
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function getSoftCommit()
     {
@@ -168,7 +168,7 @@ class PreCommit extends Event
     /**
      * Optionally override the value.
      *
-     * @param boolean $waitSearcher
+     * @param bool $waitSearcher
      */
     public function setWaitSearcher($waitSearcher)
     {
@@ -176,7 +176,7 @@ class PreCommit extends Event
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function getWaitSearcher()
     {

--- a/library/Solarium/Plugin/BufferedAdd/Event/PreFlush.php
+++ b/library/Solarium/Plugin/BufferedAdd/Event/PreFlush.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\Plugin\BufferedAdd\Event;
 
-use Symfony\Component\EventDispatcher\Event;
 use Solarium\QueryType\Select\Result\DocumentInterface;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * PreFlush event, see Events for details.
@@ -54,7 +54,7 @@ class PreFlush extends Event
     protected $buffer;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $overwrite;
 
@@ -66,9 +66,9 @@ class PreFlush extends Event
     /**
      * Event constructor.
      *
-     * @param array   $buffer
-     * @param boolean $overwrite
-     * @param int     $commitWithin
+     * @param array $buffer
+     * @param bool  $overwrite
+     * @param int   $commitWithin
      */
     public function __construct($buffer, $overwrite, $commitWithin)
     {
@@ -118,7 +118,7 @@ class PreFlush extends Event
     /**
      * Optionally override the value.
      *
-     * @param boolean $overwrite
+     * @param bool $overwrite
      */
     public function setOverwrite($overwrite)
     {
@@ -126,7 +126,7 @@ class PreFlush extends Event
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function getOverwrite()
     {

--- a/library/Solarium/Plugin/CustomizeRequest/Customization.php
+++ b/library/Solarium/Plugin/CustomizeRequest/Customization.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -170,7 +170,7 @@ class Customization extends Configurable
     /**
      * Set persistent on/off.
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return Customization
      */
@@ -184,7 +184,7 @@ class Customization extends Configurable
     /**
      * Get persistent setting.
      *
-     * @return boolean
+     * @return bool
      */
     public function getPersistent()
     {
@@ -194,7 +194,7 @@ class Customization extends Configurable
     /**
      * Set overwrite option on/off.
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return Customization
      */
@@ -208,7 +208,7 @@ class Customization extends Configurable
     /**
      * Get overwrite option value.
      *
-     * @return boolean
+     * @return bool
      */
     public function getOverwrite()
     {
@@ -223,7 +223,7 @@ class Customization extends Configurable
     public function isValid()
     {
         $type = $this->getType();
-        if ($type !== self::TYPE_PARAM && $type !== self::TYPE_HEADER) {
+        if (self::TYPE_PARAM !== $type && self::TYPE_HEADER !== $type) {
             return false;
         }
 

--- a/library/Solarium/Plugin/CustomizeRequest/CustomizeRequest.php
+++ b/library/Solarium/Plugin/CustomizeRequest/CustomizeRequest.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,11 +40,11 @@
 
 namespace Solarium\Plugin\CustomizeRequest;
 
+use Solarium\Core\Event\Events;
+use Solarium\Core\Event\PreExecuteRequest as preExecuteRequestEvent;
 use Solarium\Core\Plugin\AbstractPlugin;
 use Solarium\Exception\InvalidArgumentException;
 use Solarium\Exception\RuntimeException;
-use Solarium\Core\Event\Events;
-use Solarium\Core\Event\PreExecuteRequest as preExecuteRequestEvent;
 
 /**
  * CustomizeRequest plugin.
@@ -77,14 +77,14 @@ class CustomizeRequest extends AbstractPlugin
      */
     public function createCustomization($options = null)
     {
-        if (is_string($options)) {
+        if (\is_string($options)) {
             $fq = new Customization();
             $fq->setKey($options);
         } else {
             $fq = new Customization($options);
         }
 
-        if ($fq->getKey() !== null) {
+        if (null !== $fq->getKey()) {
             $this->addCustomization($fq);
         }
 
@@ -97,27 +97,28 @@ class CustomizeRequest extends AbstractPlugin
      * Supports a Customization instance or a config array, in that case a new
      * Customization instance wil be created based on the options.
      *
-     * @throws InvalidArgumentException
      *
      * @param Customization|array $customization
+     *
+     * @throws InvalidArgumentException
      *
      * @return self Provides fluent interface
      */
     public function addCustomization($customization)
     {
-        if (is_array($customization)) {
+        if (\is_array($customization)) {
             $customization = new Customization($customization);
         }
 
         $key = $customization->getKey();
 
         // check for non-empty key
-        if (0 === strlen($key)) {
+        if (0 === \strlen($key)) {
             throw new InvalidArgumentException('A Customization must have a key value');
         }
 
         // check for a unique key
-        if (array_key_exists($key, $this->customizations)) {
+        if (\array_key_exists($key, $this->customizations)) {
             //double add calls for the same customization are ignored, others cause an exception
             if ($this->customizations[$key] !== $customization) {
                 throw new InvalidArgumentException('A Customization must have a unique key value');
@@ -140,7 +141,7 @@ class CustomizeRequest extends AbstractPlugin
     {
         foreach ($customizations as $key => $customization) {
             // in case of a config array: add key to config
-            if (is_array($customization) && !isset($customization['key'])) {
+            if (\is_array($customization) && !isset($customization['key'])) {
                 $customization['key'] = $key;
             }
 
@@ -161,8 +162,6 @@ class CustomizeRequest extends AbstractPlugin
     {
         if (isset($this->customizations[$key])) {
             return $this->customizations[$key];
-        } else {
-            return;
         }
     }
 
@@ -187,7 +186,7 @@ class CustomizeRequest extends AbstractPlugin
      */
     public function removeCustomization($customization)
     {
-        if (is_object($customization)) {
+        if (\is_object($customization)) {
             $customization = $customization->getKey();
         }
 
@@ -226,9 +225,10 @@ class CustomizeRequest extends AbstractPlugin
     /**
      * Event hook to customize the request object.
      *
-     * @throws RuntimeException
      *
      * @param preExecuteRequestEvent $event
+     *
+     * @throws RuntimeException
      */
     public function preExecuteRequest(preExecuteRequestEvent $event)
     {

--- a/library/Solarium/Plugin/Loadbalancer/Event/EndpointFailure.php
+++ b/library/Solarium/Plugin/Loadbalancer/Event/EndpointFailure.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,9 +40,9 @@
 
 namespace Solarium\Plugin\Loadbalancer\Event;
 
-use Symfony\Component\EventDispatcher\Event;
 use Solarium\Core\Client\Endpoint;
 use Solarium\Exception\HttpException;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * EndpointFailure event, see Events for details.

--- a/library/Solarium/Plugin/Loadbalancer/Event/Events.php
+++ b/library/Solarium/Plugin/Loadbalancer/Event/Events.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Plugin/Loadbalancer/Loadbalancer.php
+++ b/library/Solarium/Plugin/Loadbalancer/Loadbalancer.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,20 +40,20 @@
 
 namespace Solarium\Plugin\Loadbalancer;
 
-use Solarium\Core\Plugin\AbstractPlugin;
 use Solarium\Core\Client\Client;
 use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Exception\InvalidArgumentException;
-use Solarium\Exception\OutOfBoundsException;
-use Solarium\Exception\RuntimeException;
-use Solarium\Exception\HttpException;
-use Solarium\Plugin\Loadbalancer\Event\Events;
-use Solarium\Plugin\Loadbalancer\Event\EndpointFailure as EndpointFailureEvent;
 use Solarium\Core\Event\Events as CoreEvents;
 use Solarium\Core\Event\PreCreateRequest as PreCreateRequestEvent;
 use Solarium\Core\Event\PreExecuteRequest as PreExecuteRequestEvent;
+use Solarium\Core\Plugin\AbstractPlugin;
+use Solarium\Exception\HttpException;
+use Solarium\Exception\InvalidArgumentException;
+use Solarium\Exception\OutOfBoundsException;
+use Solarium\Exception\RuntimeException;
+use Solarium\Plugin\Loadbalancer\Event\EndpointFailure as EndpointFailureEvent;
+use Solarium\Plugin\Loadbalancer\Event\Events;
 
 /**
  * Loadbalancer plugin.
@@ -101,7 +101,7 @@ class Loadbalancer extends AbstractPlugin
      *
      * The value can be null if no queries have been executed, or if the last executed query didn't use loadbalancing.
      *
-     * @var null|string
+     * @var string|null
      */
     protected $lastEndpoint;
 
@@ -158,7 +158,7 @@ class Loadbalancer extends AbstractPlugin
     /**
      * Get failoverenabled option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getFailoverEnabled()
     {
@@ -190,24 +190,24 @@ class Loadbalancer extends AbstractPlugin
     /**
      * Add an endpoint to the loadbalacing 'pool'.
      *
-     * @throws InvalidArgumentException
      *
      * @param Endpoint|string $endpoint
      * @param int             $weight   Must be a positive number
+     *
+     * @throws InvalidArgumentException
      *
      * @return self Provides fluent interface
      */
     public function addEndpoint($endpoint, $weight = 1)
     {
-        if (!is_string($endpoint)) {
+        if (!\is_string($endpoint)) {
             $endpoint = $endpoint->getKey();
         }
 
-        if (array_key_exists($endpoint, $this->endpoints)) {
+        if (\array_key_exists($endpoint, $this->endpoints)) {
             throw new InvalidArgumentException('An endpoint for the loadbalancer plugin must have a unique key');
-        } else {
-            $this->endpoints[$endpoint] = $weight;
         }
+        $this->endpoints[$endpoint] = $weight;
 
         // reset the randomizer as soon as a new endpoint is added
         $this->randomizer = null;
@@ -260,7 +260,7 @@ class Loadbalancer extends AbstractPlugin
      */
     public function removeEndpoint($endpoint)
     {
-        if (!is_string($endpoint)) {
+        if (!\is_string($endpoint)) {
             $endpoint = $endpoint->getKey();
         }
 
@@ -293,19 +293,20 @@ class Loadbalancer extends AbstractPlugin
      * If the next query cannot be loadbalanced (for instance based on the querytype) this setting is ignored
      * but will still be reset.
      *
-     * @throws OutOfBoundsException
      *
-     * @param string|null|Endpoint $endpoint
+     * @param string|Endpoint|null $endpoint
+     *
+     * @throws OutOfBoundsException
      *
      * @return self Provides fluent interface
      */
     public function setForcedEndpointForNextQuery($endpoint)
     {
-        if (!is_string($endpoint)) {
+        if (!\is_string($endpoint)) {
             $endpoint = $endpoint->getKey();
         }
 
-        if ($endpoint !== null && !array_key_exists($endpoint, $this->endpoints)) {
+        if (null !== $endpoint && !\array_key_exists($endpoint, $this->endpoints)) {
             throw new OutOfBoundsException('Unknown endpoint forced for next query');
         }
 
@@ -360,7 +361,7 @@ class Loadbalancer extends AbstractPlugin
      */
     public function addBlockedQueryType($type)
     {
-        if (!array_key_exists($type, $this->blockedQueryTypes)) {
+        if (!\array_key_exists($type, $this->blockedQueryTypes)) {
             $this->blockedQueryTypes[$type] = true;
         }
 
@@ -390,7 +391,7 @@ class Loadbalancer extends AbstractPlugin
      */
     public function removeBlockedQueryType($type)
     {
-        if (array_key_exists($type, $this->blockedQueryTypes)) {
+        if (\array_key_exists($type, $this->blockedQueryTypes)) {
             unset($this->blockedQueryTypes[$type]);
         }
     }
@@ -410,7 +411,7 @@ class Loadbalancer extends AbstractPlugin
      *
      * May return a null value if no query has been executed yet, or the last query could not be loadbalanced.
      *
-     * @return null|string
+     * @return string|null
      */
     public function getLastEndpoint()
     {
@@ -437,12 +438,12 @@ class Loadbalancer extends AbstractPlugin
         $adapter = $this->client->getAdapter();
 
         // save adapter presets (once) to allow the settings to be restored later
-        if ($this->defaultEndpoint === null) {
+        if (null === $this->defaultEndpoint) {
             $this->defaultEndpoint = $this->client->getEndpoint()->getKey();
         }
 
         // check querytype: is loadbalancing allowed?
-        if (!array_key_exists($this->queryType, $this->blockedQueryTypes)) {
+        if (!\array_key_exists($this->queryType, $this->blockedQueryTypes)) {
             $response = $this->getLoadbalancedResponse($event->getRequest());
         } else {
             $endpoint = $this->client->getEndpoint($this->defaultEndpoint);
@@ -458,9 +459,10 @@ class Loadbalancer extends AbstractPlugin
     /**
      * Execute a request using the adapter.
      *
-     * @throws RuntimeException
      *
      * @param Request $request
+     *
+     * @throws RuntimeException
      *
      * @return Response $response
      */
@@ -469,9 +471,9 @@ class Loadbalancer extends AbstractPlugin
         $this->endpointExcludes = array(); // reset for each query
         $adapter = $this->client->getAdapter();
 
-        if ($this->getFailoverEnabled() === true) {
+        if (true === $this->getFailoverEnabled()) {
             $maxRetries = $this->getFailoverMaxRetries();
-            for ($i = 0; $i <= $maxRetries; $i++) {
+            for ($i = 0; $i <= $maxRetries; ++$i) {
                 $endpoint = $this->getRandomEndpoint();
                 try {
                     return $adapter->execute($request, $endpoint);
@@ -487,12 +489,11 @@ class Loadbalancer extends AbstractPlugin
 
             // if we get here no more retries available, throw exception
             throw new RuntimeException('Maximum number of loadbalancer retries reached');
-        } else {
-            // no failover retries, just execute and let an exception bubble upwards
-            $endpoint = $this->getRandomEndpoint();
-
-            return $adapter->execute($request, $endpoint);
         }
+        // no failover retries, just execute and let an exception bubble upwards
+        $endpoint = $this->getRandomEndpoint();
+
+        return $adapter->execute($request, $endpoint);
     }
 
     /**
@@ -503,7 +504,7 @@ class Loadbalancer extends AbstractPlugin
     protected function getRandomEndpoint()
     {
         // determine the endpoint to use
-        if ($this->nextEndpoint !== null) {
+        if (null !== $this->nextEndpoint) {
             $key = $this->nextEndpoint;
             // reset forced endpoint directly after use
             $this->nextEndpoint = null;
@@ -524,7 +525,7 @@ class Loadbalancer extends AbstractPlugin
      */
     protected function getRandomizer()
     {
-        if ($this->randomizer === null) {
+        if (null === $this->randomizer) {
             $this->randomizer = new WeightedRandomChoice($this->endpoints);
         }
 

--- a/library/Solarium/Plugin/Loadbalancer/WeightedRandomChoice.php
+++ b/library/Solarium/Plugin/Loadbalancer/WeightedRandomChoice.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -74,9 +74,10 @@ class WeightedRandomChoice
     /**
      * Constructor.
      *
-     * @throws InvalidArgumentException
      *
      * @param array $choices
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($choices)
     {
@@ -90,22 +91,23 @@ class WeightedRandomChoice
             $this->lookup[$i] = $this->totalWeight;
             $this->values[$i] = $key;
 
-            $i++;
+            ++$i;
         }
     }
 
     /**
      * Get a (weighted) random entry.
      *
-     * @throws RuntimeException
      *
      * @param array $excludes Keys to exclude
+     *
+     * @throws RuntimeException
      *
      * @return string
      */
     public function getRandom($excludes = array())
     {
-        if (count($excludes) == count($this->values)) {
+        if (\count($excludes) == \count($this->values)) {
             throw new RuntimeException('No more server entries available');
         }
 
@@ -113,7 +115,7 @@ class WeightedRandomChoice
         $result = null;
         while (1) {
             $result = $this->values[$this->getKey()];
-            if (!in_array($result, $excludes)) {
+            if (!\in_array($result, $excludes, true)) {
                 break;
             }
         }
@@ -129,7 +131,7 @@ class WeightedRandomChoice
     protected function getKey()
     {
         $random = mt_rand(1, $this->totalWeight);
-        $high = count($this->lookup)-1;
+        $high = \count($this->lookup) - 1;
         $low = 0;
 
         while ($low < $high) {
@@ -145,8 +147,8 @@ class WeightedRandomChoice
 
         if ($this->lookup[$low] >= $random) {
             return $low;
-        } else {
-            return $low+1;
         }
+
+        return $low + 1;
     }
 }

--- a/library/Solarium/Plugin/MinimumScoreFilter/Document.php
+++ b/library/Solarium/Plugin/MinimumScoreFilter/Document.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\Plugin\MinimumScoreFilter;
 
-use Solarium\QueryType\Select\Result\DocumentInterface;
 use Solarium\Exception\RuntimeException;
+use Solarium\QueryType\Select\Result\DocumentInterface;
 
 /**
  * Minimum score filter query result document.
@@ -60,7 +60,7 @@ class Document implements \IteratorAggregate, \Countable, \ArrayAccess
     /**
      * Is this document marked as a low score?
      *
-     * @var boolean
+     * @var bool
      */
     protected $marked;
 
@@ -74,16 +74,6 @@ class Document implements \IteratorAggregate, \Countable, \ArrayAccess
     {
         $this->document = $document;
         $this->marked = $threshold > $document->score;
-    }
-
-    /**
-     * Get markedAsLowScore status.
-     *
-     * @return bool
-     */
-    public function markedAsLowScore()
-    {
-        return $this->marked;
     }
 
     /**
@@ -116,11 +106,38 @@ class Document implements \IteratorAggregate, \Countable, \ArrayAccess
      *
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function __isset($name)
     {
         return $this->document->__isset($name);
+    }
+
+    /**
+     * Set field value.
+     *
+     * Magic method for setting a field as property of this object. Since this
+     * is a readonly document an exception will be thrown to prevent this.
+     *
+     *
+     * @param string $name
+     * @param string $value
+     *
+     * @throws RuntimeException
+     */
+    public function __set($name, $value)
+    {
+        throw new RuntimeException('A readonly document cannot be altered');
+    }
+
+    /**
+     * Get markedAsLowScore status.
+     *
+     * @return bool
+     */
+    public function markedAsLowScore()
+    {
+        return $this->marked;
     }
 
     /**
@@ -175,22 +192,6 @@ class Document implements \IteratorAggregate, \Countable, \ArrayAccess
     public function offsetGet($offset)
     {
         return $this->document->offsetGet($offset);
-    }
-
-    /**
-     * Set field value.
-     *
-     * Magic method for setting a field as property of this object. Since this
-     * is a readonly document an exception will be thrown to prevent this.
-     *
-     * @throws RuntimeException
-     *
-     * @param string $name
-     * @param string $value
-     */
-    public function __set($name, $value)
-    {
-        throw new RuntimeException('A readonly document cannot be altered');
     }
 
     /**

--- a/library/Solarium/Plugin/MinimumScoreFilter/Filter.php
+++ b/library/Solarium/Plugin/MinimumScoreFilter/Filter.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2014 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Plugin/MinimumScoreFilter/MinimumScoreFilter.php
+++ b/library/Solarium/Plugin/MinimumScoreFilter/MinimumScoreFilter.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2014 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Plugin/MinimumScoreFilter/Query.php
+++ b/library/Solarium/Plugin/MinimumScoreFilter/Query.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -65,16 +65,16 @@ class Query extends SelectQuery
      * @var array
      */
     protected $options = array(
-        'handler'       => 'select',
-        'resultclass'   => 'Solarium\QueryType\Select\Result\Result',
+        'handler' => 'select',
+        'resultclass' => 'Solarium\QueryType\Select\Result\Result',
         'documentclass' => 'Solarium\QueryType\Select\Result\Document',
-        'query'         => '*:*',
-        'start'         => 0,
-        'rows'          => 10,
-        'fields'        => '*,score',
-        'omitheader'    => true,
-        'filterratio'  => 0.1,
-        'filter_mode'   => self::FILTER_MODE_REMOVE,
+        'query' => '*:*',
+        'start' => 0,
+        'rows' => 10,
+        'fields' => '*,score',
+        'omitheader' => true,
+        'filterratio' => 0.1,
+        'filter_mode' => self::FILTER_MODE_REMOVE,
     );
 
     /**
@@ -131,7 +131,7 @@ class Query extends SelectQuery
     public function getFields()
     {
         $fields = parent::getFields();
-        if (!in_array('score', $fields)) {
+        if (!\in_array('score', $fields, true)) {
             $fields[] = 'score';
         }
 

--- a/library/Solarium/Plugin/MinimumScoreFilter/QueryGroupResult.php
+++ b/library/Solarium/Plugin/MinimumScoreFilter/QueryGroupResult.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -63,7 +63,7 @@ class QueryGroupResult extends StandardQueryGroupResult
     protected $filterRatio;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $filtered = false;
 
@@ -83,7 +83,7 @@ class QueryGroupResult extends StandardQueryGroupResult
         $this->filterRatio = $query->getFilterRatio();
 
         // Use the maximumScore of the first group as maximum for all groups
-        if (self::$overallMaximumScore === null) {
+        if (null === self::$overallMaximumScore) {
             self::$overallMaximumScore = $maximumScore;
         }
 

--- a/library/Solarium/Plugin/MinimumScoreFilter/Result.php
+++ b/library/Solarium/Plugin/MinimumScoreFilter/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2014 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -57,7 +57,7 @@ class Result extends SelectResult
     protected function mapData($mapData)
     {
         foreach ($mapData as $key => $data) {
-            if ($key == 'documents') {
+            if ('documents' == $key) {
                 $filter = new Filter();
                 $mode = $this->getQuery()->getFilterMode();
                 $ratio = $this->getQuery()->getFilterRatio();

--- a/library/Solarium/Plugin/MinimumScoreFilter/ValueGroupResult.php
+++ b/library/Solarium/Plugin/MinimumScoreFilter/ValueGroupResult.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -63,7 +63,7 @@ class ValueGroupResult extends StandardValueGroup
     protected $filterRatio;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $filtered = false;
 

--- a/library/Solarium/Plugin/ParallelExecution/Event/Events.php
+++ b/library/Solarium/Plugin/ParallelExecution/Event/Events.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Plugin/ParallelExecution/Event/ExecuteEnd.php
+++ b/library/Solarium/Plugin/ParallelExecution/Event/ExecuteEnd.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Plugin/ParallelExecution/Event/ExecuteStart.php
+++ b/library/Solarium/Plugin/ParallelExecution/Event/ExecuteStart.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Plugin/ParallelExecution/ParallelExecution.php
+++ b/library/Solarium/Plugin/ParallelExecution/ParallelExecution.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,13 +40,13 @@
 
 namespace Solarium\Plugin\ParallelExecution;
 
-use Solarium\Core\Plugin\AbstractPlugin;
 use Solarium\Core\Client\Endpoint;
-use Solarium\Exception\HttpException;
+use Solarium\Core\Plugin\AbstractPlugin;
 use Solarium\Core\Query\AbstractQuery;
+use Solarium\Exception\HttpException;
 use Solarium\Plugin\ParallelExecution\Event\Events;
-use Solarium\Plugin\ParallelExecution\Event\ExecuteStart as ExecuteStartEvent;
 use Solarium\Plugin\ParallelExecution\Event\ExecuteEnd as ExecuteEndEvent;
+use Solarium\Plugin\ParallelExecution\Event\ExecuteStart as ExecuteStartEvent;
 
 /**
  * ParallelExecution plugin.
@@ -82,17 +82,17 @@ class ParallelExecution extends AbstractPlugin
      *
      * @param string               $key
      * @param AbstractQuery        $query
-     * @param null|string|Endpoint $endpoint
+     * @param string|Endpoint|null $endpoint
      *
      * @return self Provides fluent interface
      */
     public function addQuery($key, $query, $endpoint = null)
     {
-        if (is_object($endpoint)) {
+        if (\is_object($endpoint)) {
             $endpoint = $endpoint->getKey();
         }
 
-        if ($endpoint === null) {
+        if (null === $endpoint) {
             $endpoint = $this->client->getEndpoint()->getKey();
         }
 
@@ -152,17 +152,17 @@ class ParallelExecution extends AbstractPlugin
 
         do {
             $mrc = curl_multi_exec($multiHandle, $active);
-        } while ($mrc == CURLM_CALL_MULTI_PERFORM);
+        } while (CURLM_CALL_MULTI_PERFORM == $mrc);
 
         $timeout = $this->getOption('curlmultiselecttimeout');
-        while ($active && $mrc == CURLM_OK) {
-            if (curl_multi_select($multiHandle, $timeout) == -1) {
+        while ($active && CURLM_OK == $mrc) {
+            if (-1 == curl_multi_select($multiHandle, $timeout)) {
                 usleep(100);
             }
 
             do {
                 $mrc = curl_multi_exec($multiHandle, $active);
-            } while ($mrc == CURLM_CALL_MULTI_PERFORM);
+            } while (CURLM_CALL_MULTI_PERFORM == $mrc);
         }
 
         $this->client->getEventDispatcher()->dispatch(Events::EXECUTE_END, new ExecuteEndEvent());

--- a/library/Solarium/Plugin/PostBigRequest.php
+++ b/library/Solarium/Plugin/PostBigRequest.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,10 +40,10 @@
 
 namespace Solarium\Plugin;
 
-use Solarium\Core\Plugin\AbstractPlugin;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Event\Events;
 use Solarium\Core\Event\PostCreateRequest as PostCreateRequestEvent;
+use Solarium\Core\Plugin\AbstractPlugin;
 
 /**
  * PostBigRequest plugin.
@@ -69,7 +69,7 @@ class PostBigRequest extends AbstractPlugin
     /**
      * Set maxquerystringlength enabled option.
      *
-     * @param integer $value
+     * @param int $value
      *
      * @return self Provides fluent interface
      */
@@ -81,7 +81,7 @@ class PostBigRequest extends AbstractPlugin
     /**
      * Get maxquerystringlength option.
      *
-     * @return integer
+     * @return int
      */
     public function getMaxQueryStringLength()
     {
@@ -97,8 +97,8 @@ class PostBigRequest extends AbstractPlugin
     {
         $request = $event->getRequest();
         $queryString = $request->getQueryString();
-        if ($request->getMethod() == Request::METHOD_GET &&
-            strlen($queryString) > $this->getMaxQueryStringLength()) {
+        if (Request::METHOD_GET == $request->getMethod() &&
+            \strlen($queryString) > $this->getMaxQueryStringLength()) {
             $request->setMethod(Request::METHOD_POST);
             $request->setRawData($queryString);
             $request->clearParams();

--- a/library/Solarium/Plugin/PrefetchIterator.php
+++ b/library/Solarium/Plugin/PrefetchIterator.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,11 +40,11 @@
 
 namespace Solarium\Plugin;
 
+use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Plugin\AbstractPlugin;
 use Solarium\QueryType\Select\Query\Query as SelectQuery;
-use Solarium\QueryType\Select\Result\Result as SelectResult;
 use Solarium\QueryType\Select\Result\DocumentInterface;
-use Solarium\Core\Client\Endpoint;
+use Solarium\QueryType\Select\Result\Result as SelectResult;
 
 /**
  * Prefetch plugin.
@@ -101,7 +101,7 @@ class PrefetchIterator extends AbstractPlugin implements \Iterator, \Countable
     /**
      * Set prefetch option.
      *
-     * @param integer $value
+     * @param int $value
      *
      * @return self Provides fluent interface
      */
@@ -115,7 +115,7 @@ class PrefetchIterator extends AbstractPlugin implements \Iterator, \Countable
     /**
      * Get prefetch option.
      *
-     * @return integer
+     * @return int
      */
     public function getPrefetch()
     {
@@ -232,14 +232,14 @@ class PrefetchIterator extends AbstractPlugin implements \Iterator, \Countable
     /**
      * Iterator implementation.
      *
-     * @return boolean
+     * @return bool
      */
     public function valid()
     {
         $adjustedIndex = $this->position % $this->options['prefetch'];
 
         // this condition prevent useless re-fetching of data if a count is done before the iterator is used
-        if ($adjustedIndex === 0 && ($this->position !== 0 || null === $this->result)) {
+        if (0 === $adjustedIndex && (0 !== $this->position || null === $this->result)) {
             $this->fetchNext();
         }
 

--- a/library/Solarium/QueryType/Analysis/Query/AbstractQuery.php
+++ b/library/Solarium/QueryType/Analysis/Query/AbstractQuery.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -59,7 +59,7 @@ abstract class AbstractQuery extends BaseQuery
      */
     public function setQuery($query, $bind = null)
     {
-        if (!is_null($bind)) {
+        if (null !== $bind) {
             $query = $this->getHelper()->assemble($query, $bind);
         }
 
@@ -79,7 +79,7 @@ abstract class AbstractQuery extends BaseQuery
     /**
      * Set the showmatch option.
      *
-     * @param boolean $show
+     * @param bool $show
      *
      * @return self Provides fluent interface
      */

--- a/library/Solarium/QueryType/Analysis/Query/Document.php
+++ b/library/Solarium/QueryType/Analysis/Query/Document.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -42,8 +42,8 @@ namespace Solarium\QueryType\Analysis\Query;
 
 use Solarium\Core\Client\Client;
 use Solarium\Exception\RuntimeException;
-use Solarium\QueryType\Analysis\ResponseParser\Document as ResponseParser;
 use Solarium\QueryType\Analysis\RequestBuilder\Document as RequestBuilder;
+use Solarium\QueryType\Analysis\ResponseParser\Document as ResponseParser;
 use Solarium\QueryType\Select\Result\DocumentInterface as ReadOnlyDocumentInterface;
 use Solarium\QueryType\Update\Query\Document\DocumentInterface as DocumentInterface;
 
@@ -69,9 +69,9 @@ class Document extends AbstractQuery
      * @var array
      */
     protected $options = array(
-        'handler'       => 'analysis/document',
-        'resultclass'   => 'Solarium\QueryType\Analysis\Result\Document',
-        'omitheader'    => true,
+        'handler' => 'analysis/document',
+        'resultclass' => 'Solarium\QueryType\Analysis\Result\Document',
+        'omitheader' => true,
     );
 
     /**
@@ -109,14 +109,14 @@ class Document extends AbstractQuery
      *
      * @param ReadOnlyDocumentInterface|DocumentInterface $document
      *
-     * @return self Provides fluent interface
-     *
      * @throws RuntimeException If the given document doesn't have the right interface
+     *
+     * @return self Provides fluent interface
      */
     public function addDocument($document)
     {
         if (!($document instanceof ReadOnlyDocumentInterface) && !($document instanceof DocumentInterface)) {
-            throw new RuntimeException(sprintf(static::DOCUMENT_TYPE_HINT_EXCEPTION_MESSAGE, get_class($document)));
+            throw new RuntimeException(sprintf(static::DOCUMENT_TYPE_HINT_EXCEPTION_MESSAGE, \get_class($document)));
         }
 
         $this->documents[] = $document;
@@ -129,15 +129,15 @@ class Document extends AbstractQuery
      *
      * @param ReadOnlyDocumentInterface[]|DocumentInterface[] $documents
      *
-     * @return self Provides fluent interface
-     *
      * @throws RuntimeException If the given documents doesn't have the right interface
+     *
+     * @return self Provides fluent interface
      */
     public function addDocuments($documents)
     {
         foreach ($documents as $document) {
             if (!($document instanceof ReadOnlyDocumentInterface) && !($document instanceof DocumentInterface)) {
-                throw new RuntimeException(sprintf(static::DOCUMENT_TYPE_HINT_EXCEPTION_MESSAGE, get_class($document)));
+                throw new RuntimeException(sprintf(static::DOCUMENT_TYPE_HINT_EXCEPTION_MESSAGE, \get_class($document)));
             }
         }
 

--- a/library/Solarium/QueryType/Analysis/Query/Field.php
+++ b/library/Solarium/QueryType/Analysis/Query/Field.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -41,8 +41,8 @@
 namespace Solarium\QueryType\Analysis\Query;
 
 use Solarium\Core\Client\Client;
-use Solarium\QueryType\Analysis\ResponseParser\Field as ResponseParser;
 use Solarium\QueryType\Analysis\RequestBuilder\Field as RequestBuilder;
+use Solarium\QueryType\Analysis\ResponseParser\Field as ResponseParser;
 
 /**
  * Analysis document query.
@@ -55,9 +55,9 @@ class Field extends AbstractQuery
      * @var array
      */
     protected $options = array(
-        'handler'       => 'analysis/field',
-        'resultclass'   => 'Solarium\QueryType\Analysis\Result\Field',
-        'omitheader'    => true,
+        'handler' => 'analysis/field',
+        'resultclass' => 'Solarium\QueryType\Analysis\Result\Field',
+        'omitheader' => true,
     );
 
     /**

--- a/library/Solarium/QueryType/Analysis/Query/Query.php
+++ b/library/Solarium/QueryType/Analysis/Query/Query.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2015 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -41,7 +41,7 @@
 namespace Solarium\QueryType\Analysis\Query;
 
 /**
- * This class is for backwards compatibility, will be removed in 4.x releases in favor of AbstractQuery
+ * This class is for backwards compatibility, will be removed in 4.x releases in favor of AbstractQuery.
  *
  * @deprecated
  */

--- a/library/Solarium/QueryType/Analysis/RequestBuilder/Document.php
+++ b/library/Solarium/QueryType/Analysis/RequestBuilder/Document.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,10 +40,10 @@
 
 namespace Solarium\QueryType\Analysis\RequestBuilder;
 
-use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Client\Request;
-use Solarium\QueryType\Analysis\Query\Document as QueryDocument;
+use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
+use Solarium\QueryType\Analysis\Query\Document as QueryDocument;
 
 /**
  * Build a document analysis request.
@@ -81,7 +81,7 @@ class Document extends BaseRequestBuilder
             $xml .= '<doc>';
 
             foreach ($doc->getFields() as $name => $value) {
-                if (is_array($value)) {
+                if (\is_array($value)) {
                     foreach ($value as $multival) {
                         $xml .= $this->buildFieldXml($name, $multival);
                     }

--- a/library/Solarium/QueryType/Analysis/RequestBuilder/Field.php
+++ b/library/Solarium/QueryType/Analysis/RequestBuilder/Field.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,9 +40,9 @@
 
 namespace Solarium\QueryType\Analysis\RequestBuilder;
 
-use Solarium\QueryType\Analysis\Query\Field as QueryField;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Query\QueryInterface;
+use Solarium\QueryType\Analysis\Query\Field as QueryField;
 
 /**
  * Build a field analysis request.

--- a/library/Solarium/QueryType/Analysis/RequestBuilder/RequestBuilder.php
+++ b/library/Solarium/QueryType/Analysis/RequestBuilder/RequestBuilder.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Analysis\RequestBuilder;
 
-use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Client\Request;
+use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 
 /**

--- a/library/Solarium/QueryType/Analysis/ResponseParser/Document.php
+++ b/library/Solarium/QueryType/Analysis/ResponseParser/Document.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/Analysis/ResponseParser/Field.php
+++ b/library/Solarium/QueryType/Analysis/ResponseParser/Field.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,13 +40,13 @@
 
 namespace Solarium\QueryType\Analysis\ResponseParser;
 
-use Solarium\Core\Query\Result\Result;
-use Solarium\QueryType\Analysis\Result as AnalysisResult;
-use Solarium\QueryType\Analysis\Result\ResultList;
-use Solarium\QueryType\Analysis\Result\Item;
-use Solarium\QueryType\Analysis\Result\Types;
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
 use Solarium\Core\Query\ResponseParserInterface as ResponseParserInterface;
+use Solarium\Core\Query\Result\Result;
+use Solarium\QueryType\Analysis\Result as AnalysisResult;
+use Solarium\QueryType\Analysis\Result\Item;
+use Solarium\QueryType\Analysis\Result\ResultList;
+use Solarium\QueryType\Analysis\Result\Types;
 
 /**
  * Parse document analysis response data.
@@ -110,7 +110,7 @@ class Field extends ResponseParserAbstract implements ResponseParserInterface
             foreach ($fieldData as $typeKey => $typeData) {
                 if ($query->getResponseWriter() == $query::WT_JSON) {
                     // fix for extra level for key fields
-                    if (count($typeData) == 1) {
+                    if (1 == \count($typeData)) {
                         $typeData = current($typeData);
                     }
                     $typeData = $this->convertToKeyValueArray($typeData);
@@ -118,7 +118,7 @@ class Field extends ResponseParserAbstract implements ResponseParserInterface
 
                 $classes = array();
                 foreach ($typeData as $class => $analysis) {
-                    if (is_string($analysis)) {
+                    if (\is_string($analysis)) {
                         $item = new Item(
                             array(
                                 'text' => $analysis,

--- a/library/Solarium/QueryType/Analysis/Result/Document.php
+++ b/library/Solarium/QueryType/Analysis/Result/Document.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -133,7 +133,7 @@ class Document extends BaseResult implements \IteratorAggregate, \Countable
     {
         $this->parseResponse();
 
-        return count($this->items);
+        return \count($this->items);
     }
 
     /**
@@ -149,8 +149,6 @@ class Document extends BaseResult implements \IteratorAggregate, \Countable
 
         if (isset($this->items[$key])) {
             return $this->items[$key];
-        } else {
-            return;
         }
     }
 }

--- a/library/Solarium/QueryType/Analysis/Result/Field.php
+++ b/library/Solarium/QueryType/Analysis/Result/Field.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -133,6 +133,6 @@ class Field extends BaseResult implements \IteratorAggregate, \Countable
     {
         $this->parseResponse();
 
-        return count($this->items);
+        return \count($this->items);
     }
 }

--- a/library/Solarium/QueryType/Analysis/Result/Item.php
+++ b/library/Solarium/QueryType/Analysis/Result/Item.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -97,7 +97,7 @@ class Item
     /**
      * Match.
      *
-     * @var boolean
+     * @var bool
      */
     protected $match = false;
 
@@ -183,11 +183,11 @@ class Item
      */
     public function getPositionHistory()
     {
-        if (is_array($this->positionHistory)) {
+        if (\is_array($this->positionHistory)) {
             return $this->positionHistory;
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**
@@ -203,7 +203,7 @@ class Item
     /**
      * Get match value.
      *
-     * @return boolean
+     * @return bool
      */
     public function getMatch()
     {

--- a/library/Solarium/QueryType/Analysis/Result/ResultList.php
+++ b/library/Solarium/QueryType/Analysis/Result/ResultList.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -108,6 +108,6 @@ class ResultList implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->items);
+        return \count($this->items);
     }
 }

--- a/library/Solarium/QueryType/Analysis/Result/Types.php
+++ b/library/Solarium/QueryType/Analysis/Result/Types.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -60,7 +60,7 @@ class Types extends ResultList
     public function getIndexAnalysis()
     {
         foreach ($this->items as $item) {
-            if ($item->getName() == 'index') {
+            if ('index' == $item->getName()) {
                 return $item;
             }
         }
@@ -74,7 +74,7 @@ class Types extends ResultList
     public function getQueryAnalysis()
     {
         foreach ($this->items as $item) {
-            if ($item->getName() == 'query') {
+            if ('query' == $item->getName()) {
                 return $item;
             }
         }

--- a/library/Solarium/QueryType/Extract/Query.php
+++ b/library/Solarium/QueryType/Extract/Query.php
@@ -33,7 +33,7 @@
  * @copyright Copyright 2012 Alexander Brausewetter <alex@helpdeskhq.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -42,10 +42,10 @@
 
 namespace Solarium\QueryType\Extract;
 
-use Solarium\Core\Query\AbstractQuery as BaseQuery;
 use Solarium\Core\Client\Client;
-use Solarium\QueryType\Update\ResponseParser as UpdateResponseParser;
+use Solarium\Core\Query\AbstractQuery as BaseQuery;
 use Solarium\QueryType\Update\Query\Document\DocumentInterface;
+use Solarium\QueryType\Update\ResponseParser as UpdateResponseParser;
 
 /**
  * Extract query.
@@ -64,10 +64,10 @@ class Query extends BaseQuery
      * @var array
      */
     protected $options = array(
-        'handler'     => 'update/extract',
+        'handler' => 'update/extract',
         'resultclass' => 'Solarium\QueryType\Extract\Result',
         'documentclass' => 'Solarium\QueryType\Update\Query\Document\Document',
-        'omitheader'  => true,
+        'omitheader' => true,
         'extractonly' => false,
     );
 
@@ -396,7 +396,7 @@ class Query extends BaseQuery
     /**
      * Get the ExtractOnly parameter of SOLR Extraction Handler.
      *
-     * @return boolean
+     * @return bool
      */
     public function getExtractOnly()
     {

--- a/library/Solarium/QueryType/Extract/RequestBuilder.php
+++ b/library/Solarium/QueryType/Extract/RequestBuilder.php
@@ -33,7 +33,7 @@
  * @copyright Copyright 2012 Alexander Brausewetter <alex@helpdeskhq.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -42,9 +42,9 @@
 
 namespace Solarium\QueryType\Extract;
 
-use Solarium\Core\Query\QueryInterface;
-use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Client\Request;
+use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
+use Solarium\Core\Query\QueryInterface;
 use Solarium\Exception\RuntimeException;
 
 /**
@@ -55,9 +55,10 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build the request.
      *
-     * @throws RuntimeException
      *
      * @param Query|QueryInterface $query
+     *
+     * @throws RuntimeException
      *
      * @return Request
      */
@@ -80,8 +81,8 @@ class RequestBuilder extends BaseRequestBuilder
         }
 
         // add document settings to request
-        if (($doc = $query->getDocument()) !== null) {
-            if ($doc->getBoost() !== null) {
+        if (null !== ($doc = $query->getDocument())) {
+            if (null !== $doc->getBoost()) {
                 throw new RuntimeException('Extract does not support document-level boosts, use field boosts instead.');
             }
 

--- a/library/Solarium/QueryType/Extract/Result.php
+++ b/library/Solarium/QueryType/Extract/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/MoreLikeThis/Query.php
+++ b/library/Solarium/QueryType/MoreLikeThis/Query.php
@@ -34,7 +34,7 @@
  * @copyright Copyright 2011 Gasol Wu <gasol.wu@gmail.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -43,8 +43,8 @@
 
 namespace Solarium\QueryType\MoreLikeThis;
 
-use Solarium\QueryType\Select\Query\Query as SelectQuery;
 use Solarium\Core\Client\Client;
+use Solarium\QueryType\Select\Query\Query as SelectQuery;
 
 /**
  * MoreLikeThis Query.
@@ -61,18 +61,18 @@ class Query extends SelectQuery
      * @var array
      */
     protected $options = array(
-        'handler'       => 'mlt',
-        'resultclass'   => 'Solarium\QueryType\MoreLikeThis\Result',
+        'handler' => 'mlt',
+        'resultclass' => 'Solarium\QueryType\MoreLikeThis\Result',
         'documentclass' => 'Solarium\QueryType\Select\Result\Document',
-        'query'         => '*:*',
-        'start'         => 0,
-        'rows'          => 10,
-        'fields'        => '*,score',
+        'query' => '*:*',
+        'start' => 0,
+        'rows' => 10,
+        'fields' => '*,score',
         'interestingTerms' => 'none',
-        'matchinclude'  => false,
-        'matchoffset'   => 0,
-        'stream'        => false,
-        'omitheader'    => true,
+        'matchinclude' => false,
+        'matchoffset' => 0,
+        'stream' => false,
+        'omitheader' => true,
     );
 
     /**
@@ -110,9 +110,9 @@ class Query extends SelectQuery
      *
      * Set to true to post query content instead of using the URL param
      *
-     * @link http://wiki.apache.org/solr/ContentStream ContentStream
+     * @see http://wiki.apache.org/solr/ContentStream ContentStream
      *
-     * @param boolean $stream
+     * @param bool $stream
      *
      * @return self Provides fluent interface
      */
@@ -124,7 +124,7 @@ class Query extends SelectQuery
     /**
      * Get stream option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getQueryStream()
     {
@@ -160,7 +160,7 @@ class Query extends SelectQuery
      *
      * @see http://wiki.apache.org/solr/MoreLikeThisHandler#Params
      *
-     * @param boolean $include
+     * @param bool $include
      *
      * @return self Provides fluent interface
      */
@@ -218,7 +218,7 @@ class Query extends SelectQuery
      */
     public function setMltFields($fields)
     {
-        if (is_string($fields)) {
+        if (\is_string($fields)) {
             $fields = explode(',', $fields);
             $fields = array_map('trim', $fields);
         }
@@ -234,7 +234,7 @@ class Query extends SelectQuery
     public function getMltFields()
     {
         $value = $this->getOption('mltfields');
-        if ($value === null) {
+        if (null === $value) {
             $value = array();
         }
 
@@ -259,7 +259,7 @@ class Query extends SelectQuery
     /**
      * Get minimumtermfrequency option.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getMinimumTermFrequency()
     {
@@ -284,7 +284,7 @@ class Query extends SelectQuery
     /**
      * Get minimumdocumentfrequency option.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getMinimumDocumentFrequency()
     {
@@ -308,7 +308,7 @@ class Query extends SelectQuery
     /**
      * Get minimumwordlength option.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getMinimumWordLength()
     {
@@ -332,7 +332,7 @@ class Query extends SelectQuery
     /**
      * Get maximumwordlength option.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getMaximumWordLength()
     {
@@ -357,7 +357,7 @@ class Query extends SelectQuery
     /**
      * Get maximumqueryterms option.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getMaximumQueryTerms()
     {
@@ -382,7 +382,7 @@ class Query extends SelectQuery
     /**
      * Get maximumnumberoftokens option.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getMaximumNumberOfTokens()
     {
@@ -394,7 +394,7 @@ class Query extends SelectQuery
      *
      * If true the query will be boosted by the interesting term relevance.
      *
-     * @param boolean $boost
+     * @param bool $boost
      *
      * @return self Provides fluent interface
      */
@@ -406,7 +406,7 @@ class Query extends SelectQuery
     /**
      * Get boost option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getBoost()
     {
@@ -427,7 +427,7 @@ class Query extends SelectQuery
      */
     public function setQueryFields($queryFields)
     {
-        if (is_string($queryFields)) {
+        if (\is_string($queryFields)) {
             $queryFields = explode(',', $queryFields);
             $queryFields = array_map('trim', $queryFields);
         }
@@ -443,7 +443,7 @@ class Query extends SelectQuery
     public function getQueryFields()
     {
         $value = $this->getOption('queryfields');
-        if ($value === null) {
+        if (null === $value) {
             $value = array();
         }
 

--- a/library/Solarium/QueryType/MoreLikeThis/RequestBuilder.php
+++ b/library/Solarium/QueryType/MoreLikeThis/RequestBuilder.php
@@ -34,7 +34,7 @@
  * @copyright Copyright 2011 Gasol Wu <gasol.wu@gmail.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -44,8 +44,8 @@
 namespace Solarium\QueryType\MoreLikeThis;
 
 use Solarium\Core\Client\Request;
-use Solarium\QueryType\Select\RequestBuilder\RequestBuilder as SelectRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
+use Solarium\QueryType\Select\RequestBuilder\RequestBuilder as SelectRequestBuilder;
 
 /**
  * Build a MoreLikeThis request.

--- a/library/Solarium/QueryType/MoreLikeThis/ResponseParser.php
+++ b/library/Solarium/QueryType/MoreLikeThis/ResponseParser.php
@@ -32,7 +32,7 @@
  * @copyright Copyright 2011 Gasol Wu <gasol.wu@gmail.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/MoreLikeThis/Result.php
+++ b/library/Solarium/QueryType/MoreLikeThis/Result.php
@@ -32,7 +32,7 @@
  * @copyright Copyright 2011 Gasol Wu <gasol.wu@gmail.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -41,9 +41,9 @@
 
 namespace Solarium\QueryType\MoreLikeThis;
 
+use Solarium\Exception\UnexpectedValueException;
 use Solarium\QueryType\Select\Result\Document as ReadOnlyDocument;
 use Solarium\QueryType\Select\Result\Result as SelectResult;
-use Solarium\Exception\UnexpectedValueException;
 
 /**
  * MoreLikeThis query result.

--- a/library/Solarium/QueryType/Ping/Query.php
+++ b/library/Solarium/QueryType/Ping/Query.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Ping;
 
-use Solarium\Core\Query\AbstractQuery as BaseQuery;
 use Solarium\Core\Client\Client;
+use Solarium\Core\Query\AbstractQuery as BaseQuery;
 
 /**
  * Ping query.
@@ -60,7 +60,7 @@ class Query extends BaseQuery
     protected $options = array(
         'resultclass' => 'Solarium\QueryType\Ping\Result',
         'handler' => 'admin/ping',
-        'omitheader'    => true,
+        'omitheader' => true,
     );
 
     /**

--- a/library/Solarium/QueryType/Ping/RequestBuilder.php
+++ b/library/Solarium/QueryType/Ping/RequestBuilder.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/Ping/Result.php
+++ b/library/Solarium/QueryType/Ping/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/RealtimeGet/Query.php
+++ b/library/Solarium/QueryType/RealtimeGet/Query.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\RealtimeGet;
 
-use Solarium\Core\Query\AbstractQuery as BaseQuery;
 use Solarium\Core\Client\Client;
+use Solarium\Core\Query\AbstractQuery as BaseQuery;
 use Solarium\QueryType\Select\ResponseParser\ResponseParser;
 
 /**
@@ -62,7 +62,7 @@ class Query extends BaseQuery
         'resultclass' => 'Solarium\QueryType\RealtimeGet\Result',
         'documentclass' => 'Solarium\QueryType\Select\Result\Document',
         'handler' => 'get',
-        'omitheader'    => true,
+        'omitheader' => true,
     );
 
     /**
@@ -125,7 +125,7 @@ class Query extends BaseQuery
      */
     public function addIds($ids)
     {
-        if (is_string($ids)) {
+        if (\is_string($ids)) {
             $ids = explode(',', $ids);
             $ids = array_map('trim', $ids);
         }

--- a/library/Solarium/QueryType/RealtimeGet/RequestBuilder.php
+++ b/library/Solarium/QueryType/RealtimeGet/RequestBuilder.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2012 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/RealtimeGet/Result.php
+++ b/library/Solarium/QueryType/RealtimeGet/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\RealtimeGet;
 
-use Solarium\QueryType\Select\Result\Result as BaseResult;
 use Solarium\QueryType\Select\Result\DocumentInterface;
+use Solarium\QueryType\Select\Result\Result as BaseResult;
 
 /**
  * RealtimeGet query results.

--- a/library/Solarium/QueryType/Select/Query/Component/AbstractComponent.php
+++ b/library/Solarium/QueryType/Select/Query/Component/AbstractComponent.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -42,8 +42,8 @@ namespace Solarium\QueryType\Select\Query\Component;
 
 use Solarium\Core\Configurable;
 use Solarium\Core\Query\AbstractQuery;
-use Solarium\QueryType\Select\ResponseParser\Component\ComponentParserInterface;
 use Solarium\QueryType\Select\RequestBuilder\Component\ComponentRequestBuilderInterface;
+use Solarium\QueryType\Select\ResponseParser\Component\ComponentParserInterface;
 
 /**
  * Query component base class.

--- a/library/Solarium/QueryType/Select/Query/Component/BoostQuery.php
+++ b/library/Solarium/QueryType/Select/Query/Component/BoostQuery.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -46,7 +46,7 @@ use Solarium\Core\Query\Helper;
 /**
  * Filterquery.
  *
- * @link http://wiki.apache.org/solr/CommonQueryParameters#fq
+ * @see http://wiki.apache.org/solr/CommonQueryParameters#fq
  */
 class BoostQuery extends Configurable
 {
@@ -91,7 +91,7 @@ class BoostQuery extends Configurable
      */
     public function setQuery($query, $bind = null)
     {
-        if (!is_null($bind)) {
+        if (null !== $bind) {
             $helper = new Helper();
             $query = $helper->assemble($query, $bind);
         }

--- a/library/Solarium/QueryType/Select/Query/Component/Debug.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Debug.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -47,7 +47,7 @@ use Solarium\QueryType\Select\ResponseParser\Component\Debug as ResponseParser;
 /**
  * Debug component.
  *
- * @link http://wiki.apache.org/solr/CommonQueryParameters#Debugging
+ * @see http://wiki.apache.org/solr/CommonQueryParameters#Debugging
  */
 class Debug extends AbstractComponent
 {

--- a/library/Solarium/QueryType/Select/Query/Component/DisMax.php
+++ b/library/Solarium/QueryType/Select/Query/Component/DisMax.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -47,7 +47,7 @@ use Solarium\QueryType\Select\RequestBuilder\Component\DisMax as RequestBuilder;
 /**
  * DisMax component.
  *
- * @link http://wiki.apache.org/solr/DisMaxQParserPlugin
+ * @see http://wiki.apache.org/solr/DisMaxQParserPlugin
  */
 class DisMax extends AbstractComponent
 {
@@ -300,16 +300,16 @@ class DisMax extends AbstractComponent
      */
     public function getBoostQuery($key = null)
     {
-        if ($key !== null) {
-            if (array_key_exists($key, $this->boostQueries)) {
+        if (null !== $key) {
+            if (\array_key_exists($key, $this->boostQueries)) {
                 return $this->boostQueries[$key]->getQuery();
             }
-        } else if (!empty($this->boostQueries)) {
+        } elseif (!empty($this->boostQueries)) {
             /** @var BoostQuery[] $boostQueries */
             $boostQueries = array_values($this->boostQueries);
 
             return $boostQueries[0]->getQuery();
-        } else if (array_key_exists('boostquery', $this->options)) {
+        } elseif (\array_key_exists('boostquery', $this->options)) {
             return $this->options['boostquery'];
         }
 
@@ -322,30 +322,30 @@ class DisMax extends AbstractComponent
      * Supports a boostquery instance or a config array, in that case a new
      * boostquery instance wil be created based on the options.
      *
-     * @throws InvalidArgumentException
      *
      * @param BoostQuery|array $boostQuery
+     *
+     * @throws InvalidArgumentException
      *
      * @return self Provides fluent interface
      */
     public function addBoostQuery($boostQuery)
     {
-        if (is_array($boostQuery)) {
+        if (\is_array($boostQuery)) {
             $boostQuery = new BoostQuery($boostQuery);
         }
 
         $key = $boostQuery->getKey();
 
-        if (0 === strlen($key)) {
+        if (0 === \strlen($key)) {
             throw new InvalidArgumentException('A boostquery must have a key value');
         }
 
         //double add calls for the same BQ are ignored, but non-unique keys cause an exception
-        if (array_key_exists($key, $this->boostQueries) && $this->boostQueries[$key] !== $boostQuery) {
+        if (\array_key_exists($key, $this->boostQueries) && $this->boostQueries[$key] !== $boostQuery) {
             throw new InvalidArgumentException('A boostquery must have a unique key value within a query');
-        } else {
-            $this->boostQueries[$key] = $boostQuery;
         }
+        $this->boostQueries[$key] = $boostQuery;
 
         return $this;
     }
@@ -361,7 +361,7 @@ class DisMax extends AbstractComponent
     {
         foreach ($boostQueries as $key => $boostQuery) {
             // in case of a config array: add key to config
-            if (is_array($boostQuery) && !isset($boostQuery['key'])) {
+            if (\is_array($boostQuery) && !isset($boostQuery['key'])) {
                 $boostQuery['key'] = $key;
             }
 
@@ -392,7 +392,7 @@ class DisMax extends AbstractComponent
      */
     public function removeBoostQuery($boostQuery)
     {
-        if (is_object($boostQuery)) {
+        if (\is_object($boostQuery)) {
             $boostQuery = $boostQuery->getKey();
         }
 

--- a/library/Solarium/QueryType/Select/Query/Component/DistributedSearch.php
+++ b/library/Solarium/QueryType/Select/Query/Component/DistributedSearch.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -46,8 +46,8 @@ use Solarium\QueryType\Select\RequestBuilder\Component\DistributedSearch as Requ
 /**
  * Distributed Search (sharding) component.
  *
- * @link http://wiki.apache.org/solr/DistributedSearch
- * @link http://wiki.apache.org/solr/SolrCloud/
+ * @see http://wiki.apache.org/solr/DistributedSearch
+ * @see http://wiki.apache.org/solr/SolrCloud/
  */
 class DistributedSearch extends AbstractComponent
 {
@@ -107,7 +107,7 @@ class DistributedSearch extends AbstractComponent
      *
      * @return self Provides fluent interface
      *
-     * @link http://wiki.apache.org/solr/DistributedSearch
+     * @see http://wiki.apache.org/solr/DistributedSearch
      */
     public function addShard($key, $shard)
     {
@@ -244,7 +244,7 @@ class DistributedSearch extends AbstractComponent
      *
      * @return self Provides fluent interface
      *
-     * @link http://wiki.apache.org/solr/SolrCloud/
+     * @see http://wiki.apache.org/solr/SolrCloud/
      */
     public function addCollection($key, $collection)
     {
@@ -332,7 +332,7 @@ class DistributedSearch extends AbstractComponent
      *
      * @return self Provides fluent interface
      *
-     * @link https://cwiki.apache.org/confluence/display/solr/Distributed+Requests
+     * @see https://cwiki.apache.org/confluence/display/solr/Distributed+Requests
      */
     public function addReplica($key, $replica)
     {

--- a/library/Solarium/QueryType/Select/Query/Component/EdisMax.php
+++ b/library/Solarium/QueryType/Select/Query/Component/EdisMax.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2012 Marc Morera <yuhu@mmoreram.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -46,7 +46,7 @@ use Solarium\QueryType\Select\RequestBuilder\Component\EdisMax as RequestBuilder
 /**
  * EdisMax component.
  *
- * @link http://wiki.apache.org/solr/ExtendedDisMax
+ * @see http://wiki.apache.org/solr/ExtendedDisMax
  */
 class EdisMax extends DisMax
 {

--- a/library/Solarium/QueryType/Select/Query/Component/Facet/AbstractFacet.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Facet/AbstractFacet.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -45,7 +45,7 @@ use Solarium\Core\Configurable;
 /**
  * Facet base class.
  *
- * @link http://wiki.apache.org/solr/SimpleFacetParameters
+ * @see http://wiki.apache.org/solr/SimpleFacetParameters
  */
 abstract class AbstractFacet extends Configurable
 {
@@ -179,7 +179,7 @@ abstract class AbstractFacet extends Configurable
                     $this->setKey($value);
                     break;
                 case 'exclude':
-                    if (!is_array($value)) {
+                    if (!\is_array($value)) {
                         $value = explode(',', $value);
                     }
                     $this->setExcludes($value);

--- a/library/Solarium/QueryType/Select/Query/Component/Facet/Field.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Facet/Field.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -45,7 +45,7 @@ use Solarium\QueryType\Select\Query\Component\FacetSet;
 /**
  * Facet query.
  *
- * @link http://wiki.apache.org/solr/SimpleFacetParameters#Field_Value_Faceting_Parameters
+ * @see http://wiki.apache.org/solr/SimpleFacetParameters#Field_Value_Faceting_Parameters
  */
 class Field extends AbstractFacet
 {
@@ -157,12 +157,13 @@ class Field extends AbstractFacet
     }
 
     /**
-     * Limit the terms for faceting by a string they must contain
+     * Limit the terms for faceting by a string they must contain.
      *
      * This is a global value for all facets in this facetset
      *
-     * @param  string $contains
-     * @return self   Provides fluent interface
+     * @param string $contains
+     *
+     * @return self Provides fluent interface
      */
     public function setContains($contains)
     {
@@ -170,7 +171,7 @@ class Field extends AbstractFacet
     }
 
     /**
-     * Get the facet contains
+     * Get the facet contains.
      *
      * This is a global value for all facets in this facetset
      *
@@ -181,14 +182,14 @@ class Field extends AbstractFacet
         return $this->getOption('contains');
     }
 
-
     /**
-     * Case sensitivity of matching string that facet terms must contain
+     * Case sensitivity of matching string that facet terms must contain.
      *
      * This is a global value for all facets in this facetset
      *
-     * @param  boolean $containsIgnoreCase
-     * @return self    Provides fluent interface
+     * @param bool $containsIgnoreCase
+     *
+     * @return self Provides fluent interface
      */
     public function setContainsIgnoreCase($containsIgnoreCase)
     {
@@ -196,11 +197,11 @@ class Field extends AbstractFacet
     }
 
     /**
-     * Get the case sensitivity of facet contains
+     * Get the case sensitivity of facet contains.
      *
      * This is a global value for all facets in this facetset
      *
-     * @return boolean
+     * @return bool
      */
     public function getContainsIgnoreCase()
     {
@@ -208,7 +209,9 @@ class Field extends AbstractFacet
     }
 
     /**
-     * Set the facet limit
+     * Set the facet limit.
+     *
+     * @param mixed $limit
      *
      * @return self Provides fluent interface
      */
@@ -274,7 +277,7 @@ class Field extends AbstractFacet
     /**
      * Set the missing count option.
      *
-     * @param boolean $missing
+     * @param bool $missing
      *
      * @return self Provides fluent interface
      */
@@ -286,7 +289,7 @@ class Field extends AbstractFacet
     /**
      * Get the facet missing option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getMissing()
     {

--- a/library/Solarium/QueryType/Select/Query/Component/Facet/Interval.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Facet/Interval.php
@@ -30,31 +30,97 @@
  *
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
- * @link http://www.solarium-project.org/
+ *
+ * @see http://www.solarium-project.org/
  */
 
 /**
  * @namespace
  */
+
 namespace Solarium\QueryType\Select\Query\Component\Facet;
 
 use Solarium\QueryType\Select\Query\Component\FacetSet;
 
 /**
- * Facet interval
+ * Facet interval.
  *
- * @link http://wiki.apache.org/solr/SimpleFacetParameters#Interval_Faceting
+ * @see http://wiki.apache.org/solr/SimpleFacetParameters#Interval_Faceting
  */
 class Interval extends AbstractFacet
 {
+    /**
+     * Get the facet type.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return FacetSet::FACET_INTERVAL;
+    }
 
     /**
-     * Initialize options
+     * Set the field name.
+     *
+     * @param string $field
+     *
+     * @return self Provides fluent interface
+     */
+    public function setField($field)
+    {
+        return $this->setOption('field', $field);
+    }
+
+    /**
+     * Get the field name.
+     *
+     * @return string
+     */
+    public function getField()
+    {
+        return $this->getOption('field');
+    }
+
+    /**
+     * Set set counts.
+     *
+     * Use one of the constants as value.
+     * If you want to use multiple values supply an array or comma separated string
+     *
+     * @param string|array $set
+     *
+     * @return self Provides fluent interface
+     */
+    public function setSet($set)
+    {
+        if (\is_string($set)) {
+            $set = explode(',', $set);
+            $set = array_map('trim', $set);
+        }
+
+        return $this->setOption('set', $set);
+    }
+
+    /**
+     * Get set counts.
+     *
+     * @return array
+     */
+    public function getSet()
+    {
+        $set = $this->getOption('set');
+        if (null === $set) {
+            $set = array();
+        }
+
+        return $set;
+    }
+
+    /**
+     * Initialize options.
      *
      * Several options need some extra checks or setup work, for these options
      * the setters are called.
-     *
-     * @return void
      */
     protected function init()
     {
@@ -68,70 +134,4 @@ class Interval extends AbstractFacet
             }
         }
     }
-
-    /**
-     * Get the facet type
-     *
-     * @return string
-     */
-    public function getType()
-    {
-        return FacetSet::FACET_INTERVAL;
-    }
-
-    /**
-     * Set the field name
-     *
-     * @param  string $field
-     * @return self   Provides fluent interface
-     */
-    public function setField($field)
-    {
-        return $this->setOption('field', $field);
-    }
-
-    /**
-     * Get the field name
-     *
-     * @return string
-     */
-    public function getField()
-    {
-        return $this->getOption('field');
-    }
-
-    /**
-     * Set set counts
-     *
-     * Use one of the constants as value.
-     * If you want to use multiple values supply an array or comma separated string
-     *
-     * @param  string|array $set
-     * @return self         Provides fluent interface
-     */
-    public function setSet($set)
-    {
-        if (is_string($set)) {
-            $set = explode(',', $set);
-            $set = array_map('trim', $set);
-        }
-
-        return $this->setOption('set', $set);
-    }
-
-    /**
-     * Get set counts
-     *
-     * @return array
-     */
-    public function getSet()
-    {
-        $set = $this->getOption('set');
-        if ($set === null) {
-            $set = array();
-        }
-
-        return $set;
-    }
-
 }

--- a/library/Solarium/QueryType/Select/Query/Component/Facet/MultiQuery.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Facet/MultiQuery.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,9 +40,9 @@
 
 namespace Solarium\QueryType\Select\Query\Component\Facet;
 
-use Solarium\QueryType\Select\Query\Component\FacetSet;
-use Solarium\QueryType\Select\Query\Component\Facet\Query as FacetQuery;
 use Solarium\Exception\InvalidArgumentException;
+use Solarium\QueryType\Select\Query\Component\Facet\Query as FacetQuery;
+use Solarium\QueryType\Select\Query\Component\FacetSet;
 
 /**
  * Facet MultiQuery.
@@ -100,25 +100,26 @@ class MultiQuery extends AbstractFacet
      * Supports a facetquery instance or a config array, in that case a new
      * facetquery instance wil be created based on the options.
      *
-     * @throws InvalidArgumentException
      *
      * @param Query|array $facetQuery
+     *
+     * @throws InvalidArgumentException
      *
      * @return self Provides fluent interface
      */
     public function addQuery($facetQuery)
     {
-        if (is_array($facetQuery)) {
+        if (\is_array($facetQuery)) {
             $facetQuery = new Query($facetQuery);
         }
 
         $key = $facetQuery->getKey();
 
-        if (0 === strlen($key)) {
+        if (0 === \strlen($key)) {
             throw new InvalidArgumentException('A facetquery must have a key value');
         }
 
-        if (array_key_exists($key, $this->facetQueries)) {
+        if (\array_key_exists($key, $this->facetQueries)) {
             throw new InvalidArgumentException('A query must have a unique key value within a multiquery facet');
         }
 
@@ -141,7 +142,7 @@ class MultiQuery extends AbstractFacet
     {
         foreach ($facetQueries as $key => $facetQuery) {
             // in case of a config array: add key to config
-            if (is_array($facetQuery) && !isset($facetQuery['key'])) {
+            if (\is_array($facetQuery) && !isset($facetQuery['key'])) {
                 $facetQuery['key'] = $key;
             }
 
@@ -162,8 +163,6 @@ class MultiQuery extends AbstractFacet
     {
         if (isset($this->facetQueries[$key])) {
             return $this->facetQueries[$key];
-        } else {
-            return;
         }
     }
 
@@ -188,7 +187,7 @@ class MultiQuery extends AbstractFacet
      */
     public function removeQuery($query)
     {
-        if (is_object($query)) {
+        if (\is_object($query)) {
             $query = $query->getKey();
         }
 
@@ -304,7 +303,7 @@ class MultiQuery extends AbstractFacet
         foreach ($this->options as $name => $value) {
             switch ($name) {
                 case 'query':
-                    if (!is_array($value)) {
+                    if (!\is_array($value)) {
                         $value = array(array('query' => $value));
                     }
                     $this->addQueries($value);

--- a/library/Solarium/QueryType/Select/Query/Component/Facet/Pivot.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Facet/Pivot.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -45,7 +45,7 @@ use Solarium\QueryType\Select\Query\Component\FacetSet;
 /**
  * Facet pivot.
  *
- * @link http://wiki.apache.org/solr/SimpleFacetParameters#Pivot_.28ie_Decision_Tree.29_Faceting
+ * @see http://wiki.apache.org/solr/SimpleFacetParameters#Pivot_.28ie_Decision_Tree.29_Faceting
  */
 class Pivot extends AbstractFacet
 {
@@ -57,14 +57,14 @@ class Pivot extends AbstractFacet
     protected $fields = array();
 
     /**
-     * Optional stats
+     * Optional stats.
      *
      * @var array
      */
     protected $stats = array();
 
     /**
-     * Get the facet type
+     * Get the facet type.
      *
      * @return string
      */
@@ -120,7 +120,7 @@ class Pivot extends AbstractFacet
      */
     public function addFields($fields)
     {
-        if (is_string($fields)) {
+        if (\is_string($fields)) {
             $fields = explode(',', $fields);
         }
 
@@ -187,10 +187,11 @@ class Pivot extends AbstractFacet
     }
 
     /**
-     * Add stat
+     * Add stat.
      *
      * @param string $stat
-     * @return self  Provides fluent interface
+     *
+     * @return self Provides fluent interface
      */
     public function addStat($stat)
     {
@@ -200,16 +201,16 @@ class Pivot extends AbstractFacet
     }
 
     /**
-     * Specify multiple Stats
+     * Specify multiple Stats.
      *
      * @param string|array $stats can be an array or string with comma
-     *                             separated statnames
+     *                            separated statnames
      *
      * @return self Provides fluent interface
      */
     public function addStats($stats)
     {
-        if (is_string($stats)) {
+        if (\is_string($stats)) {
             $stats = explode(',', $stats);
             $stats = array_map('trim', $stats);
         }
@@ -222,10 +223,11 @@ class Pivot extends AbstractFacet
     }
 
     /**
-     * Remove a stat from the stats list
+     * Remove a stat from the stats list.
      *
-     * @param  string $stat
-     * @return self   Provides fluent interface
+     * @param string $stat
+     *
+     * @return self Provides fluent interface
      */
     public function removeStat($stat)
     {
@@ -249,7 +251,7 @@ class Pivot extends AbstractFacet
     }
 
     /**
-     * Get the list of stats
+     * Get the list of stats.
      *
      * @return array
      */
@@ -259,12 +261,13 @@ class Pivot extends AbstractFacet
     }
 
     /**
-     * Set multiple stats
+     * Set multiple stats.
      *
      * This overwrites any existing stats
      *
-     * @param  array $stats
-     * @return self  Provides fluent interface
+     * @param array $stats
+     *
+     * @return self Provides fluent interface
      */
     public function setStats($stats)
     {
@@ -275,9 +278,7 @@ class Pivot extends AbstractFacet
     }
 
     /**
-     * Initialize options
-     *
-     * @return void
+     * Initialize options.
      */
     protected function init()
     {

--- a/library/Solarium/QueryType/Select/Query/Component/Facet/Query.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Facet/Query.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,13 +40,13 @@
 
 namespace Solarium\QueryType\Select\Query\Component\Facet;
 
-use Solarium\QueryType\Select\Query\Component\FacetSet;
 use Solarium\Core\Query\Helper;
+use Solarium\QueryType\Select\Query\Component\FacetSet;
 
 /**
  * Facet query.
  *
- * @link http://wiki.apache.org/solr/SimpleFacetParameters#facet.query_:_Arbitrary_Query_Faceting
+ * @see http://wiki.apache.org/solr/SimpleFacetParameters#facet.query_:_Arbitrary_Query_Faceting
  */
 class Query extends AbstractFacet
 {
@@ -81,7 +81,7 @@ class Query extends AbstractFacet
      */
     public function setQuery($query, $bind = null)
     {
-        if (!is_null($bind)) {
+        if (null !== $bind) {
             $helper = new Helper();
             $query = $helper->assemble($query, $bind);
         }

--- a/library/Solarium/QueryType/Select/Query/Component/Facet/Range.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Facet/Range.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -45,7 +45,7 @@ use Solarium\QueryType\Select\Query\Component\FacetSet;
 /**
  * Facet range.
  *
- * @link http://wiki.apache.org/solr/SimpleFacetParameters#Facet_by_Range
+ * @see http://wiki.apache.org/solr/SimpleFacetParameters#Facet_by_Range
  */
 class Range extends AbstractFacet
 {
@@ -207,7 +207,7 @@ class Range extends AbstractFacet
      * A Boolean parameter instructing Solr what to do in the event that facet.range.gap
      * does not divide evenly between facet.range.start and facet.range.end
      *
-     * @param boolean $hardend
+     * @param bool $hardend
      *
      * @return self Provides fluent interface
      */
@@ -219,7 +219,7 @@ class Range extends AbstractFacet
     /**
      * Get hardend option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getHardend()
     {
@@ -238,7 +238,7 @@ class Range extends AbstractFacet
      */
     public function setOther($other)
     {
-        if (is_string($other)) {
+        if (\is_string($other)) {
             $other = explode(',', $other);
             $other = array_map('trim', $other);
         }
@@ -254,7 +254,7 @@ class Range extends AbstractFacet
     public function getOther()
     {
         $other = $this->getOption('other');
-        if ($other === null) {
+        if (null === $other) {
             $other = array();
         }
 
@@ -273,7 +273,7 @@ class Range extends AbstractFacet
      */
     public function setInclude($include)
     {
-        if (is_string($include)) {
+        if (\is_string($include)) {
             $include = explode(',', $include);
             $include = array_map('trim', $include);
         }
@@ -289,7 +289,7 @@ class Range extends AbstractFacet
     public function getInclude()
     {
         $include = $this->getOption('include');
-        if ($include === null) {
+        if (null === $include) {
             $include = array();
         }
 

--- a/library/Solarium/QueryType/Select/Query/Component/FacetSet.php
+++ b/library/Solarium/QueryType/Select/Query/Component/FacetSet.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,17 +40,17 @@
 
 namespace Solarium\QueryType\Select\Query\Component;
 
-use Solarium\QueryType\Select\Query\Query as SelectQuery;
-use Solarium\QueryType\Select\RequestBuilder\Component\FacetSet as RequestBuilder;
-use Solarium\QueryType\Select\ResponseParser\Component\FacetSet as ResponseParser;
 use Solarium\Exception\InvalidArgumentException;
 use Solarium\Exception\OutOfBoundsException;
 use Solarium\QueryType\Select\Query\Component\Facet\AbstractFacet;
+use Solarium\QueryType\Select\Query\Query as SelectQuery;
+use Solarium\QueryType\Select\RequestBuilder\Component\FacetSet as RequestBuilder;
+use Solarium\QueryType\Select\ResponseParser\Component\FacetSet as ResponseParser;
 
 /**
  * MoreLikeThis component.
  *
- * @link http://wiki.apache.org/solr/MoreLikeThis
+ * @see http://wiki.apache.org/solr/MoreLikeThis
  */
 class FacetSet extends AbstractComponent
 {
@@ -80,12 +80,12 @@ class FacetSet extends AbstractComponent
     const FACET_PIVOT = 'pivot';
 
     /**
-     * Facet type interval
+     * Facet type interval.
      */
     const FACET_INTERVAL = 'interval';
 
     /**
-     * Facet type mapping
+     * Facet type mapping.
      *
      * @var array
      */
@@ -146,7 +146,7 @@ class FacetSet extends AbstractComponent
      * Allow extraction of facets without having to define
      * them on the query.
      *
-     * @param boolean $extract
+     * @param bool $extract
      *
      * @return self Provides fluent interface
      */
@@ -158,7 +158,7 @@ class FacetSet extends AbstractComponent
     /**
      * Get the extractfromresponse option value.
      *
-     * @return boolean
+     * @return bool
      */
     public function getExtractFromResponse()
     {
@@ -192,12 +192,13 @@ class FacetSet extends AbstractComponent
     }
 
     /**
-     * Limit the terms for faceting by a string they must contain
+     * Limit the terms for faceting by a string they must contain.
      *
      * This is a global value for all facets in this facetset
      *
-     * @param  string $contains
-     * @return self   Provides fluent interface
+     * @param string $contains
+     *
+     * @return self Provides fluent interface
      */
     public function setContains($contains)
     {
@@ -205,7 +206,7 @@ class FacetSet extends AbstractComponent
     }
 
     /**
-     * Get the facet contains
+     * Get the facet contains.
      *
      * This is a global value for all facets in this facetset
      *
@@ -216,14 +217,14 @@ class FacetSet extends AbstractComponent
         return $this->getOption('contains');
     }
 
-
     /**
-     * Case sensitivity of matching string that facet terms must contain
+     * Case sensitivity of matching string that facet terms must contain.
      *
      * This is a global value for all facets in this facetset
      *
-     * @param  boolean $containsIgnoreCase
-     * @return self    Provides fluent interface
+     * @param bool $containsIgnoreCase
+     *
+     * @return self Provides fluent interface
      */
     public function setContainsIgnoreCase($containsIgnoreCase)
     {
@@ -231,11 +232,11 @@ class FacetSet extends AbstractComponent
     }
 
     /**
-     * Get the case sensitivity of facet contains
+     * Get the case sensitivity of facet contains.
      *
      * This is a global value for all facets in this facetset
      *
-     * @return boolean
+     * @return bool
      */
     public function getContainsIgnoreCase()
     {
@@ -243,7 +244,7 @@ class FacetSet extends AbstractComponent
     }
 
     /**
-     * Set the facet sort order
+     * Set the facet sort order.
      *
      * Use one of the SORT_* constants as the value
      *
@@ -327,7 +328,7 @@ class FacetSet extends AbstractComponent
      *
      * This is a global value for all facets in this facetset
      *
-     * @param boolean $missing
+     * @param bool $missing
      *
      * @return self Provides fluent interface
      */
@@ -341,7 +342,7 @@ class FacetSet extends AbstractComponent
      *
      * This is a global value for all facets in this facetset
      *
-     * @return boolean
+     * @return bool
      */
     public function getMissing()
     {
@@ -351,30 +352,30 @@ class FacetSet extends AbstractComponent
     /**
      * Add a facet.
      *
-     * @throws InvalidArgumentException
      *
      * @param \Solarium\QueryType\Select\Query\Component\Facet\AbstractFacet|array $facet
+     *
+     * @throws InvalidArgumentException
      *
      * @return self Provides fluent interface
      */
     public function addFacet($facet)
     {
-        if (is_array($facet)) {
+        if (\is_array($facet)) {
             $facet = $this->createFacet($facet['type'], $facet, false);
         }
 
         $key = $facet->getKey();
 
-        if (0 === strlen($key)) {
+        if (0 === \strlen($key)) {
             throw new InvalidArgumentException('A facet must have a key value');
         }
 
         //double add calls for the same facet are ignored, but non-unique keys cause an exception
-        if (array_key_exists($key, $this->facets) && $this->facets[$key] !== $facet) {
+        if (\array_key_exists($key, $this->facets) && $this->facets[$key] !== $facet) {
             throw new InvalidArgumentException('A facet must have a unique key value within a query');
-        } else {
-            $this->facets[$key] = $facet;
         }
+        $this->facets[$key] = $facet;
 
         return $this;
     }
@@ -390,7 +391,7 @@ class FacetSet extends AbstractComponent
     {
         foreach ($facets as $key => $facet) {
             // in case of a config array: add key to config
-            if (is_array($facet) && !isset($facet['key'])) {
+            if (\is_array($facet) && !isset($facet['key'])) {
                 $facet['key'] = $key;
             }
 
@@ -411,8 +412,6 @@ class FacetSet extends AbstractComponent
     {
         if (isset($this->facets[$key])) {
             return $this->facets[$key];
-        } else {
-            return;
         }
     }
 
@@ -437,7 +436,7 @@ class FacetSet extends AbstractComponent
      */
     public function removeFacet($facet)
     {
-        if (is_object($facet)) {
+        if (\is_object($facet)) {
             $facet = $facet->getKey();
         }
 
@@ -483,11 +482,12 @@ class FacetSet extends AbstractComponent
      * When no key is supplied the facet cannot be added, in that case you will need to add it manually
      * after setting the key, by using the addFacet method.
      *
-     * @throws OutOfBoundsException
      *
      * @param string            $type
      * @param array|object|null $options
-     * @param boolean           $add
+     * @param bool              $add
+     *
+     * @throws OutOfBoundsException
      *
      * @return \Solarium\QueryType\Select\Query\Component\Facet\AbstractFacet
      */
@@ -496,12 +496,12 @@ class FacetSet extends AbstractComponent
         $type = strtolower($type);
 
         if (!isset($this->facetTypes[$type])) {
-            throw new OutOfBoundsException("Facettype unknown: ".$type);
+            throw new OutOfBoundsException('Facettype unknown: '.$type);
         }
 
         $class = $this->facetTypes[$type];
 
-        if (is_string($options)) {
+        if (\is_string($options)) {
             /** @var \Solarium\QueryType\Select\Query\Component\Facet\Facet $facet */
             $facet = new $class();
             $facet->setKey($options);
@@ -509,7 +509,7 @@ class FacetSet extends AbstractComponent
             $facet = new $class($options);
         }
 
-        if ($add && $facet->getKey() !== null) {
+        if ($add && null !== $facet->getKey()) {
             $this->addFacet($facet);
         }
 
@@ -582,6 +582,19 @@ class FacetSet extends AbstractComponent
     }
 
     /**
+     * Get a facet interval instance.
+     *
+     * @param mixed $options
+     * @param bool  $add
+     *
+     * @return \Solarium\QueryType\Select\Query\Component\Facet\Interval
+     */
+    public function createFacetInterval($options = null, $add = true)
+    {
+        return $this->createFacet(self::FACET_INTERVAL, $options, $add);
+    }
+
+    /**
      * Initialize options.
      *
      * Several options need some extra checks or setup work, for these options
@@ -598,17 +611,5 @@ class FacetSet extends AbstractComponent
                 $this->addFacet($config);
             }
         }
-    }
-
-    /**
-     * Get a facet interval instance
-     *
-     * @param  mixed $options
-     * @param  bool  $add
-     * @return \Solarium\QueryType\Select\Query\Component\Facet\Interval
-     */
-    public function createFacetInterval($options = null, $add = true)
-    {
-        return $this->createFacet(self::FACET_INTERVAL, $options, $add);
     }
 }

--- a/library/Solarium/QueryType/Select/Query/Component/Grouping.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Grouping.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -50,7 +50,7 @@ use Solarium\QueryType\Select\ResponseParser\Component\Grouping as ResponseParse
  * Also known as Result Grouping or Field Collapsing.
  * See the Solr wiki for more info about this functionality
  *
- * @link  http://wiki.apache.org/solr/FieldCollapsing
+ * @see  http://wiki.apache.org/solr/FieldCollapsing
  * @since 2.1.0
  */
 class Grouping extends AbstractComponent
@@ -153,7 +153,7 @@ class Grouping extends AbstractComponent
      */
     public function addFields($fields)
     {
-        if (is_string($fields)) {
+        if (\is_string($fields)) {
             $fields = explode(',', $fields);
             $fields = array_map('trim', $fields);
         }
@@ -227,7 +227,7 @@ class Grouping extends AbstractComponent
      */
     public function addQueries($queries)
     {
-        if (!is_array($queries)) {
+        if (!\is_array($queries)) {
             $queries = array($queries);
         }
 
@@ -349,7 +349,7 @@ class Grouping extends AbstractComponent
      * If true, the result of the first field grouping command is used as the main
      * result list in the response, using group format 'simple'
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return self Provides fluent interface
      */
@@ -361,7 +361,7 @@ class Grouping extends AbstractComponent
     /**
      * Get mainresult option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getMainResult()
     {
@@ -373,7 +373,7 @@ class Grouping extends AbstractComponent
      *
      * If true, includes the number of groups that have matched the query.
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return self Provides fluent interface
      */
@@ -385,7 +385,7 @@ class Grouping extends AbstractComponent
     /**
      * Get numberofgroups option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getNumberOfGroups()
     {
@@ -402,7 +402,7 @@ class Grouping extends AbstractComponent
      * wildcard queries and fuzzy queries. For simple queries like a term query or
      * a match all query this cache has a negative impact on performance
      *
-     * @param integer $value
+     * @param int $value
      *
      * @return self Provides fluent interface
      */
@@ -414,7 +414,7 @@ class Grouping extends AbstractComponent
     /**
      * Get cachepercentage option.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getCachePercentage()
     {
@@ -427,7 +427,7 @@ class Grouping extends AbstractComponent
      * If true, facet counts are based on the most relevant document of each group matching the query.
      * Same applies for StatsComponent. Default is false. Only available from Solr 3.4
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return self Provides fluent interface
      */
@@ -439,7 +439,7 @@ class Grouping extends AbstractComponent
     /**
      * Get truncate option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getTruncate()
     {
@@ -477,7 +477,7 @@ class Grouping extends AbstractComponent
      * Grouped facets are computed based on the first specified group.
      * This parameter only is supported on Solr 4.0+
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return self Provides fluent interface
      */
@@ -489,7 +489,7 @@ class Grouping extends AbstractComponent
     /**
      * Get facet option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getFacet()
     {

--- a/library/Solarium/QueryType/Select/Query/Component/Highlighting/Field.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Highlighting/Field.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -45,7 +45,7 @@ use Solarium\Core\Configurable;
 /**
  * Highlighting per-field settings.
  *
- * @link http://wiki.apache.org/solr/HighlightingParameters
+ * @see http://wiki.apache.org/solr/HighlightingParameters
  */
 class Field extends Configurable
 {
@@ -134,7 +134,7 @@ class Field extends Configurable
      *
      * Collapse contiguous fragments into a single fragment
      *
-     * @param boolean $merge
+     * @param bool $merge
      *
      * @return self Provides fluent interface
      */
@@ -146,7 +146,7 @@ class Field extends Configurable
     /**
      * Get mergeContiguous option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getMergeContiguous()
     {
@@ -178,7 +178,7 @@ class Field extends Configurable
     /**
      * Set preserveMulti option.
      *
-     * @param boolean $preservemulti
+     * @param bool $preservemulti
      *
      * @return self Provides fluent interface
      */
@@ -190,7 +190,7 @@ class Field extends Configurable
     /**
      * Get preserveMulti option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getPreserveMulti()
     {
@@ -298,7 +298,7 @@ class Field extends Configurable
     /**
      * Set useFastVectorHighlighter option.
      *
-     * @param boolean $use
+     * @param bool $use
      *
      * @return self Provides fluent interface
      */
@@ -310,7 +310,7 @@ class Field extends Configurable
     /**
      * Get useFastVectorHighlighter option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getUseFastVectorHighlighter()
     {

--- a/library/Solarium/QueryType/Select/Query/Component/Highlighting/Highlighting.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Highlighting/Highlighting.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,16 +40,16 @@
 
 namespace Solarium\QueryType\Select\Query\Component\Highlighting;
 
-use Solarium\QueryType\Select\Query\Query as SelectQuery;
+use Solarium\Exception\InvalidArgumentException;
 use Solarium\QueryType\Select\Query\Component\AbstractComponent;
+use Solarium\QueryType\Select\Query\Query as SelectQuery;
 use Solarium\QueryType\Select\RequestBuilder\Component\Highlighting as RequestBuilder;
 use Solarium\QueryType\Select\ResponseParser\Component\Highlighting as ResponseParser;
-use Solarium\Exception\InvalidArgumentException;
 
 /**
  * Highlighting component.
  *
- * @link http://wiki.apache.org/solr/HighlightingParameters
+ * @see http://wiki.apache.org/solr/HighlightingParameters
  */
 class Highlighting extends AbstractComponent
 {
@@ -123,8 +123,8 @@ class Highlighting extends AbstractComponent
     /**
      * Get a field options object.
      *
-     * @param string  $name
-     * @param boolean $autocreate
+     * @param string $name
+     * @param bool   $autocreate
      *
      * @return Field
      */
@@ -136,31 +136,30 @@ class Highlighting extends AbstractComponent
             $this->addField($name);
 
             return $this->fields[$name];
-        } else {
-            return;
         }
     }
 
     /**
      * Add a field for highlighting.
      *
-     * @throws InvalidArgumentException
      *
      * @param string|array|Field $field
+     *
+     * @throws InvalidArgumentException
      *
      * @return self Provides fluent interface
      */
     public function addField($field)
     {
         // autocreate object for string input
-        if (is_string($field)) {
+        if (\is_string($field)) {
             $field = new Field(array('name' => $field));
-        } elseif (is_array($field)) {
+        } elseif (\is_array($field)) {
             $field = new Field($field);
         }
 
         // validate field
-        if ($field->getName() === null) {
+        if (null === $field->getName()) {
             throw new InvalidArgumentException(
                 'To add a highlighting field it needs to have at least a "name" setting'
             );
@@ -181,14 +180,14 @@ class Highlighting extends AbstractComponent
      */
     public function addFields($fields)
     {
-        if (is_string($fields)) {
+        if (\is_string($fields)) {
             $fields = explode(',', $fields);
             $fields = array_map('trim', $fields);
         }
 
         foreach ($fields as $key => $field) {
             // in case of a config array without key: add key to config
-            if (is_array($field) && !isset($field['name'])) {
+            if (\is_array($field) && !isset($field['name'])) {
                 $field['name'] = $key;
             }
 
@@ -306,7 +305,7 @@ class Highlighting extends AbstractComponent
      *
      * Collapse contiguous fragments into a single fragment
      *
-     * @param boolean $merge
+     * @param bool $merge
      *
      * @return self Provides fluent interface
      */
@@ -318,7 +317,7 @@ class Highlighting extends AbstractComponent
     /**
      * Get mergeContiguous option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getMergeContiguous()
     {
@@ -328,7 +327,7 @@ class Highlighting extends AbstractComponent
     /**
      * Set requireFieldMatch option.
      *
-     * @param boolean $require
+     * @param bool $require
      *
      * @return self Provides fluent interface
      */
@@ -340,7 +339,7 @@ class Highlighting extends AbstractComponent
     /**
      * Get requireFieldMatch option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getRequireFieldMatch()
     {
@@ -418,7 +417,7 @@ class Highlighting extends AbstractComponent
     /**
      * Set preserveMulti option.
      *
-     * @param boolean $preservemulti
+     * @param bool $preservemulti
      *
      * @return self Provides fluent interface
      */
@@ -430,7 +429,7 @@ class Highlighting extends AbstractComponent
     /**
      * Get preserveMulti option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getPreserveMulti()
     {
@@ -634,7 +633,7 @@ class Highlighting extends AbstractComponent
     /**
      * Set useFastVectorHighlighter option.
      *
-     * @param boolean $use
+     * @param bool $use
      *
      * @return self Provides fluent interface
      */
@@ -646,7 +645,7 @@ class Highlighting extends AbstractComponent
     /**
      * Get useFastVectorHighlighter option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getUseFastVectorHighlighter()
     {
@@ -656,7 +655,7 @@ class Highlighting extends AbstractComponent
     /**
      * Set usePhraseHighlighter option.
      *
-     * @param boolean $use
+     * @param bool $use
      *
      * @return self Provides fluent interface
      */
@@ -668,7 +667,7 @@ class Highlighting extends AbstractComponent
     /**
      * Get usePhraseHighlighter option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getUsePhraseHighlighter()
     {
@@ -678,7 +677,7 @@ class Highlighting extends AbstractComponent
     /**
      * Set HighlightMultiTerm option.
      *
-     * @param boolean $highlight
+     * @param bool $highlight
      *
      * @return self Provides fluent interface
      */
@@ -690,7 +689,7 @@ class Highlighting extends AbstractComponent
     /**
      * Get HighlightMultiTerm option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getHighlightMultiTerm()
     {

--- a/library/Solarium/QueryType/Select/Query/Component/MoreLikeThis.php
+++ b/library/Solarium/QueryType/Select/Query/Component/MoreLikeThis.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -47,7 +47,7 @@ use Solarium\QueryType\Select\ResponseParser\Component\MoreLikeThis as ResponseP
 /**
  * MoreLikeThis component.
  *
- * @link http://wiki.apache.org/solr/MoreLikeThis
+ * @see http://wiki.apache.org/solr/MoreLikeThis
  */
 class MoreLikeThis extends AbstractComponent
 {
@@ -95,7 +95,7 @@ class MoreLikeThis extends AbstractComponent
      */
     public function setFields($fields)
     {
-        if (is_string($fields)) {
+        if (\is_string($fields)) {
             $fields = explode(',', $fields);
             $fields = array_map('trim', $fields);
         }
@@ -111,7 +111,7 @@ class MoreLikeThis extends AbstractComponent
     public function getFields()
     {
         $fields = $this->getOption('fields');
-        if ($fields === null) {
+        if (null === $fields) {
             $fields = array();
         }
 
@@ -136,7 +136,7 @@ class MoreLikeThis extends AbstractComponent
     /**
      * Get minimumtermfrequency option.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getMinimumTermFrequency()
     {
@@ -161,7 +161,7 @@ class MoreLikeThis extends AbstractComponent
     /**
      * Get minimumdocumentfrequency option.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getMinimumDocumentFrequency()
     {
@@ -185,7 +185,7 @@ class MoreLikeThis extends AbstractComponent
     /**
      * Get minimumwordlength option.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getMinimumWordLength()
     {
@@ -209,7 +209,7 @@ class MoreLikeThis extends AbstractComponent
     /**
      * Get maximumwordlength option.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getMaximumWordLength()
     {
@@ -234,7 +234,7 @@ class MoreLikeThis extends AbstractComponent
     /**
      * Get maximumqueryterms option.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getMaximumQueryTerms()
     {
@@ -259,7 +259,7 @@ class MoreLikeThis extends AbstractComponent
     /**
      * Get maximumnumberoftokens option.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getMaximumNumberOfTokens()
     {
@@ -271,7 +271,7 @@ class MoreLikeThis extends AbstractComponent
      *
      * If true the query will be boosted by the interesting term relevance.
      *
-     * @param boolean $boost
+     * @param bool $boost
      *
      * @return self Provides fluent interface
      */
@@ -283,7 +283,7 @@ class MoreLikeThis extends AbstractComponent
     /**
      * Get boost option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getBoost()
     {
@@ -304,7 +304,7 @@ class MoreLikeThis extends AbstractComponent
      */
     public function setQueryFields($queryFields)
     {
-        if (is_string($queryFields)) {
+        if (\is_string($queryFields)) {
             $queryFields = explode(',', $queryFields);
             $queryFields = array_map('trim', $queryFields);
         }
@@ -320,7 +320,7 @@ class MoreLikeThis extends AbstractComponent
     public function getQueryFields()
     {
         $queryfields = $this->getOption('queryfields');
-        if ($queryfields === null) {
+        if (null === $queryfields) {
             $queryfields = array();
         }
 

--- a/library/Solarium/QueryType/Select/Query/Component/Spatial.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Spatial.php
@@ -8,7 +8,7 @@ use Solarium\QueryType\Select\RequestBuilder\Component\Spatial as RequestBuilder
 /**
  * Spatial component.
  *
- * @link https://cwiki.apache.org/confluence/display/solr/Spatial+Search
+ * @see https://cwiki.apache.org/confluence/display/solr/Spatial+Search
  */
 class Spatial extends AbstractComponent
 {

--- a/library/Solarium/QueryType/Select/Query/Component/Spellcheck.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Spellcheck.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -47,7 +47,7 @@ use Solarium\QueryType\Select\ResponseParser\Component\Spellcheck as ResponsePar
 /**
  * Spellcheck component.
  *
- * @link http://wiki.apache.org/solr/SpellCheckComponent
+ * @see http://wiki.apache.org/solr/SpellCheckComponent
  */
 class Spellcheck extends AbstractComponent
 {
@@ -98,7 +98,7 @@ class Spellcheck extends AbstractComponent
      */
     public function setQuery($query, $bind = null)
     {
-        if (!is_null($bind)) {
+        if (null !== $bind) {
             $query = $this->getQueryInstance()->getHelper()->assemble($query, $bind);
         }
 
@@ -120,7 +120,7 @@ class Spellcheck extends AbstractComponent
      *
      * Build the spellcheck?
      *
-     * @param boolean $build
+     * @param bool $build
      *
      * @return self Provides fluent interface
      */
@@ -132,7 +132,7 @@ class Spellcheck extends AbstractComponent
     /**
      * Get build option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getBuild()
     {
@@ -144,7 +144,7 @@ class Spellcheck extends AbstractComponent
      *
      * Reload the dictionary?
      *
-     * @param boolean $reload
+     * @param bool $reload
      *
      * @return self Provides fluent interface
      */
@@ -156,7 +156,7 @@ class Spellcheck extends AbstractComponent
     /**
      * Get fragsize option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getReload()
     {
@@ -216,7 +216,7 @@ class Spellcheck extends AbstractComponent
      *
      * Only return suggestions that result in more hits for the query than the existing query
      *
-     * @param boolean $onlyMorePopular
+     * @param bool $onlyMorePopular
      *
      * @return self Provides fluent interface
      */
@@ -228,7 +228,7 @@ class Spellcheck extends AbstractComponent
     /**
      * Get onlyMorePopular option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getOnlyMorePopular()
     {
@@ -238,7 +238,7 @@ class Spellcheck extends AbstractComponent
     /**
      * Set extendedResults option.
      *
-     * @param boolean $extendedResults
+     * @param bool $extendedResults
      *
      * @return self Provides fluent interface
      */
@@ -250,7 +250,7 @@ class Spellcheck extends AbstractComponent
     /**
      * Get extendedResults option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getExtendedResults()
     {
@@ -260,7 +260,7 @@ class Spellcheck extends AbstractComponent
     /**
      * Set collate option.
      *
-     * @param boolean $collate
+     * @param bool $collate
      *
      * @return self Provides fluent interface
      */
@@ -272,7 +272,7 @@ class Spellcheck extends AbstractComponent
     /**
      * Get collate option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getCollate()
     {

--- a/library/Solarium/QueryType/Select/Query/Component/Stats/Field.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Stats/Field.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -55,14 +55,14 @@ class Field extends Configurable
     protected $facets = array();
 
     /**
-     * pivot facets for these stats
+     * pivot facets for these stats.
      *
      * @var array
      */
     protected $pivots = array();
 
     /**
-     * Get key value
+     * Get key value.
      *
      * @return string
      */
@@ -107,7 +107,7 @@ class Field extends Configurable
      */
     public function addFacets($facets)
     {
-        if (is_string($facets)) {
+        if (\is_string($facets)) {
             $facets = explode(',', $facets);
             $facets = array_map('trim', $facets);
         }
@@ -175,10 +175,11 @@ class Field extends Configurable
     }
 
     /**
-     * Add pivot
+     * Add pivot.
      *
      * @param string $pivot
-     * @return self  Provides fluent interface
+     *
+     * @return self Provides fluent interface
      */
     public function addPivot($pivot)
     {
@@ -188,7 +189,7 @@ class Field extends Configurable
     }
 
     /**
-     * Specify multiple Pivots
+     * Specify multiple Pivots.
      *
      * @param string|array $pivots can be an array or string with comma
      *                             separated facetnames
@@ -197,7 +198,7 @@ class Field extends Configurable
      */
     public function addPivots($pivots)
     {
-        if (is_string($pivots)) {
+        if (\is_string($pivots)) {
             $pivots = explode(',', $pivots);
             $pivots = array_map('trim', $pivots);
         }
@@ -210,10 +211,11 @@ class Field extends Configurable
     }
 
     /**
-     * Remove a pivot facet from the pivot list
+     * Remove a pivot facet from the pivot list.
      *
-     * @param  string $pivot
-     * @return self   Provides fluent interface
+     * @param string $pivot
+     *
+     * @return self Provides fluent interface
      */
     public function removePivot($pivot)
     {
@@ -237,7 +239,7 @@ class Field extends Configurable
     }
 
     /**
-     * Get the list of pivot facets
+     * Get the list of pivot facets.
      *
      * @return array
      */
@@ -247,12 +249,13 @@ class Field extends Configurable
     }
 
     /**
-     * Set multiple pivot facets
+     * Set multiple pivot facets.
      *
      * This overwrites any existing pivots
      *
-     * @param  array $pivots
-     * @return self  Provides fluent interface
+     * @param array $pivots
+     *
+     * @return self Provides fluent interface
      */
     public function setPivots($pivots)
     {
@@ -263,12 +266,10 @@ class Field extends Configurable
     }
 
     /**
-     * Initialize options
+     * Initialize options.
      *
      * Several options need some extra checks or setup work, for these options
      * the setters are called.
-     *
-     * @return void
      */
     protected function init()
     {

--- a/library/Solarium/QueryType/Select/Query/Component/Stats/Stats.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Stats/Stats.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,16 +40,16 @@
 
 namespace Solarium\QueryType\Select\Query\Component\Stats;
 
-use Solarium\QueryType\Select\Query\Query as SelectQuery;
+use Solarium\Exception\InvalidArgumentException;
 use Solarium\QueryType\Select\Query\Component\AbstractComponent;
+use Solarium\QueryType\Select\Query\Query as SelectQuery;
 use Solarium\QueryType\Select\RequestBuilder\Component\Stats as RequestBuilder;
 use Solarium\QueryType\Select\ResponseParser\Component\Stats as ResponseParser;
-use Solarium\Exception\InvalidArgumentException;
 
 /**
  * Stats component.
  *
- * @link http://wiki.apache.org/solr/StatsComponent
+ * @see http://wiki.apache.org/solr/StatsComponent
  */
 class Stats extends AbstractComponent
 {
@@ -113,14 +113,14 @@ class Stats extends AbstractComponent
      */
     public function createField($options = null)
     {
-        if (is_string($options)) {
+        if (\is_string($options)) {
             $fq = new Field();
             $fq->setKey($options);
         } else {
             $fq = new Field($options);
         }
 
-        if ($fq->getKey() !== null) {
+        if (null !== $fq->getKey()) {
             $this->addField($fq);
         }
 
@@ -133,30 +133,30 @@ class Stats extends AbstractComponent
      * Supports a field instance or a config array, in that case a new
      * field instance wil be created based on the options.
      *
-     * @throws InvalidArgumentException
      *
      * @param Field|array $field
+     *
+     * @throws InvalidArgumentException
      *
      * @return self Provides fluent interface
      */
     public function addField($field)
     {
-        if (is_array($field)) {
+        if (\is_array($field)) {
             $field = new Field($field);
         }
 
         $key = $field->getKey();
 
-        if (0 === strlen($key)) {
+        if (0 === \strlen($key)) {
             throw new InvalidArgumentException('A field must have a key value');
         }
 
         //double add calls for the same field are ignored, but non-unique keys cause an exception
-        if (array_key_exists($key, $this->fields) && $this->fields[$key] !== $field) {
+        if (\array_key_exists($key, $this->fields) && $this->fields[$key] !== $field) {
             throw new InvalidArgumentException('A field must have a unique key value');
-        } else {
-            $this->fields[$key] = $field;
         }
+        $this->fields[$key] = $field;
 
         return $this;
     }
@@ -172,7 +172,7 @@ class Stats extends AbstractComponent
     {
         foreach ($fields as $key => $field) {
             // in case of a config array: add key to config
-            if (is_array($field) && !isset($field['key'])) {
+            if (\is_array($field) && !isset($field['key'])) {
                 $field['key'] = $key;
             }
 
@@ -193,8 +193,6 @@ class Stats extends AbstractComponent
     {
         if (isset($this->fields[$key])) {
             return $this->fields[$key];
-        } else {
-            return;
         }
     }
 
@@ -219,7 +217,7 @@ class Stats extends AbstractComponent
      */
     public function removeField($field)
     {
-        if (is_object($field)) {
+        if (\is_object($field)) {
             $field = $field->getKey();
         }
 
@@ -283,7 +281,7 @@ class Stats extends AbstractComponent
      */
     public function addFacets($facets)
     {
-        if (is_string($facets)) {
+        if (\is_string($facets)) {
             $facets = explode(',', $facets);
             $facets = array_map('trim', $facets);
         }

--- a/library/Solarium/QueryType/Select/Query/FilterQuery.php
+++ b/library/Solarium/QueryType/Select/Query/FilterQuery.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -46,7 +46,7 @@ use Solarium\Core\Query\Helper;
 /**
  * Filterquery.
  *
- * @link http://wiki.apache.org/solr/CommonQueryParameters#fq
+ * @see http://wiki.apache.org/solr/CommonQueryParameters#fq
  */
 class FilterQuery extends Configurable
 {
@@ -98,7 +98,7 @@ class FilterQuery extends Configurable
      */
     public function setQuery($query, $bind = null)
     {
-        if (!is_null($bind)) {
+        if (null !== $bind) {
             $helper = new Helper();
             $query = $helper->assemble($query, $bind);
         }
@@ -210,7 +210,7 @@ class FilterQuery extends Configurable
         foreach ($this->options as $name => $value) {
             switch ($name) {
                 case 'tag':
-                    if (!is_array($value)) {
+                    if (!\is_array($value)) {
                         $value = array($value);
                     }
                     $this->addTags($value);

--- a/library/Solarium/QueryType/Select/Query/Query.php
+++ b/library/Solarium/QueryType/Select/Query/Query.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -42,11 +42,11 @@ namespace Solarium\QueryType\Select\Query;
 
 use Solarium\Core\Client\Client;
 use Solarium\Core\Query\AbstractQuery as BaseQuery;
-use Solarium\QueryType\Select\RequestBuilder\RequestBuilder;
-use Solarium\QueryType\Select\ResponseParser\ResponseParser;
 use Solarium\Exception\InvalidArgumentException;
 use Solarium\Exception\OutOfBoundsException;
 use Solarium\QueryType\Select\Query\Component\AbstractComponent as AbstractComponent;
+use Solarium\QueryType\Select\RequestBuilder\RequestBuilder;
+use Solarium\QueryType\Select\ResponseParser\ResponseParser;
 
 /**
  * Select Query.
@@ -138,14 +138,14 @@ class Query extends BaseQuery
      * @var array
      */
     protected $options = array(
-        'handler'       => 'select',
-        'resultclass'   => 'Solarium\QueryType\Select\Result\Result',
+        'handler' => 'select',
+        'resultclass' => 'Solarium\QueryType\Select\Result\Result',
         'documentclass' => 'Solarium\QueryType\Select\Result\Document',
-        'query'         => '*:*',
-        'start'         => 0,
-        'rows'          => 10,
-        'fields'        => '*,score',
-        'omitheader'    => true,
+        'query' => '*:*',
+        'start' => 0,
+        'rows' => 10,
+        'fields' => '*,score',
+        'omitheader' => true,
     );
 
     /**
@@ -161,17 +161,17 @@ class Query extends BaseQuery
      * @var array
      */
     protected $componentTypes = array(
-        self::COMPONENT_FACETSET          => 'Solarium\QueryType\Select\Query\Component\FacetSet',
-        self::COMPONENT_DISMAX            => 'Solarium\QueryType\Select\Query\Component\DisMax',
-        self::COMPONENT_EDISMAX           => 'Solarium\QueryType\Select\Query\Component\EdisMax',
-        self::COMPONENT_MORELIKETHIS      => 'Solarium\QueryType\Select\Query\Component\MoreLikeThis',
-        self::COMPONENT_HIGHLIGHTING      => 'Solarium\QueryType\Select\Query\Component\Highlighting\Highlighting',
-        self::COMPONENT_GROUPING          => 'Solarium\QueryType\Select\Query\Component\Grouping',
-        self::COMPONENT_SPELLCHECK        => 'Solarium\QueryType\Select\Query\Component\Spellcheck',
+        self::COMPONENT_FACETSET => 'Solarium\QueryType\Select\Query\Component\FacetSet',
+        self::COMPONENT_DISMAX => 'Solarium\QueryType\Select\Query\Component\DisMax',
+        self::COMPONENT_EDISMAX => 'Solarium\QueryType\Select\Query\Component\EdisMax',
+        self::COMPONENT_MORELIKETHIS => 'Solarium\QueryType\Select\Query\Component\MoreLikeThis',
+        self::COMPONENT_HIGHLIGHTING => 'Solarium\QueryType\Select\Query\Component\Highlighting\Highlighting',
+        self::COMPONENT_GROUPING => 'Solarium\QueryType\Select\Query\Component\Grouping',
+        self::COMPONENT_SPELLCHECK => 'Solarium\QueryType\Select\Query\Component\Spellcheck',
         self::COMPONENT_DISTRIBUTEDSEARCH => 'Solarium\QueryType\Select\Query\Component\DistributedSearch',
-        self::COMPONENT_STATS             => 'Solarium\QueryType\Select\Query\Component\Stats\Stats',
-        self::COMPONENT_DEBUG             => 'Solarium\QueryType\Select\Query\Component\Debug',
-        self::COMPONENT_SPATIAL           => 'Solarium\QueryType\Select\Query\Component\Spatial',
+        self::COMPONENT_STATS => 'Solarium\QueryType\Select\Query\Component\Stats\Stats',
+        self::COMPONENT_DEBUG => 'Solarium\QueryType\Select\Query\Component\Debug',
+        self::COMPONENT_SPATIAL => 'Solarium\QueryType\Select\Query\Component\Spatial',
     );
 
     /**
@@ -245,11 +245,11 @@ class Query extends BaseQuery
      */
     public function setQuery($query, $bind = null)
     {
-        if (!is_null($bind)) {
+        if (null !== $bind) {
             $query = $this->getHelper()->assemble($query, $bind);
         }
 
-        if (!is_null($query)) {
+        if (null !== $query) {
             $query = trim($query);
         }
 
@@ -283,7 +283,7 @@ class Query extends BaseQuery
     /**
      * Get the default query operator.
      *
-     * @return null|string
+     * @return string|null
      */
     public function getQueryDefaultOperator()
     {
@@ -305,7 +305,7 @@ class Query extends BaseQuery
     /**
      * Get the default query field.
      *
-     * @return null|string
+     * @return string|null
      */
     public function getQueryDefaultField()
     {
@@ -315,7 +315,7 @@ class Query extends BaseQuery
     /**
      * Set the start offset.
      *
-     * @param integer $start
+     * @param int $start
      *
      * @return self Provides fluent interface
      */
@@ -327,7 +327,7 @@ class Query extends BaseQuery
     /**
      * Get the start offset.
      *
-     * @return integer
+     * @return int
      */
     public function getStart()
     {
@@ -387,7 +387,7 @@ class Query extends BaseQuery
     /**
      * Set the number of rows to fetch.
      *
-     * @param integer $rows
+     * @param int $rows
      *
      * @return self Provides fluent interface
      */
@@ -399,7 +399,7 @@ class Query extends BaseQuery
     /**
      * Get the number of rows.
      *
-     * @return integer
+     * @return int
      */
     public function getRows()
     {
@@ -430,7 +430,7 @@ class Query extends BaseQuery
      */
     public function addFields($fields)
     {
-        if (is_string($fields)) {
+        if (\is_string($fields)) {
             $fields = explode(',', $fields);
             $fields = array_map('trim', $fields);
         }
@@ -601,14 +601,14 @@ class Query extends BaseQuery
      */
     public function createFilterQuery($options = null)
     {
-        if (is_string($options)) {
+        if (\is_string($options)) {
             $fq = new FilterQuery();
             $fq->setKey($options);
         } else {
             $fq = new FilterQuery($options);
         }
 
-        if ($fq->getKey() !== null) {
+        if (null !== $fq->getKey()) {
             $this->addFilterQuery($fq);
         }
 
@@ -621,30 +621,30 @@ class Query extends BaseQuery
      * Supports a filterquery instance or a config array, in that case a new
      * filterquery instance wil be created based on the options.
      *
-     * @throws InvalidArgumentException
      *
      * @param FilterQuery|array $filterQuery
+     *
+     * @throws InvalidArgumentException
      *
      * @return self Provides fluent interface
      */
     public function addFilterQuery($filterQuery)
     {
-        if (is_array($filterQuery)) {
+        if (\is_array($filterQuery)) {
             $filterQuery = new FilterQuery($filterQuery);
         }
 
         $key = $filterQuery->getKey();
 
-        if (0 === strlen($key)) {
+        if (0 === \strlen($key)) {
             throw new InvalidArgumentException('A filterquery must have a key value');
         }
 
         //double add calls for the same FQ are ignored, but non-unique keys cause an exception
-        if (array_key_exists($key, $this->filterQueries) && $this->filterQueries[$key] !== $filterQuery) {
+        if (\array_key_exists($key, $this->filterQueries) && $this->filterQueries[$key] !== $filterQuery) {
             throw new InvalidArgumentException('A filterquery must have a unique key value within a query');
-        } else {
-            $this->filterQueries[$key] = $filterQuery;
         }
+        $this->filterQueries[$key] = $filterQuery;
 
         return $this;
     }
@@ -660,7 +660,7 @@ class Query extends BaseQuery
     {
         foreach ($filterQueries as $key => $filterQuery) {
             // in case of a config array: add key to config
-            if (is_array($filterQuery) && !isset($filterQuery['key'])) {
+            if (\is_array($filterQuery) && !isset($filterQuery['key'])) {
                 $filterQuery['key'] = $key;
             }
 
@@ -681,8 +681,6 @@ class Query extends BaseQuery
     {
         if (isset($this->filterQueries[$key])) {
             return $this->filterQueries[$key];
-        } else {
-            return;
         }
     }
 
@@ -707,7 +705,7 @@ class Query extends BaseQuery
      */
     public function removeFilterQuery($filterQuery)
     {
-        if (is_object($filterQuery)) {
+        if (\is_object($filterQuery)) {
             $filterQuery = $filterQuery->getKey();
         }
 
@@ -784,11 +782,12 @@ class Query extends BaseQuery
      * You can optionally supply an autoload class to create a new component
      * instance if there is no registered component for the given key yet.
      *
-     * @throws OutOfBoundsException
      *
-     * @param string         $key      Use one of the constants
-     * @param string|boolean $autoload Class to autoload if component needs to be created
-     * @param array|null     $config   Configuration to use for autoload
+     * @param string      $key      Use one of the constants
+     * @param string|bool $autoload Class to autoload if component needs to be created
+     * @param array|null  $config   Configuration to use for autoload
+     *
+     * @throws OutOfBoundsException
      *
      * @return object|null
      */
@@ -796,21 +795,18 @@ class Query extends BaseQuery
     {
         if (isset($this->components[$key])) {
             return $this->components[$key];
-        } else {
-            if ($autoload === true) {
-                if (!isset($this->componentTypes[$key])) {
-                    throw new OutOfBoundsException('Cannot autoload unknown component: '.$key);
-                }
-
-                $className = $this->componentTypes[$key];
-                $className = class_exists($className) ? $className : $className.strrchr($className, '\\');
-                $component = new $className($config);
-                $this->setComponent($key, $component);
-
-                return $component;
+        }
+        if (true === $autoload) {
+            if (!isset($this->componentTypes[$key])) {
+                throw new OutOfBoundsException('Cannot autoload unknown component: '.$key);
             }
 
-            return;
+            $className = $this->componentTypes[$key];
+            $className = class_exists($className) ? $className : $className.strrchr($className, '\\');
+            $component = new $className($config);
+            $this->setComponent($key, $component);
+
+            return $component;
         }
     }
 
@@ -843,7 +839,7 @@ class Query extends BaseQuery
      */
     public function removeComponent($component)
     {
-        if (is_object($component)) {
+        if (\is_object($component)) {
             foreach ($this->components as $key => $instance) {
                 if ($instance === $component) {
                     unset($this->components[$key]);
@@ -1107,7 +1103,7 @@ class Query extends BaseQuery
                     $this->createComponents($value);
                     break;
                 case 'tag':
-                    if (!is_array($value)) {
+                    if (!\is_array($value)) {
                         $value = explode(',', $value);
                     }
                     $this->addTags($value);

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/ComponentRequestBuilderInterface.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/ComponentRequestBuilderInterface.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Select\RequestBuilder\Component;
 
-use Solarium\QueryType\Select\Query\Component\AbstractComponent;
 use Solarium\Core\Client\Request;
+use Solarium\QueryType\Select\Query\Component\AbstractComponent;
 
 /**
  * ComponentRequestBuilderInterface.

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/Debug.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/Debug.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Select\RequestBuilder\Component;
 
-use Solarium\QueryType\Select\Query\Component\Debug as DebugComponent;
 use Solarium\Core\Client\Request;
+use Solarium\QueryType\Select\Query\Component\Debug as DebugComponent;
 
 /**
  * Add select component debug to the request.

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/DisMax.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/DisMax.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Select\RequestBuilder\Component;
 
-use Solarium\QueryType\Select\Query\Component\DisMax as DismaxComponent;
 use Solarium\Core\Client\Request;
+use Solarium\QueryType\Select\Query\Component\DisMax as DismaxComponent;
 
 /**
  * Add select component dismax to the request.
@@ -71,7 +71,7 @@ class DisMax implements ComponentRequestBuilderInterface
 
         // add boostqueries to request
         $boostQueries = $component->getBoostQueries();
-        if (count($boostQueries) !== 0) {
+        if (0 !== \count($boostQueries)) {
             foreach ($boostQueries as $boostQuery) {
                 $request->addParam('bq', $boostQuery->getQuery());
             }

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/DistributedSearch.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/DistributedSearch.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Select\RequestBuilder\Component;
 
-use Solarium\QueryType\Select\Query\Component\DistributedSearch as DistributedSearchComponent;
 use Solarium\Core\Client\Request;
+use Solarium\QueryType\Select\Query\Component\DistributedSearch as DistributedSearchComponent;
 
 /**
  * Add select component distributedsearch to the request.
@@ -60,13 +60,13 @@ class DistributedSearch implements ComponentRequestBuilderInterface
     {
         // add shards to request
         $shards = array_values($component->getShards());
-        if (count($shards)) {
+        if (\count($shards)) {
             $request->addParam('shards', implode(',', $shards));
         }
 
         $replicas = array_values($component->getReplicas());
 
-        if (count($replicas)) {
+        if (\count($replicas)) {
             $value = ($request->getParam('shards')) ? $request->getParam('shards').','.implode('|', $replicas) : implode('|', $replicas);
 
             $request->addParam('shards', $value, true);
@@ -76,7 +76,7 @@ class DistributedSearch implements ComponentRequestBuilderInterface
 
         // add collections to request
         $collections = array_values($component->getCollections());
-        if (count($collections)) {
+        if (\count($collections)) {
             $request->addParam('collection', implode(',', $collections));
         }
 

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/EdisMax.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/EdisMax.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2012 Marc Morera <yuhu@mmoreram.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Select\RequestBuilder\Component;
 
-use Solarium\QueryType\Select\Query\Component\EdisMax as EdismaxComponent;
 use Solarium\Core\Client\Request;
+use Solarium\QueryType\Select\Query\Component\EdisMax as EdismaxComponent;
 
 /**
  * Add select component edismax to the request.
@@ -75,7 +75,7 @@ class EdisMax implements ComponentRequestBuilderInterface
 
         // add boostqueries to request
         $boostQueries = $component->getBoostQueries();
-        if (count($boostQueries) !== 0) {
+        if (0 !== \count($boostQueries)) {
             foreach ($boostQueries as $boostQuery) {
                 $request->addParam('bq', $boostQuery->getQuery());
             }

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/FacetSet.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/FacetSet.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -41,15 +41,15 @@
 namespace Solarium\QueryType\Select\RequestBuilder\Component;
 
 use Solarium\Core\Client\Request;
-use Solarium\QueryType\Select\RequestBuilder\RequestBuilder;
-use Solarium\QueryType\Select\Query\Component\FacetSet as FacetsetComponent;
+use Solarium\Exception\UnexpectedValueException;
 use Solarium\QueryType\Select\Query\Component\Facet\Field as FacetField;
+use Solarium\QueryType\Select\Query\Component\Facet\Interval as FacetInterval;
 use Solarium\QueryType\Select\Query\Component\Facet\MultiQuery as FacetMultiQuery;
+use Solarium\QueryType\Select\Query\Component\Facet\Pivot as FacetPivot;
 use Solarium\QueryType\Select\Query\Component\Facet\Query as FacetQuery;
 use Solarium\QueryType\Select\Query\Component\Facet\Range as FacetRange;
-use Solarium\QueryType\Select\Query\Component\Facet\Pivot as FacetPivot;
-use Solarium\QueryType\Select\Query\Component\Facet\Interval as FacetInterval;
-use Solarium\Exception\UnexpectedValueException;
+use Solarium\QueryType\Select\Query\Component\FacetSet as FacetsetComponent;
+use Solarium\QueryType\Select\RequestBuilder\RequestBuilder;
 
 /**
  * Add select component FacetSet to the request.
@@ -59,17 +59,18 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
     /**
      * Add request settings for FacetSet.
      *
-     * @throws UnexpectedValueException
      *
      * @param FacetsetComponent $component
      * @param Request           $request
+     *
+     * @throws UnexpectedValueException
      *
      * @return Request
      */
     public function buildComponent($component, $request)
     {
         $facets = $component->getFacets();
-        if (count($facets) !== 0) {
+        if (0 !== \count($facets)) {
             // enable faceting
             $request->addParam('facet', 'true');
 
@@ -77,7 +78,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
             $request->addParam('facet.sort', $component->getSort());
             $request->addParam('facet.prefix', $component->getPrefix());
             $request->addParam('facet.contains', $component->getContains());
-            $request->addParam('facet.contains.ignoreCase', is_null($ignoreCase = $component->getContainsIgnoreCase()) ? null : ($ignoreCase ? 'true' : 'false'));
+            $request->addParam('facet.contains.ignoreCase', null === ($ignoreCase = $component->getContainsIgnoreCase()) ? null : ($ignoreCase ? 'true' : 'false'));
             $request->addParam('facet.missing', $component->getMissing());
             $request->addParam('facet.mincount', $component->getMinCount());
             $request->addParam('facet.limit', $component->getLimit());
@@ -133,7 +134,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
         $request->addParam("f.$field.facet.sort", $facet->getSort());
         $request->addParam("f.$field.facet.prefix", $facet->getPrefix());
         $request->addParam("f.$field.facet.contains", $facet->getContains());
-        $request->addParam("f.$field.facet.contains.ignoreCase", is_null($ignoreCase = $facet->getContainsIgnoreCase()) ? null : ($ignoreCase ? 'true' : 'false'));
+        $request->addParam("f.$field.facet.contains.ignoreCase", null === ($ignoreCase = $facet->getContainsIgnoreCase()) ? null : ($ignoreCase ? 'true' : 'false'));
         $request->addParam("f.$field.facet.offset", $facet->getOffset());
         $request->addParam("f.$field.facet.mincount", $facet->getMinCount());
         $request->addParam("f.$field.facet.missing", $facet->getMissing());
@@ -213,7 +214,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
     {
         $stats = $facet->getStats();
 
-        if (count($stats) > 0) {
+        if (\count($stats) > 0) {
             $key = array('stats' => implode('', $stats));
 
             // when specifying stats, solr sets the field as key
@@ -233,11 +234,10 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
     }
 
     /**
-     * Add params for a interval facet to request
+     * Add params for a interval facet to request.
      *
-     * @param  Request    $request
-     * @param  FacetInterval $facet
-     * @return void
+     * @param Request       $request
+     * @param FacetInterval $facet
      */
     public function addFacetInterval($request, $facet)
     {
@@ -252,7 +252,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
         );
 
         foreach ($facet->getSet() as $key => $setValue) {
-            if(is_string($key)) {
+            if (\is_string($key)) {
                 $setValue = '{!key="'.$key.'"}'.$setValue;
             }
             $request->addParam("f.$field.facet.interval.set", $setValue);

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/Grouping.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/Grouping.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Select\RequestBuilder\Component;
 
-use Solarium\QueryType\Select\Query\Component\Grouping as GroupingComponent;
 use Solarium\Core\Client\Request;
+use Solarium\QueryType\Select\Query\Component\Grouping as GroupingComponent;
 
 /**
  * Add select component Grouping to the request.

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/Highlighting.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/Highlighting.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,9 +40,9 @@
 
 namespace Solarium\QueryType\Select\RequestBuilder\Component;
 
-use Solarium\QueryType\Select\Query\Component\Highlighting\Highlighting as HighlightingComponent;
-use Solarium\QueryType\Select\Query\Component\Highlighting\Field as HighlightingField;
 use Solarium\Core\Client\Request;
+use Solarium\QueryType\Select\Query\Component\Highlighting\Field as HighlightingField;
+use Solarium\QueryType\Select\Query\Component\Highlighting\Highlighting as HighlightingComponent;
 
 /**
  * Add select component Highlighting to the request.
@@ -63,7 +63,7 @@ class Highlighting implements ComponentRequestBuilderInterface
         $request->addParam('hl', 'true');
 
         // set global highlighting params
-        if (count($component->getFields()) > 0) {
+        if (\count($component->getFields()) > 0) {
             $request->addParam('hl.fl', implode(',', array_keys($component->getFields())));
         }
         $request->addParam('hl.snippets', $component->getSnippets());

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/MoreLikeThis.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/MoreLikeThis.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Select\RequestBuilder\Component;
 
-use Solarium\QueryType\Select\Query\Component\MoreLikeThis as MoreLikeThisComponent;
 use Solarium\Core\Client\Request;
+use Solarium\QueryType\Select\Query\Component\MoreLikeThis as MoreLikeThisComponent;
 
 /**
  * Add select component morelikethis to the request.
@@ -61,7 +61,7 @@ class MoreLikeThis implements ComponentRequestBuilderInterface
         // enable morelikethis
         $request->addParam('mlt', 'true');
 
-        $request->addParam('mlt.fl', count($component->getFields()) ? implode(',', $component->getFields()) : null);
+        $request->addParam('mlt.fl', \count($component->getFields()) ? implode(',', $component->getFields()) : null);
         $request->addParam('mlt.mintf', $component->getMinimumTermFrequency());
         $request->addParam('mlt.mindf', $component->getMinimumDocumentFrequency());
         $request->addParam('mlt.minwl', $component->getMinimumWordLength());
@@ -71,7 +71,7 @@ class MoreLikeThis implements ComponentRequestBuilderInterface
         $request->addParam('mlt.boost', $component->getBoost());
         $request->addParam(
             'mlt.qf',
-            count($component->getQueryFields()) ? $component->getQueryFields() : null
+            \count($component->getQueryFields()) ? $component->getQueryFields() : null
         );
         $request->addParam('mlt.count', $component->getCount());
 

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/Spatial.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/Spatial.php
@@ -2,8 +2,8 @@
 
 namespace Solarium\QueryType\Select\RequestBuilder\Component;
 
-use Solarium\QueryType\Select\Query\Component\Spatial as SpatialComponent;
 use Solarium\Core\Client\Request;
+use Solarium\QueryType\Select\Query\Component\Spatial as SpatialComponent;
 
 /**
  * Add select component spatial to the request.
@@ -14,7 +14,7 @@ class Spatial implements ComponentRequestBuilderInterface
      * Add request settings for Spatial.
      *
      * @param SpatialComponent $component
-     * @param Request         $request
+     * @param Request          $request
      *
      * @return Request
      */

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/Spellcheck.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/Spellcheck.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Select\RequestBuilder\Component;
 
-use Solarium\QueryType\Select\Query\Component\Spellcheck as SpellcheckComponent;
 use Solarium\Core\Client\Request;
+use Solarium\QueryType\Select\Query\Component\Spellcheck as SpellcheckComponent;
 
 /**
  * Add select component Spellcheck to the request.

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/Stats.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/Stats.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Select\RequestBuilder\Component;
 
-use Solarium\QueryType\Select\Query\Component\Stats\Stats as StatsComponent;
 use Solarium\Core\Client\Request;
+use Solarium\QueryType\Select\Query\Component\Stats\Stats as StatsComponent;
 
 /**
  * Add select component stats to the request.
@@ -65,8 +65,8 @@ class Stats implements ComponentRequestBuilderInterface
         foreach ($component->getFields() as $field) {
             $pivots = $field->getPivots();
 
-            $prefix = (count($pivots) > 0) ? '{!tag='.implode(',', $pivots).'}' : '';
-            $request->addParam('stats.field', $prefix . $field->getKey());
+            $prefix = (\count($pivots) > 0) ? '{!tag='.implode(',', $pivots).'}' : '';
+            $request->addParam('stats.field', $prefix.$field->getKey());
 
             // add field specific facet stats
             foreach ($field->getFacets() as $facet) {

--- a/library/Solarium/QueryType/Select/RequestBuilder/RequestBuilder.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/RequestBuilder.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,10 +40,10 @@
 
 namespace Solarium\QueryType\Select\RequestBuilder;
 
-use Solarium\QueryType\Select\Query\Query as SelectQuery;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
+use Solarium\QueryType\Select\Query\Query as SelectQuery;
 
 /**
  * Build a select request.
@@ -80,13 +80,13 @@ class RequestBuilder extends BaseRequestBuilder
         foreach ($query->getSorts() as $field => $order) {
             $sort[] = $field.' '.$order;
         }
-        if (count($sort) !== 0) {
+        if (0 !== \count($sort)) {
             $request->addParam('sort', implode(',', $sort));
         }
 
         // add filterqueries to request
         $filterQueries = $query->getFilterQueries();
-        if (count($filterQueries) !== 0) {
+        if (0 !== \count($filterQueries)) {
             foreach ($filterQueries as $filterQuery) {
                 $fq = $this->renderLocalParams(
                     $filterQuery->getQuery(),

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/ComponentParserInterface.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/ComponentParserInterface.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Debug.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Debug.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,13 +40,13 @@
 
 namespace Solarium\QueryType\Select\ResponseParser\Component;
 
-use Solarium\QueryType\Select\Query\Query;
 use Solarium\QueryType\Select\Query\Component\Debug as DebugComponent;
-use Solarium\QueryType\Select\Result\Debug\Result;
-use Solarium\QueryType\Select\Result\Debug\DocumentSet;
-use Solarium\QueryType\Select\Result\Debug\Timing;
+use Solarium\QueryType\Select\Query\Query;
 use Solarium\QueryType\Select\Result\Debug\Detail;
 use Solarium\QueryType\Select\Result\Debug\Document;
+use Solarium\QueryType\Select\Result\Debug\DocumentSet;
+use Solarium\QueryType\Select\Result\Debug\Result;
+use Solarium\QueryType\Select\Result\Debug\Timing;
 use Solarium\QueryType\Select\Result\Debug\TimingPhase;
 
 /**
@@ -77,14 +77,14 @@ class Debug implements ComponentParserInterface
             $otherQuery = (isset($debug['otherQuery'])) ? $debug['otherQuery'] : '';
 
             // parse explain data
-            if (isset($debug['explain']) && is_array($debug['explain'])) {
+            if (isset($debug['explain']) && \is_array($debug['explain'])) {
                 $explain = $this->parseDocumentSet($debug['explain']);
             } else {
                 $explain = new DocumentSet(array());
             }
 
             // parse explainOther data
-            if (isset($debug['explainOther']) && is_array($debug['explainOther'])) {
+            if (isset($debug['explainOther']) && \is_array($debug['explainOther'])) {
                 $explainOther = $this->parseDocumentSet($debug['explainOther']);
             } else {
                 $explainOther = new DocumentSet(array());
@@ -92,7 +92,7 @@ class Debug implements ComponentParserInterface
 
             // parse timing data
             $timing = null;
-            if (isset($debug['timing']) && is_array($debug['timing'])) {
+            if (isset($debug['timing']) && \is_array($debug['timing'])) {
                 $time = null;
                 $timingPhases = array();
                 foreach ($debug['timing'] as $key => $timingData) {
@@ -136,7 +136,7 @@ class Debug implements ComponentParserInterface
         $docs = array();
         foreach ($data as $key => $documentData) {
             $details = array();
-            if (isset($documentData['details']) && is_array($documentData['details'])) {
+            if (isset($documentData['details']) && \is_array($documentData['details'])) {
                 foreach ($documentData['details'] as $detailData) {
                     $detail = new Detail(
                         $detailData['match'],
@@ -144,7 +144,7 @@ class Debug implements ComponentParserInterface
                         $detailData['description']
                     );
 
-                    if (isset($detailData['details']) && is_array($detailData['details'])) {
+                    if (isset($detailData['details']) && \is_array($detailData['details'])) {
                         $detail->setSubDetails($detailData['details']);
                     }
                     $details[] = $detail;

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/FacetSet.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/FacetSet.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,22 +40,22 @@
 
 namespace Solarium\QueryType\Select\ResponseParser\Component;
 
-use Solarium\QueryType\Select\Query\Query;
-use Solarium\QueryType\Select\Query\Component\FacetSet as QueryFacetSet;
-use Solarium\QueryType\Select\Query\Component\Facet\Field as QueryFacetField;
-use Solarium\QueryType\Select\Query\Component\Facet\Query as QueryFacetQuery;
-use Solarium\QueryType\Select\Query\Component\Facet\MultiQuery as QueryFacetMultiQuery;
-use Solarium\QueryType\Select\Query\Component\Facet\Range as QueryFacetRange;
-use Solarium\QueryType\Select\Query\Component\Facet\Pivot as QueryFacetPivot;
-use Solarium\QueryType\Select\Result\FacetSet as ResultFacetSet;
-use Solarium\QueryType\Select\Result\Facet\Field as ResultFacetField;
-use Solarium\QueryType\Select\Result\Facet\Query as ResultFacetQuery;
-use Solarium\QueryType\Select\Result\Facet\MultiQuery as ResultFacetMultiQuery;
-use Solarium\QueryType\Select\Result\Facet\Range as ResultFacetRange;
-use Solarium\QueryType\Select\Result\Facet\Pivot\Pivot as ResultFacetPivot;
-use Solarium\QueryType\Select\Result\Facet\Interval as ResultFacetInterval;
-use Solarium\Exception\RuntimeException;
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
+use Solarium\Exception\RuntimeException;
+use Solarium\QueryType\Select\Query\Component\Facet\Field as QueryFacetField;
+use Solarium\QueryType\Select\Query\Component\Facet\MultiQuery as QueryFacetMultiQuery;
+use Solarium\QueryType\Select\Query\Component\Facet\Pivot as QueryFacetPivot;
+use Solarium\QueryType\Select\Query\Component\Facet\Query as QueryFacetQuery;
+use Solarium\QueryType\Select\Query\Component\Facet\Range as QueryFacetRange;
+use Solarium\QueryType\Select\Query\Component\FacetSet as QueryFacetSet;
+use Solarium\QueryType\Select\Query\Query;
+use Solarium\QueryType\Select\Result\Facet\Field as ResultFacetField;
+use Solarium\QueryType\Select\Result\Facet\Interval as ResultFacetInterval;
+use Solarium\QueryType\Select\Result\Facet\MultiQuery as ResultFacetMultiQuery;
+use Solarium\QueryType\Select\Result\Facet\Pivot\Pivot as ResultFacetPivot;
+use Solarium\QueryType\Select\Result\Facet\Query as ResultFacetQuery;
+use Solarium\QueryType\Select\Result\Facet\Range as ResultFacetRange;
+use Solarium\QueryType\Select\Result\FacetSet as ResultFacetSet;
 
 /**
  * Parse select component FacetSet result from the data.
@@ -65,18 +65,19 @@ class FacetSet extends ResponseParserAbstract implements ComponentParserInterfac
     /**
      * Parse result data into result objects.
      *
-     * @throws RuntimeException
      *
      * @param Query         $query
      * @param QueryFacetSet $facetSet
      * @param array         $data
      *
+     * @throws RuntimeException
+     *
      * @return ResultFacetSet
      */
     public function parse($query, $facetSet, $data)
     {
-        if ($facetSet->getExtractFromResponse() === true) {
-            if (empty($data['facet_counts']) === false) {
+        if (true === $facetSet->getExtractFromResponse()) {
+            if (false === empty($data['facet_counts'])) {
                 foreach ($data['facet_counts'] as $key => $facets) {
                     switch ($key) {
                         case 'facet_fields':
@@ -99,7 +100,7 @@ class FacetSet extends ResponseParserAbstract implements ComponentParserInterfac
                     }
                     foreach ($facets as $k => $facet) {
                         $facetObject = $facetSet->$method($k);
-                        if ($key == 'facet_pivot') {
+                        if ('facet_pivot' == $key) {
                             /* @var \Solarium\QueryType\Select\Query\Component\Facet\Pivot $facetObject */
                             $facetObject->setFields($k);
                         }
@@ -133,7 +134,7 @@ class FacetSet extends ResponseParserAbstract implements ComponentParserInterfac
                     throw new RuntimeException('Unknown facet type');
             }
 
-            if ($result !== null) {
+            if (null !== $result) {
                 $facets[$key] = $result;
             }
         }
@@ -215,7 +216,7 @@ class FacetSet extends ResponseParserAbstract implements ComponentParserInterfac
             }
         }
 
-        if (count($values) <= 0) {
+        if (\count($values) <= 0) {
             return;
         }
 
@@ -252,13 +253,14 @@ class FacetSet extends ResponseParserAbstract implements ComponentParserInterfac
 
         return new ResultFacetRange($data['counts'], $before, $after, $between, $start, $end, $gap);
     }
-    
+
     /**
-     * Add a facet result for a interval facet
+     * Add a facet result for a interval facet.
      *
-     * @param  Query                    $query
-     * @param  QueryFacetInterval       $facet
-     * @param  array                    $data
+     * @param Query              $query
+     * @param QueryFacetInterval $facet
+     * @param array              $data
+     *
      * @return ResultFacetInterval|null
      */
     protected function facetInterval($query, $facet, $data)
@@ -267,7 +269,7 @@ class FacetSet extends ResponseParserAbstract implements ComponentParserInterfac
         if (!isset($data['facet_counts']['facet_intervals'][$key])) {
             return null;
         }
-        
+
         return new ResultFacetInterval($data['facet_counts']['facet_intervals'][$key]);
     }
 

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Grouping.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Grouping.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,10 +40,10 @@
 
 namespace Solarium\QueryType\Select\ResponseParser\Component;
 
-use Solarium\QueryType\Select\Query\Query;
 use Solarium\QueryType\Select\Query\Component\Grouping as GroupingComponent;
-use Solarium\QueryType\Select\Result\Grouping\Result;
+use Solarium\QueryType\Select\Query\Query;
 use Solarium\QueryType\Select\Result\Grouping\FieldGroup;
+use Solarium\QueryType\Select\Result\Grouping\Result;
 
 /**
  * Parse select component Grouping result from the data.
@@ -81,7 +81,7 @@ class Grouping implements ComponentParserInterface
 
             $matches = (isset($result['matches'])) ? $result['matches'] : null;
             $groupCount = (isset($result['ngroups'])) ? $result['ngroups'] : null;
-            if ($grouping->getFormat() === GroupingComponent::FORMAT_SIMPLE) {
+            if (GroupingComponent::FORMAT_SIMPLE === $grouping->getFormat()) {
                 $valueGroups = array($this->extractValueGroup($valueResultClass, $documentClass, $result, $query));
                 $groups[$field] = new FieldGroup($matches, $groupCount, $valueGroups);
                 continue;
@@ -110,7 +110,7 @@ class Grouping implements ComponentParserInterface
                 // create document instances
                 $documentClass = $query->getOption('documentclass');
                 $documents = array();
-                if (isset($result['doclist']['docs']) && is_array($result['doclist']['docs'])) {
+                if (isset($result['doclist']['docs']) && \is_array($result['doclist']['docs'])) {
                     foreach ($result['doclist']['docs'] as $doc) {
                         $documents[] = new $documentClass($doc);
                     }
@@ -128,10 +128,10 @@ class Grouping implements ComponentParserInterface
     /**
      * Helper method to extract a ValueGroup object from the given value group result array.
      *
-     * @param string $valueResultClass The grouping resultvaluegroupclass option.
-     * @param string $documentClass    The name of the solr document class to use.
-     * @param array  $valueGroupResult The group result from the solr response.
-     * @param Query  $query            The current solr query.
+     * @param string $valueResultClass the grouping resultvaluegroupclass option
+     * @param string $documentClass    the name of the solr document class to use
+     * @param array  $valueGroupResult the group result from the solr response
+     * @param Query  $query            the current solr query
      *
      * @return object
      */
@@ -152,7 +152,7 @@ class Grouping implements ComponentParserInterface
         // create document instances
         $documents = array();
         if (isset($valueGroupResult['doclist']['docs']) &&
-            is_array($valueGroupResult['doclist']['docs'])) {
+            \is_array($valueGroupResult['doclist']['docs'])) {
             foreach ($valueGroupResult['doclist']['docs'] as $doc) {
                 $documents[] = new $documentClass($doc);
             }

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Highlighting.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Highlighting.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Select\ResponseParser\Component;
 
-use Solarium\QueryType\Select\Query\Query;
 use Solarium\QueryType\Select\Query\Component\Highlighting\Highlighting as HighlightingComponent;
+use Solarium\QueryType\Select\Query\Query;
 use Solarium\QueryType\Select\Result\Highlighting\Highlighting as HighlightingResult;
 use Solarium\QueryType\Select\Result\Highlighting\Result;
 

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/MoreLikeThis.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/MoreLikeThis.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,10 +40,10 @@
 
 namespace Solarium\QueryType\Select\ResponseParser\Component;
 
-use Solarium\QueryType\Select\Query\Query;
 use Solarium\QueryType\Select\Query\Component\MoreLikeThis as MoreLikeThisComponent;
-use Solarium\QueryType\Select\Result\MoreLikeThis\Result;
+use Solarium\QueryType\Select\Query\Query;
 use Solarium\QueryType\Select\Result\MoreLikeThis\MoreLikeThis as MoreLikeThisResult;
+use Solarium\QueryType\Select\Result\MoreLikeThis\Result;
 
 /**
  * Parse select component MoreLikeThis result from the data.

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Spellcheck.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Spellcheck.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,13 +40,13 @@
 
 namespace Solarium\QueryType\Select\ResponseParser\Component;
 
-use Solarium\QueryType\Select\Query\Query;
-use Solarium\QueryType\Select\Query\Component\Spellcheck as SpellcheckComponent;
-use Solarium\QueryType\Select\Result\Spellcheck as SpellcheckResult;
-use Solarium\QueryType\Select\Result\Spellcheck\Result;
-use Solarium\QueryType\Select\Result\Spellcheck\Collation;
-use Solarium\QueryType\Select\Result\Spellcheck\Suggestion;
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
+use Solarium\QueryType\Select\Query\Component\Spellcheck as SpellcheckComponent;
+use Solarium\QueryType\Select\Query\Query;
+use Solarium\QueryType\Select\Result\Spellcheck as SpellcheckResult;
+use Solarium\QueryType\Select\Result\Spellcheck\Collation;
+use Solarium\QueryType\Select\Result\Spellcheck\Result;
+use Solarium\QueryType\Select\Result\Spellcheck\Suggestion;
 
 /**
  * Parse select component Highlighting result from the data.
@@ -65,8 +65,8 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
     public function parse($query, $spellcheck, $data)
     {
         if (isset($data['spellcheck']['suggestions']) &&
-            is_array($data['spellcheck']['suggestions']) &&
-            count($data['spellcheck']['suggestions']) > 0
+            \is_array($data['spellcheck']['suggestions']) &&
+            \count($data['spellcheck']['suggestions']) > 0
         ) {
             $spellcheckResults = $data['spellcheck']['suggestions'];
             if ($query->getResponseWriter() == $query::WT_JSON) {
@@ -86,7 +86,7 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
                         $collations = $this->parseCollation($query, $value);
                         break;
                     default:
-                        if (array_key_exists(0, $value)) {
+                        if (\array_key_exists(0, $value)) {
                             foreach ($value as $currentValue) {
                                 $suggestions[] = $this->parseSuggestion($key, $currentValue);
                             }
@@ -102,21 +102,19 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
              * directly under spellcheck.
              */
             if (isset($data['spellcheck']['collations']) &&
-                is_array($data['spellcheck']['collations'])
+                \is_array($data['spellcheck']['collations'])
             ) {
-              foreach ($this->convertToKeyValueArray($data['spellcheck']['collations']) as $collationResult) {
-                $collations = array_merge($collations, $this->parseCollation($query, $collationResult ));
-              }
+                foreach ($this->convertToKeyValueArray($data['spellcheck']['collations']) as $collationResult) {
+                    $collations = array_merge($collations, $this->parseCollation($query, $collationResult));
+                }
             }
 
             if (isset($data['spellcheck']['correctlySpelled'])
             ) {
-              $correctlySpelled = $data['spellcheck']['correctlySpelled'];
+                $correctlySpelled = $data['spellcheck']['correctlySpelled'];
             }
 
             return new SpellcheckResult\Result($suggestions, $collations, $correctlySpelled);
-        } else {
-            return;
         }
     }
 
@@ -131,24 +129,24 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
     protected function parseCollation($queryObject, $values)
     {
         $collations = array();
-        if (is_string($values)) {
+        if (\is_string($values)) {
             $collations[] = new Collation($values, null, array());
-        } elseif (is_array($values) && isset($values[0]) && is_string($values[0]) && $values[0] !== 'collationQuery') {
+        } elseif (\is_array($values) && isset($values[0]) && \is_string($values[0]) && 'collationQuery' !== $values[0]) {
             foreach ($values as $value) {
                 $collations[] = new Collation($value, null, array());
             }
         } else {
             if ($queryObject->getResponseWriter() == $queryObject::WT_JSON) {
-                if (is_array(current($values))) {
+                if (\is_array(current($values))) {
                     foreach ($values as $key => $value) {
-                        if (array_key_exists('collationQuery', $value)) {
+                        if (\array_key_exists('collationQuery', $value)) {
                             $values[$key] = $value;
                         } else {
                             $values[$key] = $this->convertToKeyValueArray($value);
                         }
                     }
                 } else {
-                    if (array_key_exists('collationQuery', $values)) {
+                    if (\array_key_exists('collationQuery', $values)) {
                         $values = array($values);
                     } else {
                         $values = array($this->convertToKeyValueArray($values));
@@ -176,7 +174,7 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
                 }
 
                 $corrections = array();
-                if ($correctionResult !== null) {
+                if (null !== $correctionResult) {
                     if ($queryObject->getResponseWriter() == $queryObject::WT_JSON) {
                         $correctionResult = $this->convertToKeyValueArray($correctionResult);
                     }
@@ -209,9 +207,9 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
         $originalFrequency = (isset($value['origFreq'])) ? $value['origFreq'] : null;
 
         $words = array();
-        if (isset($value['suggestion']) && is_array($value['suggestion'])) {
+        if (isset($value['suggestion']) && \is_array($value['suggestion'])) {
             foreach ($value['suggestion'] as $suggestion) {
-                if (is_string($suggestion)) {
+                if (\is_string($suggestion)) {
                     $suggestion = array(
                         'word' => $suggestion,
                         'freq' => null,

--- a/library/Solarium/QueryType/Select/ResponseParser/Component/Stats.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/Component/Stats.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,11 +40,11 @@
 
 namespace Solarium\QueryType\Select\ResponseParser\Component;
 
-use Solarium\QueryType\Select\Query\Query;
 use Solarium\QueryType\Select\Query\Component\Stats\Stats as StatsComponent;
-use Solarium\QueryType\Select\Result\Stats\Stats as ResultStats;
-use Solarium\QueryType\Select\Result\Stats\Result as ResultStatsResult;
+use Solarium\QueryType\Select\Query\Query;
 use Solarium\QueryType\Select\Result\Stats\FacetValue as ResultStatsFacetValue;
+use Solarium\QueryType\Select\Result\Stats\Result as ResultStatsResult;
+use Solarium\QueryType\Select\Result\Stats\Stats as ResultStats;
 
 /**
  * Parse select component Stats result from the data.

--- a/library/Solarium/QueryType/Select/ResponseParser/ResponseParser.php
+++ b/library/Solarium/QueryType/Select/ResponseParser/ResponseParser.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -42,9 +42,9 @@ namespace Solarium\QueryType\Select\ResponseParser;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
 use Solarium\Core\Query\ResponseParserInterface as ResponseParserInterface;
-use Solarium\QueryType\Select\Result\Result;
 use Solarium\Exception\RuntimeException;
 use Solarium\QueryType\Select\Query\Query;
+use Solarium\QueryType\Select\Result\Result;
 
 /**
  * Parse select response data.
@@ -54,9 +54,10 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
     /**
      * Get result data for the response.
      *
-     * @throws RuntimeException
      *
      * @param Result $result
+     *
+     * @throws RuntimeException
      *
      * @return array
      */
@@ -72,8 +73,8 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         // create document instances
         $documentClass = $query->getOption('documentclass');
         $classes = class_implements($documentClass);
-        if (!in_array('Solarium\QueryType\Select\Result\DocumentInterface', $classes) &&
-            !in_array('Solarium\QueryType\Update\Query\Document\DocumentInterface', $classes)
+        if (!\in_array('Solarium\QueryType\Select\Result\DocumentInterface', $classes, true) &&
+            !\in_array('Solarium\QueryType\Update\Query\Document\DocumentInterface', $classes, true)
         ) {
             throw new RuntimeException('The result document class must implement a document interface');
         }

--- a/library/Solarium/QueryType/Select/Result/AbstractDocument.php
+++ b/library/Solarium/QueryType/Select/Result/AbstractDocument.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -51,16 +51,6 @@ abstract class AbstractDocument implements \IteratorAggregate, \Countable, \Arra
      * @var array
      */
     protected $fields;
-
-    /**
-     * Get all fields.
-     *
-     * @return array
-     */
-    public function getFields()
-    {
-        return $this->fields;
-    }
 
     /**
      * Get field value by name.
@@ -89,11 +79,21 @@ abstract class AbstractDocument implements \IteratorAggregate, \Countable, \Arra
      *
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function __isset($name)
     {
         return isset($this->fields[$name]);
+    }
+
+    /**
+     * Get all fields.
+     *
+     * @return array
+     */
+    public function getFields()
+    {
+        return $this->fields;
     }
 
     /**
@@ -113,7 +113,7 @@ abstract class AbstractDocument implements \IteratorAggregate, \Countable, \Arra
      */
     public function count()
     {
-        return count($this->fields);
+        return \count($this->fields);
     }
 
     /**
@@ -136,7 +136,7 @@ abstract class AbstractDocument implements \IteratorAggregate, \Countable, \Arra
      */
     public function offsetExists($offset)
     {
-        return ($this->__get($offset) !== null);
+        return null !== $this->__get($offset);
     }
 
     /**

--- a/library/Solarium/QueryType/Select/Result/Debug/Detail.php
+++ b/library/Solarium/QueryType/Select/Result/Debug/Detail.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -55,7 +55,7 @@ class Detail
     /**
      * Match.
      *
-     * @var boolean
+     * @var bool
      */
     protected $match;
 
@@ -74,9 +74,9 @@ class Detail
     /**
      * Constructor.
      *
-     * @param boolean $match
-     * @param float   $value
-     * @param string  $description
+     * @param bool   $match
+     * @param float  $value
+     * @param string $description
      */
     public function __construct($match, $value, $description)
     {

--- a/library/Solarium/QueryType/Select/Result/Debug/Document.php
+++ b/library/Solarium/QueryType/Select/Result/Debug/Document.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -62,11 +62,11 @@ class Document extends Detail implements \IteratorAggregate, \Countable
     /**
      * Constructor.
      *
-     * @param string  $key
-     * @param boolean $match
-     * @param float   $value
-     * @param string  $description
-     * @param array   $details
+     * @param string $key
+     * @param bool   $match
+     * @param float  $value
+     * @param string $description
+     * @param array  $details
      */
     public function __construct($key, $match, $value, $description, $details)
     {
@@ -112,6 +112,6 @@ class Document extends Detail implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->details);
+        return \count($this->details);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Debug/DocumentSet.php
+++ b/library/Solarium/QueryType/Select/Result/Debug/DocumentSet.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -73,8 +73,6 @@ class DocumentSet implements \IteratorAggregate, \Countable
     {
         if (isset($this->docs[$key])) {
             return $this->docs[$key];
-        } else {
-            return;
         }
     }
 
@@ -105,6 +103,6 @@ class DocumentSet implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->docs);
+        return \count($this->docs);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Debug/Result.php
+++ b/library/Solarium/QueryType/Select/Result/Debug/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -205,6 +205,6 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->explain);
+        return \count($this->explain);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Debug/Timing.php
+++ b/library/Solarium/QueryType/Select/Result/Debug/Timing.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -92,8 +92,6 @@ class Timing implements \IteratorAggregate, \Countable
     {
         if (isset($this->phases[$key])) {
             return $this->phases[$key];
-        } else {
-            return;
         }
     }
 
@@ -124,6 +122,6 @@ class Timing implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->phases);
+        return \count($this->phases);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Debug/TimingPhase.php
+++ b/library/Solarium/QueryType/Select/Result/Debug/TimingPhase.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -101,8 +101,6 @@ class TimingPhase implements \IteratorAggregate, \Countable
     {
         if (isset($this->timings[$key])) {
             return $this->timings[$key];
-        } else {
-            return;
         }
     }
 
@@ -133,6 +131,6 @@ class TimingPhase implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->timings);
+        return \count($this->timings);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Document.php
+++ b/library/Solarium/QueryType/Select/Result/Document.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -73,10 +73,11 @@ class Document extends AbstractDocument implements DocumentInterface
      * Magic method for setting a field as property of this object. Since this
      * is a readonly document an exception will be thrown to prevent this.
      *
-     * @throws RuntimeException
      *
      * @param string $name
      * @param string $value
+     *
+     * @throws RuntimeException
      */
     public function __set($name, $value)
     {

--- a/library/Solarium/QueryType/Select/Result/DocumentInterface.php
+++ b/library/Solarium/QueryType/Select/Result/DocumentInterface.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/Select/Result/Facet/Field.php
+++ b/library/Solarium/QueryType/Select/Result/Facet/Field.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -93,6 +93,6 @@ class Field implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->values);
+        return \count($this->values);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Facet/Interval.php
+++ b/library/Solarium/QueryType/Select/Result/Facet/Interval.php
@@ -30,16 +30,18 @@
  *
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
- * @link http://www.solarium-project.org/
+ *
+ * @see http://www.solarium-project.org/
  */
 
 /**
  * @namespace
  */
+
 namespace Solarium\QueryType\Select\Result\Facet;
 
 /**
- * Select interval facet result
+ * Select interval facet result.
  *
  * A interval facet will usually return a dataset of multiple rows, in each row a
  * value and its count. You can access the values as an array using
@@ -47,5 +49,4 @@ namespace Solarium\QueryType\Select\Result\Facet;
  */
 class Interval extends Field
 {
-   
 }

--- a/library/Solarium/QueryType/Select/Result/Facet/MultiQuery.php
+++ b/library/Solarium/QueryType/Select/Result/Facet/MultiQuery.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/Select/Result/Facet/Pivot/Pivot.php
+++ b/library/Solarium/QueryType/Select/Result/Facet/Pivot/Pivot.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -91,6 +91,6 @@ class Pivot implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->pivot);
+        return \count($this->pivot);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Facet/Pivot/PivotItem.php
+++ b/library/Solarium/QueryType/Select/Result/Facet/Pivot/PivotItem.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -69,14 +69,14 @@ class PivotItem extends Pivot
     protected $count;
 
     /**
-     * Field stats
+     * Field stats.
      *
      * @var mixed
      */
     protected $stats;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param array $data
      */
@@ -88,7 +88,7 @@ class PivotItem extends Pivot
 
         if (isset($data['pivot'])) {
             foreach ($data['pivot'] as $pivotData) {
-                $this->pivot[] = new PivotItem($pivotData);
+                $this->pivot[] = new self($pivotData);
             }
         }
 
@@ -128,8 +128,8 @@ class PivotItem extends Pivot
     }
 
     /**
-     * Get stats
-     * 
+     * Get stats.
+     *
      * @return Stats
      */
     public function getStats()

--- a/library/Solarium/QueryType/Select/Result/Facet/Query.php
+++ b/library/Solarium/QueryType/Select/Result/Facet/Query.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/Select/Result/Facet/Range.php
+++ b/library/Solarium/QueryType/Select/Result/Facet/Range.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/Select/Result/FacetSet.php
+++ b/library/Solarium/QueryType/Select/Result/FacetSet.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -73,8 +73,6 @@ class FacetSet implements \IteratorAggregate, \Countable
     {
         if (isset($this->facets[$key])) {
             return $this->facets[$key];
-        } else {
-            return;
         }
     }
 
@@ -105,6 +103,6 @@ class FacetSet implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->facets);
+        return \count($this->facets);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Grouping/FieldGroup.php
+++ b/library/Solarium/QueryType/Select/Result/Grouping/FieldGroup.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -131,6 +131,6 @@ class FieldGroup implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->valueGroups);
+        return \count($this->valueGroups);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Grouping/QueryGroup.php
+++ b/library/Solarium/QueryType/Select/Result/Grouping/QueryGroup.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -176,6 +176,6 @@ class QueryGroup implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->getDocuments());
+        return \count($this->getDocuments());
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Grouping/Result.php
+++ b/library/Solarium/QueryType/Select/Result/Grouping/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -85,8 +85,6 @@ class Result implements \IteratorAggregate, \Countable
     {
         if (isset($this->groups[$key])) {
             return $this->groups[$key];
-        } else {
-            return;
         }
     }
 
@@ -107,6 +105,6 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->groups);
+        return \count($this->groups);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Grouping/ValueGroup.php
+++ b/library/Solarium/QueryType/Select/Result/Grouping/ValueGroup.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -176,6 +176,6 @@ class ValueGroup implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->getDocuments());
+        return \count($this->getDocuments());
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Highlighting/Highlighting.php
+++ b/library/Solarium/QueryType/Select/Result/Highlighting/Highlighting.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -73,8 +73,6 @@ class Highlighting implements \IteratorAggregate, \Countable
     {
         if (isset($this->results[$key])) {
             return $this->results[$key];
-        } else {
-            return;
         }
     }
 
@@ -105,6 +103,6 @@ class Highlighting implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->results);
+        return \count($this->results);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Highlighting/Result.php
+++ b/library/Solarium/QueryType/Select/Result/Highlighting/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -83,9 +83,9 @@ class Result implements \IteratorAggregate, \Countable
     {
         if (isset($this->fields[$key])) {
             return $this->fields[$key];
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**
@@ -105,6 +105,6 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->fields);
+        return \count($this->fields);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/MoreLikeThis/MoreLikeThis.php
+++ b/library/Solarium/QueryType/Select/Result/MoreLikeThis/MoreLikeThis.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -73,8 +73,6 @@ class MoreLikeThis implements \IteratorAggregate, \Countable
     {
         if (isset($this->results[$key])) {
             return $this->results[$key];
-        } else {
-            return;
         }
     }
 
@@ -105,6 +103,6 @@ class MoreLikeThis implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->results);
+        return \count($this->results);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/MoreLikeThis/Result.php
+++ b/library/Solarium/QueryType/Select/Result/MoreLikeThis/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -134,6 +134,6 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->documents);
+        return \count($this->documents);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Result.php
+++ b/library/Solarium/QueryType/Select/Result/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Select\Result;
 
-use Solarium\QueryType\Select\Query\Query as SelectQuery;
 use Solarium\Core\Query\Result\QueryType as BaseResult;
+use Solarium\QueryType\Select\Query\Query as SelectQuery;
 
 /**
  * Select query result.
@@ -204,7 +204,7 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     {
         $this->parseResponse();
 
-        return count($this->documents);
+        return \count($this->documents);
     }
 
     /**
@@ -232,8 +232,6 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
         if (isset($this->components[$key])) {
             return $this->components[$key];
-        } else {
-            return;
         }
     }
 

--- a/library/Solarium/QueryType/Select/Result/Spellcheck/Collation.php
+++ b/library/Solarium/QueryType/Select/Result/Spellcheck/Collation.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -135,6 +135,6 @@ class Collation implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->corrections);
+        return \count($this->corrections);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Spellcheck/Result.php
+++ b/library/Solarium/QueryType/Select/Result/Spellcheck/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -62,16 +62,16 @@ class Result implements \IteratorAggregate, \Countable
     /**
      * Correctly spelled?
      *
-     * @var boolean
+     * @var bool
      */
     protected $correctlySpelled;
 
     /**
      * Constructor.
      *
-     * @param array   $suggestions
-     * @param array   $collations
-     * @param boolean $correctlySpelled
+     * @param array $suggestions
+     * @param array $collations
+     * @param bool  $correctlySpelled
      */
     public function __construct($suggestions, $collations, $correctlySpelled)
     {
@@ -89,16 +89,15 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function getCollation($key = null)
     {
-        $nrOfCollations = count($this->collations);
-        if ($nrOfCollations == 0) {
+        $nrOfCollations = \count($this->collations);
+        if (0 == $nrOfCollations) {
             return;
-        } else {
-            if ($key === null) {
-                return reset($this->collations);
-            }
-
-            return $this->collations[$key];
         }
+        if (null === $key) {
+            return reset($this->collations);
+        }
+
+        return $this->collations[$key];
     }
 
     /**
@@ -134,8 +133,6 @@ class Result implements \IteratorAggregate, \Countable
     {
         if (isset($this->suggestions[$key])) {
             return $this->suggestions[$key];
-        } else {
-            return;
         }
     }
 
@@ -166,6 +163,6 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->suggestions);
+        return \count($this->suggestions);
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Spellcheck/Suggestion.php
+++ b/library/Solarium/QueryType/Select/Result/Spellcheck/Suggestion.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -115,9 +115,9 @@ class Suggestion
         $word = reset($this->words);
         if (isset($word['word'])) {
             return $word['word'];
-        } else {
-            return $word;
         }
+
+        return $word;
     }
 
     /**
@@ -142,8 +142,6 @@ class Suggestion
         $word = reset($this->words);
         if (isset($word['freq'])) {
             return $word['freq'];
-        } else {
-            return;
         }
     }
 }

--- a/library/Solarium/QueryType/Select/Result/Stats/FacetValue.php
+++ b/library/Solarium/QueryType/Select/Result/Stats/FacetValue.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/Select/Result/Stats/Result.php
+++ b/library/Solarium/QueryType/Select/Result/Stats/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -170,7 +170,7 @@ class Result
     {
         return $this->getValue('facets');
     }
-    
+
     /**
      * Get percentile stats.
      *
@@ -184,10 +184,12 @@ class Result
     /**
      * Get value by name.
      *
+     * @param mixed $name
+     *
      * @return string
      */
     protected function getValue($name)
     {
         return isset($this->stats[$name]) ? $this->stats[$name] : null;
-    }    
+    }
 }

--- a/library/Solarium/QueryType/Select/Result/Stats/Stats.php
+++ b/library/Solarium/QueryType/Select/Result/Stats/Stats.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -73,8 +73,6 @@ class Stats implements \IteratorAggregate, \Countable
     {
         if (isset($this->results[$key])) {
             return $this->results[$key];
-        } else {
-            return;
         }
     }
 
@@ -105,6 +103,6 @@ class Stats implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->results);
+        return \count($this->results);
     }
 }

--- a/library/Solarium/QueryType/Suggester/Query.php
+++ b/library/Solarium/QueryType/Suggester/Query.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Suggester;
 
-use Solarium\Core\Query\AbstractQuery as BaseQuery;
 use Solarium\Core\Client\Client;
+use Solarium\Core\Query\AbstractQuery as BaseQuery;
 
 /**
  * Suggester Query.
@@ -56,10 +56,10 @@ class Query extends BaseQuery
      * @var array
      */
     protected $options = array(
-        'handler'       => 'suggest',
-        'resultclass'   => 'Solarium\QueryType\Suggester\Result\Result',
-        'termclass'     => 'Solarium\QueryType\Suggester\Result\Term',
-        'omitheader'    => true,
+        'handler' => 'suggest',
+        'resultclass' => 'Solarium\QueryType\Suggester\Result\Result',
+        'termclass' => 'Solarium\QueryType\Suggester\Result\Term',
+        'omitheader' => true,
     );
 
     /**
@@ -169,7 +169,7 @@ class Query extends BaseQuery
      *
      * Only return suggestions that result in more hits for the query than the existing query
      *
-     * @param boolean $onlyMorePopular
+     * @param bool $onlyMorePopular
      *
      * @return self Provides fluent interface
      */
@@ -181,7 +181,7 @@ class Query extends BaseQuery
     /**
      * Get onlyMorePopular option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getOnlyMorePopular()
     {
@@ -191,7 +191,7 @@ class Query extends BaseQuery
     /**
      * Set collate option.
      *
-     * @param boolean $collate
+     * @param bool $collate
      *
      * @return self Provides fluent interface
      */
@@ -203,7 +203,7 @@ class Query extends BaseQuery
     /**
      * Get collate option.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function getCollate()
     {

--- a/library/Solarium/QueryType/Suggester/RequestBuilder.php
+++ b/library/Solarium/QueryType/Suggester/RequestBuilder.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/Suggester/ResponseParser.php
+++ b/library/Solarium/QueryType/Suggester/ResponseParser.php
@@ -32,7 +32,7 @@
  * @copyright Copyright 2011 Gasol Wu <gasol.wu@gmail.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -66,7 +66,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         $allSuggestions = array();
         $collation = null;
 
-        if (isset($data['spellcheck']['suggestions']) && is_array($data['spellcheck']['suggestions'])) {
+        if (isset($data['spellcheck']['suggestions']) && \is_array($data['spellcheck']['suggestions'])) {
             $suggestResults = $data['spellcheck']['suggestions'];
             $termClass = $query->getOption('termclass');
 
@@ -75,17 +75,17 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
             }
 
             foreach ($suggestResults as $term => $termData) {
-                if ($term == 'collation') {
+                if ('collation' == $term) {
                     $collation = $termData;
                 } else {
-                    if (!array_key_exists(0, $termData)) {
+                    if (!\array_key_exists(0, $termData)) {
                         $termData = array($termData);
                     }
 
                     foreach ($termData as $currentTermData) {
                         $allSuggestions[] = $this->createTerm($termClass, $currentTermData);
 
-                        if (!array_key_exists($term, $suggestions)) {
+                        if (!\array_key_exists($term, $suggestions)) {
                             $suggestions[$term] = $this->createTerm($termClass, $currentTermData);
                         }
                     }

--- a/library/Solarium/QueryType/Suggester/Result/Result.php
+++ b/library/Solarium/QueryType/Suggester/Result/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -153,9 +153,9 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
         if (isset($this->results[$term])) {
             return $this->results[$term];
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**
@@ -179,13 +179,13 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     {
         $this->parseResponse();
 
-        return count($this->results);
+        return \count($this->results);
     }
 
     /**
      * Get collation.
      *
-     * @return null|string
+     * @return string|null
      */
     public function getCollation()
     {

--- a/library/Solarium/QueryType/Suggester/Result/Term.php
+++ b/library/Solarium/QueryType/Suggester/Result/Term.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -146,6 +146,6 @@ class Term implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return count($this->suggestions);
+        return \count($this->suggestions);
     }
 }

--- a/library/Solarium/QueryType/Terms/Query.php
+++ b/library/Solarium/QueryType/Terms/Query.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -60,8 +60,8 @@ class Query extends BaseQuery
      */
     protected $options = array(
         'resultclass' => 'Solarium\QueryType\Terms\Result',
-        'handler'     => 'terms',
-        'omitheader'  => true,
+        'handler' => 'terms',
+        'omitheader' => true,
     );
 
     /**
@@ -105,7 +105,7 @@ class Query extends BaseQuery
      */
     public function setFields($value)
     {
-        if (is_string($value)) {
+        if (\is_string($value)) {
             $value = explode(',', $value);
             $value = array_map('trim', $value);
         }
@@ -121,7 +121,7 @@ class Query extends BaseQuery
     public function getFields()
     {
         $value = $this->getOption('fields');
-        if ($value === null) {
+        if (null === $value) {
             $value = array();
         }
 
@@ -153,7 +153,7 @@ class Query extends BaseQuery
     /**
      * Set lowerboundinclude.
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return self Provides fluent interface
      */
@@ -165,7 +165,7 @@ class Query extends BaseQuery
     /**
      * Get lowerboundinclude.
      *
-     * @return boolean
+     * @return bool
      */
     public function getLowerboundInclude()
     {
@@ -175,7 +175,7 @@ class Query extends BaseQuery
     /**
      * Set mincount (the minimum doc frequency for terms in order to be included).
      *
-     * @param integer $value
+     * @param int $value
      *
      * @return self Provides fluent interface
      */
@@ -187,7 +187,7 @@ class Query extends BaseQuery
     /**
      * Get mincount.
      *
-     * @return integer
+     * @return int
      */
     public function getMinCount()
     {
@@ -197,7 +197,7 @@ class Query extends BaseQuery
     /**
      * Set maxcount (the maximum doc frequency for terms in order to be included).
      *
-     * @param integer $value
+     * @param int $value
      *
      * @return self Provides fluent interface
      */
@@ -209,7 +209,7 @@ class Query extends BaseQuery
     /**
      * Get maxcount.
      *
-     * @return integer
+     * @return int
      */
     public function getMaxCount()
     {
@@ -271,7 +271,7 @@ class Query extends BaseQuery
      */
     public function setRegexFlags($value)
     {
-        if (is_string($value)) {
+        if (\is_string($value)) {
             $value = explode(',', $value);
             $value = array_map('trim', $value);
         }
@@ -287,7 +287,7 @@ class Query extends BaseQuery
     public function getRegexFlags()
     {
         $value = $this->getOption('regexflags');
-        if ($value === null) {
+        if (null === $value) {
             $value = array();
         }
 
@@ -299,7 +299,7 @@ class Query extends BaseQuery
      *
      * If < 0 all terms are included
      *
-     * @param integer $value
+     * @param int $value
      *
      * @return self Provides fluent interface
      */
@@ -311,7 +311,7 @@ class Query extends BaseQuery
     /**
      * Get limit.
      *
-     * @return integer
+     * @return int
      */
     public function getLimit()
     {
@@ -343,7 +343,7 @@ class Query extends BaseQuery
     /**
      * Set upperboundinclude.
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return self Provides fluent interface
      */
@@ -355,7 +355,7 @@ class Query extends BaseQuery
     /**
      * Get upperboundinclude.
      *
-     * @return boolean
+     * @return bool
      */
     public function getUpperboundInclude()
     {
@@ -365,7 +365,7 @@ class Query extends BaseQuery
     /**
      * Set raw option.
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return self Provides fluent interface
      */
@@ -377,7 +377,7 @@ class Query extends BaseQuery
     /**
      * Get raw option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getRaw()
     {

--- a/library/Solarium/QueryType/Terms/RequestBuilder.php
+++ b/library/Solarium/QueryType/Terms/RequestBuilder.php
@@ -34,7 +34,7 @@
  * @copyright Copyright 2011 Gasol Wu <gasol.wu@gmail.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -43,8 +43,8 @@
 
 namespace Solarium\QueryType\Terms;
 
-use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Client\Request;
+use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 
 /**

--- a/library/Solarium/QueryType/Terms/ResponseParser.php
+++ b/library/Solarium/QueryType/Terms/ResponseParser.php
@@ -32,7 +32,7 @@
  * @copyright Copyright 2011 Gasol Wu <gasol.wu@gmail.com>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -68,7 +68,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         $query = $result->getQuery();
 
         // Special case to handle Solr 1.4 data
-        if (isset($data['terms']) && count($data['terms']) == count($query->getFields()) * 2) {
+        if (isset($data['terms']) && \count($data['terms']) == \count($query->getFields()) * 2) {
             $data['terms'] = $this->convertToKeyValueArray($data['terms']);
         }
 

--- a/library/Solarium/QueryType/Terms/Result.php
+++ b/library/Solarium/QueryType/Terms/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -125,9 +125,9 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
         if (isset($this->results[$field])) {
             return $this->results[$field];
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**
@@ -151,6 +151,6 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     {
         $this->parseResponse();
 
-        return count($this->results);
+        return \count($this->results);
     }
 }

--- a/library/Solarium/QueryType/Update/Query/Command/AbstractCommand.php
+++ b/library/Solarium/QueryType/Update/Query/Command/AbstractCommand.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/Update/Query/Command/Add.php
+++ b/library/Solarium/QueryType/Update/Query/Command/Add.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,14 +40,14 @@
 
 namespace Solarium\QueryType\Update\Query\Command;
 
-use Solarium\QueryType\Update\Query\Query as UpdateQuery;
-use Solarium\QueryType\Update\Query\Document\DocumentInterface;
 use Solarium\Exception\RuntimeException;
+use Solarium\QueryType\Update\Query\Document\DocumentInterface;
+use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 
 /**
  * Update query add command.
  *
- * @link http://wiki.apache.org/solr/UpdateXmlMessages#add.2BAC8-update
+ * @see http://wiki.apache.org/solr/UpdateXmlMessages#add.2BAC8-update
  */
 class Add extends AbstractCommand
 {
@@ -71,9 +71,10 @@ class Add extends AbstractCommand
     /**
      * Add a single document.
      *
-     * @throws RuntimeException
      *
      * @param DocumentInterface $document
+     *
+     * @throws RuntimeException
      *
      * @return self Provides fluent interface
      */
@@ -89,14 +90,14 @@ class Add extends AbstractCommand
      *
      * @param array|\Traversable $documents
      *
-     * @return self Provides fluent interface
-     *
      * @throws RuntimeException If any of the given documents does not implement DocumentInterface
+     *
+     * @return self Provides fluent interface
      */
     public function addDocuments($documents)
     {
         //only check documents for type if in an array (iterating a Traversable may do unnecessary work)
-        if (is_array($documents)) {
+        if (\is_array($documents)) {
             foreach ($documents as $document) {
                 if (!($document instanceof DocumentInterface)) {
                     throw new RuntimeException('Documents must implement DocumentInterface.');
@@ -137,7 +138,7 @@ class Add extends AbstractCommand
     /**
      * Set overwrite option.
      *
-     * @param boolean $overwrite
+     * @param bool $overwrite
      *
      * @return self Provides fluent interface
      */
@@ -149,7 +150,7 @@ class Add extends AbstractCommand
     /**
      * Get overwrite option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getOverwrite()
     {
@@ -159,7 +160,7 @@ class Add extends AbstractCommand
     /**
      * Get commitWithin option.
      *
-     * @param boolean $commitWithin
+     * @param bool $commitWithin
      *
      * @return self Provides fluent interface
      */
@@ -171,7 +172,7 @@ class Add extends AbstractCommand
     /**
      * Set commitWithin option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getCommitWithin()
     {

--- a/library/Solarium/QueryType/Update/Query/Command/Commit.php
+++ b/library/Solarium/QueryType/Update/Query/Command/Commit.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -45,7 +45,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query commit command.
  *
- * @link http://wiki.apache.org/solr/UpdateXmlMessages#A.22commit.22_and_.22optimize.22
+ * @see http://wiki.apache.org/solr/UpdateXmlMessages#A.22commit.22_and_.22optimize.22
  */
 class Commit extends AbstractCommand
 {
@@ -62,7 +62,7 @@ class Commit extends AbstractCommand
     /**
      * Get softCommit option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getSoftCommit()
     {
@@ -72,7 +72,7 @@ class Commit extends AbstractCommand
     /**
      * Set softCommit option.
      *
-     * @param boolean $softCommit
+     * @param bool $softCommit
      *
      * @return self Provides fluent interface
      */
@@ -84,7 +84,7 @@ class Commit extends AbstractCommand
     /**
      * Get waitSearcher option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getWaitSearcher()
     {
@@ -94,7 +94,7 @@ class Commit extends AbstractCommand
     /**
      * Set waitSearcher option.
      *
-     * @param boolean $waitSearcher
+     * @param bool $waitSearcher
      *
      * @return self Provides fluent interface
      */
@@ -106,7 +106,7 @@ class Commit extends AbstractCommand
     /**
      * Get expungeDeletes option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getExpungeDeletes()
     {
@@ -116,7 +116,7 @@ class Commit extends AbstractCommand
     /**
      * Set expungeDeletes option.
      *
-     * @param boolean $expungeDeletes
+     * @param bool $expungeDeletes
      *
      * @return self Provides fluent interface
      */

--- a/library/Solarium/QueryType/Update/Query/Command/Delete.php
+++ b/library/Solarium/QueryType/Update/Query/Command/Delete.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -45,7 +45,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query delete command.
  *
- * @link http://wiki.apache.org/solr/UpdateXmlMessages#A.22delete.22_by_ID_and_by_Query
+ * @see http://wiki.apache.org/solr/UpdateXmlMessages#A.22delete.22_by_ID_and_by_Query
  */
 class Delete extends AbstractCommand
 {
@@ -156,7 +156,7 @@ class Delete extends AbstractCommand
     {
         $id = $this->getOption('id');
         if (null !== $id) {
-            if (is_array($id)) {
+            if (\is_array($id)) {
                 $this->addIds($id);
             } else {
                 $this->addId($id);
@@ -165,7 +165,7 @@ class Delete extends AbstractCommand
 
         $queries = $this->getOption('query');
         if (null !== $queries) {
-            if (is_array($queries)) {
+            if (\is_array($queries)) {
                 $this->addQueries($queries);
             } else {
                 $this->addQuery($queries);

--- a/library/Solarium/QueryType/Update/Query/Command/Optimize.php
+++ b/library/Solarium/QueryType/Update/Query/Command/Optimize.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -45,7 +45,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query optimize command.
  *
- * @link http://wiki.apache.org/solr/UpdateXmlMessages#A.22commit.22_and_.22optimize.22
+ * @see http://wiki.apache.org/solr/UpdateXmlMessages#A.22commit.22_and_.22optimize.22
  */
 class Optimize extends AbstractCommand
 {
@@ -62,7 +62,7 @@ class Optimize extends AbstractCommand
     /**
      * Get softCommit option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getSoftCommit()
     {
@@ -72,7 +72,7 @@ class Optimize extends AbstractCommand
     /**
      * Set softCommit option.
      *
-     * @param boolean $softCommit
+     * @param bool $softCommit
      *
      * @return self Provides fluent interface
      */
@@ -84,7 +84,7 @@ class Optimize extends AbstractCommand
     /**
      * Get waitSearcher option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getWaitSearcher()
     {
@@ -94,7 +94,7 @@ class Optimize extends AbstractCommand
     /**
      * Set waitSearcher option.
      *
-     * @param boolean $waitSearcher
+     * @param bool $waitSearcher
      *
      * @return self Provides fluent interface
      */
@@ -106,7 +106,7 @@ class Optimize extends AbstractCommand
     /**
      * Get maxSegments option.
      *
-     * @return boolean
+     * @return bool
      */
     public function getMaxSegments()
     {
@@ -116,7 +116,7 @@ class Optimize extends AbstractCommand
     /**
      * Set maxSegments option.
      *
-     * @param boolean $maxSegments
+     * @param bool $maxSegments
      *
      * @return self Provides fluent interface
      */

--- a/library/Solarium/QueryType/Update/Query/Command/Rollback.php
+++ b/library/Solarium/QueryType/Update/Query/Command/Rollback.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -45,7 +45,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query rollback command.
  *
- * @link http://wiki.apache.org/solr/UpdateXmlMessages#A.22rollback.22
+ * @see http://wiki.apache.org/solr/UpdateXmlMessages#A.22rollback.22
  */
 class Rollback extends AbstractCommand
 {

--- a/library/Solarium/QueryType/Update/Query/Document/Document.php
+++ b/library/Solarium/QueryType/Update/Query/Document/Document.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -41,8 +41,8 @@
 namespace Solarium\QueryType\Update\Query\Document;
 
 use Solarium\Core\Query\Helper;
-use Solarium\QueryType\Select\Result\AbstractDocument;
 use Solarium\Exception\RuntimeException;
+use Solarium\QueryType\Select\Result\AbstractDocument;
 
 /**
  * Read/Write Solr document.
@@ -173,6 +173,36 @@ class Document extends AbstractDocument implements DocumentInterface
     }
 
     /**
+     * Set field value.
+     *
+     * Magic method for setting fields as properties of this document
+     * object, by field name.
+     *
+     * If you supply NULL as the value the field will be removed
+     * If you supply an array a multivalue field will be created.
+     * In all cases any existing (multi)value will be overwritten.
+     *
+     * @param string      $name
+     * @param string|null $value
+     */
+    public function __set($name, $value)
+    {
+        $this->setField($name, $value);
+    }
+
+    /**
+     * Unset field value.
+     *
+     * Magic method for removing fields by unsetting object properties
+     *
+     * @param string $name
+     */
+    public function __unset($name)
+    {
+        $this->removeField($name);
+    }
+
+    /**
      * Add a field value.
      *
      * If a field already has a value it will be converted
@@ -191,17 +221,17 @@ class Document extends AbstractDocument implements DocumentInterface
             $this->setField($key, $value, $boost, $modifier);
         } else {
             // convert single value to array if needed
-            if (!is_array($this->fields[$key])) {
+            if (!\is_array($this->fields[$key])) {
                 $this->fields[$key] = array($this->fields[$key]);
             }
 
-            if ($this->filterControlCharacters && is_string($value)) {
+            if ($this->filterControlCharacters && \is_string($value)) {
                 $value = $this->getHelper()->filterControlCharacters($value);
             }
 
             $this->fields[$key][] = $value;
             $this->setFieldBoost($key, $boost);
-            if ($modifier !== null) {
+            if (null !== $modifier) {
                 $this->setFieldModifier($key, $modifier);
             }
         }
@@ -225,16 +255,16 @@ class Document extends AbstractDocument implements DocumentInterface
      */
     public function setField($key, $value, $boost = null, $modifier = null)
     {
-        if ($value === null && $modifier === null) {
+        if (null === $value && null === $modifier) {
             $this->removeField($key);
         } else {
-            if ($this->filterControlCharacters && is_string($value)) {
+            if ($this->filterControlCharacters && \is_string($value)) {
                 $value = $this->getHelper()->filterControlCharacters($value);
             }
 
             $this->fields[$key] = $value;
             $this->setFieldBoost($key, $boost);
-            if ($modifier !== null) {
+            if (null !== $modifier) {
                 $this->setFieldModifier($key, $modifier);
             }
         }
@@ -273,8 +303,6 @@ class Document extends AbstractDocument implements DocumentInterface
     {
         if (isset($this->fieldBoosts[$key])) {
             return $this->fieldBoosts[$key];
-        } else {
-            return;
         }
     }
 
@@ -342,36 +370,6 @@ class Document extends AbstractDocument implements DocumentInterface
     }
 
     /**
-     * Set field value.
-     *
-     * Magic method for setting fields as properties of this document
-     * object, by field name.
-     *
-     * If you supply NULL as the value the field will be removed
-     * If you supply an array a multivalue field will be created.
-     * In all cases any existing (multi)value will be overwritten.
-     *
-     * @param string      $name
-     * @param string|null $value
-     */
-    public function __set($name, $value)
-    {
-        $this->setField($name, $value);
-    }
-
-    /**
-     * Unset field value.
-     *
-     * Magic method for removing fields by unsetting object properties
-     *
-     * @param string $name
-     */
-    public function __unset($name)
-    {
-        $this->removeField($name);
-    }
-
-    /**
      * Sets the uniquely identifying key for use in atomic updating.
      *
      * You can set an existing field as key by supplying that field name as key, or add a new field by also supplying a
@@ -385,7 +383,7 @@ class Document extends AbstractDocument implements DocumentInterface
     public function setKey($key, $value = null)
     {
         $this->key = $key;
-        if ($value !== null) {
+        if (null !== $value) {
             $this->addField($key, $value);
         }
 
@@ -404,7 +402,7 @@ class Document extends AbstractDocument implements DocumentInterface
      */
     public function setFieldModifier($key, $modifier = null)
     {
-        if (!in_array($modifier, array(self::MODIFIER_ADD, self::MODIFIER_REMOVE, self::MODIFIER_INC, self::MODIFIER_SET))) {
+        if (!\in_array($modifier, array(self::MODIFIER_ADD, self::MODIFIER_REMOVE, self::MODIFIER_INC, self::MODIFIER_SET), true)) {
             throw new RuntimeException('Attempt to set an atomic update modifier that is not supported');
         }
         $this->modifiers[$key] = $modifier;
@@ -417,7 +415,7 @@ class Document extends AbstractDocument implements DocumentInterface
      *
      * @param string $key
      *
-     * @return null|string
+     * @return string|null
      */
     public function getFieldModifier($key)
     {
@@ -435,7 +433,7 @@ class Document extends AbstractDocument implements DocumentInterface
      */
     public function getFields()
     {
-        if (count($this->modifiers) > 0 && ($this->key === null || !isset($this->fields[$this->key]))) {
+        if (\count($this->modifiers) > 0 && (null === $this->key || !isset($this->fields[$this->key]))) {
             throw new RuntimeException(
                 'A document that uses modifiers (atomic updates) must have a key defined before it is used'
             );
@@ -487,7 +485,7 @@ class Document extends AbstractDocument implements DocumentInterface
     /**
      * Whether values should be filtered for control characters automatically.
      *
-     * @param boolean $filterControlCharacters
+     * @param bool $filterControlCharacters
      */
     public function setFilterControlCharacters($filterControlCharacters)
     {
@@ -497,7 +495,7 @@ class Document extends AbstractDocument implements DocumentInterface
     /**
      * Returns whether values should be filtered automatically or control characters.
      *
-     * @return boolean
+     * @return bool
      */
     public function getFilterControlCharacters()
     {

--- a/library/Solarium/QueryType/Update/Query/Document/DocumentInterface.php
+++ b/library/Solarium/QueryType/Update/Query/Document/DocumentInterface.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/QueryType/Update/Query/Query.php
+++ b/library/Solarium/QueryType/Update/Query/Query.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -42,10 +42,8 @@ namespace Solarium\QueryType\Update\Query;
 
 use Solarium\Core\Client\Client;
 use Solarium\Core\Query\AbstractQuery as BaseQuery;
-use Solarium\QueryType\Update\RequestBuilder;
-use Solarium\QueryType\Update\ResponseParser;
-use Solarium\Exception\RuntimeException;
 use Solarium\Exception\InvalidArgumentException;
+use Solarium\Exception\RuntimeException;
 use Solarium\QueryType\Update\Query\Command\AbstractCommand;
 use Solarium\QueryType\Update\Query\Command\Add as AddCommand;
 use Solarium\QueryType\Update\Query\Command\Commit as CommitCommand;
@@ -53,6 +51,8 @@ use Solarium\QueryType\Update\Query\Command\Delete as DeleteCommand;
 use Solarium\QueryType\Update\Query\Command\Optimize as OptimizeCommand;
 use Solarium\QueryType\Update\Query\Command\Rollback as RollbackCommand;
 use Solarium\QueryType\Update\Query\Document\DocumentInterface;
+use Solarium\QueryType\Update\RequestBuilder;
+use Solarium\QueryType\Update\ResponseParser;
 
 /**
  * Update query.
@@ -107,10 +107,10 @@ class Query extends BaseQuery
      * @var array
      */
     protected $options = array(
-        'handler'       => 'update',
-        'resultclass'   => 'Solarium\QueryType\Update\Result',
+        'handler' => 'update',
+        'resultclass' => 'Solarium\QueryType\Update\Result',
         'documentclass' => 'Solarium\QueryType\Update\Query\Document\Document',
-        'omitheader'    => false,
+        'omitheader' => false,
     );
 
     /**
@@ -156,10 +156,11 @@ class Query extends BaseQuery
     /**
      * Create a command instance.
      *
-     * @throws InvalidArgumentException
      *
      * @param string $type
      * @param mixed  $options
+     *
+     * @throws InvalidArgumentException
      *
      * @return AbstractCommand
      */
@@ -168,7 +169,7 @@ class Query extends BaseQuery
         $type = strtolower($type);
 
         if (!isset($this->commandTypes[$type])) {
-            throw new InvalidArgumentException("Update commandtype unknown: ".$type);
+            throw new InvalidArgumentException('Update commandtype unknown: '.$type);
         }
 
         $class = $this->commandTypes[$type];
@@ -199,7 +200,7 @@ class Query extends BaseQuery
      */
     public function add($key, $command)
     {
-        if (0 !== strlen($key)) {
+        if (0 !== \strlen($key)) {
             $this->commands[$key] = $command;
         } else {
             $this->commands[] = $command;
@@ -219,7 +220,7 @@ class Query extends BaseQuery
      */
     public function remove($command)
     {
-        if (is_object($command)) {
+        if (\is_object($command)) {
             foreach ($this->commands as $key => $instance) {
                 if ($instance === $command) {
                     unset($this->commands[$key]);
@@ -261,7 +262,7 @@ class Query extends BaseQuery
      */
     public function addDeleteQuery($query, $bind = null)
     {
-        if (!is_null($bind)) {
+        if (null !== $bind) {
             $query = $this->getHelper()->assemble($query, $bind);
         }
 
@@ -332,7 +333,7 @@ class Query extends BaseQuery
      * create you own command instance and use the add method.
      *
      * @param DocumentInterface $document
-     * @param boolean           $overwrite
+     * @param bool              $overwrite
      * @param int               $commitWithin
      *
      * @return self Provides fluent interface
@@ -348,9 +349,9 @@ class Query extends BaseQuery
      * If you need more control, like choosing a key for the command you need to
      * create you own command instance and use the add method.
      *
-     * @param array   $documents
-     * @param boolean $overwrite
-     * @param int     $commitWithin
+     * @param array $documents
+     * @param bool  $overwrite
+     * @param int   $commitWithin
      *
      * @return self Provides fluent interface
      */
@@ -377,9 +378,9 @@ class Query extends BaseQuery
      * If you need more control, like choosing a key for the command you need to
      * create you own command instance and use the add method.
      *
-     * @param boolean $softCommit
-     * @param boolean $waitSearcher
-     * @param boolean $expungeDeletes
+     * @param bool $softCommit
+     * @param bool $waitSearcher
+     * @param bool $expungeDeletes
      *
      * @return self Provides fluent interface
      */
@@ -408,9 +409,9 @@ class Query extends BaseQuery
      * If you need more control, like choosing a key for the command you need to
      * create you own command instance and use the add method.
      *
-     * @param boolean $softCommit
-     * @param boolean $waitSearcher
-     * @param int     $maxSegments
+     * @param bool $softCommit
+     * @param bool $waitSearcher
+     * @param int  $maxSegments
      *
      * @return self Provides fluent interface
      */
@@ -494,9 +495,9 @@ class Query extends BaseQuery
             foreach ($this->options['command'] as $key => $value) {
                 $type = $value['type'];
 
-                if ($type == self::COMMAND_ADD) {
+                if (self::COMMAND_ADD == $type) {
                     throw new RuntimeException(
-                        "Adding documents is not supported in configuration, use the API for this"
+                        'Adding documents is not supported in configuration, use the API for this'
                     );
                 }
 

--- a/library/Solarium/QueryType/Update/RequestBuilder.php
+++ b/library/Solarium/QueryType/Update/RequestBuilder.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -41,10 +41,10 @@
 namespace Solarium\QueryType\Update;
 
 use Solarium\Core\Client\Request;
-use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 use Solarium\Exception\RuntimeException;
+use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 
 /**
  * Build an update request.
@@ -112,7 +112,7 @@ class RequestBuilder extends BaseRequestBuilder
      * Build XML for an add command.
      *
      * @param \Solarium\QueryType\Update\Query\Command\Add $command
-     * @param UpdateQuery $query
+     * @param UpdateQuery                                  $query
      *
      * @return string
      */
@@ -135,7 +135,7 @@ class RequestBuilder extends BaseRequestBuilder
             }
 
             $version = $doc->getVersion();
-            if ($version !== null) {
+            if (null !== $version) {
                 $xml .= $this->buildFieldXml('_version_', null, $version);
             }
 
@@ -158,10 +158,10 @@ class RequestBuilder extends BaseRequestBuilder
     {
         $xml = '<delete>';
         foreach ($command->getIds() as $id) {
-            $xml .= '<id>' . htmlspecialchars($id, ENT_NOQUOTES, 'UTF-8') . '</id>';
+            $xml .= '<id>'.htmlspecialchars($id, ENT_NOQUOTES, 'UTF-8').'</id>';
         }
         foreach ($command->getQueries() as $query) {
-            $xml .= '<query>' . htmlspecialchars($query, ENT_NOQUOTES, 'UTF-8') . '</query>';
+            $xml .= '<query>'.htmlspecialchars($query, ENT_NOQUOTES, 'UTF-8').'</query>';
         }
         $xml .= '</delete>';
 
@@ -219,24 +219,24 @@ class RequestBuilder extends BaseRequestBuilder
      *
      * Used in the add command
      *
-     * @param string $name
-     * @param float $boost
-     * @param mixed $value
-     * @param string $modifier
+     * @param string      $name
+     * @param float       $boost
+     * @param mixed       $value
+     * @param string      $modifier
      * @param UpdateQuery $query
      *
      * @return string
      */
     protected function buildFieldXml($name, $boost, $value, $modifier = null, $query = null)
     {
-        $xml = '<field name="' . $name . '"';
+        $xml = '<field name="'.$name.'"';
         $xml .= $this->attrib('boost', $boost);
         $xml .= $this->attrib('update', $modifier);
-        if ($value === null) {
+        if (null === $value) {
             $xml .= $this->attrib('null', 'true');
-        } elseif ($value === false) {
+        } elseif (false === $value) {
             $value = 'false';
-        } elseif ($value === true) {
+        } elseif (true === $value) {
             $value = 'true';
         } elseif ($value instanceof \DateTime) {
             $value = $query->getHelper()->formatDate($value);
@@ -244,37 +244,35 @@ class RequestBuilder extends BaseRequestBuilder
             $value = htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8');
         }
 
-        $xml .= '>' . $value . '</field>';
+        $xml .= '>'.$value.'</field>';
 
         return $xml;
     }
 
     /**
-     * @param string $key
-     *
-     * @param float $boost
-     * @param mixed $value
-     * @param string $modifier
+     * @param string      $key
+     * @param float       $boost
+     * @param mixed       $value
+     * @param string      $modifier
      * @param UpdateQuery $query
+     *
      * @return string
      */
     private function buildFieldsXml($key, $boost, $value, $modifier, $query)
     {
         $xml = '';
-        if (is_array($value)) {
+        if (\is_array($value)) {
             foreach ($value as $multival) {
-                if (is_array($multival)) {
+                if (\is_array($multival)) {
                     $xml .= '<doc>';
                     foreach ($multival as $k => $v) {
                         $xml .= $this->buildFieldsXml($k, $boost, $v, $modifier, $query);
                     }
                     $xml .= '</doc>';
-
                 } else {
                     $xml .= $this->buildFieldXml($key, $boost, $multival, $modifier, $query);
                 }
             }
-
         } else {
             $xml .= $this->buildFieldXml($key, $boost, $value, $modifier, $query);
         }

--- a/library/Solarium/QueryType/Update/ResponseParser.php
+++ b/library/Solarium/QueryType/Update/ResponseParser.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**
@@ -40,8 +40,8 @@
 
 namespace Solarium\QueryType\Update;
 
-use Solarium\Core\Query\ResponseParserInterface;
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
+use Solarium\Core\Query\ResponseParserInterface;
 
 /**
  * Parse update response data.

--- a/library/Solarium/QueryType/Update/Result.php
+++ b/library/Solarium/QueryType/Update/Result.php
@@ -31,7 +31,7 @@
  * @copyright Copyright 2011 Bas de Nooijer <solarium@raspberry.nl>
  * @license http://github.com/basdenooijer/solarium/raw/master/COPYING
  *
- * @link http://www.solarium-project.org/
+ * @see http://www.solarium-project.org/
  */
 
 /**

--- a/library/Solarium/Support/DataFixtures/Loader.php
+++ b/library/Solarium/Support/DataFixtures/Loader.php
@@ -77,7 +77,7 @@ class Loader
             $reflClass = new \ReflectionClass($className);
             $sourceFile = $reflClass->getFileName();
 
-            if (in_array($sourceFile, $includedFiles)) {
+            if (\in_array($sourceFile, $includedFiles, true)) {
                 $fixture = new $className();
 
                 $this->addFixture($fixture);


### PR DESCRIPTION
this should resolve both failing travis and style ci tests for the 3.x branch

did exclude the ``tests`` directory from php-cs-fxier as it continues to modify instances of ``assertNotEquals`` to ``assertNotFalse`` regardless of the ``php_unit_strict`` settings i try.

fixed hhvm tot v3.3 in travis because: https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html

and really tried to get a working php 5.3 environment, but you appaer to have an impossible set of dependencies (guzzle v.s. event dispatcher v.s. coveralls).

i think the main discussion should be how long you're willing to continue supporting php 5.3