### PR TITLE
multilevel pivot stats

### DIFF
--- a/src/Component/Result/Facet/Pivot/PivotItem.php
+++ b/src/Component/Result/Facet/Pivot/PivotItem.php
@@ -33,7 +33,7 @@ class PivotItem extends Pivot
     /**
      * Field stats.
      *
-     * @var mixed
+     * @var Stats|null
      */
     protected $stats;
 
@@ -94,9 +94,9 @@ class PivotItem extends Pivot
     /**
      * Get stats.
      *
-     * @return Stats
+     * @return Stats|null
      */
-    public function getStats(): Stats
+    public function getStats(): ?Stats
     {
         return $this->stats;
     }

--- a/src/Component/Result/Stats/Stats.php
+++ b/src/Component/Result/Stats/Stats.php
@@ -37,6 +37,19 @@ class Stats implements \IteratorAggregate, \Countable
     }
 
     /**
+     * @param string                                  $key
+     * @param \Solarium\Component\Result\Stats\Result $result
+     *
+     * @return $this
+     */
+    public function setResult(string $key, Result $result): self
+    {
+        $this->results[$key] = $result;
+
+        return $this;
+    }
+
+    /**
      * Get all results.
      *
      * @return Result[]


### PR DESCRIPTION
stats can be defined on pivots on all levels. 

this recurses through the facet set response and make sure the stats results are properly defined.

fixes a fatal error when ``$stats->getResult('foo')`` returned an array rather than an instance of ``Stats\Result``