### PR TITLE
select query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [unreleased]
 ### Added
+- Filter query builder
 - Range facet pivot support
 
 ### Fixed

--- a/src/Builder/AbstractExpressionVisitor.php
+++ b/src/Builder/AbstractExpressionVisitor.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder;
+
+use Solarium\Exception\RuntimeException;
+
+/**
+ * Expression Visitor.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+abstract class AbstractExpressionVisitor
+{
+    /**
+     * Converts a comparison expression into solr query language.
+     *
+     * @param \Solarium\Builder\ExpressionInterface $expression
+     *
+     * @return mixed
+     */
+    abstract public function walkExpression(ExpressionInterface $expression);
+
+    /**
+     * Converts a value expression into solr query part.
+     *
+     * @param \Solarium\Builder\Value $value
+     *
+     * @return mixed
+     */
+    abstract public function walkValue(Value $value);
+
+    /**
+     * @param \Solarium\Builder\ExpressionInterface $expr
+     *
+     * @return mixed
+     */
+    abstract public function walkCompositeExpression(ExpressionInterface $expr);
+
+    /**
+     * @param \Solarium\Builder\ExpressionInterface $expr
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return mixed
+     */
+    public function dispatch(ExpressionInterface $expr)
+    {
+        switch (true) {
+            case $expr instanceof Comparison:
+                return $this->walkExpression($expr);
+            case $expr instanceof Value:
+                return $this->walkValue($expr);
+            case $expr instanceof CompositeComparison:
+                return $this->walkCompositeExpression($expr);
+            default:
+                throw new RuntimeException('Unknown Expression '.\get_class($expr));
+        }
+    }
+}

--- a/src/Builder/Comparison.php
+++ b/src/Builder/Comparison.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder;
+
+/**
+ * Comparison.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class Comparison implements ExpressionInterface
+{
+    /**
+     * Equals.
+     */
+    public const EQ = '=';
+
+    /**
+     * Does not equal.
+     */
+    public const NEQ = '<>';
+
+    /**
+     * Less than.
+     */
+    public const LT = '<';
+
+    /**
+     * Less than or equal to.
+     */
+    public const LTE = '<=';
+
+    /**
+     * Greater than.
+     */
+    public const GT = '>';
+
+    /**
+     * Greater than or equal to.
+     */
+    public const GTE = '>=';
+
+    /**
+     * In.
+     */
+    public const IN = 'IN';
+
+    /**
+     * Not in.
+     */
+    public const NIN = 'NIN';
+
+    /**
+     * Range.
+     */
+    public const RANGE = 'RANGE';
+
+    /**
+     * Regular expression.
+     */
+    public const REGEXP = 'REGEXP';
+
+    /**
+     * Like.
+     */
+    public const LIKE = 'LIKE';
+
+    /**
+     * Matching.
+     */
+    public const MATCH = 'MATCH';
+
+    /**
+     * @var string
+     */
+    private $field;
+
+    /**
+     * @var string
+     */
+    private $operator;
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $field
+     * @param string $operator
+     * @param mixed  $value
+     */
+    public function __construct(string $field, string $operator, $value)
+    {
+        if (!($value instanceof Value)) {
+            $value = new Value($value);
+        }
+
+        $this->field = $field;
+        $this->operator = $operator;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOperator(): string
+    {
+        return $this->operator;
+    }
+
+    /**
+     * @return \Solarium\Builder\Value
+     */
+    public function getValue(): Value
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function visit(AbstractExpressionVisitor $visitor)
+    {
+        return $visitor->walkExpression($this);
+    }
+}

--- a/src/Builder/CompositeComparison.php
+++ b/src/Builder/CompositeComparison.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder;
+
+use Solarium\Exception\RuntimeException;
+
+/**
+ * Composite Expression.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class CompositeComparison implements ExpressionInterface
+{
+    public const TYPE_AND = 'AND';
+
+    public const TYPE_OR = 'OR';
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var \Solarium\Builder\Comparison[]
+     */
+    private $comparisons = [];
+
+    /**
+     * @param string $type
+     * @param array  $comparisons
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function __construct($type, array $comparisons)
+    {
+        $this->type = $type;
+
+        foreach ($comparisons as $expr) {
+            if ($expr instanceof Value) {
+                throw new RuntimeException('Values are not supported expressions as children of and/or expressions.');
+            }
+            if (!($expr instanceof ExpressionInterface)) {
+                throw new RuntimeException('No expression given to CompositeExpression.');
+            }
+
+            $this->comparisons[] = $expr;
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return \Solarium\Builder\Comparison[]
+     */
+    public function getComparisons(): array
+    {
+        return $this->comparisons;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function visit(AbstractExpressionVisitor $visitor)
+    {
+        return $visitor->walkCompositeExpression($this);
+    }
+}

--- a/src/Builder/ExpressionInterface.php
+++ b/src/Builder/ExpressionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder;
+
+/**
+ * Expression Interface.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+interface ExpressionInterface
+{
+    /**
+     * @param \Solarium\Builder\AbstractExpressionVisitor $visitor
+     *
+     * @return mixed
+     */
+    public function visit(AbstractExpressionVisitor $visitor);
+}

--- a/src/Builder/Select/ExpressionBuilder.php
+++ b/src/Builder/Select/ExpressionBuilder.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder\Select;
+
+use Solarium\Builder\Comparison;
+use Solarium\Builder\CompositeComparison;
+
+/**
+ * Expression Builder.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class ExpressionBuilder
+{
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\CompositeComparison
+     */
+    public function andX($x = null): CompositeComparison
+    {
+        return new CompositeComparison(CompositeComparison::TYPE_AND, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\CompositeComparison
+     */
+    public function orX($x = null): CompositeComparison
+    {
+        return new CompositeComparison(CompositeComparison::TYPE_OR, \func_get_args());
+    }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return \Solarium\Builder\Comparison
+     */
+    public function eq(string $field, $value): Comparison
+    {
+        return new Comparison($field, Comparison::EQ, $value);
+    }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return \Solarium\Builder\Comparison
+     */
+    public function neq(string $field, $value): Comparison
+    {
+        return new Comparison($field, Comparison::NEQ, $value);
+    }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return \Solarium\Builder\Comparison
+     */
+    public function lt(string $field, $value): Comparison
+    {
+        return new Comparison($field, Comparison::LT, $value);
+    }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return \Solarium\Builder\Comparison
+     */
+    public function gt(string $field, $value): Comparison
+    {
+        return new Comparison($field, Comparison::GT, $value);
+    }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return \Solarium\Builder\Comparison
+     */
+    public function lte(string $field, $value): Comparison
+    {
+        return new Comparison($field, Comparison::LTE, $value);
+    }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return \Solarium\Builder\Comparison
+     */
+    public function gte(string $field, $value): Comparison
+    {
+        return new Comparison($field, Comparison::GTE, $value);
+    }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return \Solarium\Builder\Comparison
+     */
+    public function in(string $field, $value): Comparison
+    {
+        return new Comparison($field, Comparison::IN, $value);
+    }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return \Solarium\Builder\Comparison
+     */
+    public function notIn(string $field, $value): Comparison
+    {
+        return new Comparison($field, Comparison::NIN, $value);
+    }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return \Solarium\Builder\Comparison
+     */
+    public function range(string $field, $value): Comparison
+    {
+        return new Comparison($field, Comparison::RANGE, $value);
+    }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return \Solarium\Builder\Comparison
+     */
+    public function regexp(string $field, $value): Comparison
+    {
+        return new Comparison($field, Comparison::REGEXP, $value);
+    }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return \Solarium\Builder\Comparison
+     */
+    public function like(string $field, $value): Comparison
+    {
+        return new Comparison($field, Comparison::LIKE, $value);
+    }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return \Solarium\Builder\Comparison
+     */
+    public function match(string $field, $value): Comparison
+    {
+        return new Comparison($field, Comparison::MATCH, $value);
+    }
+}

--- a/src/Builder/Select/FilterBuilder.php
+++ b/src/Builder/Select/FilterBuilder.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder\Select;
+
+use Solarium\Builder\ExpressionInterface;
+
+/**
+ * Query Builder.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class FilterBuilder
+{
+    /**
+     * @var \Solarium\Builder\ExpressionInterface[]
+     */
+    private $expressions = [];
+
+    /**
+     * @var \Solarium\Builder\Select\ExpressionBuilder
+     */
+    private static $expressionBuilder;
+
+    /**
+     * @return static
+     */
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    /**
+     * @return \Solarium\Builder\Select\ExpressionBuilder
+     */
+    public static function expr(): ExpressionBuilder
+    {
+        if (null === self::$expressionBuilder) {
+            self::$expressionBuilder = new ExpressionBuilder();
+        }
+
+        return self::$expressionBuilder;
+    }
+
+    /**
+     * @param \Solarium\Builder\ExpressionInterface $comparison
+     *
+     * @return $this
+     */
+    public function where(ExpressionInterface $comparison): self
+    {
+        $this->expressions[] = $comparison;
+
+        return $this;
+    }
+
+    /**
+     * Convenience method for readability.
+     *
+     * @param \Solarium\Builder\ExpressionInterface $comparison
+     *
+     * @return $this
+     */
+    public function andWhere(ExpressionInterface $comparison): self
+    {
+        return $this->where($comparison);
+    }
+
+    /**
+     * @return \Solarium\Builder\ExpressionInterface[]
+     */
+    public function getExpressions(): array
+    {
+        return $this->expressions;
+    }
+}

--- a/src/Builder/Select/QueryExpressionVisitor.php
+++ b/src/Builder/Select/QueryExpressionVisitor.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder\Select;
+
+use Solarium\Builder\AbstractExpressionVisitor;
+use Solarium\Builder\Comparison;
+use Solarium\Builder\CompositeComparison;
+use Solarium\Builder\ExpressionInterface;
+use Solarium\Builder\Value;
+use Solarium\Core\Query\Helper;
+use Solarium\Exception\RuntimeException;
+
+/**
+ * Query Expression Visitor.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class QueryExpressionVisitor extends AbstractExpressionVisitor
+{
+    /**
+     * @var Helper
+     */
+    private $helper;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->helper = new Helper();
+    }
+
+    /**
+     * @param \Solarium\Builder\ExpressionInterface $expression
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return mixed|string
+     */
+    public function walkExpression(ExpressionInterface $expression)
+    {
+        $field = $expression->getField();
+        $value = $expression->getValue()->getValue();
+
+        switch ($expression->getOperator()) {
+            case Comparison::EQ:
+            case Comparison::NEQ:
+                $strValue = $this->valueToString($value, ',', '"');
+
+                if ($value instanceof \DateTime) {
+                    $strValue = sprintf('[%1$s TO %1$s]', $strValue);
+                }
+
+                $not = (Comparison::NEQ === $expression->getOperator()) ? '-' : '';
+
+                return sprintf('%s%s:%s', $not, $field, $strValue);
+            case Comparison::GT:
+                return sprintf('%s:{%s TO *]', $field, $this->valueToString($value));
+            case Comparison::GTE:
+                return sprintf('%s:[%s TO *]', $field, $this->valueToString($value));
+            case Comparison::LT:
+                return sprintf('%s:[* TO %s}', $field, $this->valueToString($value));
+            case Comparison::LTE:
+                return sprintf('%s:[* TO %s]', $field, $this->valueToString($value));
+            case Comparison::RANGE:
+                if (\is_array($value)) {
+                    if (2 === \count($value)) {
+                        return sprintf('%s:[%s TO %s]', $field, $this->valueToString($value[0]), $this->valueToString($value[1]));
+                    }
+
+                    if (1 === \count($value)) {
+                        return sprintf('%s:[%s TO *]', $field, $this->valueToString($value[0]));
+                    }
+                }
+
+                throw new RuntimeException(sprintf('Invalid range value: %s', $value));
+            case Comparison::IN:
+                if (\is_array($value)) {
+                    return sprintf('%s:(%s)', $field, $this->valueToString($value, ' OR ', '"'));
+                }
+
+                return sprintf('%s:%s', $field, $this->valueToString($value, ',', '"'));
+            case Comparison::LIKE:
+            case Comparison::MATCH:
+                if (\is_array($value)) {
+                    return sprintf('%s:(%s)', $field, $this->valueToString($value, ' OR ', '', false));
+                }
+
+                return sprintf('%s:%s', $field, $this->valueToString($value, ',', '', false));
+            case Comparison::NIN:
+                if (\is_array($value)) {
+                    return sprintf('-%s:(%s)', $field, $this->valueToString($value, ' OR ', '"'));
+                }
+
+                return sprintf('-%s:%s', $field, $this->valueToString($value, ',', '"'));
+            case Comparison::REGEXP:
+                if ('/' !== $value[0]) {
+                    $value = sprintf('/%s/', $value);
+                }
+
+                return sprintf('%s:%s', $field, $this->valueToString($value, ',', '', false));
+            default:
+                throw new RuntimeException('Unknown comparison operator: '.$expression->getOperator());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkValue(Value $value)
+    {
+        return $value->getValue();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function walkCompositeExpression(ExpressionInterface $expr)
+    {
+        $comparisons = [];
+
+        foreach ($expr->getComparisons() as $child) {
+            $comparisons[] = $this->dispatch($child);
+        }
+
+        switch ($expr->getType()) {
+            case CompositeComparison::TYPE_AND:
+                return implode(' AND ', $comparisons);
+            case CompositeComparison::TYPE_OR:
+                return implode(' OR ', $comparisons);
+            default:
+                throw new RuntimeException('Unknown composite '.$expr->getType());
+        }
+    }
+
+    /**
+     * @param mixed  $value
+     * @param string $separator
+     * @param string $quote
+     * @param bool   $escape
+     *
+     * @return string
+     */
+    private function valueToString($value, string $separator = ',', string $quote = '', bool $escape = true): string
+    {
+        if (\is_array($value)) {
+            $ret = [];
+
+            foreach ($value as $v) {
+                $ret[] = $this->typedValueToString($v, $quote, $escape);
+            }
+
+            return implode($separator, $ret);
+        }
+
+        return $this->typedValueToString($value, $quote, $escape);
+    }
+
+    /**
+     * @param mixed  $value
+     * @param string $quote
+     * @param bool   $escape
+     *
+     * @return string
+     */
+    private function typedValueToString($value, string $quote = '', $escape = true): string
+    {
+        if (null === $value) {
+            return '[* TO *]';
+        }
+
+        if ($value instanceof \DateTime) {
+            return $this->helper->formatDate($value);
+        }
+
+        if (true === $escape && \is_string($value)) {
+            $value = $this->helper->escapeTerm($value);
+        }
+
+        if (\is_string($value)) {
+            $value = sprintf('%1$s%2$s%1$s', $quote, $value);
+        }
+
+        return (string) $value;
+    }
+}

--- a/src/Builder/Value.php
+++ b/src/Builder/Value.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder;
+
+/**
+ * Value.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class Value implements ExpressionInterface
+{
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * @param mixed $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function visit(AbstractExpressionVisitor $visitor)
+    {
+        return $visitor->walkValue($this);
+    }
+}

--- a/tests/Builder/Select/SelectQueryBuilderTest.php
+++ b/tests/Builder/Select/SelectQueryBuilderTest.php
@@ -1,0 +1,357 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Tests\Builder\Select;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Exception\RuntimeException;
+use Solarium\Builder\AbstractExpressionVisitor;
+use Solarium\Builder\Comparison;
+use Solarium\Builder\CompositeComparison;
+use Solarium\Builder\ExpressionInterface;
+use Solarium\Builder\Select\FilterBuilder;
+use Solarium\Builder\Select\QueryExpressionVisitor;
+use Solarium\Builder\Value;
+
+/**
+ * Select Query Builder Test.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class SelectQueryBuilderTest extends TestCase
+{
+    /**
+     * @var \Solarium\Builder\Select\QueryExpressionVisitor
+     */
+    private $visitor;
+
+    /**
+     * Set up.
+     */
+    public function setUp(): void
+    {
+        $this->visitor = new QueryExpressionVisitor();
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testEquals(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->eq('foo', 'bar'));
+
+        $this->assertSame('foo:"bar"', $this->visitor->dispatch($filter->getExpressions()[0]));
+
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->eq('foo', date_create('2020-01-01')));
+
+        $this->assertSame('foo:[2020-01-01T00:00:00Z TO 2020-01-01T00:00:00Z]', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testNullValue(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->eq('foo', null));
+
+        $this->assertSame('foo:[* TO *]', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testDoesNotEqual(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->neq('foo', 'bar'));
+
+        $this->assertSame('-foo:"bar"', $this->visitor->dispatch($filter->getExpressions()[0]));
+
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->neq('foo', date_create('2020-01-01')));
+
+        $this->assertSame('-foo:[2020-01-01T00:00:00Z TO 2020-01-01T00:00:00Z]', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testGreaterThan(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->gt('foo', 2));
+
+        $this->assertSame('foo:{2 TO *]', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testGreaterThanEqual(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->gte('foo', 2));
+
+        $this->assertSame('foo:[2 TO *]', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testLowerThan(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->lt('foo', 2));
+
+        $this->assertSame('foo:[* TO 2}', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testLowerThanEqual(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->lte('foo', 2));
+
+        $this->assertSame('foo:[* TO 2]', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testRange(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->range('foo', [2]));
+
+        $this->assertSame('foo:[2 TO *]', $this->visitor->dispatch($filter->getExpressions()[0]));
+
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->range('foo', [2, 5]));
+
+        $this->assertSame('foo:[2 TO 5]', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testRangeInvalidValue(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->range('foo', 'bar'));
+
+        $this->expectException(RuntimeException::class);
+
+        $this->visitor->dispatch($filter->getExpressions()[0]);
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testIn(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->in('foo', [2, 5]));
+
+        $this->assertSame('foo:(2 OR 5)', $this->visitor->dispatch($filter->getExpressions()[0]));
+
+        $filter = FilterBuilder::create()
+            ->andWhere(FilterBuilder::expr()->in('foo', 'bar'));
+
+        $this->assertSame('foo:"bar"', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testNotIn(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->notIn('foo', [2, 5]));
+
+        $this->assertSame('-foo:(2 OR 5)', $this->visitor->dispatch($filter->getExpressions()[0]));
+
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->notIn('foo', 'bar'));
+
+        $this->assertSame('-foo:"bar"', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testLike(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->like('title', ['*foo', 'bar*']));
+
+        $this->assertSame('title:(*foo OR bar*)', $this->visitor->dispatch($filter->getExpressions()[0]));
+
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->like('title', 'foo*'));
+
+        $this->assertSame('title:foo*', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testRegularExpression(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->regexp('title', '[0-9]{5}'));
+
+        $this->assertSame('title:/[0-9]{5}/', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testMatch(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->match('title', 'foo*'));
+
+        $this->assertSame('title:foo*', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testCompositeAnd(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->andX(
+                FilterBuilder::expr()->eq('title', 'foo'),
+                FilterBuilder::expr()->in('description', ['bar', 'baz'])
+            ));
+
+        $this->assertSame('title:"foo" AND description:("bar" OR "baz")', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testCompositeOr(): void
+    {
+        $filter = FilterBuilder::create()
+            ->where(FilterBuilder::expr()->orX(
+                FilterBuilder::expr()->eq('title', 'foo'),
+                FilterBuilder::expr()->in('description', ['bar', 'baz'])
+            ));
+
+        $this->assertSame('title:"foo" OR description:("bar" OR "baz")', $this->visitor->dispatch($filter->getExpressions()[0]));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testVisitExpressions(): void
+    {
+        $expression = FilterBuilder::expr()->eq('title', 'foo');
+
+        $this->assertSame('title:"foo"', $expression->visit($this->visitor));
+
+        $compositeExpression = FilterBuilder::expr()->andX(
+            FilterBuilder::expr()->eq('title', 'foo'),
+            FilterBuilder::expr()->in('description', ['bar', 'baz'])
+        );
+
+        $this->assertSame('title:"foo" AND description:("bar" OR "baz")', $compositeExpression->visit($this->visitor));
+
+        $value = new Value('foo');
+        $this->assertSame('foo', $value->visit($this->visitor));
+        $this->assertSame('foo', $this->visitor->dispatch($value));
+    }
+
+    /**
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testInvalidCompositeExpressionWithValue(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        new CompositeComparison(CompositeComparison::TYPE_OR, [new Value('foo')]);
+    }
+
+    /**
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testInvalidCompositeExpressionWithObject(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        new CompositeComparison(CompositeComparison::TYPE_AND, [new \DateTime()]);
+    }
+
+    /**
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testUnknownExpression(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->visitor->dispatch(new ExpressionDummy());
+    }
+
+    /**
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testUnknownCompositeComparison(): void
+    {
+        $comparison = new CompositeComparison('TO', [FilterBuilder::expr()->eq('title', 'foo')]);
+
+        $this->expectException(RuntimeException::class);
+
+        $this->visitor->walkCompositeExpression($comparison);
+    }
+
+    /**
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testUnknownComparison(): void
+    {
+        $comparison = new Comparison('title', 'FOO', 'bar');
+
+        $this->expectException(RuntimeException::class);
+
+        $this->visitor->walkExpression($comparison);
+    }
+}
+
+/**
+ * ExpressionDummy.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class ExpressionDummy implements ExpressionInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function visit(AbstractExpressionVisitor $visitor)
+    {
+        return $visitor->walkExpression($this);
+    }
+}


### PR DESCRIPTION
not sure whether this would be a useful addition to this library so i'm just going to leave this here for you guys to decide.

the intention is to ease the writing of solr filter queries by using a builder which, as you can see, is heavily inspired by doctrine's criteria object.

this pr has no integration with the select query type for now, but should be fairly simple to create a method which takes a filter builder instance as arguments and iterates over the expressions and add them as filter queries.

see the phpunit test for various examples, writing filter queries will be as easy as
```php
$filter = FilterBuilder::create()
    ->where(FilterBuilder::expr()->eq('title', 'foo'))
    ->andWhere(FilterBuilder::expr()->like('description, 'bar*'))
;
```