### PR TITLE
Raw XML from file in Update query

### DIFF
--- a/docs/queries/update-query/building-an-update-query/rawxml-command.md
+++ b/docs/queries/update-query/building-an-update-query/rawxml-command.md
@@ -38,8 +38,12 @@ $xml = '
 </add>
 ';
 
-// add the XML string and a commit command to the update query
+// or use an XML file containing a valid update command
+$xmlfile = 'example.xml';
+
+// add the XML string, the XML file and a commit command to the update query
 $update->addRawXmlCommand($xml);
+$update->addRawXmlFile($xmlfile);
 $update->addCommit();
 
 // this executes the query and returns the result

--- a/examples/2.2.6-rawxml.php
+++ b/examples/2.2.6-rawxml.php
@@ -25,8 +25,12 @@ $xml = '
 </add>
 ';
 
-// add the XML string and a commit command to the update query
+// or use an XML file containing a valid update command
+$xmlfile = 'example.xml';
+
+// add the XML string, the XML file and a commit command to the update query
 $update->addRawXmlCommand($xml);
+$update->addRawXmlFile($xmlfile);
 $update->addCommit();
 
 // this executes the query and returns the result

--- a/src/QueryType/Update/Query/Command/RawXml.php
+++ b/src/QueryType/Update/Query/Command/RawXml.php
@@ -74,7 +74,7 @@ class RawXml extends AbstractCommand
             throw new RuntimeException('Update query raw XML file path/url invalid or not available');
         }
 
-        // discard UTF-8 Byte Order Marker
+        // discard UTF-8 Byte Order Mark
         if (pack('CCC', 0xEF, 0xBB, 0xBF) === substr($command, 0, 3)) {
             $command = substr($command, 3);
         }

--- a/src/QueryType/Update/Query/Command/RawXml.php
+++ b/src/QueryType/Update/Query/Command/RawXml.php
@@ -2,6 +2,7 @@
 
 namespace Solarium\QueryType\Update\Query\Command;
 
+use Solarium\Exception\RuntimeException;
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 
 /**
@@ -52,6 +53,38 @@ class RawXml extends AbstractCommand
     public function addCommands(array $commands): self
     {
         $this->commands = array_merge($this->commands, $commands);
+
+        return $this;
+    }
+
+    /**
+     * Add an XML command string from a file to the command.
+     *
+     * @param string $filename
+     *
+     * @throws RuntimeException
+     *
+     * @return self Provides fluent interface
+     */
+    public function addCommandFromFile(string $filename): self
+    {
+        $command = @file_get_contents($filename);
+
+        if (false === $command) {
+            throw new RuntimeException('Update query raw XML file path/url invalid or not available');
+        }
+
+        // discard UTF-8 Byte Order Marker
+        if (pack('CCC', 0xEF, 0xBB, 0xBF) === substr($command, 0, 3)) {
+            $command = substr($command, 3);
+        }
+
+        // discard XML declaration
+        if ('<?xml' === substr($command, 0, 5)) {
+            $command = substr($command, strpos($command, '?>') + 2);
+        }
+
+        $this->addCommand($command);
 
         return $this;
     }

--- a/src/QueryType/Update/Query/Query.php
+++ b/src/QueryType/Update/Query/Query.php
@@ -444,6 +444,25 @@ class Query extends BaseQuery
     }
 
     /**
+     * Convenience method for adding a raw XML command from a file.
+     *
+     * If you need more control, like choosing a key for the command you need to
+     * create you own command instance and use the add method.
+     *
+     * @param string $filename
+     *
+     * @return self Provides fluent interface
+     */
+    public function addRawXmlFile(string $filename): self
+    {
+        $raw = new RawXmlCommand();
+
+        $raw->addCommandFromFile($filename);
+
+        return $this->add(null, $raw);
+    }
+
+    /**
      * Set a custom document class for use in the createDocument method.
      *
      * This class should implement the document interface

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -510,8 +510,7 @@ abstract class AbstractTechproductsTest extends TestCase
 
         // add from files without and with Byte Order Mark and XML declaration
         $update = $this->client->createUpdate();
-        foreach (glob(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'testxml[1234]-add*.xml') as $file)
-        {
+        foreach (glob(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'testxml[1234]-add*.xml') as $file) {
             $update->addRawXmlFile($file);
         }
         $update->addCommit(true, true);

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -124,11 +124,13 @@ abstract class AbstractTechproductsTest extends TestCase
         $result = $this->client->select($select);
         $this->assertSame(0, $result->getNumFound());
 
-        $this->assertSame([
-            'power' => 'power',
-            'cort' => 'cord',
-        ],
-        $result->getSpellcheck()->getCollations()[0]->getCorrections());
+        $this->assertSame(
+            [
+                'power' => 'power',
+                'cort' => 'cord',
+            ],
+            $result->getSpellcheck()->getCollations()[0]->getCorrections()
+        );
 
         $words = [];
         foreach ($result->getSpellcheck()->getSuggestions()[0]->getWords() as $suggestion) {
@@ -145,11 +147,13 @@ abstract class AbstractTechproductsTest extends TestCase
         $result = $this->client->select($select);
         $this->assertSame(0, $result->getNumFound());
 
-        $this->assertSame([
-            'power' => 'power',
-            'cort' => 'cord',
-        ],
-        $result->getSpellcheck()->getCollations()[0]->getCorrections());
+        $this->assertSame(
+            [
+                'power' => 'power',
+                'cort' => 'cord',
+            ],
+            $result->getSpellcheck()->getCollations()[0]->getCorrections()
+        );
 
         $select->setQuery('power cord');
         // Activate highlighting.
@@ -166,17 +170,21 @@ abstract class AbstractTechproductsTest extends TestCase
 
         $this->assertSame(
             ['car <b>power</b> adapter, white'],
-            $result->getHighlighting()->getResult('F8V7067-APL-KIT')->getField('features'));
+            $result->getHighlighting()->getResult('F8V7067-APL-KIT')->getField('features')
+        );
 
         $this->assertSame(
             ['Belkin Mobile <b>Power</b> <b>Cord</b> for iPod w&#x2F; Dock'],
-            $result->getHighlighting()->getResult('F8V7067-APL-KIT')->getField('name'));
+            $result->getHighlighting()->getResult('F8V7067-APL-KIT')->getField('name')
+        );
 
-        $this->assertSame([
+        $this->assertSame(
+            [
                 'features' => ['car <b>power</b> adapter, white'],
                 'name' => ['Belkin Mobile <b>Power</b> <b>Cord</b> for iPod w&#x2F; Dock'],
             ],
-            $result->getHighlighting()->getResult('F8V7067-APL-KIT')->getFields());
+            $result->getHighlighting()->getResult('F8V7067-APL-KIT')->getFields()
+        );
 
         foreach ($result->getFacetSet() as $facetFieldName => $facetField) {
             $this->assertSame('stock', $facetFieldName);

--- a/tests/Integration/Fixtures/testxml1-add.xml
+++ b/tests/Integration/Fixtures/testxml1-add.xml
@@ -1,0 +1,14 @@
+<!--
+ test addRawXmlFile with
+ - no Byte Order Mark
+ - no XML declaration
+-->
+
+<add>
+	<doc>
+		<field name="id">solarium-test-1</field>
+		<field name="name">Solarium Test 1</field>
+		<field name="cat">solarium-test</field>
+		<field name="price">3.14</field>
+	</doc>
+</add>

--- a/tests/Integration/Fixtures/testxml2-add-bom.xml
+++ b/tests/Integration/Fixtures/testxml2-add-bom.xml
@@ -1,0 +1,14 @@
+﻿<!--
+ test addRawXmlFile with
+ - UTF-8 Byte Order Mark (U+FEFF)
+ - no XML declaration
+-->
+
+<add>
+	<doc>
+		<field name="id">solarium-test-2</field>
+		<field name="name">Solarium Test 2</field>
+		<field name="cat">solarium-test</field>
+		<field name="price">42.0</field>
+	</doc>
+</add>

--- a/tests/Integration/Fixtures/testxml3-add-declaration.xml
+++ b/tests/Integration/Fixtures/testxml3-add-declaration.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ test addRawXmlFile with
+ - no Byte Order Mark
+ - an XML declaration
+-->
+
+<add>
+	<doc>
+		<field name="id">solarium-test-3</field>
+		<field name="name">Solarium Test 3</field>
+		<field name="cat">solarium-test</field>
+		<field name="price">17.01</field>
+	</doc>
+</add>

--- a/tests/Integration/Fixtures/testxml4-add-bom-declaration.xml
+++ b/tests/Integration/Fixtures/testxml4-add-bom-declaration.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ test addRawXmlFile with
+ - UTF-8 Byte Order Mark (U+FEFF)
+ - an XML declaration
+-->
+
+<add>
+	<doc>
+		<field name="id">solarium-test-4</field>
+		<field name="name">Solarium Test 4</field>
+		<field name="cat">solarium-test</field>
+		<field name="price">3.59</field>
+	</doc>
+</add>

--- a/tests/Integration/Fixtures/testxml5-delete.xml
+++ b/tests/Integration/Fixtures/testxml5-delete.xml
@@ -1,0 +1,16 @@
+<!--
+ test addRawXmlFile with
+ - grouped commands
+ - meanwhile deleting docs added in testxml?-add*.xml
+-->
+
+<update>
+	<delete>
+		<id>solarium-test-1</id>
+		<query>id:solarium-test-2</query>
+	</delete>
+	<delete>
+		<id>solarium-test-3</id>
+		<query>id:solarium-test-4</query>
+	</delete>
+</update>

--- a/tests/QueryType/Update/Query/QueryTest.php
+++ b/tests/QueryType/Update/Query/QueryTest.php
@@ -417,6 +417,27 @@ class QueryTest extends TestCase
         );
     }
 
+    public function testAddRawXmlFile()
+    {
+        $tmpfname = tempnam(sys_get_temp_dir(), 'xml');
+        file_put_contents($tmpfname, '<add><doc><field name="id">1</field></doc></add>');
+
+        $this->query->addRawXmlFile($tmpfname);
+        $commands = $this->query->getCommands();
+
+        $this->assertSame(
+            Query::COMMAND_RAWXML,
+            $commands[0]->getType()
+        );
+
+        $this->assertSame(
+            ['<add><doc><field name="id">1</field></doc></add>'],
+            $commands[0]->getCommands()
+        );
+
+        unlink($tmpfname);
+    }
+
     public function testCreateCommand()
     {
         $type = Query::COMMAND_ROLLBACK;

--- a/tests/QueryType/Update/RequestBuilderTest.php
+++ b/tests/QueryType/Update/RequestBuilderTest.php
@@ -460,12 +460,32 @@ class RequestBuilderTest extends TestCase
     public function testBuildRawXmlXmlGroupedCommands()
     {
         $command = new RawXmlCommand();
-        $command->addCommand('<update><add><doc><field name="id">1</field></doc></add></update>');
-        $command->addCommand(' <update ><add><doc><field name="id">2</field></doc></add></update> ');
-        $command->addCommand('<!-- comment --><update><add><doc><field name="id">3</field></doc></add></update>');
+        $command->addCommand('<update><add><doc><field name="id">1</field></doc></add><add><doc><field name="id">2</field></doc></add></update>');
 
         $this->assertSame(
-            '<add><doc><field name="id">1</field></doc></add><add><doc><field name="id">2</field></doc></add><add><doc><field name="id">3</field></doc></add>',
+            '<add><doc><field name="id">1</field></doc></add><add><doc><field name="id">2</field></doc></add>',
+            $this->builder->buildRawXmlXml($command)
+        );
+    }
+
+    public function testBuildRawXmlXmlGroupedCommandsWithCommentsInsignificantWhitespace()
+    {
+        $command = new RawXmlCommand();
+        $command->addCommand(' <update ><add><doc><field name="id">1</field></doc></add><add><doc><field name="id">2</field></doc></add></update> ');
+
+        $this->assertSame(
+            '<add><doc><field name="id">1</field></doc></add><add><doc><field name="id">2</field></doc></add>',
+            $this->builder->buildRawXmlXml($command)
+        );
+    }
+
+    public function testBuildRawXmlXmlGroupedCommandsWithComments()
+    {
+        $command = new RawXmlCommand();
+        $command->addCommand('<!-- comment --><update><add><doc><field name="id">1</field></doc></add><add><doc><field name="id">2</field></doc></add></update><!-- -->');
+
+        $this->assertSame(
+            '<add><doc><field name="id">1</field></doc></add><add><doc><field name="id">2</field></doc></add>',
             $this->builder->buildRawXmlXml($command)
         );
     }


### PR DESCRIPTION
This is a prerequisite for #751. It deals with the intricacies of reading XML as a string from a file.
- There might be a UTF-8 Byte Order Mark that has to be discarded.
- There might be an XML declaration that has to be discarded.

Other BOMs exist (a.o. for UTF-16 and UTF-32), but U+FEFF is the only one I've ever encountered in the wild.

This PR opens up use cases as well. You could let any tool generate XML files, drop them in a folder and use Solarium as a batch processor without the need for an intermediate format that has to be parsed first.