### PR TITLE
add conflict with phpstan 0.12.26 and 0.12.27

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,8 @@
         "psr-4": {
             "Solarium\\Tests\\": "tests/"
         }
+    },
+    "conflict": {
+        "phpstan/phpstan": "0.12.26 || 0.12.27"
     }
 }


### PR DESCRIPTION
PHPstan switched to AST based static analysis and there seem to be some issues with that.

The fail is actually wrong:

```
 ------ ---------------------------------------------------------------------------------- 
  Line   src/Component/Facet/JsonRange.php                                                 
 ------ ---------------------------------------------------------------------------------- 
  38     Call to an undefined method Solarium\Component\Facet\JsonRange::jsonFacetInit().  
 ------ ---------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 1 error   
```  

Reported the bug: https://github.com/phpstan/phpstan/issues/3415