### PR TITLE
adjust documentation for Client and Adapter changes in 5.2

### DIFF
--- a/docs/customizing-solarium.md
+++ b/docs/customizing-solarium.md
@@ -38,9 +38,10 @@ htmlHeader();
 // And you can use only a part of the flow. You could for instance use the query object and request builder,
 // but execute the request in your own code.
 
+// ...
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // create a select query instance
 $query = $client->createSelect();
@@ -200,7 +201,11 @@ htmlHeader();
 
 // create a client instance and register the plugin
 $plugin = new BasicDebug();
-$client = new Solarium\Client($config);
+
+// ...
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);;
 $client->registerPlugin('debugger', $plugin);
 
 // execute a select query and display the results

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -36,8 +36,10 @@ Example usage
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createQuery($client::QUERY_SELECT);
@@ -144,8 +146,10 @@ Example usage
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ See [<https://packagist.org>](https://packagist.org) for other packages.
 ```json
 {
     "require": {
-        "solarium/solarium": "~5.0.0"
+        "solarium/solarium": "^5.2"
     }
 }
 ```
@@ -55,7 +55,11 @@ htmlHeader();
 echo 'Solarium library version: ' . Solarium\Client::VERSION . ' - ';
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client(
+    new Solarium\Core\Client\Adapter\Curl(), // or any other adapter implementing AdapterInterface
+    new Symfony\Component\EventDispatcher\EventDispatcher(),
+    $config
+);
 
 // create a ping query
 $ping = $client->createPing();
@@ -147,7 +151,11 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client(
+    new Solarium\Core\Client\Adapter\Curl(), // or any other adapter implementing AdapterInterface
+    new Symfony\Component\EventDispatcher\EventDispatcher(),
+    $config
+);
 
 // get a select query instance
 $query = $client->createQuery($client::QUERY_SELECT);
@@ -193,7 +201,11 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client(
+    new Solarium\Core\Client\Adapter\Curl(), // or any other adapter implementing AdapterInterface
+    new Symfony\Component\EventDispatcher\EventDispatcher(),
+    $config
+);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -242,7 +254,11 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client(
+    new Solarium\Core\Client\Adapter\Curl(), // or any other adapter implementing AdapterInterface
+    new Symfony\Component\EventDispatcher\EventDispatcher(),
+    $config
+);
 
 // get an update query instance
 $update = $client->createUpdate();
@@ -271,7 +287,11 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client(
+    new Solarium\Core\Client\Adapter\Curl(), // or any other adapter implementing AdapterInterface
+    new Symfony\Component\EventDispatcher\EventDispatcher(),
+    $config
+);
 
 // get an update query instance
 $update = $client->createUpdate();
@@ -304,7 +324,11 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client(
+    new Solarium\Core\Client\Adapter\Curl(), // or any other adapter implementing AdapterInterface
+    new Symfony\Component\EventDispatcher\EventDispatcher(),
+    $config
+);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -261,8 +261,10 @@ require(__DIR__.'/init.php');
 
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // enable the plugin and get a query instance
 $filter = $client->getPlugin('minimumscorefilter');
@@ -464,8 +466,10 @@ require(__DIR__.'/init.php');
 
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/analysis-query/analysis-document.md
+++ b/docs/queries/analysis-query/analysis-document.md
@@ -34,8 +34,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an analysis document query
 $query = $client->createAnalysisDocument();

--- a/docs/queries/analysis-query/analysis-field.md
+++ b/docs/queries/analysis-query/analysis-field.md
@@ -37,8 +37,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an analysis document query
 $query = $client->createAnalysisField();

--- a/docs/queries/extract-query.md
+++ b/docs/queries/extract-query.md
@@ -36,8 +36,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an extract query instance and add settings
 $query = $client->createExtract();

--- a/docs/queries/ping-query.md
+++ b/docs/queries/ping-query.md
@@ -38,8 +38,10 @@ htmlHeader();
 // check solarium version available
 echo 'Solarium library version: ' . Solarium\Client::VERSION . ' - ';
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // create a ping query
 $ping = $client->createPing();

--- a/docs/queries/query-helper/escaping.md
+++ b/docs/queries/query-helper/escaping.md
@@ -8,8 +8,10 @@ An example of term escaping in use for a query that would fail without escaping:
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/query-helper/placeholders.md
+++ b/docs/queries/query-helper/placeholders.md
@@ -38,8 +38,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/query-helper/query-helper.md
+++ b/docs/queries/query-helper/query-helper.md
@@ -36,8 +36,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance and a query helper instance
 $query = $client->createSelect();

--- a/docs/queries/realtimeget-query.md
+++ b/docs/queries/realtimeget-query.md
@@ -35,8 +35,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/select-query/building-a-select-query/adding-filterqueries.md
+++ b/docs/queries/select-query/building-a-select-query/adding-filterqueries.md
@@ -21,8 +21,10 @@ Examples
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/building-a-select-query.md
+++ b/docs/queries/select-query/building-a-select-query/building-a-select-query.md
@@ -35,8 +35,10 @@ require(__DIR__.'/init.php');
 
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -117,8 +119,10 @@ $select = array(
     ),
 );
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance based on the config
 $query = $client->createSelect($select);

--- a/docs/queries/select-query/building-a-select-query/components/debug-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/debug-component.md
@@ -17,8 +17,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/dismax-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/dismax-component.md
@@ -32,8 +32,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/distributed-search-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/distributed-search-component.md
@@ -20,8 +20,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/edismax-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/edismax-component.md
@@ -31,8 +31,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
@@ -30,8 +30,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-multiquery.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-multiquery.md
@@ -15,8 +15,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-pivot.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-pivot.md
@@ -22,8 +22,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-query.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-query.md
@@ -21,8 +21,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-range.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-range.md
@@ -29,8 +29,10 @@ Examples
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -79,8 +81,10 @@ or when specifying pivot fields:
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/grouping-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/grouping-component.md
@@ -32,8 +32,10 @@ Grouping by field:
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -92,8 +94,10 @@ Grouping by query:
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
@@ -48,8 +48,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -106,8 +108,10 @@ Per-field settings:
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
@@ -26,8 +26,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
@@ -24,8 +24,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/query-rerankquery-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-rerankquery-component.md
@@ -23,8 +23,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/spellcheck-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/spellcheck-component.md
@@ -36,8 +36,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/stats-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/stats-component.md
@@ -18,8 +18,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/executing-a-select-query.md
+++ b/docs/queries/select-query/executing-a-select-query.md
@@ -8,8 +8,10 @@ See the example code below.
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createQuery($client::QUERY_SELECT);

--- a/docs/queries/select-query/result-of-a-select-query/component-results/facetset-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/facetset-result.md
@@ -17,8 +17,10 @@ You can also use the `Countable` interface to get the number of counts.
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -69,8 +71,10 @@ A facet query result is really simple. It has just one value: the count. You can
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -118,8 +122,10 @@ A multiquery facet is basically a combination of multiple facet query instances.
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -174,8 +180,10 @@ A range facet is also similar to a facet field, but instead of field value count
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/result-of-a-select-query/component-results/grouping-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/grouping-result.md
@@ -19,8 +19,10 @@ Grouped by field:
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -79,8 +81,10 @@ Grouped by query:
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/result-of-a-select-query/component-results/highlighting-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/highlighting-result.md
@@ -11,8 +11,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
@@ -11,8 +11,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/result-of-a-select-query/result-of-a-select-query.md
+++ b/docs/queries/select-query/result-of-a-select-query/result-of-a-select-query.md
@@ -42,8 +42,10 @@ A basic usage example:
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createQuery($client::QUERY_SELECT);

--- a/docs/queries/server-query/core-admin-query.md
+++ b/docs/queries/server-query/core-admin-query.md
@@ -13,8 +13,10 @@ The following example shows how your can build a core admin query that executes 
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // create a core admin query
 $coreAdminQuery = $client->createCoreAdmin();

--- a/docs/queries/suggester-query.md
+++ b/docs/queries/suggester-query.md
@@ -34,8 +34,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a suggester query instance
 $query = $client->createSuggester();

--- a/docs/queries/terms-query.md
+++ b/docs/queries/terms-query.md
@@ -43,8 +43,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a terms query instance
 $query = $client->createTerms();

--- a/docs/queries/update-query/building-an-update-query/add-command.md
+++ b/docs/queries/update-query/building-an-update-query/add-command.md
@@ -30,8 +30,10 @@ Examples
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/update-query/building-an-update-query/building-an-update-query.md
+++ b/docs/queries/update-query/building-an-update-query/building-an-update-query.md
@@ -37,8 +37,10 @@ Add documents:
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();
@@ -78,8 +80,10 @@ Delete by query:
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/update-query/building-an-update-query/commit-command.md
+++ b/docs/queries/update-query/building-an-update-query/commit-command.md
@@ -28,8 +28,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/update-query/building-an-update-query/delete-command.md
+++ b/docs/queries/update-query/building-an-update-query/delete-command.md
@@ -16,8 +16,10 @@ Examples
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();
@@ -43,8 +45,10 @@ htmlFooter();
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/update-query/building-an-update-query/optimize-command.md
+++ b/docs/queries/update-query/building-an-update-query/optimize-command.md
@@ -28,8 +28,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/update-query/building-an-update-query/rollback-command.md
+++ b/docs/queries/update-query/building-an-update-query/rollback-command.md
@@ -16,8 +16,10 @@ Example
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/update-query/executing-an-update-query.md
+++ b/docs/queries/update-query/executing-an-update-query.md
@@ -8,8 +8,10 @@ See the example code below.
 require(__DIR__.'/init.php');
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);;
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/solarium-concepts.md
+++ b/docs/solarium-concepts.md
@@ -27,8 +27,10 @@ require(__DIR__.'/init.php');
 
 htmlHeader();
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -107,8 +109,10 @@ $select = array(
     ),
 );
 
+// ...
+
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance based on the config
 $query = $client->createSelect($select);


### PR DESCRIPTION
- addresses change of `Client` constructor signature
- remove mentions of deprecated adapters
- mention new `Psr18Adapter` with an example
- mention new timeout handling