### PR TITLE
Make Psr18Adapter not final and private members/methods protected

### DIFF
--- a/src/Core/Client/Adapter/Psr18Adapter.php
+++ b/src/Core/Client/Adapter/Psr18Adapter.php
@@ -13,22 +13,22 @@ use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
 use Solarium\Exception\HttpException;
 
-final class Psr18Adapter implements AdapterInterface
+class Psr18Adapter implements AdapterInterface
 {
     /**
      * @var ClientInterface
      */
-    private $httpClient;
+    protected $httpClient;
 
     /**
      * @var RequestFactoryInterface
      */
-    private $requestFactory;
+    protected $requestFactory;
 
     /**
      * @var StreamFactoryInterface
      */
-    private $streamFactory;
+    protected $streamFactory;
 
     public function __construct(
         ClientInterface $httpClient,
@@ -49,7 +49,7 @@ final class Psr18Adapter implements AdapterInterface
         }
     }
 
-    private function createPsr7Request(Request $request, Endpoint $endpoint): RequestInterface
+    protected function createPsr7Request(Request $request, Endpoint $endpoint): RequestInterface
     {
         $uri = AdapterHelper::buildUri($request, $endpoint);
 
@@ -71,7 +71,7 @@ final class Psr18Adapter implements AdapterInterface
         return $psr7Request;
     }
 
-    private function createResponse(ResponseInterface $psr7Response): Response
+    protected function createResponse(ResponseInterface $psr7Response): Response
     {
         $headerLines = [
             sprintf(
@@ -89,7 +89,7 @@ final class Psr18Adapter implements AdapterInterface
         return new Response((string) $psr7Response->getBody(), $headerLines);
     }
 
-    private function getRequestBody(Request $request): ?string
+    protected function getRequestBody(Request $request): ?string
     {
         if (Request::METHOD_PUT == $request->getMethod()) {
             return $request->getRawData();
@@ -106,7 +106,7 @@ final class Psr18Adapter implements AdapterInterface
         return $request->getRawData();
     }
 
-    private function getRequestHeaders(Request $request, Endpoint $endpoint): array
+    protected function getRequestHeaders(Request $request, Endpoint $endpoint): array
     {
         $headers = [];
 

--- a/src/Core/Client/Adapter/TimeoutAwareTrait.php
+++ b/src/Core/Client/Adapter/TimeoutAwareTrait.php
@@ -10,7 +10,7 @@ trait TimeoutAwareTrait
     /**
      * @var int
      */
-    private $timeout = TimeoutAwareInterface::DEFAULT_TIMEOUT;
+    protected $timeout = TimeoutAwareInterface::DEFAULT_TIMEOUT;
 
     public function setTimeout(int $timeoutInSeconds): void
     {


### PR DESCRIPTION
I've turned `Psr18Adapter` into a non-`final` class and made all private members and methods protected instead. This is in line with the customisation philosophy described in the docs.

https://github.com/solariumphp/solarium/blob/559f8a8b4a6c7b764c404e544731b2226203c1c1/docs/customizing-solarium.md#L8

This closes #795.