### PR TITLE
range pivot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+### Added
+- Range facet pivot support
+
 ### Fixed
 - setting limit for pivot facets
 

--- a/src/Component/Facet/AbstractRange.php
+++ b/src/Component/Facet/AbstractRange.php
@@ -261,6 +261,24 @@ abstract class AbstractRange extends AbstractFacet
     }
 
     /**
+     * @param string|array $pivot
+     *
+     * @return \Solarium\Core\Configurable
+     */
+    public function setPivot($pivot)
+    {
+        return $this->setOption('pivot', $pivot);
+    }
+
+    /**
+     * @return string|array|null
+     */
+    public function getPivot()
+    {
+        return $this->getOption('pivot');
+    }
+
+    /**
      * Initialize options.
      *
      * Several options need some extra checks or setup work, for these options

--- a/src/Component/Facet/AbstractRange.php
+++ b/src/Component/Facet/AbstractRange.php
@@ -261,7 +261,7 @@ abstract class AbstractRange extends AbstractFacet
     }
 
     /**
-     * @param string|array $pivot
+     * @param \Solarium\Component\Facet\Pivot|array $pivot
      *
      * @return \Solarium\Core\Configurable
      */
@@ -271,7 +271,7 @@ abstract class AbstractRange extends AbstractFacet
     }
 
     /**
-     * @return string|array|null
+     * @return \Solarium\Component\Facet\Pivot|array|null
      */
     public function getPivot()
     {

--- a/src/Component/Facet/Range.php
+++ b/src/Component/Facet/Range.php
@@ -46,6 +46,24 @@ class Range extends AbstractRange
     }
 
     /**
+     * @param string $tag
+     *
+     * @return \Solarium\Core\Configurable
+     */
+    public function setTag($tag)
+    {
+        return $this->setOption('tag', $tag);
+    }
+
+    /**
+     * @return string
+     */
+    public function getTag()
+    {
+        return $this->getOption('tag');
+    }
+
+    /**
      * Initialize options.
      *
      * Several options need some extra checks or setup work, for these options

--- a/src/Component/Facet/Range.php
+++ b/src/Component/Facet/Range.php
@@ -46,24 +46,6 @@ class Range extends AbstractRange
     }
 
     /**
-     * @param string $tag
-     *
-     * @return \Solarium\Core\Configurable
-     */
-    public function setTag($tag)
-    {
-        return $this->setOption('tag', $tag);
-    }
-
-    /**
-     * @return string
-     */
-    public function getTag()
-    {
-        return $this->getOption('tag');
-    }
-
-    /**
      * Initialize options.
      *
      * Several options need some extra checks or setup work, for these options
@@ -78,6 +60,8 @@ class Range extends AbstractRange
                 case 'exclude':
                     $this->getLocalParameters()->addExcludes($value);
                     break;
+                case 'pivot':
+                    $this->setPivot(new Pivot($value));
             }
         }
     }

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -199,7 +199,6 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
     public function addFacetRange($request, $facet)
     {
         $field = $facet->getField();
-        $key = (null !== $facet->getTag()) ? ['tag' => $facet->getTag()] : ['key' => $facet->getKey()];
 
         $request->addParam(
             'facet.range',
@@ -221,15 +220,9 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
         }
 
         if (null !== $pivot = $facet->getPivot()) {
-            $link = $facet->getTag() ?: $facet->getKey();
-            $pivot = is_array($pivot) ? $pivot : [$pivot];
-
             $request->addParam(
                 'facet.pivot',
-                $this->renderLocalParams(
-                    implode(',', $pivot),
-                    [FacetsetComponent::FACET_RANGE => $link]
-                )
+                sprintf('%s%s', $pivot->getLocalParameters()->render(), implode(',', $pivot->getFields()))
             );
         }
     }

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -199,6 +199,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
     public function addFacetRange($request, $facet)
     {
         $field = $facet->getField();
+        $key = (null !== $facet->getTag()) ? ['tag' => $facet->getTag()] : ['key' => $facet->getKey()];
 
         $request->addParam(
             'facet.range',
@@ -217,6 +218,19 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
 
         foreach ($facet->getInclude() as $includeValue) {
             $request->addParam("f.$field.facet.range.include", $includeValue);
+        }
+
+        if (null !== $pivot = $facet->getPivot()) {
+            $link = $facet->getTag() ?: $facet->getKey();
+            $pivot = is_array($pivot) ? $pivot : [$pivot];
+
+            $request->addParam(
+                'facet.pivot',
+                $this->renderLocalParams(
+                    implode(',', $pivot),
+                    [FacetsetComponent::FACET_RANGE => $link]
+                )
+            );
         }
     }
 

--- a/src/Component/Result/Facet/Pivot/PivotItem.php
+++ b/src/Component/Result/Facet/Pivot/PivotItem.php
@@ -3,6 +3,7 @@
 namespace Solarium\Component\Result\Facet\Pivot;
 
 use Solarium\Component\Result\Stats\Stats;
+use Solarium\Component\Result\Facet\Range;
 
 /**
  * Select field pivot result.
@@ -38,6 +39,11 @@ class PivotItem extends Pivot
     protected $stats;
 
     /**
+     * @var \Solarium\Component\Result\Facet\Range[]
+     */
+    protected $ranges;
+
+    /**
      * Constructor.
      *
      * @param array $data
@@ -58,6 +64,18 @@ class PivotItem extends Pivot
 
         if (isset($data['stats'])) {
             $this->stats = new Stats($data['stats']);
+        }
+
+        if (isset($data['ranges'])) {
+            foreach ($data['ranges'] as $range) {
+                $before = $range['before'] ?? null;
+                $after = $range['after'] ?? null;
+                $between = $range['between'] ?? null;
+                $start = $range['start'] ?? null;
+                $end = $range['end'] ?? null;
+                $gap = $range['gap'] ?? null;
+                $this->ranges[] = new Range($range['counts'], $before, $after, $between, $start, $end, $gap);
+            }
         }
     }
 
@@ -99,5 +117,15 @@ class PivotItem extends Pivot
     public function getStats(): ?Stats
     {
         return $this->stats;
+    }
+
+    /**
+     * Get ranges.
+     *
+     * @return \Solarium\Component\Result\Facet\Range[]
+     */
+    public function getRanges(): array
+    {
+        return $this->ranges;
     }
 }

--- a/src/Component/Result/Facet/Range.php
+++ b/src/Component/Result/Facet/Range.php
@@ -2,6 +2,8 @@
 
 namespace Solarium\Component\Result\Facet;
 
+use Solarium\Component\Result\Facet\Pivot\Pivot;
+
 /**
  * Select range facet result.
  *
@@ -57,6 +59,11 @@ class Range extends Field
     protected $gap;
 
     /**
+     * @var \Solarium\Component\Result\Facet\Pivot\Pivot|null
+     */
+    protected $pivot;
+
+    /**
      * Constructor.
      *
      * @param array           $values
@@ -66,16 +73,19 @@ class Range extends Field
      * @param string|int|null $start
      * @param string|int|null $end
      * @param string|int|null $gap
+     * @param Pivot|null      $pivot
      */
-    public function __construct(array $values, ?int $before, ?int $after, ?int $between, $start, $end, $gap)
+    public function __construct(array $values, ?int $before, ?int $after, ?int $between, $start, $end, $gap, ?Pivot $pivot = null)
     {
         parent::__construct($values);
+
         $this->before = $before;
         $this->after = $after;
         $this->between = $between;
         $this->start = $start;
         $this->end = $end;
         $this->gap = $gap;
+        $this->pivot = $pivot;
     }
 
     /**
@@ -151,5 +161,13 @@ class Range extends Field
     public function getGap(): string
     {
         return (string) $this->gap;
+    }
+
+    /**
+     * @return \Solarium\Component\Result\Facet\Pivot\Pivot|null
+     */
+    public function getPivot(): ?Pivot
+    {
+        return $this->pivot;
     }
 }

--- a/tests/Component/RequestBuilder/FacetSetTest.php
+++ b/tests/Component/RequestBuilder/FacetSetTest.php
@@ -279,6 +279,31 @@ class FacetSetTest extends TestCase
         );
     }
 
+    public function testBuildWithRangeFacetAndPivot()
+    {
+        $this->component->addFacet(
+            new FacetRange(
+                [
+                    'key' => 'key',
+                    'tag' => 'r1',
+                    'field' => 'manufacturedate_dt',
+                    'start' => '2006-01-01T00:00:00Z',
+                    'end' => 'NOW/YEAR',
+                    'gap' => '+1YEAR',
+                    'pivot' => ['cat', 'inStock'],
+                ]
+            )
+        );
+
+        $request = $this->builder->buildComponent($this->component, $this->request);
+
+        $this->assertNull($request->getRawData());
+        $this->assertEquals(
+            '?facet.range={!tag=r1}manufacturedate_dt&f.manufacturedate_dt.facet.range.start=2006-01-01T00:00:00Z&f.manufacturedate_dt.facet.range.end=NOW/YEAR&f.manufacturedate_dt.facet.range.gap=+1YEAR&facet.pivot={!range=r1}cat,inStock&facet=true',
+            urldecode($request->getUri())
+        );
+    }
+
     public function testBuildWithFacetsAndGlobalFacetSettings()
     {
         $this->component->setMissing(true);

--- a/tests/Component/RequestBuilder/FacetSetTest.php
+++ b/tests/Component/RequestBuilder/FacetSetTest.php
@@ -285,12 +285,12 @@ class FacetSetTest extends TestCase
             new FacetRange(
                 [
                     'key' => 'key',
-                    'tag' => 'r1',
+                    'local_tag' => 'r1',
                     'field' => 'manufacturedate_dt',
                     'start' => '2006-01-01T00:00:00Z',
                     'end' => 'NOW/YEAR',
                     'gap' => '+1YEAR',
-                    'pivot' => ['cat', 'inStock'],
+                    'pivot' => ['fields' => ['cat', 'inStock'], 'local_range' => 'r1'],
                 ]
             )
         );
@@ -299,7 +299,7 @@ class FacetSetTest extends TestCase
 
         $this->assertNull($request->getRawData());
         $this->assertEquals(
-            '?facet.range={!tag=r1}manufacturedate_dt&f.manufacturedate_dt.facet.range.start=2006-01-01T00:00:00Z&f.manufacturedate_dt.facet.range.end=NOW/YEAR&f.manufacturedate_dt.facet.range.gap=+1YEAR&facet.pivot={!range=r1}cat,inStock&facet=true',
+            '?facet.range={!key=key tag=r1}manufacturedate_dt&f.manufacturedate_dt.facet.range.start=2006-01-01T00:00:00Z&f.manufacturedate_dt.facet.range.end=NOW/YEAR&f.manufacturedate_dt.facet.range.gap=+1YEAR&facet.pivot={!range=r1}cat,inStock&facet=true',
             urldecode($request->getUri())
         );
     }

--- a/tests/Component/ResponseParser/FacetSetTest.php
+++ b/tests/Component/ResponseParser/FacetSetTest.php
@@ -46,7 +46,7 @@ class FacetSetTest extends TestCase
             ]
         );
         $this->facetSet->createFacet('range', ['key' => 'keyD']);
-        $this->facetSet->createFacet('range', ['key' => 'keyD_A', 'pivot' => 'keyF']);
+        $this->facetSet->createFacet('range', ['key' => 'keyD_A', 'pivot' => ['key' => 'keyF']]);
         $this->facetSet->createFacet('pivot', ['key' => 'keyE', 'fields' => 'cat,price']);
         $this->facetSet->createFacet('pivot', ['key' => 'keyF', 'fields' => 'cat']);
 
@@ -159,7 +159,7 @@ class FacetSetTest extends TestCase
         $this->assertEquals(3, $facets['keyD']->getBefore());
         $this->assertEquals(4, $facets['keyD']->getBetween());
         $this->assertEquals(5, $facets['keyD']->getAfter());
-        $this->assertEquals(1, count($facets['keyE']));
+        $this->assertEquals(1, \count($facets['keyE']));
 
         $this->assertEquals(23, $result->getFacet('keyB')->getValue());
 

--- a/tests/QueryType/Select/Query/Component/Facet/RangeTest.php
+++ b/tests/QueryType/Select/Query/Component/Facet/RangeTest.php
@@ -30,6 +30,8 @@ class RangeTest extends TestCase
             'hardend' => true,
             'other' => 'all',
             'include' => 'lower',
+            'tag' => 'myTag',
+            'pivot' => ['pivot', 'fields'],
         ];
 
         $this->facet->setOptions($options);
@@ -112,5 +114,17 @@ class RangeTest extends TestCase
     {
         $this->facet->setInclude(['lower', 'upper']);
         $this->assertSame(['lower', 'upper'], $this->facet->getInclude());
+    }
+
+    public function testSetAndGetTag()
+    {
+        $this->facet->setTag('t1');
+        $this->assertSame('t1', $this->facet->getTag());
+    }
+
+    public function testSetAndGetPivot()
+    {
+        $this->facet->setPivot(['pivot', 'fields']);
+        $this->assertSame(['pivot', 'fields'], $this->facet->getPivot());
     }
 }

--- a/tests/QueryType/Select/Query/Component/Facet/RangeTest.php
+++ b/tests/QueryType/Select/Query/Component/Facet/RangeTest.php
@@ -116,12 +116,6 @@ class RangeTest extends TestCase
         $this->assertSame(['lower', 'upper'], $this->facet->getInclude());
     }
 
-    public function testSetAndGetTag()
-    {
-        $this->facet->setTag('t1');
-        $this->assertSame('t1', $this->facet->getTag());
-    }
-
     public function testSetAndGetPivot()
     {
         $this->facet->setPivot(['pivot', 'fields']);


### PR DESCRIPTION
this one replaces https://github.com/solariumphp/solarium/pull/654

these addition enables one to add a pivot to their range query as described over here: https://lucene.apache.org/solr/guide/6_6/faceting.html#Faceting-CombiningFacetQueriesAndFacetRangesWithPivotFacets.

the given example can now be achieved by:
```php
$facetSet = $query->getFacetSet();
$facet = $facetSet->createFacetRange(['key' => 'manufacturedate_dt', 'tag' => 'r1']);

$facet->setField('manufacturedate_dt');
$facet->setStart('2006-01-01T00:00:00Z');
$facet->setEnd('NOW/YEAR'));
$facet->setGap('+1YEAR');
$facet->setPivot(['cat', 'inStock']);
```