### PR TITLE
Input encoding can be something other than UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Raw XML commands to update query
 - Raw XML from file in update query
+- Set input encoding for select and update queries
 - Create and configure Managed Resources
 
 ## Changed

--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -90,10 +90,12 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
         }
 
         if (!isset($options['headers']['Content-Type'])) {
+            $charset = $request->getParam('ie') ?? 'utf-8';
+
             if (Request::METHOD_GET == $method) {
-                $options['headers']['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
+                $options['headers']['Content-Type'] = 'application/x-www-form-urlencoded; charset='.$charset;
             } else {
-                $options['headers']['Content-Type'] = 'application/xml; charset=utf-8';
+                $options['headers']['Content-Type'] = 'application/xml; charset='.$charset;
             }
         }
 

--- a/src/Core/Client/Adapter/Http.php
+++ b/src/Core/Client/Adapter/Http.php
@@ -110,7 +110,8 @@ class Http implements AdapterInterface, TimeoutAwareInterface
                         $data
                     );
 
-                    $request->addHeader('Content-Type: text/xml; charset=utf-8');
+                    $charset = $request->getParam('ie') ?? 'utf-8';
+                    $request->addHeader('Content-Type: text/xml; charset='.$charset);
                 }
             }
         } elseif (Request::METHOD_PUT == $method) {

--- a/src/Core/Client/Adapter/Psr18Adapter.php
+++ b/src/Core/Client/Adapter/Psr18Adapter.php
@@ -118,10 +118,12 @@ final class Psr18Adapter implements AdapterInterface
         }
 
         if (!isset($headers['Content-Type'])) {
+            $charset = $request->getParam('ie') ?? 'utf-8';
+
             if (Request::METHOD_GET == $request->getMethod()) {
-                $headers['Content-Type'] = ['application/x-www-form-urlencoded; charset=utf-8'];
+                $headers['Content-Type'] = ['application/x-www-form-urlencoded; charset='.$charset];
             } else {
-                $headers['Content-Type'] = ['application/xml; charset=utf-8'];
+                $headers['Content-Type'] = ['application/xml; charset='.$charset];
             }
         }
 

--- a/src/Core/Query/AbstractQuery.php
+++ b/src/Core/Query/AbstractQuery.php
@@ -311,4 +311,28 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
     {
         return $this->getOption('distrib');
     }
+
+    /**
+     * Set ie (input encoding) option.
+     *
+     * @param string $encoding
+     *
+     * @return self Provides fluent interface
+     */
+    public function setInputEncoding(string $encoding): self
+    {
+        $this->setOption('ie', $encoding);
+
+        return $this;
+    }
+
+    /**
+     * Get ie (input encoding) option.
+     *
+     * @return string|null
+     */
+    public function getInputEncoding(): ?string
+    {
+        return $this->getOption('ie');
+    }
 }

--- a/src/Core/Query/AbstractRequestBuilder.php
+++ b/src/Core/Query/AbstractRequestBuilder.php
@@ -33,6 +33,7 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
         $request->addParam('timeAllowed', $query->getTimeAllowed());
         $request->addParam('NOW', $query->getNow());
         $request->addParam('TZ', $query->getTimeZone());
+        $request->addParam('ie', $query->getInputEncoding());
         $request->addParams($query->getParams());
 
         $request->addParam('wt', $query->getResponseWriter());

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -474,6 +474,7 @@ class Helper
      */
     public function escapeXMLCharacterData(string $data): string
     {
+        // we don't use htmlspecialchars because it only supports a limited number of character sets
         return str_replace(['&', '<', '>'], ['&amp;', '&lt;', '&gt;'], $data);
     }
 

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -472,7 +472,7 @@ class Helper
      *
      * @return string
      */
-    public function escapePCDATAContent(string $data): string
+    public function escapeXMLCharacterData(string $data): string
     {
         return str_replace(['&', '<', '>'], ['&amp;', '&lt;', '&gt;'], $data);
     }

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -282,7 +282,6 @@ class Helper
     /**
      * Render a qparser plugin call.
      *
-     *
      * @param string $name
      * @param array  $params
      * @param bool   $dereferenced
@@ -462,8 +461,24 @@ class Helper
     }
 
     /**
-     * Render placeholders in a querystring.
+     * Escape text for use as parsed character data content in an XML element.
      *
+     * This escapes characters that can't appear as character data using their
+     * corresponding entity references. Per the definition of XML, "&" and "<"
+     * MUST be escaped when used in character data, ">" MUST be escaped in the
+     * string "]]>" and MAY be otherwise, so we escape it to be safe.
+     *
+     * @param string $data
+     *
+     * @return string
+     */
+    public function escapePCDATAContent(string $data): string
+    {
+        return str_replace(['&', '<', '>'], ['&amp;', '&lt;', '&gt;'], $data);
+    }
+
+    /**
+     * Render placeholders in a querystring.
      *
      * @param array $matches
      *

--- a/src/Plugin/PostBigRequest.php
+++ b/src/Plugin/PostBigRequest.php
@@ -65,10 +65,12 @@ class PostBigRequest extends AbstractPlugin
 
         if (Request::METHOD_GET == $request->getMethod() &&
             strlen($queryString) > $this->getMaxQueryStringLength()) {
+            $charset = $request->getParam('ie') ?? 'utf-8';
+
             $request->setMethod(Request::METHOD_POST);
             $request->setRawData($queryString);
             $request->clearParams();
-            $request->addHeader('Content-Type: application/x-www-form-urlencoded');
+            $request->addHeader('Content-Type: application/x-www-form-urlencoded; charset='.$charset);
         }
         return $this;
     }

--- a/src/QueryType/Analysis/RequestBuilder/Document.php
+++ b/src/QueryType/Analysis/RequestBuilder/Document.php
@@ -71,6 +71,6 @@ class Document extends BaseRequestBuilder
      */
     protected function buildFieldXml(string $name, string $value): string
     {
-        return '<field name="'.$name.'">'.htmlspecialchars($value, ENT_NOQUOTES).'</field>';
+        return '<field name="'.$name.'">'.$this->getHelper()->escapePCDATAContent($value).'</field>';
     }
 }

--- a/src/QueryType/Analysis/RequestBuilder/Document.php
+++ b/src/QueryType/Analysis/RequestBuilder/Document.php
@@ -71,6 +71,6 @@ class Document extends BaseRequestBuilder
      */
     protected function buildFieldXml(string $name, string $value): string
     {
-        return '<field name="'.$name.'">'.$this->getHelper()->escapePCDATAContent($value).'</field>';
+        return '<field name="'.$name.'">'.$this->getHelper()->escapeXMLCharacterData($value).'</field>';
     }
 }

--- a/src/QueryType/MoreLikeThis/RequestBuilder.php
+++ b/src/QueryType/MoreLikeThis/RequestBuilder.php
@@ -39,10 +39,12 @@ class RequestBuilder extends SelectRequestBuilder
 
         // convert query to stream if necessary
         if (true === $query->getQueryStream()) {
+            $charset = $request->getParam('ie') ?? 'utf-8';
+
             $request->removeParam('q');
             $request->setRawData($query->getQuery());
             $request->setMethod(Request::METHOD_POST);
-            $request->addHeader('Content-Type: text/plain; charset=utf-8');
+            $request->addHeader('Content-Type: text/plain; charset='.$charset);
         }
 
         return $request;

--- a/src/QueryType/Stream/RequestBuilder.php
+++ b/src/QueryType/Stream/RequestBuilder.php
@@ -21,11 +21,13 @@ class RequestBuilder implements RequestBuilderInterface
      */
     public function build(AbstractQuery $query): Request
     {
+        $charset = $query->getInputEncoding('ie') ?? 'utf-8';
+
         $request = new Request();
         $request->setHandler($query->getHandler());
         $request->addParam('expr', $query->getExpression());
         $request->addParams($query->getParams());
-        $request->addHeader('Content-Type: text/plain; charset=utf-8');
+        $request->addHeader('Content-Type: text/plain; charset='.$charset);
 
         return $request;
     }

--- a/src/QueryType/Update/RequestBuilder.php
+++ b/src/QueryType/Update/RequestBuilder.php
@@ -128,10 +128,10 @@ class RequestBuilder extends BaseRequestBuilder
     {
         $xml = '<delete>';
         foreach ($command->getIds() as $id) {
-            $xml .= '<id>'.$this->getHelper()->escapePCDATAContent($id).'</id>';
+            $xml .= '<id>'.$this->getHelper()->escapeXMLCharacterData($id).'</id>';
         }
         foreach ($command->getQueries() as $query) {
-            $xml .= '<query>'.$this->getHelper()->escapePCDATAContent($query).'</query>';
+            $xml .= '<query>'.$this->getHelper()->escapeXMLCharacterData($query).'</query>';
         }
         $xml .= '</delete>';
 
@@ -234,7 +234,7 @@ class RequestBuilder extends BaseRequestBuilder
         } elseif ($value instanceof \DateTimeInterface) {
             $value = $this->getHelper()->formatDate($value);
         } else {
-            $value = $this->getHelper()->escapePCDATAContent($value);
+            $value = $this->getHelper()->escapeXMLCharacterData($value);
         }
 
         $xml .= '>'.$value.'</field>';

--- a/src/QueryType/Update/RequestBuilder.php
+++ b/src/QueryType/Update/RequestBuilder.php
@@ -128,10 +128,10 @@ class RequestBuilder extends BaseRequestBuilder
     {
         $xml = '<delete>';
         foreach ($command->getIds() as $id) {
-            $xml .= '<id>'.htmlspecialchars($id, ENT_NOQUOTES).'</id>';
+            $xml .= '<id>'.$this->getHelper()->escapePCDATAContent($id).'</id>';
         }
         foreach ($command->getQueries() as $query) {
-            $xml .= '<query>'.htmlspecialchars($query, ENT_NOQUOTES).'</query>';
+            $xml .= '<query>'.$this->getHelper()->escapePCDATAContent($query).'</query>';
         }
         $xml .= '</delete>';
 
@@ -234,7 +234,7 @@ class RequestBuilder extends BaseRequestBuilder
         } elseif ($value instanceof \DateTimeInterface) {
             $value = $this->getHelper()->formatDate($value);
         } else {
-            $value = htmlspecialchars($value, ENT_NOQUOTES);
+            $value = $this->getHelper()->escapePCDATAContent($value);
         }
 
         $xml .= '>'.$value.'</field>';

--- a/tests/Core/Query/HelperTest.php
+++ b/tests/Core/Query/HelperTest.php
@@ -413,11 +413,11 @@ class HelperTest extends TestCase
         );
     }
 
-    public function testEscapePCDATAContent()
+    public function testEscapeXMLCharacterData()
     {
         $this->assertSame(
             '&lt;&amp;&gt;',
-            $this->helper->escapePCDATAContent('<&>')
+            $this->helper->escapeXMLCharacterData('<&>')
         );
     }
 

--- a/tests/Core/Query/HelperTest.php
+++ b/tests/Core/Query/HelperTest.php
@@ -413,6 +413,14 @@ class HelperTest extends TestCase
         );
     }
 
+    public function testEscapePCDATAContent()
+    {
+        $this->assertSame(
+            '&lt;&amp;&gt;',
+            $this->helper->escapePCDATAContent("<&>")
+        );
+    }
+
     protected function mockFormatDateOutput($timestamp)
     {
         $date = new \DateTime('@'.$timestamp);

--- a/tests/Core/Query/HelperTest.php
+++ b/tests/Core/Query/HelperTest.php
@@ -417,7 +417,7 @@ class HelperTest extends TestCase
     {
         $this->assertSame(
             '&lt;&amp;&gt;',
-            $this->helper->escapePCDATAContent("<&>")
+            $this->helper->escapePCDATAContent('<&>')
         );
     }
 

--- a/tests/Core/Query/QueryTest.php
+++ b/tests/Core/Query/QueryTest.php
@@ -109,6 +109,20 @@ class QueryTest extends TestCase
         $query->setTimeZone('Europe/Brussels');
         $this->assertSame('Europe/Brussels', $query->getTimeZone());
     }
+
+    public function testSetAndGetDistrib()
+    {
+        $query = new TestQuery();
+        $query->setDistrib(true);
+        $this->assertTrue($query->getDistrib());
+    }
+
+    public function testSetAndGetInputEncoding()
+    {
+        $query = new TestQuery();
+        $query->setInputEncoding('ISO-8859-1');
+        $this->assertSame('ISO-8859-1', $query->getInputEncoding());
+    }
 }
 
 class TestQuery extends AbstractQuery

--- a/tests/Core/Query/RequestBuilderTest.php
+++ b/tests/Core/Query/RequestBuilderTest.php
@@ -132,6 +132,20 @@ class RequestBuilderTest extends TestCase
         );
     }
 
+    public function testBuildWithInputEncoding()
+    {
+        $query = new SelectQuery();
+        $query->addParam('p1', 'v1');
+        $query->addParam('p2', 'v2');
+        $query->setInputEncoding('ISO-8859-1');
+        $request = $this->builder->build($query);
+
+        $this->assertSame(
+            'select?omitHeader=true&ie=ISO-8859-1&p1=v1&p2=v2&wt=json&json.nl=flat',
+            urldecode($request->getUri())
+        );
+    }
+
     public function testRenderLocalParams()
     {
         $myParams = ['tag' => 'mytag', 'ex' => ['exclude1', 'exclude2']];

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -779,7 +779,7 @@ abstract class AbstractTechproductsTest extends TestCase
         // output encoding: UTF-8 (always)
         $select->setQuery('cat:áéíóú');
         $result = $this->client->select($select);
-        $this->assertSame(1, $result->count());
+        $this->assertCount(1, $result);
         $this->assertSame([
             'id' => 'solarium-test-1',
             'name' => 'Sølåríùm Tëst 1',
@@ -791,7 +791,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $select->setQuery('cat:'.utf8_decode('áéíóú'));
         $select->setInputEncoding('ISO-8859-1');
         $result = $this->client->select($select);
-        $this->assertSame(1, $result->count());
+        $this->assertCount(1, $result);
         $this->assertSame([
             'id' => 'solarium-test-1',
             'name' => 'Sølåríùm Tëst 1',
@@ -815,7 +815,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $select->setQuery('cat:áéíóú');
         $select->setInputEncoding('UTF-8');
         $result = $this->client->select($select);
-        $this->assertSame(2, $result->count());
+        $this->assertCount(2, $result);
         $iterator = $result->getIterator();
         $this->assertSame([
             'id' => 'solarium-test-1',
@@ -834,7 +834,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $update->addCommit(true, true);
         $this->client->update($update);
         $result = $this->client->select($select);
-        $this->assertSame(0, $result->count());
+        $this->assertCount(0, $result);
     }
 }
 

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -516,15 +516,23 @@ abstract class AbstractTechproductsTest extends TestCase
         $result = $this->client->select($select);
         $this->assertCount(0, $result);
 
-        // add from files without and with Byte Order Mark and XML declaration
+        // add from UTF-8 encoded files without and with Byte Order Mark and XML declaration
         $update = $this->client->createUpdate();
         foreach (glob(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'testxml[1234]-add*.xml') as $file) {
             $update->addRawXmlFile($file);
         }
         $update->addCommit(true, true);
         $this->client->update($update);
+
+        // add from non-UTF-8 encoded file
+        $update = $this->client->createUpdate();
+        $update->setInputEncoding('ISO-8859-1');
+        $update->addRawXmlFile(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'testxml5-add-iso-8859-1.xml');
+        $update->addCommit(true, true);
+        $this->client->update($update);
+
         $result = $this->client->select($select);
-        $this->assertCount(4, $result);
+        $this->assertCount(5, $result);
         $iterator = $result->getIterator();
         $this->assertSame([
             'id' => 'solarium-test-1',
@@ -549,10 +557,16 @@ abstract class AbstractTechproductsTest extends TestCase
             'name' => 'Solarium Test 4',
             'price' => 3.59,
         ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => 'solarium-test-5',
+            'name' => 'Sølåríùm Tëst 5',
+            'price' => 9.81,
+        ], $iterator->current()->getFields());
 
         // delete from file with grouped delete commands
         $update = $this->client->createUpdate();
-        $update->addRawXmlFile(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'testxml5-delete.xml');
+        $update->addRawXmlFile(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'testxml6-delete.xml');
         $update->addCommit(true, true);
         $this->client->update($update);
         $result = $this->client->select($select);
@@ -742,6 +756,85 @@ abstract class AbstractTechproductsTest extends TestCase
         } else {
             $this->markTestSkipped('V2 API requires Solr 7.');
         }
+    }
+
+    public function testInputEncoding()
+    {
+        $select = $this->client->createSelect();
+        $select->addSort('id', $select::SORT_ASC);
+        $select->setFields('id,name,price');
+
+        // input encoding: UTF-8 (default)
+        $update = $this->client->createUpdate();
+        $doc = $update->createDocument();
+        $doc->setField('id', 'solarium-test-1');
+        $doc->setField('name', 'Sølåríùm Tëst 1');
+        $doc->setField('cat', ['solarium-test', 'áéíóú']);
+        $doc->setField('price', 3.14);
+        $update->addDocument($doc);
+        $update->addCommit(true, true);
+        $this->client->update($update);
+
+        // input encoding: UTF-8 (default)
+        // output encoding: UTF-8 (always)
+        $select->setQuery('cat:áéíóú');
+        $result = $this->client->select($select);
+        $this->assertSame(1, $result->count());
+        $this->assertSame([
+            'id' => 'solarium-test-1',
+            'name' => 'Sølåríùm Tëst 1',
+            'price' => 3.14,
+        ], $result->getIterator()->current()->getFields());
+
+        // input encoding: ISO-8859-1
+        // output encoding: UTF-8 (always)
+        $select->setQuery('cat:'.utf8_decode('áéíóú'));
+        $select->setInputEncoding('ISO-8859-1');
+        $result = $this->client->select($select);
+        $this->assertSame(1, $result->count());
+        $this->assertSame([
+            'id' => 'solarium-test-1',
+            'name' => 'Sølåríùm Tëst 1',
+            'price' => 3.14,
+        ], $result->getIterator()->current()->getFields());
+
+        // input encoding: ISO-8859-1
+        $update = $this->client->createUpdate();
+        $update->setInputEncoding('ISO-8859-1');
+        $doc = $update->createDocument();
+        $doc->setField('id', utf8_decode('solarium-test-2'));
+        $doc->setField('name', utf8_decode('Sølåríùm Tëst 2'));
+        $doc->setField('cat', [utf8_decode('solarium-test'), utf8_decode('áéíóú')]);
+        $doc->setField('price', 42.0);
+        $update->addDocument($doc);
+        $update->addCommit(true, true);
+        $this->client->update($update);
+
+        // input encoding: UTF-8 (explicit)
+        // output encoding: UTF-8 (always)
+        $select->setQuery('cat:áéíóú');
+        $select->setInputEncoding('UTF-8');
+        $result = $this->client->select($select);
+        $this->assertSame(2, $result->count());
+        $iterator = $result->getIterator();
+        $this->assertSame([
+            'id' => 'solarium-test-1',
+            'name' => 'Sølåríùm Tëst 1',
+            'price' => 3.14,
+        ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => 'solarium-test-2',
+            'name' => 'Sølåríùm Tëst 2',
+            'price' => 42.0,
+        ], $iterator->current()->getFields());
+
+        $update = $this->client->createUpdate();
+        $update->addDeleteQuery('cat:solarium-test');
+        $update->addCommit(true, true);
+        $this->client->update($update);
+        $result = $this->client->select($select);
+        $this->assertSame(0, $result->count());
     }
 }
 

--- a/tests/Integration/Fixtures/testxml5-add-iso-8859-1.xml
+++ b/tests/Integration/Fixtures/testxml5-add-iso-8859-1.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+ test addRawXmlFile with
+ - no Byte Order Mark
+ - an XML declaration
+ - a non-UTF-8 encoding
+-->
+
+<add>
+	<doc>
+		<field name="id">solarium-test-5</field>
+		<field name="name">Sølåríùm Tëst 5</field>
+		<field name="cat">solarium-test</field>
+		<field name="cat">sóláríúm-tést</field>
+		<field name="price">9.81</field>
+	</doc>
+</add>

--- a/tests/Integration/Fixtures/testxml6-delete.xml
+++ b/tests/Integration/Fixtures/testxml6-delete.xml
@@ -12,5 +12,6 @@
 	<delete>
 		<id>solarium-test-3</id>
 		<query>id:solarium-test-4</query>
+		<query>cat:sóláríúm-tést</query>
 	</delete>
 </update>


### PR DESCRIPTION
Solr supports other input encodings than UTF-8. It could already be set in Solarium with a custom parameter for GET requests, but not for POST. I need to set it to import the `techproducts` testdata (suggested in #751) because not all sample XMLs are UTF-8 encoded. This PR closes #367 as well.

There is a parameter `ie` since Solr 4.5.0, but it isn't listed among the [Common Query Parameters](https://lucene.apache.org/solr/guide/8_5/common-query-parameters.html) in the Solr Ref Guide. The [changelog](https://github.com/apache/lucene-solr/blob/d4dbd0b9e75cb0bd5b0188a0f70070b6867fd94b/solr/CHANGES.txt#L12692-L12695) mentions it though.

```
* SOLR-5082: The encoding of URL-encoded query parameters can be changed with
  the "ie" (input encoding) parameter, e.g. "select?q=m%FCller&ie=ISO-8859-1".
  The default is UTF-8. To change the encoding of POSTed content, use the
  "Content-Type" HTTP header.  (Uwe Schindler, Shawn Heisey)
```

There's also this little tidbit from Solr's [source code](https://github.com/apache/lucene-solr/blob/d4dbd0b9e75cb0bd5b0188a0f70070b6867fd94b/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java#L340-L354).

```java
  public static final String INPUT_ENCODING_KEY = "ie";
  private static final byte[] INPUT_ENCODING_BYTES = INPUT_ENCODING_KEY.getBytes(CHARSET_US_ASCII);

// ...

            if (Arrays.equals(keyBytes, INPUT_ENCODING_BYTES)) {
              // we found a charset declaration in the raw bytes
              if (charsetDecoder != null) {
                throw new SolrException(ErrorCode.BAD_REQUEST,
                  supportCharsetParam ? (
                    "Query string invalid: duplicate '"+
                    INPUT_ENCODING_KEY + "' (input encoding) key."
                  ) : (
                    "Key '" + INPUT_ENCODING_KEY + "' (input encoding) cannot "+
                    "be used in POSTed application/x-www-form-urlencoded form data. "+
                    "To set the input encoding of POSTed form data, use the "+
                    "'Content-Type' header and provide a charset!"
                  )
                );
              }
```

From a (client library) user's standpoint, it makes sense to provide a single method `setInputEncoding()` and do the heavy lifting for them. In the case of `PostBigRequest`, they don't even know if they're sending a GET or a POST.

When an input encoding is set, I add a parameter `ie` to the query string. This works for GET and is safely ignored for POST. If the request is a POST, the same encoding is set in the `Content-Type` header.

You can not set the input encoding in POSTed form data. This will fail (for good reason, Solr needs to know the encoding before it starts parsing the data).
```bash
curl -X POST -H 'Content-type:application/x-www-form-urlencoded' -d 'ie=ISO-8859-1' http://localhost:8983/solr/techproducts/update
```
This doesn't seem to be an issue with Solarium. I don't believe there's a way to generate a request like this without a custom request builder.

For importing from XML files, the onus is on the user to set the matching input encoding for the file. If the XML declaration is correct, it can be determined automatically. But that would mean a lot of added complexity if you're importing multiple files that have different encodings, such as the `techproducts` testdata. Importing like that is a rather advanced feature that's mostly for our own benefit at this moment, so I don't think this is a dealbreaker.

I ran into a small issue with the generated XML for non-UTF-8 data because `htmlspecialchars()` was used to escape element content. It needs to know the encoding to work correctly and that information wasn't readily accessible at that point in the code. It's also technically wrong to use that function, it just happens to work because XML and HTML share a similar lineage from SGML. I've replaced it with a helper function that does the escaping.

I've added unit and integration tests with ISO-8859-1 as the non-UTF-8 charset. This is a deliberate choice. It's the only non-UTF charset (besides US-ASCII, but that'd be pointless for integration testing) in the [standard charsets](https://docs.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html#standard) that every Java platform is required to support. However, since `techproducts` contains an example in GB18030, I assume that it's also supported on all Solr instances. Once we import the testdata ourselves, this will be tested _de facto_.

The input encoding doesn't apply to JSON data. That can only be encoded using UTF-8, UTF-16 or UTF-32.

It should also be noted that it's **only** possible to change the input encoding for Solr. There's no corresponding `oe` parameter to change the output encoding.