### PR TITLE
fixes #685

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [5.0.4]
+### Added
+- Solarium\Core\Query\Helper::formatDate() now handles DateTimeImmutable
+
+### Changed
+- Try to capture complete response body as error message when using guzzle instead of using guzzle's truncated message 
+
 ### Fixed
 - Complex ReRank queries should not cause Solr parse errors
 - Update request builders format \DateTimeImmutable correctly
 
-### Added
-- Solarium\Core\Query\Helper::formatDate() now handles DateTimeImmutable
 
 ## [5.0.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Solarium\Core\Query\Helper::formatDate() now handles DateTimeImmutable
 
 ### Changed
-- Try to capture complete response body as error message when using guzzle instead of using guzzle's truncated message 
+- Try to capture complete response body as error message when using guzzle instead of using guzzle's truncated message
 
 ### Fixed
 - Complex ReRank queries should not cause Solr parse errors

--- a/src/Core/Client/Adapter/Guzzle.php
+++ b/src/Core/Client/Adapter/Guzzle.php
@@ -3,6 +3,7 @@
 namespace Solarium\Core\Client\Adapter;
 
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\RequestOptions;
 use Solarium\Core\Client\Endpoint;
@@ -76,7 +77,15 @@ class Guzzle extends Configurable implements AdapterInterface
 
             return new Response((string) $guzzleResponse->getBody(), $responseHeaders);
         } catch (GuzzleException $e) {
+            // Guzzle truncates the error message, therefore we try to get the full message from Solr below
             $error = $e->getMessage();
+            if ($e instanceof BadResponseException) {
+                try {
+                    $error = $e->getResponse()->getBody()->getContents();
+                } catch (\Exception $e) {
+                    // Fall back to the short message
+                }
+            }
             throw new HttpException("HTTP request failed, {$error}");
         }
     }


### PR DESCRIPTION
Try to capture complete response body as error message when using guzzle instead of using guzzle's truncated message