### PR TITLE
Update examples and docs with new Client constructor signature

### DIFF
--- a/docs/customizing-solarium.md
+++ b/docs/customizing-solarium.md
@@ -40,7 +40,7 @@ htmlHeader();
 
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // create a select query instance
 $query = $client->createSelect();
@@ -200,7 +200,7 @@ htmlHeader();
 
 // create a client instance and register the plugin
 $plugin = new BasicDebug();
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $client->registerPlugin('debugger', $plugin);
 
 // execute a select query and display the results
@@ -261,7 +261,7 @@ class QueryCustomizer extends Plugin
 htmlHeader();
 
 // create a client instance and register the plugin
-$client = new Client($config);
+$client = new Client($adapter, $eventDispatcher, $config);
 $client->registerPlugin('querycustomizer', 'QueryCustomizer');
 
 // create a select query instance

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -37,7 +37,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createQuery($client::QUERY_SELECT);
@@ -145,7 +145,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,7 @@ htmlHeader();
 echo 'Solarium library version: ' . Solarium\Client::VERSION . ' - ';
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // create a ping query
 $ping = $client->createPing();
@@ -117,7 +117,18 @@ Basic usage
 
 All the code display below can be found in the /examples dir of the project, where you can also easily execute the code. For more info see [Example code](V3:Example_code "wikilink").
 
-All the examples use the init.php file. This file registers the Solarium autoloader and also loads the $config array for use in the client constructor. The $config array has the following contents: 
+All the examples use the init.php file. This file registers the Solarium autoloader, sets up a client adapter and event dispatcher, and also loads the `$config` array for use in the client constructor.
+
+A client adapter and event dispatcher can be set up like this:
+
+```php
+<?php
+
+$adapter = new Solarium\Core\Client\Adapter\Curl(); // or any other adapter implementing AdapterInterfac
+$eventDispatcher = new Symfony\Component\EventDispatcher\EventDispatcher();
+```
+
+The `$config` array has the following contents: 
 
 ```php
 <?php
@@ -147,7 +158,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createQuery($client::QUERY_SELECT);
@@ -193,7 +204,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -242,7 +253,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();
@@ -271,7 +282,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();
@@ -304,7 +315,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ This is a basic example that executes a simple select query with one facet and d
 
 ```php
 
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $query = $client->createSelect();
 
 $facetSet = $query->getFacetSet();

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -57,7 +57,7 @@ use Solarium\Plugin\BufferedAdd\Event\PreFlush as PreFlushEvent;
 htmlHeader();
 
 // create a client instance and autoload the buffered add plugin
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $buffer = $client->getPlugin('bufferedadd');
 $buffer->setBufferSize(10); // this is quite low, in most cases you can use a much higher value
 
@@ -115,7 +115,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and autoload the customize request plugin
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $customizer = $client->getPlugin('customizerequest');
 
 // add a persistent HTTP header (using array input values)
@@ -190,7 +190,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and create endpoints
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $endpoint1 = $client->createEndpoint('local1'); //normally you would add endpoint specific settings...
 $endpoint2 = $client->createEndpoint('local2');
 $endpoint3 = $client->createEndpoint('local3');
@@ -262,7 +262,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // enable the plugin and get a query instance
 $filter = $client->getPlugin('minimumscorefilter');
@@ -314,7 +314,7 @@ This plugin makes it possible to execute multiple Solr queries at the same time,
 
 Some important notes:
 
--   This plugin makes use of the curl client adapter and calls curl\_multi\_exec, so you do need to have curl available in your PHP environment to be able to use it.
+-   This plugin makes use of the cURL client adapter and calls curl\_multi\_exec, so you do need to have cURL available in your PHP environment to be able to use it.
 -   Only request execution is parallel, requests preparation and result parsing cannot be done parallel. Luckily these parts cost very little time, far more time is in the requests.
 -   The execution time is limited by the slowest request. If you execute 3 queries with timings of 0.2, 0.4 and 1.2 seconds the execution time for all will be (near) 1.2 seconds.
 -   If one of the requests fails the other requests will still be executed and the results parsed. In the result array the entry for the failed query will contain an exception instead of a result object. It’s your own responsibility to check the result type.
@@ -332,7 +332,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and autoload the customize request plugin
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $parallel = $client->getPlugin('parallelexecution');
 
 // Add a delay param to better show the effect, as an example Solr install with
@@ -404,7 +404,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and autoload the postbigrequest plugin
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $client->getPlugin('postbigrequest');
 
 // create a basic query to execute
@@ -465,7 +465,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/analysis-query/analysis-document.md
+++ b/docs/queries/analysis-query/analysis-document.md
@@ -35,7 +35,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an analysis document query
 $query = $client->createAnalysisDocument();

--- a/docs/queries/analysis-query/analysis-field.md
+++ b/docs/queries/analysis-query/analysis-field.md
@@ -38,7 +38,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an analysis document query
 $query = $client->createAnalysisField();

--- a/docs/queries/extract-query.md
+++ b/docs/queries/extract-query.md
@@ -37,7 +37,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an extract query instance and add settings
 $query = $client->createExtract();

--- a/docs/queries/morelikethis-query.md
+++ b/docs/queries/morelikethis-query.md
@@ -63,7 +63,7 @@ use Solarium\Client;
 htmlHeader();
 
 // create a client instance
-$client = new Client($config);
+$client = new Client($adapter, $eventDispatcher, $config);
 
 // get a morelikethis query instance
 $query = $client->createMoreLikeThis();

--- a/docs/queries/ping-query.md
+++ b/docs/queries/ping-query.md
@@ -39,7 +39,7 @@ htmlHeader();
 echo 'Solarium library version: ' . Solarium\Client::VERSION . ' - ';
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // create a ping query
 $ping = $client->createPing();

--- a/docs/queries/query-helper/escaping.md
+++ b/docs/queries/query-helper/escaping.md
@@ -9,7 +9,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/query-helper/placeholders.md
+++ b/docs/queries/query-helper/placeholders.md
@@ -39,7 +39,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/query-helper/query-helper.md
+++ b/docs/queries/query-helper/query-helper.md
@@ -37,7 +37,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance and a query helper instance
 $query = $client->createSelect();

--- a/docs/queries/realtimeget-query.md
+++ b/docs/queries/realtimeget-query.md
@@ -36,7 +36,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/select-query/building-a-select-query/adding-filterqueries.md
+++ b/docs/queries/select-query/building-a-select-query/adding-filterqueries.md
@@ -22,7 +22,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/building-a-select-query.md
+++ b/docs/queries/select-query/building-a-select-query/building-a-select-query.md
@@ -36,7 +36,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -118,7 +118,7 @@ $select = array(
 );
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance based on the config
 $query = $client->createSelect($select);

--- a/docs/queries/select-query/building-a-select-query/components/debug-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/debug-component.md
@@ -18,7 +18,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/dismax-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/dismax-component.md
@@ -33,7 +33,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/distributed-search-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/distributed-search-component.md
@@ -21,7 +21,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/edismax-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/edismax-component.md
@@ -32,7 +32,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
@@ -31,7 +31,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-multiquery.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-multiquery.md
@@ -16,7 +16,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-pivot.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-pivot.md
@@ -23,7 +23,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-query.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-query.md
@@ -22,7 +22,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-range.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-range.md
@@ -30,7 +30,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -80,7 +80,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/grouping-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/grouping-component.md
@@ -33,7 +33,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -93,7 +93,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
@@ -49,7 +49,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -107,7 +107,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
@@ -27,7 +27,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
@@ -25,7 +25,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/query-rerankquery-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-rerankquery-component.md
@@ -24,7 +24,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/spellcheck-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/spellcheck-component.md
@@ -37,7 +37,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/building-a-select-query/components/stats-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/stats-component.md
@@ -19,7 +19,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/executing-a-select-query.md
+++ b/docs/queries/select-query/executing-a-select-query.md
@@ -9,7 +9,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createQuery($client::QUERY_SELECT);

--- a/docs/queries/select-query/re-use-of-queries.md
+++ b/docs/queries/select-query/re-use-of-queries.md
@@ -12,7 +12,7 @@ use Solarium\QueryType\Select\Query\Query as Select;
 htmlHeader();
 
 // create a client instance
-$client = new Client($config);
+$client = new Client($adapter, $eventDispatcher, $config);
 
 
 // first create a base query as a query class

--- a/docs/queries/select-query/result-of-a-select-query/component-results/facetset-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/facetset-result.md
@@ -18,7 +18,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -70,7 +70,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -119,7 +119,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -175,7 +175,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/result-of-a-select-query/component-results/grouping-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/grouping-result.md
@@ -20,7 +20,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -80,7 +80,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/result-of-a-select-query/component-results/highlighting-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/highlighting-result.md
@@ -12,7 +12,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
@@ -12,7 +12,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/docs/queries/select-query/result-of-a-select-query/result-of-a-select-query.md
+++ b/docs/queries/select-query/result-of-a-select-query/result-of-a-select-query.md
@@ -43,7 +43,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createQuery($client::QUERY_SELECT);

--- a/docs/queries/server-query/core-admin-query.md
+++ b/docs/queries/server-query/core-admin-query.md
@@ -14,7 +14,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // create a core admin query
 $coreAdminQuery = $client->createCoreAdmin();

--- a/docs/queries/suggester-query.md
+++ b/docs/queries/suggester-query.md
@@ -35,7 +35,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a suggester query instance
 $query = $client->createSuggester();

--- a/docs/queries/terms-query.md
+++ b/docs/queries/terms-query.md
@@ -44,7 +44,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a terms query instance
 $query = $client->createTerms();

--- a/docs/queries/update-query/building-an-update-query/add-command.md
+++ b/docs/queries/update-query/building-an-update-query/add-command.md
@@ -31,7 +31,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/update-query/building-an-update-query/building-an-update-query.md
+++ b/docs/queries/update-query/building-an-update-query/building-an-update-query.md
@@ -38,7 +38,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();
@@ -79,7 +79,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/update-query/building-an-update-query/commit-command.md
+++ b/docs/queries/update-query/building-an-update-query/commit-command.md
@@ -29,7 +29,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/update-query/building-an-update-query/delete-command.md
+++ b/docs/queries/update-query/building-an-update-query/delete-command.md
@@ -17,7 +17,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();
@@ -44,7 +44,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/update-query/building-an-update-query/optimize-command.md
+++ b/docs/queries/update-query/building-an-update-query/optimize-command.md
@@ -29,7 +29,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/update-query/building-an-update-query/rawxml-command.md
+++ b/docs/queries/update-query/building-an-update-query/rawxml-command.md
@@ -17,7 +17,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/update-query/building-an-update-query/rollback-command.md
+++ b/docs/queries/update-query/building-an-update-query/rollback-command.md
@@ -17,7 +17,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/queries/update-query/executing-an-update-query.md
+++ b/docs/queries/update-query/executing-an-update-query.md
@@ -9,7 +9,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/docs/solarium-concepts.md
+++ b/docs/solarium-concepts.md
@@ -28,7 +28,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();
@@ -108,7 +108,7 @@ $select = array(
 );
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance based on the config
 $query = $client->createSelect($select);
@@ -186,7 +186,7 @@ class ProductPriceLimitedQuery extends ProductQuery
 }
 
 // create a client instance
-$client = new Client($config);
+$client = new Client($adapter, $eventDispatcher, $config);
 
 // create a query instance
 $query = new ProductPriceLimitedQuery;

--- a/examples/1.1-check-solarium-and-ping.php
+++ b/examples/1.1-check-solarium-and-ping.php
@@ -7,7 +7,7 @@ htmlHeader();
 echo 'Solarium library version: ' . Solarium\Client::VERSION . ' - ';
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // create a ping query
 $ping = $client->createPing();

--- a/examples/1.1-check-solarium-and-ping.php
+++ b/examples/1.1-check-solarium-and-ping.php
@@ -7,7 +7,7 @@ htmlHeader();
 echo 'Solarium library version: ' . Solarium\Client::VERSION . ' - ';
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // create a ping query
 $ping = $client->createPing();

--- a/examples/1.2-basic-select.php
+++ b/examples/1.2-basic-select.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createQuery($client::QUERY_SELECT);

--- a/examples/1.2-basic-select.php
+++ b/examples/1.2-basic-select.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createQuery($client::QUERY_SELECT);

--- a/examples/1.3-basic-update.php
+++ b/examples/1.3-basic-update.php
@@ -7,7 +7,7 @@ if ($_POST) {
     // if data is posted add it to solr
 
     // create a client instance
-    $client = new Solarium\Client($adapter, $dispatcher, $config);
+    $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
     // get an update query instance
     $update = $client->createUpdate();

--- a/examples/1.3-basic-update.php
+++ b/examples/1.3-basic-update.php
@@ -7,7 +7,7 @@ if ($_POST) {
     // if data is posted add it to solr
 
     // create a client instance
-    $client = new Solarium\Client($config);
+    $client = new Solarium\Client($adapter, $dispatcher, $config);
 
     // get an update query instance
     $update = $client->createUpdate();

--- a/examples/2.1.1-query-params.php
+++ b/examples/2.1.1-query-params.php
@@ -5,7 +5,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.1-query-params.php
+++ b/examples/2.1.1-query-params.php
@@ -5,7 +5,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.2-custom-result-document.php
+++ b/examples/2.1.2-custom-result-document.php
@@ -15,7 +15,7 @@ class MyDoc extends Solarium\QueryType\Select\Result\Document
 
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.2-custom-result-document.php
+++ b/examples/2.1.2-custom-result-document.php
@@ -15,7 +15,7 @@ class MyDoc extends Solarium\QueryType\Select\Result\Document
 
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.3-filterquery.php
+++ b/examples/2.1.3-filterquery.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.3-filterquery.php
+++ b/examples/2.1.3-filterquery.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.1.1-facet-field.php
+++ b/examples/2.1.5.1.1-facet-field.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.1.1-facet-field.php
+++ b/examples/2.1.5.1.1-facet-field.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.1.2-facet-query.php
+++ b/examples/2.1.5.1.2-facet-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.1.2-facet-query.php
+++ b/examples/2.1.5.1.2-facet-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.1.3-facet-multiquery.php
+++ b/examples/2.1.5.1.3-facet-multiquery.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.1.3-facet-multiquery.php
+++ b/examples/2.1.5.1.3-facet-multiquery.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.1.4-facet-range.php
+++ b/examples/2.1.5.1.4-facet-range.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.1.4-facet-range.php
+++ b/examples/2.1.5.1.4-facet-range.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.1.5-facet-pivot.php
+++ b/examples/2.1.5.1.5-facet-pivot.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.1.5-facet-pivot.php
+++ b/examples/2.1.5.1.5-facet-pivot.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.1.6-facet-interval.php
+++ b/examples/2.1.5.1.6-facet-interval.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.1.6-facet-interval.php
+++ b/examples/2.1.5.1.6-facet-interval.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.10-stats.php
+++ b/examples/2.1.5.10-stats.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.10-stats.php
+++ b/examples/2.1.5.10-stats.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.11-debug.php
+++ b/examples/2.1.5.11-debug.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.11-debug.php
+++ b/examples/2.1.5.11-debug.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.12-queryelevation.php
+++ b/examples/2.1.5.12-queryelevation.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.12-queryelevation.php
+++ b/examples/2.1.5.12-queryelevation.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.2-morelikethis.php
+++ b/examples/2.1.5.2-morelikethis.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.2-morelikethis.php
+++ b/examples/2.1.5.2-morelikethis.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.3-highlighting.php
+++ b/examples/2.1.5.3-highlighting.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.3-highlighting.php
+++ b/examples/2.1.5.3-highlighting.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.3.1-per-field-highlighting.php
+++ b/examples/2.1.5.3.1-per-field-highlighting.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.3.1-per-field-highlighting.php
+++ b/examples/2.1.5.3.1-per-field-highlighting.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.4-dismax.php
+++ b/examples/2.1.5.4-dismax.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.4-dismax.php
+++ b/examples/2.1.5.4-dismax.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.5-edismax.php
+++ b/examples/2.1.5.5-edismax.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.5-edismax.php
+++ b/examples/2.1.5.5-edismax.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.6-grouping-by-field.php
+++ b/examples/2.1.5.6-grouping-by-field.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.6-grouping-by-field.php
+++ b/examples/2.1.5.6-grouping-by-field.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.7-grouping-by-query.php
+++ b/examples/2.1.5.7-grouping-by-query.php
@@ -6,7 +6,7 @@ htmlHeader();
 echo "<h2>Note: Query grouping seems to be broken in Solr 8.0.0!</h2>";
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.7-grouping-by-query.php
+++ b/examples/2.1.5.7-grouping-by-query.php
@@ -6,7 +6,7 @@ htmlHeader();
 echo "<h2>Note: Query grouping seems to be broken in Solr 8.0.0!</h2>";
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.8-distributed-search.php
+++ b/examples/2.1.5.8-distributed-search.php
@@ -6,7 +6,7 @@ htmlHeader();
 echo "<h2>Note: The techproducts isn't distributed by default!</h2>";
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.8-distributed-search.php
+++ b/examples/2.1.5.8-distributed-search.php
@@ -6,7 +6,7 @@ htmlHeader();
 echo "<h2>Note: The techproducts isn't distributed by default!</h2>";
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/2.1.5.9-spellcheck.php
+++ b/examples/2.1.5.9-spellcheck.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect()

--- a/examples/2.1.5.9-spellcheck.php
+++ b/examples/2.1.5.9-spellcheck.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect()

--- a/examples/2.1.6-helper-functions.php
+++ b/examples/2.1.6-helper-functions.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance and a query helper instance
 $query = $client->createSelect();

--- a/examples/2.1.6-helper-functions.php
+++ b/examples/2.1.6-helper-functions.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance and a query helper instance
 $query = $client->createSelect();

--- a/examples/2.1.7-query-reuse.php
+++ b/examples/2.1.7-query-reuse.php
@@ -7,7 +7,7 @@ use Solarium\QueryType\Select\Query\Query as Select;
 htmlHeader();
 
 // create a client instance
-$client = new Client($adapter, $dispatcher, $config);
+$client = new Client($adapter, $eventDispatcher, $config);
 
 
 // first create a base query as a query class

--- a/examples/2.1.7-query-reuse.php
+++ b/examples/2.1.7-query-reuse.php
@@ -7,7 +7,7 @@ use Solarium\QueryType\Select\Query\Query as Select;
 htmlHeader();
 
 // create a client instance
-$client = new Client($config);
+$client = new Client($adapter, $dispatcher, $config);
 
 
 // first create a base query as a query class

--- a/examples/2.2.1-add-docs.php
+++ b/examples/2.2.1-add-docs.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.2.1-add-docs.php
+++ b/examples/2.2.1-add-docs.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.2.2-delete-by-query.php
+++ b/examples/2.2.2-delete-by-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.2.2-delete-by-query.php
+++ b/examples/2.2.2-delete-by-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.2.3-delete-by-id.php
+++ b/examples/2.2.3-delete-by-id.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.2.3-delete-by-id.php
+++ b/examples/2.2.3-delete-by-id.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.2.4-optimize.php
+++ b/examples/2.2.4-optimize.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.2.4-optimize.php
+++ b/examples/2.2.4-optimize.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.2.5-rollback.php
+++ b/examples/2.2.5-rollback.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.2.5-rollback.php
+++ b/examples/2.2.5-rollback.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.2.6-rawxml.php
+++ b/examples/2.2.6-rawxml.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.2.6-rawxml.php
+++ b/examples/2.2.6-rawxml.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.3.1-mlt-query.php
+++ b/examples/2.3.1-mlt-query.php
@@ -6,7 +6,7 @@ use Solarium\Client;
 htmlHeader();
 
 // create a client instance
-$client = new Client($config);
+$client = new Client($adapter, $dispatcher, $config);
 
 // get a morelikethis query instance
 $query = $client->createSelect()

--- a/examples/2.3.1-mlt-query.php
+++ b/examples/2.3.1-mlt-query.php
@@ -6,7 +6,7 @@ use Solarium\Client;
 htmlHeader();
 
 // create a client instance
-$client = new Client($adapter, $dispatcher, $config);
+$client = new Client($adapter, $eventDispatcher, $config);
 
 // get a morelikethis query instance
 $query = $client->createSelect()

--- a/examples/2.3.2-mlt-stream.php
+++ b/examples/2.3.2-mlt-stream.php
@@ -6,7 +6,7 @@ htmlHeader();
 echo "<h2>Note: The techproducts example doesn't include a /mlt handler anymore!</h2>";
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a morelikethis query instance
 $query = $client->createMoreLikeThis();

--- a/examples/2.3.2-mlt-stream.php
+++ b/examples/2.3.2-mlt-stream.php
@@ -6,7 +6,7 @@ htmlHeader();
 echo "<h2>Note: The techproducts example doesn't include a /mlt handler anymore!</h2>";
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a morelikethis query instance
 $query = $client->createMoreLikeThis();

--- a/examples/2.4.1-analysis-document.php
+++ b/examples/2.4.1-analysis-document.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an analysis document query
 $query = $client->createAnalysisDocument();

--- a/examples/2.4.1-analysis-document.php
+++ b/examples/2.4.1-analysis-document.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get an analysis document query
 $query = $client->createAnalysisDocument();

--- a/examples/2.4.2-analysis-field.php
+++ b/examples/2.4.2-analysis-field.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an analysis document query
 $query = $client->createAnalysisField();

--- a/examples/2.4.2-analysis-field.php
+++ b/examples/2.4.2-analysis-field.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get an analysis document query
 $query = $client->createAnalysisField();

--- a/examples/2.5-terms-query.php
+++ b/examples/2.5-terms-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a terms query instance
 $query = $client->createTerms();

--- a/examples/2.5-terms-query.php
+++ b/examples/2.5-terms-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a terms query instance
 $query = $client->createTerms();

--- a/examples/2.6-spellcheck-query.php
+++ b/examples/2.6-spellcheck-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a spellcheck query instance
 $query = $client->createSpellcheck();

--- a/examples/2.6-spellcheck-query.php
+++ b/examples/2.6-spellcheck-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a spellcheck query instance
 $query = $client->createSpellcheck();

--- a/examples/2.6-suggester-query.php
+++ b/examples/2.6-suggester-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a suggester query instance
 $query = $client->createSuggester();

--- a/examples/2.6-suggester-query.php
+++ b/examples/2.6-suggester-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a suggester query instance
 $query = $client->createSuggester();

--- a/examples/2.7-extract-query.php
+++ b/examples/2.7-extract-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an extract query instance and add settings
 $query = $client->createExtract();

--- a/examples/2.7-extract-query.php
+++ b/examples/2.7-extract-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get an extract query instance and add settings
 $query = $client->createExtract();

--- a/examples/2.8-realtime-get-query.php
+++ b/examples/2.8-realtime-get-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.8-realtime-get-query.php
+++ b/examples/2.8-realtime-get-query.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get an update query instance
 $update = $client->createUpdate();

--- a/examples/2.9-server-core-admin-status.php
+++ b/examples/2.9-server-core-admin-status.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // create a core admin query
 $coreAdminQuery = $client->createCoreAdmin();

--- a/examples/2.9-server-core-admin-status.php
+++ b/examples/2.9-server-core-admin-status.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // create a core admin query
 $coreAdminQuery = $client->createCoreAdmin();

--- a/examples/4.1-api-usage.php
+++ b/examples/4.1-api-usage.php
@@ -5,7 +5,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/4.1-api-usage.php
+++ b/examples/4.1-api-usage.php
@@ -5,7 +5,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/4.2-configuration-usage.php
+++ b/examples/4.2-configuration-usage.php
@@ -29,7 +29,7 @@ $select = array(
 );
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance based on the config
 $query = $client->createSelect($select);

--- a/examples/4.2-configuration-usage.php
+++ b/examples/4.2-configuration-usage.php
@@ -29,7 +29,7 @@ $select = array(
 );
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance based on the config
 $query = $client->createSelect($select);

--- a/examples/4.3-extending-usage.php
+++ b/examples/4.3-extending-usage.php
@@ -40,7 +40,7 @@ class ProductPriceLimitedQuery extends ProductQuery
 }
 
 // create a client instance
-$client = new Client($config);
+$client = new Client($adapter, $dispatcher, $config);
 
 // create a query instance
 $query = new ProductPriceLimitedQuery;

--- a/examples/4.3-extending-usage.php
+++ b/examples/4.3-extending-usage.php
@@ -40,7 +40,7 @@ class ProductPriceLimitedQuery extends ProductQuery
 }
 
 // create a client instance
-$client = new Client($adapter, $dispatcher, $config);
+$client = new Client($adapter, $eventDispatcher, $config);
 
 // create a query instance
 $query = new ProductPriceLimitedQuery;

--- a/examples/5.1-partial-usage.php
+++ b/examples/5.1-partial-usage.php
@@ -10,7 +10,7 @@ htmlHeader();
 
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // create a select query instance
 $query = $client->createSelect();

--- a/examples/5.1-partial-usage.php
+++ b/examples/5.1-partial-usage.php
@@ -10,7 +10,7 @@ htmlHeader();
 
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // create a select query instance
 $query = $client->createSelect();

--- a/examples/5.2-extending.php
+++ b/examples/5.2-extending.php
@@ -27,7 +27,7 @@ class MyClient extends Client
 
 
 // create a client instance
-$client = new MyClient($adapter, $dispatcher, $config);
+$client = new MyClient($adapter, $eventDispatcher, $config);
 
 // create a select query instance
 $query = $client->createSelect();

--- a/examples/5.2-extending.php
+++ b/examples/5.2-extending.php
@@ -27,7 +27,7 @@ class MyClient extends Client
 
 
 // create a client instance
-$client = new MyClient($config);
+$client = new MyClient($adapter, $dispatcher, $config);
 
 // create a select query instance
 $query = $client->createSelect();

--- a/examples/5.3.1-plugin-event-hooks.php
+++ b/examples/5.3.1-plugin-event-hooks.php
@@ -99,7 +99,7 @@ htmlHeader();
 
 // create a client instance and register the plugin
 $plugin = new BasicDebug();
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 $client->registerPlugin('debugger', $plugin);
 
 // execute a select query and display the results

--- a/examples/5.3.1-plugin-event-hooks.php
+++ b/examples/5.3.1-plugin-event-hooks.php
@@ -99,7 +99,7 @@ htmlHeader();
 
 // create a client instance and register the plugin
 $plugin = new BasicDebug();
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $client->registerPlugin('debugger', $plugin);
 
 // execute a select query and display the results

--- a/examples/5.3.2-plugin-solarium-presets.php
+++ b/examples/5.3.2-plugin-solarium-presets.php
@@ -26,7 +26,7 @@ class QueryCustomizer extends AbstractPlugin
 htmlHeader();
 
 // create a client instance and register the plugin
-$client = new Client($config);
+$client = new Client($adapter, $dispatcher, $config);
 $client->registerPlugin('querycustomizer', 'QueryCustomizer');
 
 // create a select query instance

--- a/examples/5.3.2-plugin-solarium-presets.php
+++ b/examples/5.3.2-plugin-solarium-presets.php
@@ -26,7 +26,7 @@ class QueryCustomizer extends AbstractPlugin
 htmlHeader();
 
 // create a client instance and register the plugin
-$client = new Client($adapter, $dispatcher, $config);
+$client = new Client($adapter, $eventDispatcher, $config);
 $client->registerPlugin('querycustomizer', 'QueryCustomizer');
 
 // create a select query instance

--- a/examples/6.1.1-psr18-adapter.php
+++ b/examples/6.1.1-psr18-adapter.php
@@ -9,7 +9,7 @@ $factory = new Nyholm\Psr7\Factory\Psr17Factory();
 $adapter = new Solarium\Core\Client\Adapter\Psr18Adapter($httpClient, $factory, $factory);
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/6.1.1-psr18-adapter.php
+++ b/examples/6.1.1-psr18-adapter.php
@@ -3,11 +3,13 @@
 require(__DIR__.'/init.php');
 htmlHeader();
 
-// create a client instance
-$client = new Solarium\Client($config);
+// create a PSR-18 adapter instance
+$httpClient = new Http\Adapter\Guzzle6\Client();
+$factory = new Nyholm\Psr7\Factory\Psr17Factory();
+$adapter = new Solarium\Core\Client\Adapter\Psr18Adapter($httpClient, $factory, $factory);
 
-// set the adapter to zendhttp and get a zendhttp client instance reference
-$client->setAdapter(\Solarium\Core\Client\Adapter\Zend2Http::class);
+// create a client instance
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/6.1.2-curl-adapter.php
+++ b/examples/6.1.2-curl-adapter.php
@@ -3,13 +3,11 @@
 require(__DIR__.'/init.php');
 htmlHeader();
 
-// create a client instance
-$client = new Solarium\Client($config);
+// create a cURL adapter instance
+$adapter = new Solarium\Core\Client\Adapter\Curl();
 
-// set the adapter to curl
-// note that this is only shown for documentation purposes, normally you don't need
-// to do this as curl is the default adapter
-$client->setAdapter(\Solarium\Core\Client\Adapter\Curl::class);
+// create a client instance
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/6.1.2-curl-adapter.php
+++ b/examples/6.1.2-curl-adapter.php
@@ -7,7 +7,7 @@ htmlHeader();
 $adapter = new Solarium\Core\Client\Adapter\Curl();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/6.1.3-http-adapter.php
+++ b/examples/6.1.3-http-adapter.php
@@ -3,11 +3,11 @@
 require(__DIR__.'/init.php');
 htmlHeader();
 
-// create a client instance
-$client = new Solarium\Client($config);
+// create an HTTP adapter instance
+$adapter = new Solarium\Core\Client\Adapter\Http();
 
-// set the adapter to curl
-$client->setAdapter(\Solarium\Core\Client\Adapter\Http::class);
+// create a client instance
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/6.1.3-http-adapter.php
+++ b/examples/6.1.3-http-adapter.php
@@ -7,7 +7,7 @@ htmlHeader();
 $adapter = new Solarium\Core\Client\Adapter\Http();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/6.2-escaping.php
+++ b/examples/6.2-escaping.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/6.2-escaping.php
+++ b/examples/6.2-escaping.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/6.3-placeholder-syntax.php
+++ b/examples/6.3-placeholder-syntax.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/6.3-placeholder-syntax.php
+++ b/examples/6.3-placeholder-syntax.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/6.4-dereferenced-params.php
+++ b/examples/6.4-dereferenced-params.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and get a select query instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 
 

--- a/examples/6.4-dereferenced-params.php
+++ b/examples/6.4-dereferenced-params.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and get a select query instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 
 

--- a/examples/7.1-plugin-loadbalancer.php
+++ b/examples/7.1-plugin-loadbalancer.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and create endpoints
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 // copy the default endpoint core for the demo
 $core = $client->getEndpoint()->getCore();
 

--- a/examples/7.1-plugin-loadbalancer.php
+++ b/examples/7.1-plugin-loadbalancer.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and create endpoints
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 // copy the default endpoint core for the demo
 $core = $client->getEndpoint()->getCore();
 

--- a/examples/7.2-plugin-postbigrequest.php
+++ b/examples/7.2-plugin-postbigrequest.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and autoload the postbigrequest plugin
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 $client->getPlugin('postbigrequest');
 
 // create a basic query to execute

--- a/examples/7.2-plugin-postbigrequest.php
+++ b/examples/7.2-plugin-postbigrequest.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and autoload the postbigrequest plugin
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $client->getPlugin('postbigrequest');
 
 // create a basic query to execute

--- a/examples/7.3-plugin-customizerequest.php
+++ b/examples/7.3-plugin-customizerequest.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and autoload the customize request plugin
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 $customizer = $client->getPlugin('customizerequest');
 
 // add a persistent HTTP header (using array input values)

--- a/examples/7.3-plugin-customizerequest.php
+++ b/examples/7.3-plugin-customizerequest.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and autoload the customize request plugin
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $customizer = $client->getPlugin('customizerequest');
 
 // add a persistent HTTP header (using array input values)

--- a/examples/7.4-plugin-parallelexecution.php
+++ b/examples/7.4-plugin-parallelexecution.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and autoload the customize request plugin
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 $parallel = $client->getPlugin('parallelexecution');
 
 // Add a delay param to better show the effect, as an example Solr install with

--- a/examples/7.4-plugin-parallelexecution.php
+++ b/examples/7.4-plugin-parallelexecution.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance and autoload the customize request plugin
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $parallel = $client->getPlugin('parallelexecution');
 
 // Add a delay param to better show the effect, as an example Solr install with

--- a/examples/7.5-plugin-bufferedadd.php
+++ b/examples/7.5-plugin-bufferedadd.php
@@ -7,7 +7,7 @@ use Solarium\Plugin\BufferedAdd\Event\PreFlush as PreFlushEvent;
 htmlHeader();
 
 // create a client instance and autoload the buffered add plugin
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $buffer = $client->getPlugin('bufferedadd');
 $buffer->setBufferSize(10); // this is quite low, in most cases you can use a much higher value
 

--- a/examples/7.5-plugin-bufferedadd.php
+++ b/examples/7.5-plugin-bufferedadd.php
@@ -7,7 +7,7 @@ use Solarium\Plugin\BufferedAdd\Event\PreFlush as PreFlushEvent;
 htmlHeader();
 
 // create a client instance and autoload the buffered add plugin
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 $buffer = $client->getPlugin('bufferedadd');
 $buffer->setBufferSize(10); // this is quite low, in most cases you can use a much higher value
 

--- a/examples/7.6-plugin-prefetchiterator.php
+++ b/examples/7.6-plugin-prefetchiterator.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/7.6-plugin-prefetchiterator.php
+++ b/examples/7.6-plugin-prefetchiterator.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect();

--- a/examples/7.7-plugin-minimumscorefilter.php
+++ b/examples/7.7-plugin-minimumscorefilter.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // enable the plugin and get a query instance
 $filter = $client->getPlugin('minimumscorefilter');

--- a/examples/7.7-plugin-minimumscorefilter.php
+++ b/examples/7.7-plugin-minimumscorefilter.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // enable the plugin and get a query instance
 $filter = $client->getPlugin('minimumscorefilter');

--- a/examples/7.7.1-plugin-minimumscorefilter-grouping.php
+++ b/examples/7.7.1-plugin-minimumscorefilter-grouping.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($config);
+$client = new Solarium\Client($adapter, $dispatcher, $config);
 
 // enable the filter plugin and get a query instance
 $filter = $client->getPlugin('minimumscorefilter');

--- a/examples/7.7.1-plugin-minimumscorefilter-grouping.php
+++ b/examples/7.7.1-plugin-minimumscorefilter-grouping.php
@@ -4,7 +4,7 @@ require(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
-$client = new Solarium\Client($adapter, $dispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // enable the filter plugin and get a query instance
 $filter = $client->getPlugin('minimumscorefilter');

--- a/examples/index.html
+++ b/examples/index.html
@@ -129,9 +129,9 @@
             <ul style="list-style:none;">
                 <li>6.1 Client adapters</li>
                 <ul style="list-style:none;">
-                    <li><a href="6.1.1-zend-http-adapter.php">6.1.1 Zend_Http adapter</a></li>
-                    <li><a href="6.1.2-curl-adapter.php">6.1.2 Curl adapter</a></li>
-                    <li><a href="6.1.3-http-adapter.php">6.1.3 Http adapter (PHP stream)</a></li>
+                    <li><a href="6.1.1-psr18-adapter.php">6.1.1 PSR-18 adapter</a></li>
+                    <li><a href="6.1.2-curl-adapter.php">6.1.2 cURL adapter</a></li>
+                    <li><a href="6.1.3-http-adapter.php">6.1.3 HTTP adapter (PHP stream)</a></li>
                 </ul>
                 <li><a href="6.2-escaping.php">6.2 Escaping</a></li>
                 <li><a href="6.3-placeholder-syntax.php">6.3 Placeholder syntax</a></li>

--- a/examples/init.php
+++ b/examples/init.php
@@ -1,13 +1,19 @@
 <?php
 
+use Solarium\Core\Client\Adapter\Curl;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
 error_reporting(E_ALL);
 ini_set('display_errors', true);
 
-if (file_exists($_SERVER['DOCUMENT_ROOT'] .'/config.php')) {
-    require($_SERVER['DOCUMENT_ROOT'] .'/config.php');
+if (file_exists('config.php')) {
+    require('config.php');
 }
 
 require $config['autoload'] ?? __DIR__.'/../vendor/autoload.php';
+
+$adapter = new Curl();
+$dispatcher = new EventDispatcher();
 
 function htmlHeader()
 {

--- a/examples/init.php
+++ b/examples/init.php
@@ -13,7 +13,7 @@ if (file_exists('config.php')) {
 require $config['autoload'] ?? __DIR__.'/../vendor/autoload.php';
 
 $adapter = new Curl();
-$dispatcher = new EventDispatcher();
+$eventDispatcher = new EventDispatcher();
 
 function htmlHeader()
 {


### PR DESCRIPTION
I've updated the examples to use the new signature for the Client constructor. To avoid duplicating code, `$adapter` and `$eventDispatcher` are initialised in `init.php`. `init.php` was also modified to actually include `config.php`. The examples work out-of-the-box now (provided Solr is running on localhost).

The examples under "6.1 Client adapters" were updated to set up a specific `$adapter` to use in the Client constructor (instead of `setAdapter()`). The Zend_Http example was removed and a PSR-18 example added.

I've reflected these changes in the docs as well. I've included @dmaicher's documentation from PR #773 and added a note on how `$adapter` and `$eventDispatcher` are initialised in `init.php`.