### PR TITLE
Completed support for updatedSinceInit in Managed Resources

### DIFF
--- a/src/QueryType/ManagedResources/ResponseParser/Stopwords.php
+++ b/src/QueryType/ManagedResources/ResponseParser/Stopwords.php
@@ -29,6 +29,10 @@ class Stopwords extends ResponseParserAbstract implements ResponseParserInterfac
             $parsed['items'] = $wordSet['managedList'];
             $parsed['ignoreCase'] = $wordSet['initArgs']['ignoreCase'];
             $parsed['initializedOn'] = $wordSet['initializedOn'];
+
+            if (isset($wordSet['updatedSinceInit'])) {
+                $parsed['updatedSinceInit'] = $wordSet['updatedSinceInit'];
+            }
         }
 
         $this->addHeaderInfo($data, $parsed);

--- a/src/QueryType/ManagedResources/ResponseParser/Synonyms.php
+++ b/src/QueryType/ManagedResources/ResponseParser/Synonyms.php
@@ -37,6 +37,10 @@ class Synonyms extends ResponseParserAbstract implements ResponseParserInterface
             $parsed['items'] = $items;
             $parsed['ignoreCase'] = $synonymMappings['initArgs']['ignoreCase'];
             $parsed['initializedOn'] = $synonymMappings['initializedOn'];
+
+            if (isset($synonymMappings['updatedSinceInit'])) {
+                $parsed['updatedSinceInit'] = $synonymMappings['updatedSinceInit'];
+            }
         }
 
         $this->addHeaderInfo($data, $parsed);

--- a/src/QueryType/ManagedResources/Result/Stopwords/WordSet.php
+++ b/src/QueryType/ManagedResources/Result/Stopwords/WordSet.php
@@ -33,7 +33,7 @@ class WordSet extends BaseResult implements \IteratorAggregate, \Countable
     /**
      * Datetime when the resource was last updated.
      *
-     * @var string
+     * @var string|null
      */
     protected $updatedSinceInit;
 
@@ -115,5 +115,14 @@ class WordSet extends BaseResult implements \IteratorAggregate, \Countable
     {
         $this->parseResponse();
         return $this->initializedOn;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getUpdatedSinceInit(): ?string
+    {
+        $this->parseResponse();
+        return $this->updatedSinceInit;
     }
 }

--- a/src/QueryType/ManagedResources/Result/Synonyms/SynonymMappings.php
+++ b/src/QueryType/ManagedResources/Result/Synonyms/SynonymMappings.php
@@ -40,7 +40,7 @@ class SynonymMappings extends BaseResult implements \IteratorAggregate, \Countab
     /**
      * Datetime when the resource was last updated.
      *
-     * @var string
+     * @var string|null
      */
     protected $updatedSinceInit;
 
@@ -130,5 +130,14 @@ class SynonymMappings extends BaseResult implements \IteratorAggregate, \Countab
     {
         $this->parseResponse();
         return $this->initializedOn;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getUpdatedSinceInit(): ?string
+    {
+        $this->parseResponse();
+        return $this->updatedSinceInit;
     }
 }

--- a/tests/QueryType/ManagedResources/ResponseParser/StopwordsTest.php
+++ b/tests/QueryType/ManagedResources/ResponseParser/StopwordsTest.php
@@ -12,7 +12,7 @@ class StopwordsTest extends TestCase
 {
     public function testParse()
     {
-        $data = '{ "responseHeader":{ "status":0, "QTime":1 }, "wordSet":{ "initArgs":{"ignoreCase":true}, "initializedOn":"2014-03-28T20:53:53.058Z", "managedList":[ "a", "an", "and", "are" ]}}';
+        $data = '{ "responseHeader":{ "status":0, "QTime":1 }, "wordSet":{ "initArgs":{"ignoreCase":true}, "initializedOn":"2014-03-28T20:53:53.058Z", "updatedSinceInit":"2020-02-03T15:00:25.558Z", "managedList":[ "a", "an", "and", "are" ]}}';
 
         $query = new StopwordsQuery();
         $result = new WordSet($query, new Response($data, ['HTTP 1.1 200 OK']));
@@ -22,6 +22,7 @@ class StopwordsTest extends TestCase
         $parsed = $parser->parse($result);
 
         $this->assertSame('2014-03-28T20:53:53.058Z', $parsed['initializedOn']);
+        $this->assertSame('2020-02-03T15:00:25.558Z', $parsed['updatedSinceInit']);
         $this->assertTrue($parsed['ignoreCase']);
         $this->assertEquals([0 => 'a', 1 => 'an', 2 => 'and', 3 => 'are'], $parsed['items']);
     }

--- a/tests/QueryType/ManagedResources/ResponseParser/SynonymsTest.php
+++ b/tests/QueryType/ManagedResources/ResponseParser/SynonymsTest.php
@@ -13,7 +13,7 @@ class SynonymsTest extends TestCase
 {
     public function testParse()
     {
-        $data = '{ "responseHeader":{ "status":0, "QTime":3}, "synonymMappings":{ "initArgs":{ "ignoreCase":true, "format":"solr"}, "initializedOn":"2014-12-16T22:44:05.33Z", "managedMap":{ "GB": ["GiB", "Gigabyte"], "TV": ["Television"], "happy": ["glad", "joyful"]}}}';
+        $data = '{ "responseHeader":{ "status":0, "QTime":3}, "synonymMappings":{ "initArgs":{ "ignoreCase":true, "format":"solr"}, "initializedOn":"2014-12-16T22:44:05.33Z", "updatedSinceInit":"2020-02-03T00:54:53.049Z", "managedMap":{ "GB": ["GiB", "Gigabyte"], "TV": ["Television"], "happy": ["glad", "joyful"]}}}';
 
         $query = new SynonymsQuery();
         $result = new SynonymMappings($query, new Response($data, ['HTTP 1.1 200 OK']));
@@ -22,6 +22,7 @@ class SynonymsTest extends TestCase
         $parsed = $parser->parse($result);
 
         $this->assertSame('2014-12-16T22:44:05.33Z', $parsed['initializedOn']);
+        $this->assertSame('2020-02-03T00:54:53.049Z', $parsed['updatedSinceInit']);
         $this->assertTrue($parsed['ignoreCase']);
 
         $synonyms =


### PR DESCRIPTION
There already was a variable `$updatedSinceInit` in the Result classes, but it wasn't used. I've added parsing to the ResponseParsers and a getter in the Results.

I've included tests for the ResponseParsers. The Results are currently untested altogether.