### PR TITLE
Sf4.3 fix deprecations

### DIFF
--- a/src/Core/Event/PreCreateQuery.php
+++ b/src/Core/Event/PreCreateQuery.php
@@ -3,7 +3,7 @@
 namespace Solarium\Core\Event;
 
 use Solarium\Core\Query\QueryInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * PreCreateQuery event, see Events for details.


### PR DESCRIPTION
This fix removes following deprecation information:
User Deprecated: The "Solarium\Core\Event\PreCreateQuery" class extends "Symfony\Component\EventDispatcher\Event" that is deprecated since Symfony 4.3, use "Symfony\Contracts\EventDispatcher\Event" instead.