### PR TITLE
fix Passing glue string after array is deprecated

### DIFF
--- a/src/Core/Query/AbstractRequestBuilder.php
+++ b/src/Core/Query/AbstractRequestBuilder.php
@@ -68,7 +68,7 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
             }
 
             if (is_array($paramValue)) {
-                $paramValue = implode($paramValue, ',');
+                $paramValue = implode(',', $paramValue);
             }
 
             $params .= $paramName.'='.$paramValue.' ';

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -343,7 +343,7 @@ class Helper
             return $name.'()';
         }
 
-        return $name.'('.implode($params, ',').')';
+        return $name.'('.implode(',', $params).')';
     }
 
     /**


### PR DESCRIPTION
From Fedora CI
https://koschei.fedoraproject.org/package/php-solarium?collection=f32

With 7.4.0RC4
```
There were 7 errors:
1) Solarium\Tests\Core\Query\HelperTest::testGeodist
implode(): Passing glue string after array is deprecated. Swap the parameters
/builddir/build/BUILDROOT/php-solarium-3.8.1-8.fc32.noarch/usr/share/php/Solarium/Core/Query/Helper.php:373
/builddir/build/BUILDROOT/php-solarium-3.8.1-8.fc32.noarch/usr/share/php/Solarium/Core/Query/Helper.php:305
/builddir/build/BUILD/solarium-c353babec89fdbe8c64054bfec8e77bcb5da6705/tests/Solarium/Tests/Core/Query/HelperTest.php:153
2) Solarium\Tests\Core\Query\HelperTest::testFunctionCallNoParams
implode(): Passing glue string after array is deprecated. Swap the parameters
/builddir/build/BUILDROOT/php-solarium-3.8.1-8.fc32.noarch/usr/share/php/Solarium/Core/Query/Helper.php:373
/builddir/build/BUILD/solarium-c353babec89fdbe8c64054bfec8e77bcb5da6705/tests/Solarium/Tests/Core/Query/HelperTest.php:222
3) Solarium\Tests\Core\Query\HelperTest::testFunctionCall
implode(): Passing glue string after array is deprecated. Swap the parameters
/builddir/build/BUILDROOT/php-solarium-3.8.1-8.fc32.noarch/usr/share/php/Solarium/Core/Query/Helper.php:373
/builddir/build/BUILD/solarium-c353babec89fdbe8c64054bfec8e77bcb5da6705/tests/Solarium/Tests/Core/Query/HelperTest.php:230
4) Solarium\Tests\Core\Query\RequestBuilderTest::testRenderLocalParams
implode(): Passing glue string after array is deprecated. Swap the parameters
/builddir/build/BUILDROOT/php-solarium-3.8.1-8.fc32.noarch/usr/share/php/Solarium/Core/Query/AbstractRequestBuilder.php:95
/builddir/build/BUILD/solarium-c353babec89fdbe8c64054bfec8e77bcb5da6705/tests/Solarium/Tests/Core/Query/RequestBuilderTest.php:97
5) Solarium\Tests\QueryType\Select\RequestBuilder\Component\FacetSetTest::testBuildWithPivotFacet
implode(): Passing glue string after array is deprecated. Swap the parameters
/builddir/build/BUILDROOT/php-solarium-3.8.1-8.fc32.noarch/usr/share/php/Solarium/Core/Query/AbstractRequestBuilder.php:95
/builddir/build/BUILDROOT/php-solarium-3.8.1-8.fc32.noarch/usr/share/php/Solarium/QueryType/Select/RequestBuilder/Component/FacetSet.php:229
/builddir/build/BUILDROOT/php-solarium-3.8.1-8.fc32.noarch/usr/share/php/Solarium/QueryType/Select/RequestBuilder/Component/FacetSet.php:100
/builddir/build/BUILD/solarium-c353babec89fdbe8c64054bfec8e77bcb5da6705/tests/Solarium/Tests/QueryType/Select/RequestBuilder/Component/FacetSetTest.php:200
6) Solarium\Tests\QueryType\Select\RequestBuilder\RequestBuilderTest::testSelectUrlWithSortAndFilters
implode(): Passing glue string after array is deprecated. Swap the parameters
/builddir/build/BUILDROOT/php-solarium-3.8.1-8.fc32.noarch/usr/share/php/Solarium/Core/Query/AbstractRequestBuilder.php:95
/builddir/build/BUILDROOT/php-solarium-3.8.1-8.fc32.noarch/usr/share/php/Solarium/QueryType/Select/RequestBuilder/RequestBuilder.php:93
/builddir/build/BUILD/solarium-c353babec89fdbe8c64054bfec8e77bcb5da6705/tests/Solarium/Tests/QueryType/Select/RequestBuilder/RequestBuilderTest.php:124
7) Solarium\Tests\QueryType\Select\RequestBuilder\RequestBuilderTest::testWithTags
implode(): Passing glue string after array is deprecated. Swap the parameters
/builddir/build/BUILDROOT/php-solarium-3.8.1-8.fc32.noarch/usr/share/php/Solarium/Core/Query/AbstractRequestBuilder.php:95
/builddir/build/BUILDROOT/php-solarium-3.8.1-8.fc32.noarch/usr/share/php/Solarium/QueryType/Select/RequestBuilder/RequestBuilder.php:69
/builddir/build/BUILD/solarium-c353babec89fdbe8c64054bfec8e77bcb5da6705/tests/Solarium/Tests/QueryType/Select/RequestBuilder/RequestBuilderTest.php:179

```