### PR TITLE
fix: MoreLikeThis handler must be "select"

### DIFF
--- a/src/QueryType/MoreLikeThis/Query.php
+++ b/src/QueryType/MoreLikeThis/Query.php
@@ -23,7 +23,7 @@ class Query extends SelectQuery
      * @var array
      */
     protected $options = [
-        'handler' => 'mlt',
+        'handler' => 'select',
         'resultclass' => Result::class,
         'documentclass' => Document::class,
         'query' => '*:*',


### PR DESCRIPTION
Solr version 8.1.1
MoreLikeThis handler must be "select"