### PR TITLE
Examples and integration test for atomic updates

### DIFF
--- a/docs/documents.md
+++ b/docs/documents.md
@@ -101,17 +101,89 @@ If you have a date in your Solr schema you can set this in the document as a str
 Atomic updates
 --------------
 
-You can create atomic updates by using the setFieldModifier method. Set a modifier on the field you want to update. The supported modifiers are:
+You can create atomic updates by using the `setFieldModifier` method. Set a modifier on the field you want to update. The supported modifiers are:
 
 -   MODIFIER\_SET
--   MODIFIER\_ADD
 -   MODIFIER\_INC
+-   MODIFIER\_ADD
+-   MODIFIER\_ADD\_DISTINCT
+-   MODIFIER\_REMOVE
+-   MODIFIER\_REMOVEREGEX
 
-The addField and setField methods also support modifiers as an optional argument. Any document that uses modifiers MUST have a key, you can set the key using the setKey method.
+The addField and setField methods also support modifiers as an optional argument. Any document that uses modifiers MUST have a key, you can set the key using the `setKey` method.
 
 A document with atomic updates can be added to an update query just like any other document.
 
-For more info on Solr atomic updates please read the manual: <http://wiki.apache.org/solr/Atomic_Updates>
+```php
+<?php
+
+require(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// get an update query instance
+$update = $client->createUpdate();
+
+// create a new document
+$doc1 = $update->createDocument();
+$doc1->id = 123;
+$doc1->name = 'testdoc';
+$doc1->price = 364;
+
+// add the document and a commit command to the update query
+$update->addDocument($doc1);
+
+// now we can set a field to another value without reindexing the entire document
+$doc2 = $update->createDocument();
+$doc2->setKey('id', 123);
+$doc2->setField('name', 'Test document');
+$doc2->setFieldModifier('name', $doc2::MODIFIER_SET);
+
+// or increment a numeric value by a specific amount
+$doc3 = $update->createDocument();
+$doc3->setKey('id', 123);
+$doc3->setField('price', 10);
+$doc3->setFieldModifier('price', $doc3::MODIFIER_INC);
+
+// add the atomic updates and a commit command to the update query
+$update->addDocuments([$doc2, $doc3]);
+$update->addCommit();
+
+// this executes the query and returns the result
+$result = $client->update($update);
+
+echo '<b>Update query executed</b><br/>';
+echo 'Query status: ' . $result->getStatus(). '<br/>';
+echo 'Query time: ' . $result->getQueryTime();
+
+// get a select query instance
+$query = $client->createSelect();
+
+// create a filterquery
+$query->createFilterQuery('newprice')->setQuery('price:374');
+
+// this executes the query and returns the result
+$resultset = $client->select($query);
+
+// display the total number of documents found by solr
+echo '<hr/>NumFound: '.$resultset->getNumFound();
+
+// show documents using the resultset iterator
+foreach ($resultset as $document) {
+
+    echo '<hr/><table>';
+    echo '<tr><th>id</th><td>' . $document->id . '</td></tr>';
+    echo '<tr><th>name</th><td>' . $document->name . '</td></tr>';
+    echo '<tr><th>price</th><td>' . $document->price . '</td></tr>';
+    echo '</table>';
+}
+
+htmlFooter();
+```
+
+Your schema has to meet certain criteria for this to work. For more info on Solr atomic updates please read the manual: <https://lucene.apache.org/solr/guide/updating-parts-of-documents.html#atomic-updates>
 
 Versioning
 ----------

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -20,7 +20,7 @@ This is the default document type for a select query result. This is an immutabl
 
 The example belows shows all these options.
 
-To enforce the immutable state of this document type an exception will be thrown if you try to alter a field value. For an updateable document you should use this class: Solarium\\QueryType\\Update\\Query\\Document
+To enforce the immutable state of this document type an exception will be thrown if you try to alter a field value. For an updateable document you should use this class: `Solarium\QueryType\Update\Query\Document`.
 
 Solarium uses this document type as default for select queries for two reasons:
 
@@ -103,14 +103,14 @@ Atomic updates
 
 You can create atomic updates by using the `setFieldModifier` method. Set a modifier on the field you want to update. The supported modifiers are:
 
--   MODIFIER\_SET
--   MODIFIER\_INC
--   MODIFIER\_ADD
--   MODIFIER\_ADD\_DISTINCT
--   MODIFIER\_REMOVE
--   MODIFIER\_REMOVEREGEX
+-   `MODIFIER_SET`
+-   `MODIFIER_INC`
+-   `MODIFIER_ADD`
+-   `MODIFIER_ADD_DISTINCT`
+-   `MODIFIER_REMOVE`
+-   `MODIFIER_REMOVEREGEX`
 
-The addField and setField methods also support modifiers as an optional argument. Any document that uses modifiers MUST have a key, you can set the key using the `setKey` method.
+The `addField` and `setField` methods also support modifiers as an optional argument. Any document that uses modifiers MUST have a key, you can set the key using the `setKey` method.
 
 A document with atomic updates can be added to an update query just like any other document.
 
@@ -188,11 +188,11 @@ Your schema has to meet certain criteria for this to work. For more info on Solr
 Versioning
 ----------
 
-The document has getVersion() and setVersion methods. By default no version is used, but you can set a version manually. There is a set of predefined values:
+The document has `getVersion` and `setVersion` methods. By default no version is used, but you can set a version manually. There is a set of predefined values:
 
--   VERSION\_DONT\_CARE
--   VERSION\_MUST\_EXIST
--   VERSION\_MUST\_NOT\_EXIST
+-   `VERSION_DONT_CARE`
+-   `VERSION_MUST_EXIST`
+-   `VERSION_MUST_NOT_EXIST`
 
 But you can also set a custom version (specific ID).
 

--- a/examples/2.2.1.1-atomic-updates.php
+++ b/examples/2.2.1.1-atomic-updates.php
@@ -1,0 +1,66 @@
+<?php
+
+require(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// get an update query instance
+$update = $client->createUpdate();
+
+// create a new document
+$doc1 = $update->createDocument();
+$doc1->id = 123;
+$doc1->name = 'testdoc';
+$doc1->price = 364;
+
+// add the document and a commit command to the update query
+$update->addDocument($doc1);
+
+// now we can set a field to another value without reindexing the entire document
+$doc2 = $update->createDocument();
+$doc2->setKey('id', 123);
+$doc2->setField('name', 'Test document');
+$doc2->setFieldModifier('name', $doc2::MODIFIER_SET);
+
+// or increment a numeric value by a specific amount
+$doc3 = $update->createDocument();
+$doc3->setKey('id', 123);
+$doc3->setField('price', 10);
+$doc3->setFieldModifier('price', $doc3::MODIFIER_INC);
+
+// add the atomic updates and a commit command to the update query
+$update->addDocuments([$doc2, $doc3]);
+$update->addCommit();
+
+// this executes the query and returns the result
+$result = $client->update($update);
+
+echo '<b>Update query executed</b><br/>';
+echo 'Query status: ' . $result->getStatus(). '<br/>';
+echo 'Query time: ' . $result->getQueryTime();
+
+// get a select query instance
+$query = $client->createSelect();
+
+// create a filterquery
+$query->createFilterQuery('newprice')->setQuery('price:374');
+
+// this executes the query and returns the result
+$resultset = $client->select($query);
+
+// display the total number of documents found by solr
+echo '<hr/>NumFound: '.$resultset->getNumFound();
+
+// show documents using the resultset iterator
+foreach ($resultset as $document) {
+
+    echo '<hr/><table>';
+    echo '<tr><th>id</th><td>' . $document->id . '</td></tr>';
+    echo '<tr><th>name</th><td>' . $document->name . '</td></tr>';
+    echo '<tr><th>price</th><td>' . $document->price . '</td></tr>';
+    echo '</table>';
+}
+
+htmlFooter();

--- a/examples/index.html
+++ b/examples/index.html
@@ -59,7 +59,6 @@
                         <li><a href="2.1.5.2-morelikethis.php">2.1.5.2 MoreLikeThis</a></li>
                         <li><a href="2.1.5.3-highlighting.php">2.1.5.3 Highlighting</a></li>
                         <ul style="list-style:none;">
-
                             <li><a href="2.1.5.3.1-per-field-highlighting.php">2.1.5.3.1 Per-field highlighting options</a></li>
                         </ul>
                         <li><a href="2.1.5.4-dismax.php">2.1.5.4 Dismax</a></li>
@@ -79,6 +78,9 @@
                 <li>2.2. Update query</li>
                 <ul style="list-style:none;">
                     <li><a href="2.2.1-add-docs.php">2.2.1 Add docs</a></li>
+                    <ul style="list-style:none;">
+                        <li><a href="2.2.1.1-atomic-updates.php">2.2.2.1 Atomic updates</a></li>
+                    </ul>
                     <li><a href="2.2.2-delete-by-query.php">2.2.2 Delete by query</a></li>
                     <li><a href="2.2.3-delete-by-id.php">2.2.3 Delete by ID</a></li>
                     <li><a href="2.2.4-optimize.php">2.2.4 Optimize index</a></li>


### PR DESCRIPTION
Added a basic example of atomic updates (`set` and `inc` modifiers).

Updated the docs:
- Listed all available modifiers.
- Included the example.
- Mentioned that it depends on your schema.
- Updated the link to the latest Solr manual.

Integration test for all available modifiers.

This closes #499.