### PR TITLE
Update\Query\Document::__set should accept mixed

### DIFF
--- a/src/QueryType/Update/Query/Document.php
+++ b/src/QueryType/Update/Query/Document.php
@@ -166,8 +166,8 @@ class Document extends AbstractDocument
      * If you supply an array a multivalue field will be created.
      * In all cases any existing (multi)value will be overwritten.
      *
-     * @param string      $name
-     * @param string|null $value
+     * @param string $name
+     * @param mixed  $value
      *
      * @return self
      */


### PR DESCRIPTION
__set is an alias to setField so there's no reason not to accept the same $value types.