### PR TITLE
Add @coversNothing to integration tests

### DIFF
--- a/tests/Integration/SolrCloud/CollectionsCurlTest.php
+++ b/tests/Integration/SolrCloud/CollectionsCurlTest.php
@@ -8,6 +8,7 @@ use Solarium\Tests\Integration\AbstractCollectionsTest;
 /**
  * @group integration
  * @group solr_cloud
+ * @coversNothing
  */
 class CollectionsCurlTest extends AbstractCollectionsTest
 {

--- a/tests/Integration/SolrCloud/CollectionsHttpTest.php
+++ b/tests/Integration/SolrCloud/CollectionsHttpTest.php
@@ -8,6 +8,7 @@ use Solarium\Tests\Integration\AbstractCollectionsTest;
 /**
  * @group integration
  * @group solr_cloud
+ * @coversNothing
  */
 class CollectionsHttpTest extends AbstractCollectionsTest
 {

--- a/tests/Integration/SolrCloud/CollectionsPsr18Test.php
+++ b/tests/Integration/SolrCloud/CollectionsPsr18Test.php
@@ -7,6 +7,7 @@ use Solarium\Tests\Integration\AbstractCollectionsTest;
 /**
  * @group integration
  * @group solr_cloud
+ * @coversNothing
  */
 class CollectionsPsr18Test extends AbstractCollectionsTest
 {

--- a/tests/Integration/TechproductsAdapters/TechproductsCurlTest.php
+++ b/tests/Integration/TechproductsAdapters/TechproductsCurlTest.php
@@ -8,6 +8,7 @@ use Solarium\Tests\Integration\AbstractCoreTest;
 /**
  * @group integration
  * @group solr_no_cloud
+ * @coversNothing
  */
 class TechproductsCurlTest extends AbstractCoreTest
 {

--- a/tests/Integration/TechproductsAdapters/TechproductsHttpTest.php
+++ b/tests/Integration/TechproductsAdapters/TechproductsHttpTest.php
@@ -8,6 +8,7 @@ use Solarium\Tests\Integration\AbstractCoreTest;
 /**
  * @group integration
  * @group solr_no_cloud
+ * @coversNothing
  */
 class TechproductsHttpTest extends AbstractCoreTest
 {

--- a/tests/Integration/TechproductsAdapters/TechproductsPsr18Test.php
+++ b/tests/Integration/TechproductsAdapters/TechproductsPsr18Test.php
@@ -7,6 +7,7 @@ use Solarium\Tests\Integration\AbstractCoreTest;
 /**
  * @group integration
  * @group solr_no_cloud
+ * @coversNothing
  */
 class TechproductsPsr18Test extends AbstractCoreTest
 {


### PR DESCRIPTION
As discussed in #747.

If parts of the codebase can only be tested in an integration test, we can override this with `@covers` on a method level.