### PR TITLE
Small fixes in examples

### DIFF
--- a/docs/queries/select-query/building-a-select-query/building-a-select-query.md
+++ b/docs/queries/select-query/building-a-select-query/building-a-select-query.md
@@ -110,8 +110,8 @@ $select = array(
     'component' => array(
         'facetset' => array(
             'facet' => array(
-                // notice this config uses an inline key value, instead of array key like the filterquery
-                array('type' => 'field', 'key' => 'stock', 'field' => 'inStock'),
+                // notice this config uses an inline key value under 'local_key', instead of array key like the filterquery
+                array('type' => 'field', 'local_key' => 'stock', 'field' => 'inStock'),
             )
         ),
     ),

--- a/docs/solarium-concepts.md
+++ b/docs/solarium-concepts.md
@@ -100,8 +100,8 @@ $select = array(
     'component' => array(
         'facetset' => array(
             'facet' => array(
-                // notice this config uses an inline key value, instead of array key like the filterquery
-                array('type' => 'field', 'key' => 'stock', 'field' => 'inStock'),
+                // notice this config uses an inline key value under 'local_key', instead of array key like the filterquery
+                array('type' => 'field', 'local_key' => 'stock', 'field' => 'inStock'),
             )
         ),
     ),

--- a/examples/2.1.5.1.6-facet-interval.php
+++ b/examples/2.1.5.1.6-facet-interval.php
@@ -26,8 +26,8 @@ echo 'NumFound: '.$resultset->getNumFound();
 // display facet counts
 echo '<hr/>Facet intervals:<br/>';
 $facet = $resultset->getFacetSet()->getFacet('price');
-foreach ($facet as $range => $count) {
-    echo $range . ' to ' . ($range + 100) . ' [' . $count . ']<br/>';
+foreach ($facet as $interval => $count) {
+    echo $interval . ' [' . $count . ']<br/>';
 }
 
 // show documents using the resultset iterator

--- a/examples/4.2-configuration-usage.php
+++ b/examples/4.2-configuration-usage.php
@@ -21,8 +21,8 @@ $select = array(
     'component' => array(
         'facetset' => array(
             'facet' => array(
-                // notice this config uses an inline key value, instead of array key like the filterquery
-                array('type' => 'field', 'key' => 'stock', 'field' => 'inStock'),
+                // notice this config uses an inline key value under 'local_key', instead of array key like the filterquery
+                array('type' => 'field', 'local_key' => 'stock', 'field' => 'inStock'),
             )
         ),
     ),

--- a/examples/example.xml
+++ b/examples/example.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<add>
+    <doc>
+        <field name="id">127</field>
+        <field name="name">testdoc-5</field>
+        <field name="price">425</field>
+    </doc>
+</add>


### PR DESCRIPTION
Some examples couldn't be run because of easily fixable mistakes.

- 2.1.5.1.6-facet-interval generated a notice when displaying results (incorrectly reused code from facet-range)
- 2.2.6-rawxml shows how to load commands from an XML file, I've added an `example.xml` to run it with
- 4.2-configuration-usage specified the facet key as 'key' instead of 'local_key' in the config, this was also fixed in the docs