### PR TITLE
add phpstan on level 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ before_script:
     fi
 
 script:
+  - vendor/bin/phpstan analyze src/ tests/ --level=1
   - |
      if [ ${SOLR_CLOUD} == "true" ]; then
        vendor/bin/phpunit -c phpunit.xml.travis --exclude-group solr_no_cloud -v || travis_terminate 1;

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
         "nyholm/psr7": "^1.2",
         "php-coveralls/php-coveralls": "^2.1",
         "php-http/guzzle6-adapter": "^2.0",
-        "phpstan/phpstan": "^0.12.18",
+        "phpstan/extension-installer": "^1.0",
+        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^8.0",
         "squizlabs/php_codesniffer": "^3.4",
         "symfony/phpunit-bridge": "^5.0"

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "nyholm/psr7": "^1.2",
         "php-coveralls/php-coveralls": "^2.1",
         "php-http/guzzle6-adapter": "^2.0",
+        "phpstan/phpstan": "^0.12.18",
         "phpunit/phpunit": "^8.0",
         "squizlabs/php_codesniffer": "^3.4",
         "symfony/phpunit-bridge": "^5.0"

--- a/tests/Component/RequestBuilder/ReRankQueryTest.php
+++ b/tests/Component/RequestBuilder/ReRankQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Solarium\Tests\QueryType\Select\RequestBuilder\Component;
+namespace Solarium\Tests\Component\RequestBuilder;
 
 use PHPUnit\Framework\TestCase;
 use Solarium\Component\RequestBuilder\ReRankQuery as RequestBuilder;

--- a/tests/Component/RequestBuilder/SpatialTest.php
+++ b/tests/Component/RequestBuilder/SpatialTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Solarium\Tests\QueryType\Select\RequestBuilder\Component;
+namespace Solarium\Tests\Component\RequestBuilder;
 
 use PHPUnit\Framework\TestCase;
 use Solarium\Component\RequestBuilder\Spatial as RequestBuilder;

--- a/tests/Component/ResponseParser/GroupingTest.php
+++ b/tests/Component/ResponseParser/GroupingTest.php
@@ -91,7 +91,7 @@ class GroupingTest extends TestCase
 
     public function testGroupParsing()
     {
-        $this->assertEquals(3, count($this->result->getGroups()));
+        $this->assertCount(3, $this->result->getGroups());
 
         $fieldGroup = $this->result->getGroup('fieldA');
         $queryGroup = $this->result->getGroup('cat:1');
@@ -109,7 +109,7 @@ class GroupingTest extends TestCase
 
         $this->assertEquals(25, $fieldGroup->getMatches());
         $this->assertEquals(12, $fieldGroup->getNumberOfGroups());
-        $this->assertEquals(1, count($valueGroups));
+        $this->assertCount(1, $valueGroups);
 
         $valueGroup = $valueGroups[0];
         $this->assertEquals(13, $valueGroup->getNumFound());
@@ -179,7 +179,7 @@ class GroupingTest extends TestCase
 
         $this->assertEquals(8, $fieldGroup->getMatches());
         $this->assertEquals(3, $fieldGroup->getNumberOfGroups());
-        $this->assertEquals(1, count($valueGroups));
+        $this->assertCount(1, $valueGroups);
 
         $valueGroup = $valueGroups[0];
         $this->assertEquals(5, $valueGroup->getNumFound());
@@ -215,7 +215,7 @@ class GroupingTest extends TestCase
 
         $this->assertEquals(25, $fieldGroup->getMatches());
         $this->assertEquals(12, $fieldGroup->getNumberOfGroups());
-        $this->assertEquals(1, count($valueGroups));
+        $this->assertCount(1, $valueGroups);
 
         $valueGroup = $valueGroups[0];
         $this->assertEquals(13, $valueGroup->getNumFound());

--- a/tests/Component/Result/Debug/DebugTest.php
+++ b/tests/Component/Result/Debug/DebugTest.php
@@ -99,6 +99,6 @@ class DebugTest extends TestCase
 
     public function testCount()
     {
-        $this->assertEquals(count($this->explain), count($this->result));
+        $this->assertCount(count($this->explain), $this->result);
     }
 }

--- a/tests/Component/Result/Debug/DocumentSetTest.php
+++ b/tests/Component/Result/Debug/DocumentSetTest.php
@@ -59,6 +59,6 @@ class DocumentSetTest extends TestCase
 
     public function testCount()
     {
-        $this->assertEquals(count($this->docs), count($this->result));
+        $this->assertCount(count($this->docs), $this->result);
     }
 }

--- a/tests/Component/Result/Debug/DocumentTest.php
+++ b/tests/Component/Result/Debug/DocumentTest.php
@@ -61,6 +61,6 @@ class DocumentTest extends TestCase
 
     public function testCount()
     {
-        $this->assertEquals(count($this->details), count($this->result));
+        $this->assertCount(count($this->details), $this->result);
     }
 }

--- a/tests/Component/Result/Debug/TimingPhaseTest.php
+++ b/tests/Component/Result/Debug/TimingPhaseTest.php
@@ -69,6 +69,6 @@ class TimingPhaseTest extends TestCase
 
     public function testCount()
     {
-        $this->assertEquals(count($this->timings), count($this->result));
+        $this->assertCount(count($this->timings), $this->result);
     }
 }

--- a/tests/Component/Result/Debug/TimingTest.php
+++ b/tests/Component/Result/Debug/TimingTest.php
@@ -70,6 +70,6 @@ class TimingTest extends TestCase
 
     public function testCount()
     {
-        $this->assertEquals(count($this->phases), count($this->result));
+        $this->assertCount(count($this->phases), $this->result);
     }
 }

--- a/tests/Component/Result/MoreLikeThis/MoreLikeThisTest.php
+++ b/tests/Component/Result/MoreLikeThis/MoreLikeThisTest.php
@@ -63,6 +63,6 @@ class MoreLikeThisTest extends TestCase
 
     public function testCount()
     {
-        $this->assertEquals(count($this->results), count($this->mlt));
+        $this->assertCount(count($this->results), $this->mlt);
     }
 }

--- a/tests/Component/Result/MoreLikeThis/ResultTest.php
+++ b/tests/Component/Result/MoreLikeThis/ResultTest.php
@@ -11,7 +11,12 @@ class ResultTest extends TestCase
     /**
      * @var Result
      */
-    protected $mltResult;
+    private $mltResult;
+
+    /**
+     * @var array
+     */
+    private $docs;
 
     public function setUp(): void
     {

--- a/tests/Component/Result/MoreLikeThis/ResultTest.php
+++ b/tests/Component/Result/MoreLikeThis/ResultTest.php
@@ -55,6 +55,6 @@ class ResultTest extends TestCase
 
     public function testCount()
     {
-        $this->assertEquals(count($this->docs), count($this->mltResult));
+        $this->assertCount(count($this->docs), $this->mltResult);
     }
 }

--- a/tests/Component/Result/Spellcheck/CollationTest.php
+++ b/tests/Component/Result/Spellcheck/CollationTest.php
@@ -57,6 +57,6 @@ class CollationTest extends TestCase
 
     public function testCount()
     {
-        $this->assertEquals(count($this->corrections), count($this->result));
+        $this->assertCount(count($this->corrections), $this->result);
     }
 }

--- a/tests/Component/Result/Spellcheck/SpellcheckTest.php
+++ b/tests/Component/Result/Spellcheck/SpellcheckTest.php
@@ -89,6 +89,6 @@ class SpellcheckTest extends TestCase
 
     public function testCount()
     {
-        $this->assertEquals(count($this->suggestions), count($this->result));
+        $this->assertCount(count($this->suggestions), $this->result);
     }
 }

--- a/tests/Component/Result/Suggester/ResultTest.php
+++ b/tests/Component/Result/Suggester/ResultTest.php
@@ -57,6 +57,6 @@ class ResultTest extends TestCase
 
     public function testCount()
     {
-        $this->assertEquals(count($this->docs), count($this->result));
+        $this->assertCount(count($this->docs), $this->result);
     }
 }

--- a/tests/Component/Result/Suggester/ResultTest.php
+++ b/tests/Component/Result/Suggester/ResultTest.php
@@ -12,7 +12,12 @@ class ResultTest extends TestCase
     /**
      * @var Result
      */
-    protected $result;
+    private $result;
+
+    /**
+     * @var array
+     */
+    private $docs;
 
     public function setUp(): void
     {

--- a/tests/Core/Client/ClientTest.php
+++ b/tests/Core/Client/ClientTest.php
@@ -468,7 +468,7 @@ class ClientTest extends TestCase
     {
         $queryStub = $this->createMock(SelectQuery::class);
 
-        $observer = $this->createMock(AbstractRequestBuilder::class, ['build']);
+        $observer = $this->createMock(AbstractRequestBuilder::class);
         $observer->expects($this->once())
                  ->method('build')
                  ->with($this->equalTo($queryStub))

--- a/tests/Integration/AbstractCoreTest.php
+++ b/tests/Integration/AbstractCoreTest.php
@@ -184,7 +184,7 @@ abstract class AbstractCoreTest extends AbstractTechproductsTest
         $this->assertTrue($response->getWasSuccessful());
 
         $statusResults = $response->getStatusResults();
-        $this->assertSame(2, count($statusResults));
+        $this->assertCount(2, $statusResults);
         $this->assertGreaterThan(0, $statusResults[0]->getUptime(), 'Can not get uptime of first core');
 
         // now we unload the created core again

--- a/tests/Plugin/BufferedAdd/Event/PreCommitTest.php
+++ b/tests/Plugin/BufferedAdd/Event/PreCommitTest.php
@@ -18,10 +18,10 @@ class PreCommitTest extends TestCase
         $event = new PreCommit($buffer, $overwrite, $softCommit, $waitSearcher, $expungeDeletes);
 
         $this->assertSame($buffer, $event->getBuffer());
-        $this->assertSame($overwrite, $event->getOverwrite());
-        $this->assertSame($softCommit, $event->getSoftCommit());
-        $this->assertSame($waitSearcher, $event->getWaitSearcher());
-        $this->assertSame($expungeDeletes, $event->getExpungeDeletes());
+        $this->assertTrue($event->getOverwrite());
+        $this->assertFalse($event->getSoftCommit());
+        $this->assertTrue($event->getWaitSearcher());
+        $this->assertFalse($event->getExpungeDeletes());
 
         return $event;
     }
@@ -45,9 +45,8 @@ class PreCommitTest extends TestCase
      */
     public function testSetAndGetExpungeDeletes($event)
     {
-        $expungeDeletes = true;
-        $event->setExpungeDeletes($expungeDeletes);
-        $this->assertSame($expungeDeletes, $event->getExpungeDeletes());
+        $event->setExpungeDeletes(true);
+        $this->assertTrue($event->getExpungeDeletes());
     }
 
     /**
@@ -57,9 +56,8 @@ class PreCommitTest extends TestCase
      */
     public function testSetAndGetOverwrite($event)
     {
-        $overwrite = false;
-        $event->setOverwrite($overwrite);
-        $this->assertSame($overwrite, $event->getOverwrite());
+        $event->setOverwrite(false);
+        $this->assertFalse($event->getOverwrite());
     }
 
     /**
@@ -69,9 +67,8 @@ class PreCommitTest extends TestCase
      */
     public function testSetAndGetSoftCommit($event)
     {
-        $softCommit = true;
-        $event->setSoftCommit($softCommit);
-        $this->assertSame($softCommit, $event->getSoftCommit());
+        $event->setSoftCommit(true);
+        $this->assertTrue($event->getSoftCommit());
     }
 
     /**
@@ -81,8 +78,7 @@ class PreCommitTest extends TestCase
      */
     public function testSetAndGetWaitSearcher($event)
     {
-        $waitSearcher = false;
-        $event->setWaitSearcher($waitSearcher);
-        $this->assertSame($waitSearcher, $event->getWaitSearcher());
+        $event->setWaitSearcher(false);
+        $this->assertFalse($event->getWaitSearcher());
     }
 }

--- a/tests/Plugin/BufferedAdd/Event/PreFlushTest.php
+++ b/tests/Plugin/BufferedAdd/Event/PreFlushTest.php
@@ -10,13 +10,12 @@ class PreFlushTest extends TestCase
     public function testConstructorAndGetters()
     {
         $buffer = [1, 2, 3];
-        $overwrite = true;
         $commitWithin = 567;
 
-        $event = new PreFlush($buffer, $overwrite, $commitWithin);
+        $event = new PreFlush($buffer, true, $commitWithin);
 
         $this->assertSame($buffer, $event->getBuffer());
-        $this->assertSame($overwrite, $event->getOverwrite());
+        $this->assertTrue($event->getOverwrite());
         $this->assertSame($commitWithin, $event->getCommitWithin());
 
         return $event;
@@ -53,8 +52,7 @@ class PreFlushTest extends TestCase
      */
     public function testSetAndGetOverwrite($event)
     {
-        $overwrite = false;
-        $event->setOverwrite($overwrite);
-        $this->assertSame($overwrite, $event->getOverwrite());
+        $event->setOverwrite(false);
+        $this->assertFalse($event->getOverwrite());
     }
 }

--- a/tests/Plugin/CustomizeRequest/CustomizationTest.php
+++ b/tests/Plugin/CustomizeRequest/CustomizationTest.php
@@ -47,16 +47,14 @@ class CustomizationTest extends TestCase
 
     public function testSetAndGetPersistence()
     {
-        $value = true;
-        $this->instance->setPersistent($value);
-        $this->assertSame($value, $this->instance->getPersistent());
+        $this->instance->setPersistent(true);
+        $this->assertTrue($this->instance->getPersistent());
     }
 
     public function testSetAndGetOverwrite()
     {
-        $value = false;
-        $this->instance->setOverwrite($value);
-        $this->assertSame($value, $this->instance->getOverwrite());
+        $this->instance->setOverwrite(false);
+        $this->assertFalse($this->instance->getOverwrite());
     }
 
     public function testIsValid()

--- a/tests/Plugin/CustomizeRequest/CustomizeRequestTest.php
+++ b/tests/Plugin/CustomizeRequest/CustomizeRequestTest.php
@@ -122,7 +122,7 @@ class CustomizeRequestTest extends TestCase
         $this->assertSame($input['type'], $customization->getType());
         $this->assertSame($input['name'], $customization->getName());
         $this->assertSame($input['value'], $customization->getValue());
-        $this->assertSame($input['persistent'], $customization->getPersistent());
+        $this->assertTrue($customization->getPersistent());
     }
 
     public function testAddAndGetCustomization()

--- a/tests/Plugin/Loadbalancer/LoadbalancerTest.php
+++ b/tests/Plugin/Loadbalancer/LoadbalancerTest.php
@@ -13,6 +13,7 @@ use Solarium\Core\Event\PreCreateRequest as PreCreateRequestEvent;
 use Solarium\Core\Event\PreExecuteRequest as PreExecuteRequestEvent;
 use Solarium\Exception\HttpException;
 use Solarium\Exception\InvalidArgumentException;
+use Solarium\Exception\RuntimeException;
 use Solarium\Plugin\Loadbalancer\Loadbalancer;
 use Solarium\QueryType\Select\Query\Query as SelectQuery;
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;
@@ -435,10 +436,7 @@ class LoadbalancerTest extends TestCase
         $event = new PreCreateRequestEvent($query);
         $this->plugin->preCreateRequest($event);
 
-        $this->expectException(
-            'Solarium\Exception\RuntimeException',
-            'Maximum number of loadbalancer retries reached'
-        );
+        $this->expectException(RuntimeException::class);
 
         $event = new PreExecuteRequestEvent($request, new Endpoint());
         $this->plugin->preExecuteRequest($event);

--- a/tests/Plugin/MinimumScoreFilter/ResultTest.php
+++ b/tests/Plugin/MinimumScoreFilter/ResultTest.php
@@ -35,7 +35,7 @@ class ResultTest extends AbstractResultTest
 
     public function testGetDocuments()
     {
-        $this->assertSame(count($this->docs), count($this->result->getDocuments()));
+        $this->assertCount(count($this->docs), $this->result->getDocuments());
     }
 
     public function testIteratorWithRemoveFilter()

--- a/tests/QueryType/Analysis/Query/QueryTest.php
+++ b/tests/QueryType/Analysis/Query/QueryTest.php
@@ -32,10 +32,8 @@ class QueryTest extends TestCase
 
     public function testSetAndGetShowMatch()
     {
-        $show = true;
-
-        $this->query->setShowMatch($show);
-        $this->assertSame($show, $this->query->getShowMatch());
+        $this->query->setShowMatch(true);
+        $this->assertTrue($this->query->getShowMatch());
     }
 }
 

--- a/tests/QueryType/Analysis/ResponseParser/DocumentTest.php
+++ b/tests/QueryType/Analysis/ResponseParser/DocumentTest.php
@@ -35,7 +35,7 @@ class DocumentTest extends TestCase
 
         $result = $parserStub->parse($resultStub);
 
-        $this->assertSame(count($data['analysis']), count($result['items']));
+        $this->assertCount(count($data['analysis']), $result['items']);
         $this->assertSame('key2', $result['items'][1]->getName());
     }
 }

--- a/tests/QueryType/Analysis/Result/DocumentTest.php
+++ b/tests/QueryType/Analysis/Result/DocumentTest.php
@@ -32,7 +32,7 @@ class DocumentTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->items), count($this->result));
+        $this->assertCount(count($this->items), $this->result);
     }
 
     public function testIterator()

--- a/tests/QueryType/Analysis/Result/FieldTest.php
+++ b/tests/QueryType/Analysis/Result/FieldTest.php
@@ -27,7 +27,7 @@ class FieldTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->items), count($this->result));
+        $this->assertCount(count($this->items), $this->result);
     }
 
     public function testIterator()

--- a/tests/QueryType/Analysis/Result/ResultListTest.php
+++ b/tests/QueryType/Analysis/Result/ResultListTest.php
@@ -30,7 +30,7 @@ class ResultListTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->items), count($this->result));
+        $this->assertCount(count($this->items), $this->result);
     }
 
     public function testIterator()

--- a/tests/QueryType/Analysis/Result/TypesTest.php
+++ b/tests/QueryType/Analysis/Result/TypesTest.php
@@ -34,7 +34,7 @@ class TypesTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->items), count($this->result));
+        $this->assertCount(count($this->items), $this->result);
     }
 
     public function testIterator()

--- a/tests/QueryType/Graph/QueryTest.php
+++ b/tests/QueryType/Graph/QueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Solarium\Tests\QueryType\Graph\Query;
+namespace Solarium\Tests\QueryType\Graph;
 
 use PHPUnit\Framework\TestCase;
 use Solarium\QueryType\Graph\Query;

--- a/tests/QueryType/ManagedResources/QueryTest.php
+++ b/tests/QueryType/ManagedResources/QueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Solarium\Tests\QueryType\ManagedResources\Resources;
+namespace Solarium\Tests\QueryType\ManagedResources;
 
 use PHPUnit\Framework\TestCase;
 use Solarium\Core\Client\Client;

--- a/tests/QueryType/ManagedResources/RequestBuilder/ResourcesTest.php
+++ b/tests/QueryType/ManagedResources/RequestBuilder/ResourcesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Solarium\Tests\QueryType\ManagedResources\Resources\RequestBuilder;
+namespace Solarium\Tests\QueryType\ManagedResources\RequestBuilder;
 
 use PHPUnit\Framework\TestCase;
 use Solarium\QueryType\ManagedResources\Query\Resources as ResourcesQuery;

--- a/tests/QueryType/ManagedResources/RequestBuilder/StopwordsTest.php
+++ b/tests/QueryType/ManagedResources/RequestBuilder/StopwordsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Solarium\Tests\QueryType\ManagedResources\Resources\RequestBuilder;
+namespace Solarium\Tests\QueryType\ManagedResources\RequestBuilder;
 
 use PHPUnit\Framework\TestCase;
 use Solarium\Core\Client\Request;

--- a/tests/QueryType/ManagedResources/RequestBuilder/SynonymsTest.php
+++ b/tests/QueryType/ManagedResources/RequestBuilder/SynonymsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Solarium\Tests\QueryType\ManagedResources\Resources\RequestBuilder;
+namespace Solarium\Tests\QueryType\ManagedResources\RequestBuilder;
 
 use PHPUnit\Framework\TestCase;
 use Solarium\Core\Client\Client;

--- a/tests/QueryType/ManagedResources/ResponseParser/ResourcesTest.php
+++ b/tests/QueryType/ManagedResources/ResponseParser/ResourcesTest.php
@@ -40,7 +40,7 @@ class ResourcesTest extends TestCase
 
         $result = $parser->parse($resultStub);
 
-        $this->assertSame(count($data['managedResources']), count($result['items']));
+        $this->assertCount(count($data['managedResources']), $result['items']);
         $this->assertSame('/schema/analysis/stopwords/dutch', $result['items'][0]->getResourceId());
         $this->assertSame(1, $result['items'][0]->getNumObservers());
         $this->assertSame('org.apache.solr.rest.schema.analysis.ManagedWordSetResource', $result['items'][0]->getClass());

--- a/tests/QueryType/MoreLikeThis/QueryTest.php
+++ b/tests/QueryType/MoreLikeThis/QueryTest.php
@@ -627,13 +627,8 @@ class QueryTest extends TestCase
 
     public function testSetAndGetMatchInclude()
     {
-        $value = true;
-        $this->query->setMatchInclude($value);
-
-        $this->assertSame(
-            $value,
-            $this->query->getMatchInclude()
-        );
+        $this->query->setMatchInclude(true);
+        $this->assertTrue($this->query->getMatchInclude());
     }
 
     public function testSetAndGetMatchOffset()
@@ -682,13 +677,8 @@ class QueryTest extends TestCase
 
     public function testSetAndGetQueryStream()
     {
-        $value = true;
-        $this->query->setQueryStream($value);
-
-        $this->assertSame(
-            $value,
-            $this->query->getQueryStream()
-        );
+        $this->query->setQueryStream(true);
+        $this->assertTrue($this->query->getQueryStream());
     }
 
     public function testSetAndGetMinimumTermFrequency()
@@ -759,13 +749,8 @@ class QueryTest extends TestCase
 
     public function testSetAndGetBoost()
     {
-        $value = true;
-        $this->query->setBoost($value);
-
-        $this->assertSame(
-            $value,
-            $this->query->getBoost()
-        );
+        $this->query->setBoost(true);
+        $this->assertTrue($this->query->getBoost());
     }
 
     public function testSetAndGetQueryFields()

--- a/tests/QueryType/Select/Query/AbstractQueryTest.php
+++ b/tests/QueryType/Select/Query/AbstractQueryTest.php
@@ -430,7 +430,7 @@ abstract class AbstractQueryTest extends TestCase
         $this->assertSame($config['documentclass'], $query->getDocumentClass());
         $this->assertSame($config['resultclass'], $query->getResultClass());
         $this->assertSame($config['cursormark'], $query->getCursormark());
-        $this->assertSame($config['splitonwhitespace'], $query->getSplitOnWhitespace());
+        $this->assertFalse($query->getSplitOnWhitespace());
         $this->assertSame('published:true', $query->getFilterQuery('pub')->getQuery());
         $this->assertSame('online:true', $query->getFilterQuery('online')->getQuery());
 

--- a/tests/QueryType/Select/Query/Component/Facet/FieldTest.php
+++ b/tests/QueryType/Select/Query/Component/Facet/FieldTest.php
@@ -43,10 +43,10 @@ class FieldTest extends TestCase
         $this->assertSame($options['limit'], $this->facet->getLimit());
         $this->assertSame($options['offset'], $this->facet->getOffset());
         $this->assertSame($options['mincount'], $this->facet->getMinCount());
-        $this->assertSame($options['missing'], $this->facet->getMissing());
+        $this->assertTrue($this->facet->getMissing());
         $this->assertSame($options['method'], $this->facet->getMethod());
         $this->assertSame($options['contains'], $this->facet->getContains());
-        $this->assertSame($options['containsignorecase'], $this->facet->getContainsIgnoreCase());
+        $this->assertTrue($this->facet->getContainsIgnoreCase());
     }
 
     public function testGetType()

--- a/tests/QueryType/Select/Query/Component/Facet/JsonRangeTest.php
+++ b/tests/QueryType/Select/Query/Component/Facet/JsonRangeTest.php
@@ -38,7 +38,7 @@ class JsonRangeTest extends TestCase
         $this->assertSame((string) $options['start'], $this->facet->getStart());
         $this->assertSame((string) $options['end'], $this->facet->getEnd());
         $this->assertSame((string) $options['gap'], $this->facet->getGap());
-        $this->assertSame($options['hardend'], $this->facet->getHardend());
+        $this->assertTrue($this->facet->getHardend());
         $this->assertSame([$options['other']], $this->facet->getOther());
         $this->assertSame([$options['include']], $this->facet->getInclude());
     }

--- a/tests/QueryType/Select/Query/Component/Facet/JsonTermsTest.php
+++ b/tests/QueryType/Select/Query/Component/Facet/JsonTermsTest.php
@@ -43,12 +43,12 @@ class JsonTermsTest extends TestCase
         $this->assertSame($options['limit'], $this->facet->getLimit());
         $this->assertSame($options['offset'], $this->facet->getOffset());
         $this->assertSame($options['mincount'], $this->facet->getMinCount());
-        $this->assertSame($options['missing'], $this->facet->getMissing());
+        $this->assertTrue($this->facet->getMissing());
         $this->assertSame($options['method'], $this->facet->getMethod());
-        $this->assertSame($options['refine'], $this->facet->getRefine());
+        $this->assertTrue($this->facet->getRefine());
         $this->assertSame($options['overrequest'], $this->facet->getOverRequest());
-        $this->assertSame($options['numBuckets'], $this->facet->getNumBuckets());
-        $this->assertSame($options['allBuckets'], $this->facet->getAllBuckets());
+        $this->assertTrue($this->facet->getNumBuckets());
+        $this->assertTrue($this->facet->getAllBuckets());
     }
 
     public function testGetType()

--- a/tests/QueryType/Select/Query/Component/Facet/RangeTest.php
+++ b/tests/QueryType/Select/Query/Component/Facet/RangeTest.php
@@ -42,7 +42,7 @@ class RangeTest extends TestCase
         $this->assertSame((string) $options['start'], $this->facet->getStart());
         $this->assertSame((string) $options['end'], $this->facet->getEnd());
         $this->assertSame((string) $options['gap'], $this->facet->getGap());
-        $this->assertSame($options['hardend'], $this->facet->getHardend());
+        $this->assertTrue($this->facet->getHardend());
         $this->assertSame([$options['other']], $this->facet->getOther());
         $this->assertSame([$options['include']], $this->facet->getInclude());
     }

--- a/tests/QueryType/Select/Query/Component/FacetSetTest.php
+++ b/tests/QueryType/Select/Query/Component/FacetSetTest.php
@@ -46,14 +46,14 @@ class FacetSetTest extends TestCase
         $this->facetSet->setOptions($options);
         $facets = $this->facetSet->getFacets();
 
-        $this->assertSame(2, count($facets));
+        $this->assertCount(2, $facets);
         $this->assertSame($options['prefix'], $this->facetSet->getPrefix());
         $this->assertSame($options['sort'], $this->facetSet->getSort());
         $this->assertSame($options['mincount'], $this->facetSet->getMinCount());
-        $this->assertSame($options['missing'], $this->facetSet->getMissing());
-        $this->assertSame($options['extractfromresponse'], $this->facetSet->getExtractFromResponse());
+        $this->assertTrue($this->facetSet->getMissing());
+        $this->assertTrue($this->facetSet->getExtractFromResponse());
         $this->assertSame($options['contains'], $this->facetSet->getContains());
-        $this->assertSame($options['containsignorecase'], $this->facetSet->getContainsIgnoreCase());
+        $this->assertTrue($this->facetSet->getContainsIgnoreCase());
     }
 
     public function testGetType()
@@ -174,10 +174,7 @@ class FacetSetTest extends TestCase
 
         $this->facetSet->addFacets($facets);
 
-        $this->assertSame(
-            2,
-            count($this->facetSet->getFacets())
-        );
+        $this->assertCount(2, $this->facetSet->getFacets());
     }
 
     public function testRemoveFacet()

--- a/tests/QueryType/Select/Query/Component/GroupingTest.php
+++ b/tests/QueryType/Select/Query/Component/GroupingTest.php
@@ -195,7 +195,6 @@ class GroupingTest extends TestCase
     {
         $this->grouping->setNumberOfGroups(true);
         $this->assertTrue($this->grouping->getNumberOfGroups());
-
     }
 
     public function testSetAndGetCachePercentage()

--- a/tests/QueryType/Select/Query/Component/GroupingTest.php
+++ b/tests/QueryType/Select/Query/Component/GroupingTest.php
@@ -42,13 +42,13 @@ class GroupingTest extends TestCase
         $this->assertSame($options['limit'], $this->grouping->getLimit());
         $this->assertSame($options['offset'], $this->grouping->getOffset());
         $this->assertSame($options['sort'], $this->grouping->getSort());
-        $this->assertSame($options['mainresult'], $this->grouping->getMainResult());
-        $this->assertSame($options['numberofgroups'], $this->grouping->getNumberOfGroups());
+        $this->assertFalse($this->grouping->getMainResult());
+        $this->assertTrue($this->grouping->getNumberOfGroups());
         $this->assertSame($options['cachepercentage'], $this->grouping->getCachePercentage());
-        $this->assertSame($options['truncate'], $this->grouping->getTruncate());
+        $this->assertTrue($this->grouping->getTruncate());
         $this->assertSame($options['function'], $this->grouping->getFunction());
         $this->assertSame($options['format'], $this->grouping->getFormat());
-        $this->assertSame($options['facet'], $this->grouping->getFacet());
+        $this->assertTrue($this->grouping->getFacet());
     }
 
     public function testGetType()
@@ -187,24 +187,15 @@ class GroupingTest extends TestCase
 
     public function testSetAndGetMainResult()
     {
-        $value = true;
-        $this->grouping->setMainResult($value);
-
-        $this->assertSame(
-            $value,
-            $this->grouping->getMainResult()
-        );
+        $this->grouping->setMainResult(true);
+        $this->assertTrue($this->grouping->getMainResult());
     }
 
     public function testSetAndGetNumberOfGroups()
     {
-        $value = true;
-        $this->grouping->setNumberOfGroups($value);
+        $this->grouping->setNumberOfGroups(true);
+        $this->assertTrue($this->grouping->getNumberOfGroups());
 
-        $this->assertSame(
-            $value,
-            $this->grouping->getNumberOfGroups()
-        );
     }
 
     public function testSetAndGetCachePercentage()
@@ -220,13 +211,8 @@ class GroupingTest extends TestCase
 
     public function testSetAndGetTruncate()
     {
-        $value = true;
-        $this->grouping->setTruncate($value);
-
-        $this->assertSame(
-            $value,
-            $this->grouping->getTruncate()
-        );
+        $this->grouping->setTruncate(true);
+        $this->assertTrue($this->grouping->getTruncate());
     }
 
     public function testSetAndGetFunction()
@@ -253,12 +239,7 @@ class GroupingTest extends TestCase
 
     public function testSetAndGetFacet()
     {
-        $value = true;
-        $this->grouping->setFacet($value);
-
-        $this->assertSame(
-            $value,
-            $this->grouping->getFacet()
-        );
+        $this->grouping->setFacet(true);
+        $this->assertTrue($this->grouping->getFacet());
     }
 }

--- a/tests/QueryType/Select/Query/Component/Highlighting/FieldTest.php
+++ b/tests/QueryType/Select/Query/Component/Highlighting/FieldTest.php
@@ -82,13 +82,8 @@ class FieldTest extends TestCase
 
     public function testSetAndGetMergeContiguous()
     {
-        $value = true;
-        $this->fld->setMergeContiguous($value);
-
-        $this->assertSame(
-            $value,
-            $this->fld->getMergeContiguous()
-        );
+        $this->fld->setMergeContiguous(true);
+        $this->assertTrue($this->fld->getMergeContiguous());
     }
 
     public function testSetAndGetAlternateField()
@@ -104,13 +99,8 @@ class FieldTest extends TestCase
 
     public function testSetAndGetPreserveMulti()
     {
-        $value = true;
-        $this->fld->setPreserveMulti($value);
-
-        $this->assertSame(
-            $value,
-            $this->fld->getPreserveMulti()
-        );
+        $this->fld->setPreserveMulti(true);
+        $this->assertTrue($this->fld->getPreserveMulti());
     }
 
     public function testSetAndGetFormatter()
@@ -158,12 +148,7 @@ class FieldTest extends TestCase
 
     public function testSetAndGetUseFastVectorHighlighter()
     {
-        $value = true;
-        $this->fld->setUseFastVectorHighlighter($value);
-
-        $this->assertSame(
-            $value,
-            $this->fld->getUseFastVectorHighlighter()
-        );
+        $this->fld->setUseFastVectorHighlighter(true);
+        $this->assertTrue($this->fld->getUseFastVectorHighlighter());
     }
 }

--- a/tests/QueryType/Select/Query/Component/Highlighting/HighlightingTest.php
+++ b/tests/QueryType/Select/Query/Component/Highlighting/HighlightingTest.php
@@ -69,11 +69,11 @@ class HighlightingTest extends TestCase
         $this->assertNull($this->hlt->getField('FieldB')->getSnippets());
         $this->assertSame($options['snippets'], $this->hlt->getSnippets());
         $this->assertSame($options['fragsize'], $this->hlt->getFragSize());
-        $this->assertSame($options['mergecontiguous'], $this->hlt->getMergeContiguous());
+        $this->assertTrue($this->hlt->getMergeContiguous());
         $this->assertSame($options['maxanalyzedchars'], $this->hlt->getMaxAnalyzedChars());
         $this->assertSame($options['alternatefield'], $this->hlt->getAlternateField());
         $this->assertSame($options['maxalternatefieldlength'], $this->hlt->getMaxAlternateFieldLength());
-        $this->assertSame($options['preservemulti'], $this->hlt->getPreserveMulti());
+        $this->assertTrue($this->hlt->getPreserveMulti());
         $this->assertSame($options['formatter'], $this->hlt->getFormatter());
         $this->assertSame($options['simpleprefix'], $this->hlt->getSimplePrefix());
         $this->assertSame($options['simplepostfix'], $this->hlt->getSimplePostfix());
@@ -82,9 +82,9 @@ class HighlightingTest extends TestCase
         $this->assertSame($options['fragmenter'], $this->hlt->getFragmenter());
         $this->assertSame($options['fraglistbuilder'], $this->hlt->getFragListBuilder());
         $this->assertSame($options['fragmentsbuilder'], $this->hlt->getFragmentsBuilder());
-        $this->assertSame($options['usefastvectorhighlighter'], $this->hlt->getUseFastVectorHighlighter());
-        $this->assertSame($options['usephrasehighlighter'], $this->hlt->getUsePhraseHighlighter());
-        $this->assertSame($options['highlightmultiterm'], $this->hlt->getHighlightMultiTerm());
+        $this->assertTrue($this->hlt->getUseFastVectorHighlighter());
+        $this->assertFalse($this->hlt->getUsePhraseHighlighter());
+        $this->assertTrue($this->hlt->getHighlightMultiTerm());
         $this->assertSame($options['regexslop'], $this->hlt->getRegexSlop());
         $this->assertSame($options['regexpattern'], $this->hlt->getRegexPattern());
         $this->assertSame($options['regexmaxanalyzedchars'], $this->hlt->getRegexMaxAnalyzedChars());
@@ -276,24 +276,14 @@ class HighlightingTest extends TestCase
 
     public function testSetAndGetMergeContiguous()
     {
-        $value = true;
-        $this->hlt->setMergeContiguous($value);
-
-        $this->assertSame(
-            $value,
-            $this->hlt->getMergeContiguous()
-        );
+        $this->hlt->setMergeContiguous(true);
+        $this->assertTrue($this->hlt->getMergeContiguous());
     }
 
     public function testSetAndGetRequireFieldMatch()
     {
-        $value = true;
-        $this->hlt->setRequireFieldMatch($value);
-
-        $this->assertSame(
-            $value,
-            $this->hlt->getRequireFieldMatch()
-        );
+        $this->hlt->setRequireFieldMatch(true);
+        $this->assertTrue($this->hlt->getRequireFieldMatch());
     }
 
     public function testSetAndGetMaxAnalyzedChars()
@@ -331,13 +321,8 @@ class HighlightingTest extends TestCase
 
     public function testSetAndGetPreserveMulti()
     {
-        $value = true;
-        $this->hlt->setPreserveMulti($value);
-
-        $this->assertSame(
-            $value,
-            $this->hlt->getPreserveMulti()
-        );
+        $this->hlt->setPreserveMulti(true);
+        $this->assertTrue($this->hlt->getPreserveMulti());
     }
 
     public function testSetAndGetFormatter()
@@ -407,35 +392,20 @@ class HighlightingTest extends TestCase
 
     public function testSetAndGetUseFastVectorHighlighter()
     {
-        $value = true;
-        $this->hlt->setUseFastVectorHighlighter($value);
-
-        $this->assertSame(
-            $value,
-            $this->hlt->getUseFastVectorHighlighter()
-        );
+        $this->hlt->setUseFastVectorHighlighter(true);
+        $this->assertTrue($this->hlt->getUseFastVectorHighlighter());
     }
 
     public function testSetAndGetUsePhraseHighlighter()
     {
-        $value = true;
-        $this->hlt->setUsePhraseHighlighter($value);
-
-        $this->assertSame(
-            $value,
-            $this->hlt->getUsePhraseHighlighter()
-        );
+        $this->hlt->setUsePhraseHighlighter(true);
+        $this->assertTrue($this->hlt->getUsePhraseHighlighter());
     }
 
     public function testSetAndGetHighlightMultiTerm()
     {
-        $value = true;
-        $this->hlt->setHighlightMultiTerm($value);
-
-        $this->assertSame(
-            $value,
-            $this->hlt->getHighlightMultiTerm()
-        );
+        $this->hlt->setHighlightMultiTerm(true);
+        $this->assertTrue($this->hlt->getHighlightMultiTerm());
     }
 
     public function testSetAndGetRegexSlop()

--- a/tests/QueryType/Select/Result/AbstractDocumentTest.php
+++ b/tests/QueryType/Select/Result/AbstractDocumentTest.php
@@ -112,6 +112,6 @@ abstract class AbstractDocumentTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->fields), count($this->doc));
+        $this->assertCount(count($this->fields), $this->doc);
     }
 }

--- a/tests/QueryType/Select/Result/Facet/FieldTest.php
+++ b/tests/QueryType/Select/Result/Facet/FieldTest.php
@@ -28,7 +28,7 @@ class FieldTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->values), count($this->facet));
+        $this->assertCount(count($this->values), $this->facet);
     }
 
     public function testIterator()

--- a/tests/QueryType/Select/Result/Facet/MultiQueryTest.php
+++ b/tests/QueryType/Select/Result/Facet/MultiQueryTest.php
@@ -28,7 +28,7 @@ class MultiQueryTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->values), count($this->facet));
+        $this->assertCount(count($this->values), $this->facet);
     }
 
     public function testIterator()

--- a/tests/QueryType/Select/Result/Facet/Pivot/PivotItemTest.php
+++ b/tests/QueryType/Select/Result/Facet/Pivot/PivotItemTest.php
@@ -45,6 +45,6 @@ class PivotItemTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->values['pivot']), count($this->pivotItem));
+        $this->assertCount(count($this->values['pivot']), $this->pivotItem);
     }
 }

--- a/tests/QueryType/Select/Result/Facet/Pivot/PivotTest.php
+++ b/tests/QueryType/Select/Result/Facet/Pivot/PivotTest.php
@@ -36,6 +36,6 @@ class PivotTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->values), count($this->facet));
+        $this->assertCount(count($this->values), $this->facet);
     }
 }

--- a/tests/QueryType/Select/Result/Facet/RangeTest.php
+++ b/tests/QueryType/Select/Result/Facet/RangeTest.php
@@ -59,7 +59,7 @@ class RangeTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->values), count($this->facet));
+        $this->assertCount(count($this->values), $this->facet);
     }
 
     public function testIterator()

--- a/tests/QueryType/Select/Result/FacetSetTest.php
+++ b/tests/QueryType/Select/Result/FacetSetTest.php
@@ -58,7 +58,7 @@ class FacetSetTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->facets), count($this->result));
+        $this->assertCount(count($this->facets), $this->result);
     }
 }
 

--- a/tests/QueryType/Select/Result/Grouping/FieldGroupTest.php
+++ b/tests/QueryType/Select/Result/Grouping/FieldGroupTest.php
@@ -59,6 +59,6 @@ class FieldGroupTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->items), count($this->group));
+        $this->assertCount(count($this->items), $this->group);
     }
 }

--- a/tests/QueryType/Select/Result/Grouping/GroupingTest.php
+++ b/tests/QueryType/Select/Result/Grouping/GroupingTest.php
@@ -51,6 +51,6 @@ class GroupingTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->items), count($this->grouping));
+        $this->assertCount(count($this->items), $this->grouping);
     }
 }

--- a/tests/QueryType/Select/Result/Grouping/QueryGroupTest.php
+++ b/tests/QueryType/Select/Result/Grouping/QueryGroupTest.php
@@ -74,6 +74,6 @@ class QueryGroupTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->items), count($this->group));
+        $this->assertCount(count($this->items), $this->group);
     }
 }

--- a/tests/QueryType/Select/Result/Grouping/ValueGroupTest.php
+++ b/tests/QueryType/Select/Result/Grouping/ValueGroupTest.php
@@ -66,6 +66,6 @@ class ValueGroupTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->items), count($this->group));
+        $this->assertCount(count($this->items), $this->group);
     }
 }

--- a/tests/QueryType/Select/Result/Highlighting/HighlightingTest.php
+++ b/tests/QueryType/Select/Result/Highlighting/HighlightingTest.php
@@ -57,6 +57,6 @@ class HighlightingTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->items), count($this->result));
+        $this->assertCount(count($this->items), $this->result);
     }
 }

--- a/tests/QueryType/Select/Result/Highlighting/ResultTest.php
+++ b/tests/QueryType/Select/Result/Highlighting/ResultTest.php
@@ -57,6 +57,6 @@ class ResultTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->fields), count($this->result));
+        $this->assertCount(count($this->fields), $this->result);
     }
 }

--- a/tests/QueryType/Select/Result/Stats/StatsTest.php
+++ b/tests/QueryType/Select/Result/Stats/StatsTest.php
@@ -52,6 +52,6 @@ class StatsTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->data), count($this->stats));
+        $this->assertCount(count($this->data), $this->stats);
     }
 }

--- a/tests/QueryType/Server/Api/RequestBuilderTest.php
+++ b/tests/QueryType/Server/Api/RequestBuilderTest.php
@@ -67,7 +67,7 @@ class RequestBuilderTest extends TestCase
         $this->assertSame(Request::METHOD_GET, $request->getMethod());
         $this->assertTrue($request->getIsServerRequest());
         $this->assertSame('dummy?wt=json&json.nl=flat', $request->getUri());
-        $this->arrayHasKey('Accept: foo/bar', array_flip($request->getHeaders()));
+        $this->assertArrayHasKey('Accept: foo/bar', array_flip($request->getHeaders()));
 
         $this->query->setContentType('foo;bar');
         $request = $this->builder->build($this->query);
@@ -82,8 +82,8 @@ class RequestBuilderTest extends TestCase
         $this->assertSame(Request::METHOD_GET, $request->getMethod());
         $this->assertTrue($request->getIsServerRequest());
         $this->assertSame('dummy?wt=json&json.nl=flat', $request->getUri());
-        $this->arrayHasKey('Accept: foo/bar', array_flip($request->getHeaders()));
-        $this->arrayHasKey('Content-Type: foo;bar', array_flip($request->getHeaders()));
+        $this->assertArrayHasKey('Accept: foo/bar', array_flip($request->getHeaders()));
+        $this->assertArrayHasKey('Content-Type: foo;bar', array_flip($request->getHeaders()));
 
         $this->query->setMethod(Request::METHOD_HEAD);
         $request = $this->builder->build($this->query);
@@ -98,8 +98,8 @@ class RequestBuilderTest extends TestCase
         $this->assertSame(Request::METHOD_HEAD, $request->getMethod());
         $this->assertTrue($request->getIsServerRequest());
         $this->assertSame('dummy?wt=json&json.nl=flat', $request->getUri());
-        $this->arrayHasKey('Accept: foo/bar', array_flip($request->getHeaders()));
-        $this->arrayHasKey('Content-Type: foo;bar', array_flip($request->getHeaders()));
+        $this->assertArrayHasKey('Accept: foo/bar', array_flip($request->getHeaders()));
+        $this->assertArrayHasKey('Content-Type: foo;bar', array_flip($request->getHeaders()));
 
         $this->query->setMethod(Request::METHOD_POST);
         $this->query->setRawData('some data');
@@ -115,8 +115,8 @@ class RequestBuilderTest extends TestCase
         $this->assertSame(Request::METHOD_POST, $request->getMethod());
         $this->assertTrue($request->getIsServerRequest());
         $this->assertSame('dummy?wt=json&json.nl=flat', $request->getUri());
-        $this->arrayHasKey('Accept: foo/bar', array_flip($request->getHeaders()));
-        $this->arrayHasKey('Content-Type: foo;bar', array_flip($request->getHeaders()));
+        $this->assertArrayHasKey('Accept: foo/bar', array_flip($request->getHeaders()));
+        $this->assertArrayHasKey('Content-Type: foo;bar', array_flip($request->getHeaders()));
         $this->assertSame('some data', $request->getRawData());
     }
 }

--- a/tests/QueryType/Spellcheck/QueryTest.php
+++ b/tests/QueryType/Spellcheck/QueryTest.php
@@ -68,23 +68,13 @@ class QueryTest extends TestCase
 
     public function testSetAndGetOnlyMorePopular()
     {
-        $value = false;
-        $this->query->setOnlyMorePopular($value);
-
-        $this->assertSame(
-            $value,
-            $this->query->getOnlyMorePopular()
-        );
+        $this->query->setOnlyMorePopular(false);
+        $this->assertFalse($this->query->getOnlyMorePopular());
     }
 
     public function testSetAndGetCollate()
     {
-        $value = false;
-        $this->query->setCollate($value);
-
-        $this->assertSame(
-            $value,
-            $this->query->getCollate()
-        );
+        $this->query->setCollate(false);
+        $this->assertFalse($this->query->getCollate());
     }
 }

--- a/tests/QueryType/Spellcheck/Result/ResultTest.php
+++ b/tests/QueryType/Spellcheck/Result/ResultTest.php
@@ -77,7 +77,7 @@ class ResultTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->data), count($this->result));
+        $this->assertCount(count($this->data), $this->result);
     }
 
     public function testIterator()

--- a/tests/QueryType/Spellcheck/Result/TermTest.php
+++ b/tests/QueryType/Spellcheck/Result/TermTest.php
@@ -79,7 +79,7 @@ class TermTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->suggestions), count($this->result));
+        $this->assertCount(count($this->suggestions), $this->result);
     }
 
     public function testIterator()

--- a/tests/QueryType/Stream/ExpressionTest.php
+++ b/tests/QueryType/Stream/ExpressionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Solarium\Tests\QueryType\Stream\Query;
+namespace Solarium\Tests\QueryType\Stream;
 
 use PHPUnit\Framework\TestCase;
 use Solarium\Exception\InvalidArgumentException;

--- a/tests/QueryType/Stream/QueryTest.php
+++ b/tests/QueryType/Stream/QueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Solarium\Tests\QueryType\Stream\Query;
+namespace Solarium\Tests\QueryType\Stream;
 
 use PHPUnit\Framework\TestCase;
 use Solarium\QueryType\Stream\Query;

--- a/tests/QueryType/Suggester/QueryTest.php
+++ b/tests/QueryType/Suggester/QueryTest.php
@@ -90,7 +90,7 @@ class QueryTest extends TestCase
 
     public function testSetAndBuild()
     {
-        $this->assertFalse( $this->query->getBuild());
+        $this->assertFalse($this->query->getBuild());
         $this->query->setBuild(true);
         $this->assertTrue($this->query->getBuild());
     }

--- a/tests/QueryType/Suggester/QueryTest.php
+++ b/tests/QueryType/Suggester/QueryTest.php
@@ -90,31 +90,15 @@ class QueryTest extends TestCase
 
     public function testSetAndBuild()
     {
-        $this->assertFalse(
-            $this->query->getBuild()
-        );
-
-        $value = true;
-        $this->query->setBuild($value);
-
-        $this->assertSame(
-            $value,
-            $this->query->getBuild()
-        );
+        $this->assertFalse( $this->query->getBuild());
+        $this->query->setBuild(true);
+        $this->assertTrue($this->query->getBuild());
     }
 
     public function testSetAndReload()
     {
-        $this->assertFalse(
-            $this->query->getReload()
-        );
-
-        $value = true;
-        $this->query->setReload($value);
-
-        $this->assertSame(
-            $value,
-            $this->query->getReload()
-        );
+        $this->assertFalse($this->query->getReload());
+        $this->query->setReload(true);
+        $this->assertTrue($this->query->getReload());
     }
 }

--- a/tests/QueryType/Suggester/Result/DictionaryTest.php
+++ b/tests/QueryType/Suggester/Result/DictionaryTest.php
@@ -45,7 +45,7 @@ class DictionaryTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->terms), count($this->dictionary));
+        $this->assertCount(count($this->terms), $this->dictionary);
     }
 
     public function testIterator()

--- a/tests/QueryType/Suggester/Result/ResultTest.php
+++ b/tests/QueryType/Suggester/Result/ResultTest.php
@@ -83,7 +83,7 @@ class ResultTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->data), count($this->result));
+        $this->assertCount(count($this->data), $this->result);
     }
 
     public function testIterator()

--- a/tests/QueryType/Suggester/Result/TermTest.php
+++ b/tests/QueryType/Suggester/Result/TermTest.php
@@ -51,7 +51,7 @@ class TermTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->suggestions), count($this->result));
+        $this->assertCount(count($this->suggestions), $this->result);
     }
 
     public function testIterator()

--- a/tests/QueryType/Terms/ResultTest.php
+++ b/tests/QueryType/Terms/ResultTest.php
@@ -72,7 +72,7 @@ class ResultTest extends TestCase
 
     public function testCount()
     {
-        $this->assertSame(count($this->data), count($this->result));
+        $this->assertCount(count($this->data), $this->result);
     }
 
     public function testIterator()


### PR DESCRIPTION
What do you think about adding phpstan (for now with level=1) to the build? It can catch some simple issues.

Found issues on master were:

```
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/Component/RequestBuilder/ReRankQueryTest.php                                                                                                                          
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
         Class Solarium\Tests\QueryType\Select\RequestBuilder\Component\ReRankQueryTest was not found while trying to analyse it - autoloading is probably not configured properly.  
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   tests/Component/RequestBuilder/SpatialTest.php                                                                                                                          
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
         Class Solarium\Tests\QueryType\Select\RequestBuilder\Component\SpatialTest was not found while trying to analyse it - autoloading is probably not configured properly.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------- 
  Line   tests/Component/Result/MoreLikeThis/ResultTest.php                                               
 ------ ------------------------------------------------------------------------------------------------- 
  18     Access to an undefined property Solarium\Tests\Component\Result\MoreLikeThis\ResultTest::$docs.  
  38     Access to an undefined property Solarium\Tests\Component\Result\MoreLikeThis\ResultTest::$docs.  
  48     Access to an undefined property Solarium\Tests\Component\Result\MoreLikeThis\ResultTest::$docs.  
  53     Access to an undefined property Solarium\Tests\Component\Result\MoreLikeThis\ResultTest::$docs.  
 ------ ------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------- 
  Line   tests/Component/Result/Suggester/ResultTest.php                                               
 ------ ---------------------------------------------------------------------------------------------- 
  19     Access to an undefined property Solarium\Tests\Component\Result\Suggester\ResultTest::$docs.  
  40     Access to an undefined property Solarium\Tests\Component\Result\Suggester\ResultTest::$docs.  
  50     Access to an undefined property Solarium\Tests\Component\Result\Suggester\ResultTest::$docs.  
  55     Access to an undefined property Solarium\Tests\Component\Result\Suggester\ResultTest::$docs.  
 ------ ---------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------- 
  Line   tests/Core/Client/ClientTest.php                                                        
 ------ ---------------------------------------------------------------------------------------- 
  471    Method PHPUnit\Framework\TestCase::createMock() invoked with 2 parameters, 1 required.  
 ------ ---------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------- 
  Line   tests/Plugin/Loadbalancer/LoadbalancerTest.php                                               
 ------ --------------------------------------------------------------------------------------------- 
  438    Method PHPUnit\Framework\TestCase::expectException() invoked with 2 parameters, 1 required.  
 ------ --------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/QueryType/Graph/QueryTest.php                                                                                                               
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------- 
         Class Solarium\Tests\QueryType\Graph\Query\QueryTest was not found while trying to analyse it - autoloading is probably not configured properly.  
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/QueryType/ManagedResources/QueryTest.php                                                                                                                   
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 
         Class Solarium\Tests\QueryType\ManagedResources\Resources\QueryTest was not found while trying to analyse it - autoloading is probably not configured properly.  
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   tests/QueryType/ManagedResources/RequestBuilder/ResourcesTest.php                                                                                                                   
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
         Class Solarium\Tests\QueryType\ManagedResources\Resources\RequestBuilder\ResourcesTest was not found while trying to analyse it - autoloading is probably not configured properly.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   tests/QueryType/ManagedResources/RequestBuilder/StopwordsTest.php                                                                                                                   
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
         Class Solarium\Tests\QueryType\ManagedResources\Resources\RequestBuilder\StopwordsTest was not found while trying to analyse it - autoloading is probably not configured properly.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/QueryType/ManagedResources/RequestBuilder/SynonymsTest.php                                                                                                                   
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
         Class Solarium\Tests\QueryType\ManagedResources\Resources\RequestBuilder\SynonymsTest was not found while trying to analyse it - autoloading is probably not configured properly.  
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------- 
  Line   tests/QueryType/Server/Api/RequestBuilderTest.php                                      
 ------ --------------------------------------------------------------------------------------- 
  70     Method PHPUnit\Framework\Assert::arrayHasKey() invoked with 2 parameters, 1 required.  
  85     Method PHPUnit\Framework\Assert::arrayHasKey() invoked with 2 parameters, 1 required.  
  86     Method PHPUnit\Framework\Assert::arrayHasKey() invoked with 2 parameters, 1 required.  
  101    Method PHPUnit\Framework\Assert::arrayHasKey() invoked with 2 parameters, 1 required.  
  102    Method PHPUnit\Framework\Assert::arrayHasKey() invoked with 2 parameters, 1 required.  
  118    Method PHPUnit\Framework\Assert::arrayHasKey() invoked with 2 parameters, 1 required.  
  119    Method PHPUnit\Framework\Assert::arrayHasKey() invoked with 2 parameters, 1 required.  
 ------ --------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/QueryType/Stream/ExpressionTest.php                                                                                                               
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------- 
         Class Solarium\Tests\QueryType\Stream\Query\ExpressionTest was not found while trying to analyse it - autoloading is probably not configured properly.  
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/QueryType/Stream/QueryTest.php                                                                                                               
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------- 
         Class Solarium\Tests\QueryType\Stream\Query\QueryTest was not found while trying to analyse it - autoloading is probably not configured properly.  
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 26 errors                                                                                                
                                                                                                                        
```