### PR TITLE
PHP 7.4 deprecation: implode() $glue must be first paramter

### DIFF
--- a/src/Core/Query/AbstractRequestBuilder.php
+++ b/src/Core/Query/AbstractRequestBuilder.php
@@ -68,7 +68,7 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
             }
 
             if (is_array($paramValue)) {
-                $paramValue = implode($paramValue, ',');
+                $paramValue = implode(',', $paramValue);
             }
 
             $params .= $paramName.'='.$paramValue.' ';

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -296,9 +296,7 @@ class Helper
     {
         if ($dereferenced) {
             if (!$this->query) {
-                throw new InvalidArgumentException(
-                    'Dereferenced params can only be used in a Solarium query helper instance retrieved from the query '.'by using the getHelper() method, this instance was manually created'
-                );
+                throw new InvalidArgumentException('Dereferenced params can only be used in a Solarium query helper instance retrieved from the query '.'by using the getHelper() method, this instance was manually created');
             }
 
             foreach ($params as $paramKey => $paramValue) {

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -343,7 +343,7 @@ class Helper
             return $name.'()';
         }
 
-        return $name.'('.implode($params, ',').')';
+        return $name.'('.implode(',', $params).')';
     }
 
     /**


### PR DESCRIPTION
Passing the $glue and $pieces parameters in reverse order to implode has been deprecated since PHP 7.4; $glue should be the first parameter and $pieces the second

fixes #720 