### PR TITLE
AdapterInterface does not extend ConfigurableInterface anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Changed
 - More strict types and type hinting
+- `AdapterInterface` does not extend `ConfigurableInterface` anymore
+- `Http` Adapter does not implement `ConfigurableInterface` anymore
+- `Psr18Adapter` does not implement `ConfigurableInterface` anymore
 
 ### Removed
 - Zend2HttpAdapter

--- a/src/Core/Client/Adapter/AdapterInterface.php
+++ b/src/Core/Client/Adapter/AdapterInterface.php
@@ -5,7 +5,6 @@ namespace Solarium\Core\Client\Adapter;
 use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Core\ConfigurableInterface;
 
 /**
  * Interface for client adapters.
@@ -22,7 +21,7 @@ use Solarium\Core\ConfigurableInterface;
  *
  * However an adapter may also implement all logic by itself if needed.
  */
-interface AdapterInterface extends ConfigurableInterface
+interface AdapterInterface
 {
     /**
      * Execute a request.

--- a/src/Core/Client/Adapter/Http.php
+++ b/src/Core/Client/Adapter/Http.php
@@ -5,13 +5,12 @@ namespace Solarium\Core\Client\Adapter;
 use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Core\Configurable;
 use Solarium\Exception\HttpException;
 
 /**
  * Basic HTTP adapter using a stream.
  */
-class Http extends Configurable implements AdapterInterface, TimeoutAwareInterface
+class Http implements AdapterInterface, TimeoutAwareInterface
 {
     use TimeoutAwareTrait;
 

--- a/src/Core/Client/Adapter/Psr18Adapter.php
+++ b/src/Core/Client/Adapter/Psr18Adapter.php
@@ -11,10 +11,9 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
-use Solarium\Core\Configurable;
 use Solarium\Exception\HttpException;
 
-final class Psr18Adapter extends Configurable implements AdapterInterface
+final class Psr18Adapter implements AdapterInterface
 {
     /**
      * @var ClientInterface
@@ -36,7 +35,6 @@ final class Psr18Adapter extends Configurable implements AdapterInterface
         RequestFactoryInterface $requestFactory,
         StreamFactoryInterface $streamFactory
     ) {
-        parent::__construct();
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;
         $this->streamFactory = $streamFactory;


### PR DESCRIPTION
Closes https://github.com/solariumphp/solarium/issues/774 

- For the `Http` and `Psr18Adapter` I see no reason to implement `ConfigurableInterface`
- `Curl` offers a `proxy` option so its still implementing `ConfigurableInterface`

I would not add any deprecations on 5.x for this because I actually see no way of having useful deprecations that can be removed before moving to 6.0.