### PR TITLE
cleanup unnecessary eventDispatcher init

### DIFF
--- a/src/Core/Client/Client.php
+++ b/src/Core/Client/Client.php
@@ -1318,12 +1318,6 @@ class Client extends Configurable implements ClientInterface
      */
     protected function init()
     {
-        if (null === $this->eventDispatcher) {
-            if (class_exists('\Symfony\Component\EventDispatcher\EventDispatcher')) {
-                $this->eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
-            }
-        }
-
         foreach ($this->options as $name => $value) {
             switch ($name) {
                 case 'endpoint':


### PR DESCRIPTION
As far as I can see there is no need for this code. We enforce an instance of the eventDispatcher in the constructor and in the setter. So it cannot be null?

Tests are failing due to https://github.com/solariumphp/solarium/pull/805