### PR TITLE
analytics expression builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [unreleased]
 ### Added
+- Analytics expression builder
 - Range facet pivot support
 
 ### Fixed

--- a/src/Builder/AbstractExpressionVisitor.php
+++ b/src/Builder/AbstractExpressionVisitor.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder;
+
+use Solarium\Exception\RuntimeException;
+
+/**
+ * Expression Visitor.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+abstract class AbstractExpressionVisitor
+{
+    /**
+     * Converts a comparison expression into solr query language.
+     *
+     * @param \Solarium\Builder\ExpressionInterface $expression
+     *
+     * @return mixed
+     */
+    abstract public function walkExpression(ExpressionInterface $expression);
+
+    /**
+     * Converts a value expression into solr query part.
+     *
+     * @param \Solarium\Builder\Value $value
+     *
+     * @return mixed
+     */
+    abstract public function walkValue(Value $value);
+
+    /**
+     * @param \Solarium\Builder\ExpressionInterface $expr
+     *
+     * @return mixed
+     */
+    abstract public function walkCompositeExpression(ExpressionInterface $expr);
+
+    /**
+     * @param \Solarium\Builder\ExpressionInterface $expr
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return mixed
+     */
+    public function dispatch(ExpressionInterface $expr)
+    {
+        switch (true) {
+            case $expr instanceof Comparison:
+                return $this->walkExpression($expr);
+            case $expr instanceof Value:
+                return $this->walkValue($expr);
+            case $expr instanceof CompositeComparison:
+                return $this->walkCompositeExpression($expr);
+            default:
+                throw new RuntimeException('Unknown Expression '.\get_class($expr));
+        }
+    }
+}

--- a/src/Builder/Analytics/AnalyticsExpressionVisitor.php
+++ b/src/Builder/Analytics/AnalyticsExpressionVisitor.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder\Analytics;
+
+use Solarium\Builder\AbstractExpressionVisitor;
+use Solarium\Builder\ExpressionInterface;
+use Solarium\Builder\FunctionInterface;
+use Solarium\Builder\Value;
+use Solarium\Exception\RuntimeException;
+
+/**
+ * Analytics Expression Visitor.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class AnalyticsExpressionVisitor extends AbstractExpressionVisitor
+{
+    /**
+     * @param \Solarium\Builder\ExpressionInterface $expr
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return mixed
+     */
+    public function dispatch(ExpressionInterface $expr)
+    {
+        if (true === $expr instanceof FunctionInterface) {
+            return $this->walkExpression($expr);
+        }
+
+        throw new RuntimeException('Unknown Expression '.\get_class($expr));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkExpression(ExpressionInterface $expression)
+    {
+        return (string) $expression;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function walkValue(Value $value)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function walkCompositeExpression(ExpressionInterface $expr)
+    {
+    }
+}

--- a/src/Builder/Analytics/ExpressionBuilder.php
+++ b/src/Builder/Analytics/ExpressionBuilder.php
@@ -1,0 +1,495 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder\Analytics;
+
+use Solarium\Builder\ExpressionInterface;
+use Solarium\Builder\MappingFunction;
+use Solarium\Builder\ReductionFunction;
+
+/**
+ * Expression Builder.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class ExpressionBuilder
+{
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function count($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::COUNT, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function docCount($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::DOC_COUNT, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function missing($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::MISSING, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function unique($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::UNIQUE, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function sum($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::SUM, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function variance($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::VARIANCE, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function stddev($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::STANDARD_DEVIATION, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function mean($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::MEAN, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function weightedMean($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::WEIGHTED_MEAN, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function minimum($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::MINIMUM, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function maximum($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::MAXIMUM, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function median($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::MEDIAN, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function percentile($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::PERCENTILE, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function ordinal($x = null): ExpressionInterface
+    {
+        return new ReductionFunction(ReductionFunction::ORDINAL, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function negation($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::NEGATION, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function absolute($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::ABSOLUTE_VALUE, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function round($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::ROUND, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function ceil($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::CEILING, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function floor($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::FLOOR, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function add($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::ADDITION, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function sub($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::SUBTRACTION, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function mult($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::MULTIPLICATION, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function div($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::DIVISION, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function power($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::POWER, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function logarithm($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::LOGARITHM, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function and($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::AND, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function or($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::OR, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function exists($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::EXISTS, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function equal($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::EQUAL, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function gt($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::GREATER_THAN, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function gte($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::GREATER_THAN_EQUALS, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function lt($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::LESS_THAN, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function lte($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::LESS_THAN_EQUALS, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function top($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::TOP, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function bottom($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::BOTTOM, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function if($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::IF, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function replace($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::REPLACE, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function fillMissing($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::FILL_MISSING, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function remove($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::REMOVE, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function filter($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::FILTER, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function date($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::DATE_PARSE, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function dateMath($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::DATE_MATH, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function string($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::STRING, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function concat($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::CONCAT, \func_get_args());
+    }
+
+    /**
+     * @param null $x
+     *
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function concatSeparated($x = null): ExpressionInterface
+    {
+        return new MappingFunction(MappingFunction::CONCAT_SEPARATED, \func_get_args());
+    }
+}

--- a/src/Builder/Analytics/FunctionBuilder.php
+++ b/src/Builder/Analytics/FunctionBuilder.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder\Analytics;
+
+use Solarium\Builder\ExpressionInterface;
+
+/**
+ * FunctionBuilder.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class FunctionBuilder
+{
+    /**
+     * @var \Solarium\Builder\ExpressionInterface
+     */
+    private $function;
+
+    /**
+     * @var \Solarium\Builder\Select\ExpressionBuilder
+     */
+    private static $expressionBuilder;
+
+    /**
+     * @return static
+     */
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    /**
+     * @return \Solarium\Builder\Analytics\ExpressionBuilder
+     */
+    public static function expr(): ExpressionBuilder
+    {
+        if (null === self::$expressionBuilder) {
+            self::$expressionBuilder = new ExpressionBuilder();
+        }
+
+        return self::$expressionBuilder;
+    }
+
+    /**
+     * @param \Solarium\Builder\ExpressionInterface $function
+     *
+     * @return $this
+     */
+    public function where(ExpressionInterface $function): self
+    {
+        $this->function = $function;
+
+        return $this;
+    }
+
+    /**
+     * @return \Solarium\Builder\ExpressionInterface
+     */
+    public function getFunction(): ExpressionInterface
+    {
+        return $this->function;
+    }
+}

--- a/src/Builder/ExpressionInterface.php
+++ b/src/Builder/ExpressionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder;
+
+/**
+ * Expression Interface.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+interface ExpressionInterface
+{
+    /**
+     * @param \Solarium\Builder\AbstractExpressionVisitor $visitor
+     *
+     * @return mixed
+     */
+    public function visit(AbstractExpressionVisitor $visitor);
+}

--- a/src/Builder/FunctionInterface.php
+++ b/src/Builder/FunctionInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder;
+
+/**
+ * Reduction Function Interface.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+interface FunctionInterface
+{
+    /**
+     * @return string
+     */
+    public function __toString(): string;
+}

--- a/src/Builder/MappingFunction.php
+++ b/src/Builder/MappingFunction.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder;
+
+/**
+ * Mapping Function.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class MappingFunction implements FunctionInterface, ExpressionInterface
+{
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#negation
+     */
+    public const NEGATION = 'neg';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#absolute-value
+     */
+    public const ABSOLUTE_VALUE = 'abs';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#analytics-round
+     */
+    public const ROUND = 'round';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#ceiling
+     */
+    public const CEILING = 'ceil';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#analytics-floor
+     */
+    public const FLOOR = 'floor';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#addition
+     */
+    public const ADDITION = 'add';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#subtraction
+     */
+    public const SUBTRACTION = 'sub';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#multiplication
+     */
+    public const MULTIPLICATION = 'mult';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#division
+     */
+    public const DIVISION = 'div';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#power
+     */
+    public const POWER = 'pow';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#logarithm
+     */
+    public const LOGARITHM = 'log';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#analytics-and
+     */
+    public const AND = 'and';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#analytics-or
+     */
+    public const OR = 'or';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#exists
+     */
+    public const EXISTS = 'exists';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#equality
+     */
+    public const EQUAL = 'equal';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#greater-than
+     */
+    public const GREATER_THAN = 'gt';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#greater-than-or-equals
+     */
+    public const GREATER_THAN_EQUALS = 'gte';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#less-than
+     */
+    public const LESS_THAN = 'lt';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#less-than-or-equals
+     */
+    public const LESS_THAN_EQUALS = 'lte';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#analytics-top
+     */
+    public const TOP = 'top';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#bottom
+     */
+    public const BOTTOM = 'bottom';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#analytics-if
+     */
+    public const IF = 'if';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#replace
+     */
+    public const REPLACE = 'replace';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#fill-missing
+     */
+    public const FILL_MISSING = 'fill_missing';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#remove
+     */
+    public const REMOVE = 'remove';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#filter
+     */
+    public const FILTER = 'filter';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#date-parse
+     */
+    public const DATE_PARSE = 'date';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#analytics-date-math
+     */
+    public const DATE_MATH = 'date_math';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#explicit-casting
+     */
+    public const STRING = 'string';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#concatenation
+     */
+    public const CONCAT = 'concat';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-mapping-functions.html#separated-concatenation
+     */
+    public const CONCAT_SEPARATED = 'concat_sep';
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var \Solarium\Builder\FunctionInterface[]|float[]|string[]
+     */
+    private $arguments;
+
+    /**
+     * @param string                                                 $type
+     * @param \Solarium\Builder\FunctionInterface[]|float[]|string[] $arguments
+     */
+    public function __construct(string $type, array $arguments)
+    {
+        $this->type = $type;
+
+        foreach ($arguments as $argument) {
+            $this->arguments[] = \is_array($argument) ? sprintf('[%s]', implode(',', $argument)) : $argument;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        return sprintf('%s(%s)', $this->type, implode(',', array_map('strval', $this->arguments)));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function visit(AbstractExpressionVisitor $visitor)
+    {
+        return $visitor->walkExpression($this);
+    }
+}

--- a/src/Builder/ReductionFunction.php
+++ b/src/Builder/ReductionFunction.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Builder;
+
+use Solarium\Exception\RuntimeException;
+
+/**
+ * Reduction Function.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class ReductionFunction implements FunctionInterface, ExpressionInterface
+{
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#count
+     */
+    public const COUNT = 'count';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#doc-count
+     */
+    public const DOC_COUNT = 'doc_count';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#missing
+     */
+    public const MISSING = 'missing';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#analytics-unique
+     */
+    public const UNIQUE = 'unique';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#sum
+     */
+    public const SUM = 'sum';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#variance
+     */
+    public const VARIANCE = 'variance';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#standard-deviation
+     */
+    public const STANDARD_DEVIATION = 'stddev';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#mean
+     */
+    public const MEAN = 'mean';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#weighted-mean
+     */
+    public const WEIGHTED_MEAN = 'wmean';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#minimum
+     */
+    public const MINIMUM = 'min';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#maximum
+     */
+    public const MAXIMUM = 'max';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#median
+     */
+    public const MEDIAN = 'med';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#percentile
+     */
+    public const PERCENTILE = 'percentile';
+
+    /**
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics-reduction-functions.html#ordinal
+     */
+    public const ORDINAL = 'ordinal';
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var \Solarium\Builder\FunctionInterface[]|float[]|string[]
+     */
+    private $arguments;
+
+    /**
+     * @param string                                                 $type
+     * @param \Solarium\Builder\FunctionInterface[]|float[]|string[] $arguments
+     *
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function __construct(string $type, array $arguments)
+    {
+        $this->type = $type;
+
+        foreach ($arguments as $argument) {
+            if ($argument instanceof self) {
+                throw new RuntimeException(sprintf('No reduction function can be an argument of another reduction function %s', (string) $argument));
+            }
+
+            $this->arguments[] = \is_array($argument) ? sprintf('[%s]', implode(',', $argument)) : $argument;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        return sprintf('%s(%s)', $this->type, implode(',', array_map('strval', $this->arguments)));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function visit(AbstractExpressionVisitor $visitor)
+    {
+        return $visitor->walkExpression($this);
+    }
+}

--- a/tests/Builder/Analytics/FunctionBuilderTest.php
+++ b/tests/Builder/Analytics/FunctionBuilderTest.php
@@ -1,0 +1,633 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Tests\Builder\Analytics;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Builder\AbstractExpressionVisitor;
+use Solarium\Builder\Analytics\AnalyticsExpressionVisitor;
+use Solarium\Builder\Analytics\FunctionBuilder;
+use Solarium\Builder\ExpressionInterface;
+use Solarium\Exception\RuntimeException;
+
+/**
+ * FunctionBuilderTest.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class FunctionBuilderTest extends TestCase
+{
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     *
+     * @see https://lucene.apache.org/solr/guide/8_3/analytics.html#example-construction
+     */
+    public function testBuilder(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->div(
+                FunctionBuilder::expr()->sum(
+                    'a',
+                    FunctionBuilder::expr()->fillMissing('b', 0)
+                ),
+                FunctionBuilder::expr()->add(
+                    10.5,
+                    FunctionBuilder::expr()->count(
+                        FunctionBuilder::expr()->mult('a', 'c')
+                    )
+                )
+            ));
+
+        $this->assertSame('div(sum(a,fill_missing(b,0)),add(10.5,count(mult(a,c))))', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testCompositeReductionFunction(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->count(
+                FunctionBuilder::expr()->missing('foo')
+            ));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testVisitExpressions(): void
+    {
+        $mapping = FunctionBuilder::expr()->mult(3.5, [1, -4]);
+
+        $visitor = new AnalyticsExpressionVisitor();
+        $this->assertSame('mult(3.5,[1,-4])', $mapping->visit($visitor));
+
+        $reduction = FunctionBuilder::expr()->count('foo');
+        $this->assertSame('count(foo)', $reduction->visit($visitor));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testVisitor(): void
+    {
+        $visitor = new AnalyticsExpressionVisitor();
+        $reduction = FunctionBuilder::expr()->count('foo');
+
+        $this->assertSame('count(foo)', $visitor->dispatch($reduction));
+    }
+
+    /**
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testVisitUnsupportedExpression(): void
+    {
+        $visitor = new AnalyticsExpressionVisitor();
+        $expression = new ExpressionDummy();
+
+        $this->expectException(RuntimeException::class);
+        $visitor->dispatch($expression);
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testMultiply(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->mult(3.5, [1, -4]));
+
+        $this->assertSame('mult(3.5,[1,-4])', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testCount(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->count('foo'));
+
+        $this->assertSame('count(foo)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testDocCount(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->docCount('foo'));
+
+        $this->assertSame('doc_count(foo)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testMissing(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->missing('foo', 'bar'));
+
+        $this->assertSame('missing(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testUnique(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->unique('foo', 'bar'));
+
+        $this->assertSame('unique(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testSum(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->sum('foo', 'bar'));
+
+        $this->assertSame('sum(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testVariance(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->variance('foo', 'bar'));
+
+        $this->assertSame('variance(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testStddev(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->stddev('foo', 'bar'));
+
+        $this->assertSame('stddev(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testMean(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->mean('foo', 'bar'));
+
+        $this->assertSame('mean(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testWeightedMean(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->weightedMean('foo', 'bar'));
+
+        $this->assertSame('wmean(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testMinimum(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->minimum('foo', 'bar'));
+
+        $this->assertSame('min(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testMaximum(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->maximum('foo', 'bar'));
+
+        $this->assertSame('max(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testMedian(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->median('foo', 'bar'));
+
+        $this->assertSame('med(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testPercentile(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->percentile('foo', 'bar'));
+
+        $this->assertSame('percentile(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Solarium\Exception\RuntimeException
+     */
+    public function testOrdinal(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->ordinal('foo', 'bar'));
+
+        $this->assertSame('ordinal(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testNegation(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->negation('foo', 'bar'));
+
+        $this->assertSame('neg(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testAbsolute(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->absolute('foo', 'bar'));
+
+        $this->assertSame('abs(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testRound(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->round('foo'));
+
+        $this->assertSame('round(foo)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testCeil(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->ceil('foo'));
+
+        $this->assertSame('ceil(foo)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testFloor(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->floor('foo', 'bar'));
+
+        $this->assertSame('floor(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testAdd(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->add('foo', 'bar'));
+
+        $this->assertSame('add(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testSub(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->sub('foo', 'bar'));
+
+        $this->assertSame('sub(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testMult(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->mult('foo', 'bar'));
+
+        $this->assertSame('mult(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testDiv(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->div('foo', 'bar'));
+
+        $this->assertSame('div(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testPower(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->power('foo', 'bar'));
+
+        $this->assertSame('pow(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testLogarithm(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->logarithm('foo', 'bar'));
+
+        $this->assertSame('log(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testAnd(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->and('foo', 'bar'));
+
+        $this->assertSame('and(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testOr(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->or('foo', 'bar'));
+
+        $this->assertSame('or(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testExists(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->exists('foo', 'bar'));
+
+        $this->assertSame('exists(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testEqual(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->equal('foo', 'bar'));
+
+        $this->assertSame('equal(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testGt(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->gt('foo', 'bar'));
+
+        $this->assertSame('gt(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testGte(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->gte('foo', 'bar'));
+
+        $this->assertSame('gte(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testLt(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->lt('foo', 'bar'));
+
+        $this->assertSame('lt(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testLte(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->lte('foo', 'bar'));
+
+        $this->assertSame('lte(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testTop(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->top('foo', 'bar'));
+
+        $this->assertSame('top(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testBottom(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->bottom('foo', 'bar'));
+
+        $this->assertSame('bottom(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testIf(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->if('foo', 'bar'));
+
+        $this->assertSame('if(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testReplace(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->replace('foo', 'bar'));
+
+        $this->assertSame('replace(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testFillMissing(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->fillMissing('foo', 'bar'));
+
+        $this->assertSame('fill_missing(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testRemove(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->remove('foo', 'bar'));
+
+        $this->assertSame('remove(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testFilter(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->filter('foo', 'bar'));
+
+        $this->assertSame('filter(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testDate(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->date('foo', 'bar'));
+
+        $this->assertSame('date(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testDateMath(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->dateMath('foo', 'bar'));
+
+        $this->assertSame('date_math(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testString(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->string('foo', 'bar'));
+
+        $this->assertSame('string(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testConcat(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->concat('foo', 'bar'));
+
+        $this->assertSame('concat(foo,bar)', (string) $builder->getFunction());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testConcatSeparated(): void
+    {
+        $builder = FunctionBuilder::create()
+            ->where(FunctionBuilder::expr()->concatSeparated('foo', 'bar'));
+
+        $this->assertSame('concat_sep(foo,bar)', (string) $builder->getFunction());
+    }
+}
+
+/**
+ * Expression Dummy.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class ExpressionDummy implements ExpressionInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function visit(AbstractExpressionVisitor $visitor)
+    {
+        return $visitor->walkExpression($this);
+    }
+}


### PR DESCRIPTION
like the select query builder the main intention of this builder is to ease writing and maintenance of analytics expressions.

for now no integration with the analytics component which once more, should be fairly easy to do.

also no real sanity checks on the usage of the expression builder other than you're not allowed to inject a reduction function in another reduction function. personally i think solr will return the appropriate error when you've built an errornous expression.

writing an expression could look like something like this
```php
$builder = FunctionBuilder::create()
    ->where(FunctionBuilder::expr()->div(
        FunctionBuilder::expr()->sum(
            'a',
            FunctionBuilder::expr()->fillMissing('b', 0)
        ),
        FunctionBuilder::expr()->add(
            10.5,
            FunctionBuilder::expr()->count(
                FunctionBuilder::expr()->mult('a', 'c')
            )
        )
    ))
;
```
which will result in the following expression:
```php
'div(sum(a,fill_missing(b,0)),add(10.5,count(mult(a,c))))'
```

### note:
no tests / code coverage for the ``AbstractExpressionVisitor`` in this pr which chould be covered in pr #733 
