### PR TITLE
nullable pre-commit event arguments

### DIFF
--- a/src/Plugin/BufferedAdd/BufferedAdd.php
+++ b/src/Plugin/BufferedAdd/BufferedAdd.php
@@ -230,8 +230,8 @@ class BufferedAdd extends AbstractPlugin
             return false;
         }
 
-        $overwrite = null === $overwrite ? $this->getOverwrite() : $overwrite;
-        $commitWithin = null === $commitWithin ? $this->getCommitWithin() : $commitWithin;
+        $overwrite = $overwrite ?? $this->getOverwrite();
+        $commitWithin = $commitWithin ?? $this->getCommitWithin();
 
         $event = new PreFlushEvent($this->buffer, $overwrite, $commitWithin);
         $this->client->getEventDispatcher()->dispatch($event, Events::PRE_FLUSH);
@@ -260,6 +260,8 @@ class BufferedAdd extends AbstractPlugin
      */
     public function commit(?bool $overwrite = null, ?bool $softCommit = null, ?bool $waitSearcher = null, ?bool $expungeDeletes = null)
     {
+        $overwrite = $overwrite ?? $this->getOverwrite();
+
         $event = new PreCommitEvent($this->buffer, $overwrite, $softCommit, $waitSearcher, $expungeDeletes);
         $this->client->getEventDispatcher()->dispatch($event, Events::PRE_COMMIT);
 

--- a/src/Plugin/BufferedAdd/Event/PreCommit.php
+++ b/src/Plugin/BufferedAdd/Event/PreCommit.php
@@ -21,30 +21,30 @@ class PreCommit extends Event
     protected $overwrite;
 
     /**
-     * @var bool
+     * @var bool|null
      */
     protected $softCommit;
 
     /**
-     * @var bool
+     * @var bool|null
      */
     protected $waitSearcher;
 
     /**
-     * @var bool
+     * @var bool|null
      */
     protected $expungeDeletes;
 
     /**
      * Event constructor.
      *
-     * @param array $buffer
-     * @param bool  $overwrite
-     * @param bool  $softCommit
-     * @param bool  $waitSearcher
-     * @param bool  $expungeDeletes
+     * @param array     $buffer
+     * @param bool      $overwrite
+     * @param bool|null $softCommit
+     * @param bool|null $waitSearcher
+     * @param bool|null $expungeDeletes
      */
-    public function __construct(array $buffer, bool $overwrite, bool $softCommit, bool $waitSearcher, bool $expungeDeletes)
+    public function __construct(array $buffer, bool $overwrite, ?bool $softCommit, ?bool $waitSearcher, ?bool $expungeDeletes)
     {
         $this->buffer = $buffer;
         $this->overwrite = $overwrite;
@@ -90,9 +90,9 @@ class PreCommit extends Event
     }
 
     /**
-     * @return bool
+     * @return bool|null
      */
-    public function getExpungeDeletes(): bool
+    public function getExpungeDeletes(): ?bool
     {
         return $this->expungeDeletes;
     }
@@ -132,9 +132,9 @@ class PreCommit extends Event
     }
 
     /**
-     * @return bool
+     * @return bool|null
      */
-    public function getSoftCommit(): bool
+    public function getSoftCommit(): ?bool
     {
         return $this->softCommit;
     }
@@ -153,9 +153,9 @@ class PreCommit extends Event
     }
 
     /**
-     * @return bool
+     * @return bool|null
      */
-    public function getWaitSearcher(): bool
+    public function getWaitSearcher(): ?bool
     {
         return $this->waitSearcher;
     }

--- a/tests/Plugin/BufferedAdd/BufferedAddTest.php
+++ b/tests/Plugin/BufferedAdd/BufferedAddTest.php
@@ -170,7 +170,7 @@ class BufferedAddTest extends TestCase
             ->method('addCommit')
             ->with($this->equalTo(false), $this->equalTo(true), $this->equalTo(false));
 
-        $mockResult = $this->createMock(Result:: class);
+        $mockResult = $this->createMock(Result::class);
 
         $mockClient = $this->getClient();
         $mockClient->expects($this->exactly(2))->method('createUpdate')->willReturn($mockUpdate);
@@ -181,6 +181,33 @@ class BufferedAddTest extends TestCase
         $plugin->addDocument($doc);
 
         $this->assertSame($mockResult, $plugin->commit(true, false, true, false));
+    }
+
+    public function testCommitWithOptionalValues()
+    {
+        $data = ['id' => '123', 'name' => 'test'];
+        $doc = new Document($data);
+
+        $mockUpdate = $this->createMock(Query::class); //, array('addDocuments', 'addCommit'));
+        $mockUpdate->expects($this->once())
+            ->method('addDocuments')
+            ->with($this->equalTo([$doc]), $this->equalTo(true));
+        $mockUpdate->expects($this->once())
+            ->method('addCommit')
+            ->with($this->equalTo(null), $this->equalTo(null), $this->equalTo(null));
+
+        $mockResult = $this->createMock(Result::class);
+
+        $mockClient = $this->getClient();
+        $mockClient->expects($this->exactly(2))->method('createUpdate')->willReturn($mockUpdate);
+        $mockClient->expects($this->once())->method('update')->willReturn($mockResult);
+
+        $plugin = new BufferedAdd();
+        $plugin->initPlugin($mockClient, []);
+        $plugin->addDocument($doc);
+        $plugin->setOverwrite(true);
+
+        $this->assertSame($mockResult, $plugin->commit(null, null, null, null));
     }
 
     public function testAddDocumentEventIsTriggered()


### PR DESCRIPTION
this pr fixes an issue where ``$bufferedadd->commit()`` would result in an exception 
```
 Argument 2 passed to Solarium\Plugin\BufferedAdd\Event\PreCommit::__construct() must be of the type bool, null given
```
as ``$sofCommit``, ``$waitSearcher`` and ``$expungeDeletes`` are optional in the ``->addCommit`` method, i've made them nullable in the ``PreCommitEvent``