### PR TITLE
`testFacetHighlightSpellcheckComponent` passes in SolrCloud mode

### DIFF
--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -239,7 +239,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $select->setQuery('power cort');
 
         $spellcheck = $select->getSpellcheck();
-        // Some spellcheck dictionaries need to built first, but not on every request!
+        // Some spellcheck dictionaries need to be built first, but not on every request!
         $spellcheck->setBuild(true);
         // Order of suggestions is wrong on SolrCloud with spellcheck.extendedResults=false (SOLR-9060)
         $spellcheck->setExtendedResults(true);

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -229,11 +229,6 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertCount(10, $result);
     }
 
-    /**
-     * @todo this test should pass on Solr Cloud!
-     *
-     * @group skip_for_solr_cloud
-     */
     public function testFacetHighlightSpellcheckComponent()
     {
         $select = self::$client->createSelect();
@@ -244,8 +239,10 @@ abstract class AbstractTechproductsTest extends TestCase
         $select->setQuery('power cort');
 
         $spellcheck = $select->getSpellcheck();
-        // Some spellcheck dictionaries needs to build first, but not on every request!
+        // Some spellcheck dictionaries need to built first, but not on every request!
         $spellcheck->setBuild(true);
+        // Order of suggestions is wrong on SolrCloud with spellcheck.extendedResults=false (SOLR-9060)
+        $spellcheck->setExtendedResults(true);
 
         $result = self::$client->select($select);
         $this->assertSame(0, $result->getNumFound());


### PR DESCRIPTION
`testFacetHighlightSpellcheckComponent` failed on SolrCloud because the order of the spellcheck suggestions wasn't correct. In trying to find out why, I discovered that it only does so with `spellcheck.extendedResults=false`.

I asked on the [solr-user mailinglist](https://lucene.472066.n3.nabble.com/Order-of-spellcheck-suggestions-td4459083.html)—twice—but didn't get a response.

This behaviour looks similar to [SOLR-9060](https://issues.apache.org/jira/browse/SOLR-9060). I've added my findings there.

Since it's "officially" reported as a Solr bug, I worked around it in the test with `setExtendedResults(true)` and added a comment that points to SOLR-9060.