### PR TITLE
Use `require_once` in docs to match changes to examples in #812

### DIFF
--- a/docs/client-and-adapters.md
+++ b/docs/client-and-adapters.md
@@ -45,7 +45,7 @@ This is the standard Solarium adapter. It supports the most features (for instan
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a cURL adapter instance
@@ -71,7 +71,7 @@ This adapter has no dependencies on other classes or any special PHP extensions 
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create an HTTP adapter instance
@@ -93,7 +93,7 @@ Since Solarium 5.2 there is also a `Psr18Adapter` which can be used with any PSR
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a PSR-18 adapter instance

--- a/docs/customizing-solarium.md
+++ b/docs/customizing-solarium.md
@@ -28,7 +28,7 @@ The example code shows how to do this. It also shows how to generate the URI for
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // This example shows how to manually execute the query flow.
@@ -98,7 +98,7 @@ Solarium uses a separate library (included using Composer) for events. For more 
 This example shows all available events and how to use the events to create a very basic debugger: 
 ```php
 <?php
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 use Solarium\Core\Event\Events;
 
 // this very simple plugin shows a timing for each event and display some request debug info
@@ -232,7 +232,7 @@ htmlFooter();
 The second example shows how to replace the built-in select querytype with a custom implementation: 
 ```php
 <?php
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 use Solarium\Client;
 use Solarium\Core\Plugin\Plugin;
 use Solarium\QueryType\Select\Query\Query as Select;

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -33,7 +33,7 @@ Example usage
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -117,7 +117,7 @@ A document with atomic updates can be added to an update query just like any oth
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -213,7 +213,7 @@ Example usage
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,7 +48,7 @@ To check your installation you can do a Solarium version check with the followin
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // check solarium version available
@@ -154,7 +154,7 @@ This is the basic example of executing a select query and displaying the results
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -200,7 +200,7 @@ This example demonstrates a facet field.
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -249,7 +249,7 @@ Documents can be deleted with a query:
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -278,7 +278,7 @@ Or by id
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -311,7 +311,7 @@ This example adds some documents to the index:
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -49,7 +49,7 @@ Example usage
 
 ```php
 <?php
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 
 use Solarium\Plugin\BufferedAdd\Event\Events;
 use Solarium\Plugin\BufferedAdd\Event\PreFlush as PreFlushEvent;
@@ -110,7 +110,7 @@ Example usage
 
 ```php
 <?php
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 
 htmlHeader();
 
@@ -185,7 +185,7 @@ Example usage
 
 ```php
 <?php
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 
 htmlHeader();
 
@@ -257,7 +257,7 @@ Example usage
 
 ```php
 <?php
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 
 htmlHeader();
 
@@ -327,7 +327,7 @@ Example usage
 
 ```php
 <?php
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 
 htmlHeader();
 
@@ -399,7 +399,7 @@ Example usage
 
 ```php
 <?php
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 
 htmlHeader();
 
@@ -460,7 +460,7 @@ Example usage
 
 ```php
 <?php
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 
 htmlHeader();
 

--- a/docs/queries/analysis-query/analysis-document.md
+++ b/docs/queries/analysis-query/analysis-document.md
@@ -31,7 +31,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/analysis-query/analysis-field.md
+++ b/docs/queries/analysis-query/analysis-field.md
@@ -34,7 +34,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/extract-query.md
+++ b/docs/queries/extract-query.md
@@ -33,7 +33,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/morelikethis-query.md
+++ b/docs/queries/morelikethis-query.md
@@ -57,7 +57,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 use Solarium\Client;
 
 htmlHeader();

--- a/docs/queries/ping-query.md
+++ b/docs/queries/ping-query.md
@@ -32,7 +32,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // check solarium version available

--- a/docs/queries/query-helper/escaping.md
+++ b/docs/queries/query-helper/escaping.md
@@ -5,7 +5,7 @@ An example of term escaping in use for a query that would fail without escaping:
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/query-helper/placeholders.md
+++ b/docs/queries/query-helper/placeholders.md
@@ -35,7 +35,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/query-helper/query-helper.md
+++ b/docs/queries/query-helper/query-helper.md
@@ -33,7 +33,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/realtimeget-query.md
+++ b/docs/queries/realtimeget-query.md
@@ -32,7 +32,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/adding-filterqueries.md
+++ b/docs/queries/select-query/building-a-select-query/adding-filterqueries.md
@@ -18,7 +18,7 @@ Examples
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/building-a-select-query.md
+++ b/docs/queries/select-query/building-a-select-query/building-a-select-query.md
@@ -31,7 +31,7 @@ A simple select with some params, using the API mode:
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 
 htmlHeader();
 
@@ -89,7 +89,7 @@ An example using the select query in config mode: (filterqueries and components 
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 

--- a/docs/queries/select-query/building-a-select-query/components/debug-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/debug-component.md
@@ -14,7 +14,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/dismax-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/dismax-component.md
@@ -29,7 +29,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/distributed-search-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/distributed-search-component.md
@@ -17,7 +17,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/edismax-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/edismax-component.md
@@ -28,7 +28,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
@@ -27,7 +27,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-multiquery.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-multiquery.md
@@ -12,7 +12,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-pivot.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-pivot.md
@@ -19,7 +19,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-query.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-query.md
@@ -18,7 +18,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-range.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-range.md
@@ -26,7 +26,7 @@ Examples
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -76,7 +76,7 @@ or when specifying pivot fields:
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/grouping-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/grouping-component.md
@@ -29,7 +29,7 @@ Grouping by field:
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -89,7 +89,7 @@ Grouping by query:
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
@@ -45,7 +45,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -103,7 +103,7 @@ Per-field settings:
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
@@ -23,7 +23,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
@@ -21,7 +21,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/query-rerankquery-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-rerankquery-component.md
@@ -20,7 +20,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/spellcheck-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/spellcheck-component.md
@@ -33,7 +33,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/building-a-select-query/components/stats-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/stats-component.md
@@ -15,7 +15,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/executing-a-select-query.md
+++ b/docs/queries/select-query/executing-a-select-query.md
@@ -5,7 +5,7 @@ See the example code below.
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/re-use-of-queries.md
+++ b/docs/queries/select-query/re-use-of-queries.md
@@ -5,7 +5,7 @@ There are multiple ways to do this, depending on your use case and personal pref
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 use Solarium\Client;
 use Solarium\QueryType\Select\Query\Query as Select;
 

--- a/docs/queries/select-query/result-of-a-select-query/component-results/facetset-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/facetset-result.md
@@ -14,7 +14,7 @@ You can also use the `Countable` interface to get the number of counts.
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -66,7 +66,7 @@ A facet query result is really simple. It has just one value: the count. You can
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -115,7 +115,7 @@ A multiquery facet is basically a combination of multiple facet query instances.
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -171,7 +171,7 @@ A range facet is also similar to a facet field, but instead of field value count
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/result-of-a-select-query/component-results/grouping-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/grouping-result.md
@@ -16,7 +16,7 @@ Grouped by field:
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -76,7 +76,7 @@ Grouped by query:
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/result-of-a-select-query/component-results/highlighting-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/highlighting-result.md
@@ -8,7 +8,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
@@ -8,7 +8,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/select-query/result-of-a-select-query/result-of-a-select-query.md
+++ b/docs/queries/select-query/result-of-a-select-query/result-of-a-select-query.md
@@ -39,7 +39,7 @@ A basic usage example:
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/server-query/core-admin-query.md
+++ b/docs/queries/server-query/core-admin-query.md
@@ -10,7 +10,7 @@ The following example shows how your can build a core admin query that executes 
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/suggester-query.md
+++ b/docs/queries/suggester-query.md
@@ -31,7 +31,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/terms-query.md
+++ b/docs/queries/terms-query.md
@@ -40,7 +40,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/update-query/building-an-update-query/add-command.md
+++ b/docs/queries/update-query/building-an-update-query/add-command.md
@@ -27,7 +27,7 @@ Examples
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/update-query/building-an-update-query/building-an-update-query.md
+++ b/docs/queries/update-query/building-an-update-query/building-an-update-query.md
@@ -34,7 +34,7 @@ Add documents:
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -75,7 +75,7 @@ Delete by query:
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/update-query/building-an-update-query/commit-command.md
+++ b/docs/queries/update-query/building-an-update-query/commit-command.md
@@ -25,7 +25,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/update-query/building-an-update-query/delete-command.md
+++ b/docs/queries/update-query/building-an-update-query/delete-command.md
@@ -13,7 +13,7 @@ Examples
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance
@@ -40,7 +40,7 @@ htmlFooter();
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/update-query/building-an-update-query/optimize-command.md
+++ b/docs/queries/update-query/building-an-update-query/optimize-command.md
@@ -25,7 +25,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/update-query/building-an-update-query/rawxml-command.md
+++ b/docs/queries/update-query/building-an-update-query/rawxml-command.md
@@ -13,7 +13,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/update-query/building-an-update-query/rollback-command.md
+++ b/docs/queries/update-query/building-an-update-query/rollback-command.md
@@ -13,7 +13,7 @@ Example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/queries/update-query/executing-an-update-query.md
+++ b/docs/queries/update-query/executing-an-update-query.md
@@ -5,7 +5,7 @@ See the example code below.
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a client instance

--- a/docs/solarium-concepts.md
+++ b/docs/solarium-concepts.md
@@ -23,7 +23,7 @@ API example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 
 htmlHeader();
 
@@ -79,7 +79,7 @@ Configuration example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 htmlHeader();
 
 
@@ -146,7 +146,7 @@ Extending example
 ```php
 <?php
 
-require(__DIR__.'/init.php');
+require_once(__DIR__.'/init.php');
 use Solarium\Client;
 use Solarium\QueryType\Select\Query\Query as Select;
 


### PR DESCRIPTION
The code under `/examples` has been changed in #812 from `require(__DIR__.'/init.php');` to `require_once(__DIR__.'/init.php');`. Most code snippets under `/docs` are verbatim copies of those examples. Applying the same change might avoid confusion down the road.