### PR TITLE
Return the full body of the error

### DIFF
--- a/src/Core/Client/Adapter/Guzzle.php
+++ b/src/Core/Client/Adapter/Guzzle.php
@@ -76,7 +76,7 @@ class Guzzle extends Configurable implements AdapterInterface
 
             return new Response((string) $guzzleResponse->getBody(), $responseHeaders);
         } catch (GuzzleException $e) {
-            $error = $e->getMessage();
+            $error = $e->getResponse()->getBody()->getContents();
             throw new HttpException("HTTP request failed, {$error}");
         }
     }


### PR DESCRIPTION
The message is truncated, leaving out important details of what the actual error is.

Getting the body's content gives more clarity on what is actually going wrong.