### PR TITLE
Include support for PHP 7.4 in travis

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -28,6 +28,7 @@ return PhpCsFixer\Config::create()
        'semicolon_after_instruction' => true,
        // 'strict_comparison' => true,
        'strict_param' => true,
+       'implode_call' => true,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.2
   # phpunit/phpunit 8.0.0 requires php ^7.2 -> your PHP version (7.1.11) does not satisfy that requirement.
   #- 7.1
+  - 7.4snapshot
   - nightly
 
 env:
@@ -55,6 +56,7 @@ after_success:
 
 matrix:
   allow_failures:
+      - php: 7.4snapshot
       - php: nightly
 
 sudo: false

--- a/src/Core/Query/AbstractRequestBuilder.php
+++ b/src/Core/Query/AbstractRequestBuilder.php
@@ -68,7 +68,7 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
             }
 
             if (is_array($paramValue)) {
-                $paramValue = implode($paramValue, ',');
+                $paramValue = implode(',', $paramValue);
             }
 
             $params .= $paramName.'='.$paramValue.' ';

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -297,7 +297,8 @@ class Helper
         if ($dereferenced) {
             if (!$this->query) {
                 throw new InvalidArgumentException(
-                    'Dereferenced params can only be used in a Solarium query helper instance retrieved from the query '.'by using the getHelper() method, this instance was manually created'
+                    'Dereferenced params can only be used in a Solarium query helper instance retrieved from the query '
+                    .'by using the getHelper() method, this instance was manually created'
                 );
             }
 

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -343,7 +343,7 @@ class Helper
             return $name.'()';
         }
 
-        return $name.'('.implode($params, ',').')';
+        return $name.'('.implode(',', $params).')';
     }
 
     /**


### PR DESCRIPTION
Hello,

Since `nightly` points to PHP 8.0, adding `7.4snapshot` for use of PHP 7.4 in travis builds.