### PR TITLE
Added new placeholder for rerankquery param

### DIFF
--- a/src/Component/RequestBuilder/ReRankQuery.php
+++ b/src/Component/RequestBuilder/ReRankQuery.php
@@ -22,11 +22,12 @@ class ReRankQuery implements ComponentRequestBuilderInterface
     public function buildComponent(ConfigurableInterface $component, Request $request): Request
     {
         $subRequest = new SubRequest();
-        $subRequest->addParam('reRankQuery', $component->getQuery());
+        $subRequest->addParam('reRankQuery', '$rqq');
         $subRequest->addParam('reRankDocs', $component->getDocs());
         $subRequest->addParam('reRankWeight', $component->getWeight());
 
         $request->addParam('rq', $subRequest->getSubQuery());
+        $request->addParam('rqq', $component->getQuery());
 
         return $request;
     }

--- a/tests/Component/RequestBuilder/ReRankQueryTest.php
+++ b/tests/Component/RequestBuilder/ReRankQueryTest.php
@@ -23,9 +23,31 @@ class ReRankQueryTest extends TestCase
 
         $this->assertEquals(
             [
-                'rq' => '{!rerank reRankQuery=foo:bar reRankDocs=42 reRankWeight=48.2233}',
+                'rq' => '{!rerank reRankQuery=$rqq reRankDocs=42 reRankWeight=48.2233}',
+                'rqq' => 'foo:bar'
             ],
             $request->getParams()
         );
+    }
+
+    public function testBuildComponentWithRangeQuery()
+    {
+      $builder = new RequestBuilder();
+      $request = new Request();
+
+      $component = new Component();
+      $component->setQuery('foo:[1 TO *]');
+      $component->setDocs(42);
+      $component->setWeight(48.2233);
+
+      $request = $builder->buildComponent($component, $request);
+
+      $this->assertEquals(
+        [
+          'rq' => '{!rerank reRankQuery=$rqq reRankDocs=42 reRankWeight=48.2233}',
+          'rqq' => 'foo:[1 TO *]'
+        ],
+        $request->getParams()
+      );
     }
 }

--- a/tests/Component/RequestBuilder/ReRankQueryTest.php
+++ b/tests/Component/RequestBuilder/ReRankQueryTest.php
@@ -24,7 +24,7 @@ class ReRankQueryTest extends TestCase
         $this->assertEquals(
             [
                 'rq' => '{!rerank reRankQuery=$rqq reRankDocs=42 reRankWeight=48.2233}',
-                'rqq' => 'foo:bar'
+                'rqq' => 'foo:bar',
             ],
             $request->getParams()
         );
@@ -32,22 +32,22 @@ class ReRankQueryTest extends TestCase
 
     public function testBuildComponentWithRangeQuery()
     {
-      $builder = new RequestBuilder();
-      $request = new Request();
+        $builder = new RequestBuilder();
+        $request = new Request();
 
-      $component = new Component();
-      $component->setQuery('foo:[1 TO *]');
-      $component->setDocs(42);
-      $component->setWeight(48.2233);
+        $component = new Component();
+        $component->setQuery('foo:[1 TO *]');
+        $component->setDocs(42);
+        $component->setWeight(48.2233);
 
-      $request = $builder->buildComponent($component, $request);
+        $request = $builder->buildComponent($component, $request);
 
-      $this->assertEquals(
-        [
-          'rq' => '{!rerank reRankQuery=$rqq reRankDocs=42 reRankWeight=48.2233}',
-          'rqq' => 'foo:[1 TO *]'
-        ],
-        $request->getParams()
-      );
+        $this->assertEquals(
+            [
+                'rq' => '{!rerank reRankQuery=$rqq reRankDocs=42 reRankWeight=48.2233}',
+                'rqq' => 'foo:[1 TO *]',
+            ],
+            $request->getParams()
+        );
     }
 }


### PR DESCRIPTION
This is a fix for #687 

If you include a range query directly in solr interface like so:
```
rq={!rerank reRankQuery=availability:[1 TO *] reRankDocs=1000 reRankWeight=3}
```
You will get an error. 

It works if you do it like this: 
```
rq={!rerank reRankQuery=$rqq reRankDocs=1000 reRankWeight=3}&rqq=availability:[1 TO *]
```
So I have done the same programmatically.