### PR TITLE
An empty array as value in combination with the `set` modifier should…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [5.1.2]
 ### Fixed
 - BufferedAdd does not support Symfony event dispatcher
+- An empty array as value in combination with the `set` modifier should remove a field when performing Atomic Updates
 
 ## [5.1.1]
 ### Fixed

--- a/src/QueryType/Update/RequestBuilder.php
+++ b/src/QueryType/Update/RequestBuilder.php
@@ -11,6 +11,7 @@ use Solarium\QueryType\Update\Query\Command\Add;
 use Solarium\QueryType\Update\Query\Command\Commit;
 use Solarium\QueryType\Update\Query\Command\Delete;
 use Solarium\QueryType\Update\Query\Command\Optimize;
+use Solarium\QueryType\Update\Query\Document;
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 
 /**
@@ -225,6 +226,13 @@ class RequestBuilder extends BaseRequestBuilder
     private function buildFieldsXml(string $key, ?float $boost, $value, ?string $modifier): string
     {
         $xml = '';
+
+        // Remove the values if 'null' or empty list is specified as the new value
+        // @see https://lucene.apache.org/solr/guide/8_1/updating-parts-of-documents.html
+        if (Document::MODIFIER_SET === $modifier && is_array($value) && empty($value)) {
+            $value = null;
+        }
+
         if (is_array($value)) {
             foreach ($value as $multival) {
                 if (is_array($multival)) {

--- a/tests/QueryType/Update/RequestBuilderTest.php
+++ b/tests/QueryType/Update/RequestBuilderTest.php
@@ -193,6 +193,8 @@ class RequestBuilderTest extends TestCase
         $doc->setKey('id', 1);
         $doc->addField('category', 123, null, Document::MODIFIER_ADD);
         $doc->addField('name', 'test', 2.5, Document::MODIFIER_SET);
+        $doc->setField('skills', null, null, Document::MODIFIER_SET);
+        $doc->setField('parts', [], null, Document::MODIFIER_SET);
         $doc->setField('stock', 2, null, Document::MODIFIER_INC);
 
         $command = new AddCommand();
@@ -204,6 +206,8 @@ class RequestBuilderTest extends TestCase
             '<field name="id">1</field>'.
             '<field name="category" update="add">123</field>'.
             '<field name="name" boost="2.5" update="set">test</field>'.
+            '<field name="skills" update="set" null="true"></field>'.
+            '<field name="parts" update="set" null="true"></field>'.
             '<field name="stock" update="inc">2</field>'.
             '</doc>'.
             '</add>',


### PR DESCRIPTION
… remove a field when performing Atomic Updates

fixes #698