### PR TITLE
Use 'versionless' links to the Solr ref guide in comments and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,4 @@ If you are uncertain about any part or need help please feel free to ask for hel
 * Solarium follows the Symfony2 code standards: http://symfony.com/doc/current/contributing/code/standards.html
 * Each PR will be checked for code standards violations. Of course anything other than a 'green' status needs to be fixed before a PR can be merged.
 * Each PR will be checked by the CI environment automatically. Of course anything other than a 'green' status needs to be fixed before a PR can be merged.
+* If you link to the Solr reference guide in a comment or the docs, use a 'versionless' URL (e.g. <https://lucene.apache.org/solr/guide/getting-started.html>). This will always redirect to the latest release.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Solarium 6:
 $categoriesTerms = new Solarium\Component\Facet\JsonTerms(['local_key' => 'categories', 'field' => 'cat', 'limit'=>4,'numBuckets'=>true]);
 ```
 
-See https://lucene.apache.org/solr/guide/8_5/local-parameters-in-queries.html for an introduction about local parameters.
+See https://lucene.apache.org/solr/guide/local-parameters-in-queries.html for an introduction about local parameters.
 
 
 ### Pitfall when upgrading from 3.x or 4.x

--- a/docs/queries/extract-query.md
+++ b/docs/queries/extract-query.md
@@ -1,4 +1,4 @@
-An extract query can be used to index files in Solr. For more info see <http://wiki.apache.org/solr/ExtractingRequestHandler>
+An extract query can be used to index files in Solr. For more info see <https://lucene.apache.org/solr/guide/uploading-data-with-solr-cell-using-apache-tika.html>
 
 Building an extract query
 -------------------------

--- a/docs/queries/morelikethis-query.md
+++ b/docs/queries/morelikethis-query.md
@@ -1,6 +1,6 @@
 A MoreLikeThis (MLT) query is designed to generate information about "similar" documents using the MoreLikeThis functionality provided by Lucene. It supports faceting, paging, and filtering using CommonQueryParameters.
 
-This query uses the [Solr MoreLikeThis Handler](http://wiki.apache.org/solr/MoreLikeThisHandler) that specifically returns MLT results. Alternatively you can use the [MLT component](V2:MoreLikeThis_component "wikilink") for the select query.
+This query uses the [Solr MoreLikeThis Handler](https://lucene.apache.org/solr/guide/morelikethis.html) that specifically returns MLT results. Alternatively you can use the [MLT component](V2:MoreLikeThis_component "wikilink") for the select query.
 
 Building a MLT query
 --------------------

--- a/docs/queries/ping-query.md
+++ b/docs/queries/ping-query.md
@@ -2,7 +2,7 @@ A ping query can be used to check the connection to the Solr server and the heal
 
 *It's not advisable to check Solr with a ping before every request, this can have a big performance impact. You are better of using the ping query with intervals, or as a check after a query error to see if the query was faulty or if Solr has problems.*
 
-To use ping queries first of all you need to have a ping query defined in your solrconfig.xml file and working. See the Solr wiki for more info about this: <http://wiki.apache.org/solr/SolrConfigXml#The_Admin.2BAC8-GUI_Section>
+The search executed by a ping is configured with the Request Parameters API. For more info see <https://lucene.apache.org/solr/guide/ping.html>
 
 Creating a ping query
 ---------------------

--- a/docs/queries/query-helper/query-helper.md
+++ b/docs/queries/query-helper/query-helper.md
@@ -20,7 +20,9 @@ See the API docs (linked at the bottom of this page) for more details.
 Dereferenced params
 -------------------
 
-The query helper also supports dereferenced params. See the implementation of the join() and qparser() methods. For more info also see <http://wiki.apache.org/solr/LocalParams>: Parameter dereferencing or indirection allows one to use the value of another argument rather than specifying it directly. This can be used to simplify queries, decouple user input from query parameters, or decouple front-end GUI parameters from defaults set in solrconfig.xml.
+The query helper also supports dereferenced params. See the implementation of the join() and qparser() methods. For more info also see <https://lucene.apache.org/solr/guide/local-parameters-in-queries.html#parameter-dereferencing>:
+
+> Parameter dereferencing, or indirection, lets you use the value of another argument rather than specifying it directly. This can be used to simplify queries, decouple user input from query parameters, or decouple front-end GUI parameters from defaults set in `solrconfig.xml`.
 
 Special helper methods
 ----------------------

--- a/docs/queries/realtimeget-query.md
+++ b/docs/queries/realtimeget-query.md
@@ -1,4 +1,4 @@
-A RealtimeGet query is useful when using Solr as a NoSql store. For more info see <http://wiki.apache.org/solr/RealTimeGet>
+A RealtimeGet query is useful when using Solr as a NoSQL store. For more info see <https://lucene.apache.org/solr/guide/realtime-get.html>
 
 Building a realtime query
 -------------------------

--- a/docs/queries/select-query/building-a-select-query/components/debug-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/debug-component.md
@@ -1,4 +1,4 @@
-For a description of Solr debugging see the [http://wiki.apache.org/solr/CommonQueryParameters\#Debugging Solr wiki page](http://wiki.apache.org/solr/CommonQueryParameters#Debugging_Solr_wiki_page "wikilink").
+For a description of Solr debugging see <https://lucene.apache.org/solr/guide/common-query-parameters.html#debug-parameter>.
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/distributed-search-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/distributed-search-component.md
@@ -1,4 +1,4 @@
-For a description of Solr distributed search (also referred to as 'shards' or 'sharding') see the [http://wiki.apache.org/solr/DistributedSearch\#Distributed\_Search\_Example Solr wiki page](http://wiki.apache.org/solr/DistributedSearch#Distributed_Search_Example_Solr_wiki_page "wikilink").
+For a description of Solr distributed search (also referred to as 'shards' or 'sharding') see <https://lucene.apache.org/solr/guide/distributed-search-with-index-sharding.html>.
 
 Options
 -------
@@ -27,7 +27,7 @@ $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $query = $client->createSelect();
 
 // add distributed search settings
-// see http://wiki.apache.org/solr/DistributedSearch#Distributed_Search_Example for setting up two solr instances
+// see https://lucene.apache.org/solr/guide/distributed-search-with-index-sharding.html#testing-index-sharding-on-two-local-servers for setting up two Solr instances
 $distributedSearch = $query->getDistributedSearch();
 $distributedSearch->addShard('shard1', 'localhost:8983/solr');
 $distributedSearch->addShard('shard2', 'localhost:7574/solr');

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
@@ -18,7 +18,7 @@ Only the facet-type specific options are listed. See [Facetset component](V3:Fac
 | offset             | int     | null          | Show facet count starting from this offset.                                                                                                          |
 | mincount           | int     | null          | Minimal term count to be included in facet count results.                                                                                            |
 | missing            | boolean | null          | Also make a count of all document that have no value for the facet field.                                                                            |
-| method             | string  | null          | Use one of the class constants as value. See <http://wiki.apache.org/solr/SimpleFacetParameters#facet.method> for details.                           |
+| method             | string  | null          | Use one of the class constants as value. See <https://lucene.apache.org/solr/guide/faceting.html#field-value-faceting-parameters> for details.       |
 ||
 
 Example

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-pivot.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-pivot.md
@@ -1,4 +1,4 @@
-The facet class supports the Solr pivot facet: <http://wiki.apache.org/solr/SimpleFacetParameters#Pivot_.28ie_Decision_Tree.29_Faceting>
+The facet class supports the Solr pivot facet: <https://lucene.apache.org/solr/guide/faceting.html#pivot-decision-tree-faceting>.
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-range.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-range.md
@@ -1,4 +1,4 @@
-The facet class supports the Solr range facet: <http://wiki.apache.org/solr/SimpleFacetParameters#Facet_by_Range>
+The facet class supports the Solr range facet: <https://lucene.apache.org/solr/guide/faceting.html#range-faceting>.
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/grouping-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/grouping-component.md
@@ -1,4 +1,4 @@
-For a description of Solr grouping (also referred to as 'result grouping' or 'field collapse') see the [http://wiki.apache.org/solr/FieldCollapsing Solr wiki page](http://wiki.apache.org/solr/FieldCollapsing_Solr_wiki_page "wikilink").
+For a description of Solr grouping (also referred to as 'result grouping' or 'field collapse') see <https://lucene.apache.org/solr/guide/result-grouping.html>.
 
 It's important to have a good understanding of the available options, as they can have have big effects on the result format.
 

--- a/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
@@ -1,4 +1,4 @@
-The highlighting component can be used to highlight matches in content. For more info see <http://wiki.apache.org/solr/HighlightingParameters>
+The highlighting component can be used to highlight matches in content. For more info see <https://lucene.apache.org/solr/guide/highlighting.html>.
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
@@ -1,4 +1,4 @@
-The morelikethis component can be used if you want to retrieve similar documents for your query results. This component uses morelikethis in the standardrequesthandler, not the standalone morelikethis handler. For more info see <http://wiki.apache.org/solr/MoreLikeThis>
+The morelikethis component can be used if you want to retrieve similar documents for your query results. This component uses morelikethis in the standardrequesthandler, not the standalone morelikethis handler. For more info see <https://lucene.apache.org/solr/guide/morelikethis.html>.
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/spellcheck-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/spellcheck-component.md
@@ -1,4 +1,4 @@
-For a description of Solr spellcheck (also referred to as 'query suggest') see the [http://wiki.apache.org/solr/SpellCheckComponent Solr wiki page](http://wiki.apache.org/solr/SpellCheckComponent_Solr_wiki_page "wikilink").
+For a description of Solr spellcheck (also referred to as 'query suggest') see <https://lucene.apache.org/solr/guide/spell-checking.html>.
 
 The `setQuery()` method of this component supports [placeholders](V3:Placeholders "wikilink").
 
@@ -25,7 +25,7 @@ Options
 Collate params
 --------------
 
-Using the API method setCollateParam($param, $value) you can set any collate params you need. For more info please see this page: <http://wiki.apache.org/solr/SpellCheckComponent#spellcheck.collateParam.XX>
+Using the API method setCollateParam($param, $value) you can set any collate params you need. For more info see <https://lucene.apache.org/solr/guide/spell-checking.html#spell-check-parameters>.
 
 Example
 -------

--- a/docs/queries/select-query/building-a-select-query/components/stats-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/stats-component.md
@@ -1,4 +1,4 @@
-For a description of the Solr StatsComponent see the [http://wiki.apache.org/solr/StatsComponent Solr wiki page](http://wiki.apache.org/solr/StatsComponent_Solr_wiki_page "wikilink").
+For a description of the Solr StatsComponent see <https://lucene.apache.org/solr/guide/the-stats-component.html>.
 
 Options
 -------

--- a/docs/queries/select-query/select-query.md
+++ b/docs/queries/select-query/select-query.md
@@ -1,6 +1,5 @@
-With select queries you can select documents and/or facet counts from your Solr index. Solr select queries have lots of options. See the following pages for an intro:
+With select queries you can select documents and/or facet counts from your Solr index. Solr select queries have lots of options. See the following pages in the Solr reference guide for an intro:
 
--   <http://wiki.apache.org/solr/CommonQueryParameters>
--   <http://wiki.apache.org/solr/SearchHandler>
--   <http://wiki.apache.org/solr/SimpleFacetParameters>
-
+- [Common Query Parameters](https://lucene.apache.org/solr/guide/common-query-parameters.html)
+- [The Standard Query Parser](https://lucene.apache.org/solr/guide/the-standard-query-parser.html)
+- [Faceting](https://lucene.apache.org/solr/guide/faceting.html)

--- a/docs/queries/server-query/core-admin-query.md
+++ b/docs/queries/server-query/core-admin-query.md
@@ -1,4 +1,4 @@
-Core admin queries can be used to administrate cores on your solr server (https://lucene.apache.org/solr/guide/7_4/coreadmin-api.html)
+Core admin queries can be used to administrate cores on your solr server (https://lucene.apache.org/solr/guide/coreadmin-api.html)
 
 The core admin api on the Apache Solr server has several "actions" available and every action can have a set of arguments.
 
@@ -133,7 +133,7 @@ Split
 
 Use to split a core. 
 
-See also: https://lucene.apache.org/solr/guide/7_4/coreadmin-api.html#coreadmin-split
+See also: https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-split
 
 **Available action methods**:
 

--- a/docs/queries/suggester-query.md
+++ b/docs/queries/suggester-query.md
@@ -1,4 +1,4 @@
-A suggester query is a fast way to create an autocomplete feature. For more info on the Solr suggester component see: <http://wiki.apache.org/solr/Suggester>
+A suggester query is a fast way to create an autocomplete feature. For more info on the Solr suggester component see: <https://lucene.apache.org/solr/guide/suggester.html>.
 
 Building a suggester query
 --------------------------

--- a/docs/queries/terms-query.md
+++ b/docs/queries/terms-query.md
@@ -1,4 +1,4 @@
-A terms query provides access to the indexed terms in a field. For details see: <http://wiki.apache.org/solr/TermsComponent>
+A terms query provides access to the indexed terms in a field. For details see: <https://lucene.apache.org/solr/guide/the-terms-component.html>.
 
 Building a terms query
 ----------------------

--- a/docs/queries/update-query/building-an-update-query/building-an-update-query.md
+++ b/docs/queries/update-query/building-an-update-query/building-an-update-query.md
@@ -1,4 +1,4 @@
-An update query has options and commands. These commands and options are instructions for the client classes to build and execute a request and return the correct result. In the following sections both the options and commands will be discussed in detail. You can also take a look at <http://wiki.apache.org/solr/UpdateXmlMessages> for more information about the underlying Solr update handler XML request format.
+An update query has options and commands. These commands and options are instructions for the client classes to build and execute a request and return the correct result. In the following sections both the options and commands will be discussed in detail. You can also take a look at <https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#xml-formatted-index-updates> for more information about the underlying Solr update handler XML request format.
 
 Options
 -------

--- a/docs/queries/update-query/building-an-update-query/optimize-command.md
+++ b/docs/queries/update-query/building-an-update-query/optimize-command.md
@@ -1,6 +1,6 @@
 You can use this command to optimize your Solr index. Optimizing 'defragments' your index. The space taken by deleted document data is reclaimed and can merge the index into fewer segments. This can improve search performance a lot.
 
-See this page: <http://wiki.apache.org/solr/SolrPerformanceFactors#Optimization_Considerations> for more info about optimizing.
+See <https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#commit-and-optimize-during-updates> for more info about optimizing.
 
 While 'optimizing' sounds like it's always a good thing to do, you should use it with care, as it can have a negative performance impact *during the optimize process*. If possible use try to use it outside peak hours.
 

--- a/docs/solarium-concepts.md
+++ b/docs/solarium-concepts.md
@@ -254,7 +254,7 @@ If you want to customize Solarium please read the docs on this first. While you 
 
 ### Response parser format
 
-Solarium supports two Solr responsewriters: json and phps. The ‘phps’ responsewriter returns data as serialized PHP. This can be more efficient to decode than json, especially for large responses. For a benchmark see [http://www.raspberry.nl/2012/02/28/benchmarking-php-solr-response-data-handling/ this blogpost](http://www.raspberry.nl/2012/02/28/benchmarking-php-solr-response-data-handling/_this_blogpost "wikilink") (but be sure to test for your own use-case)
+Solarium supports two Solr responsewriters: json and phps. The ‘phps’ responsewriter returns data as serialized PHP. This can be more efficient to decode than json, especially for large responses. For a benchmark see [this blogpost](https://dzone.com/articles/benchmarks-php-solr-response) (but be sure to test for your own use-case).
 
 However this comes at the cost of a possible security risk in PHP deserialization. As long as you use a trusted Solr server this should be no issue, but to be safe the default is still JSON.
 

--- a/examples/2.1.5.8-distributed-search.php
+++ b/examples/2.1.5.8-distributed-search.php
@@ -12,7 +12,7 @@ $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $query = $client->createSelect();
 
 // add distributed search settings
-// see http://wiki.apache.org/solr/DistributedSearch#Distributed_Search_Example for setting up two solr instances
+// see https://lucene.apache.org/solr/guide/distributed-search-with-index-sharding.html#testing-index-sharding-on-two-local-servers for setting up two Solr instances
 $distributedSearch = $query->getDistributedSearch();
 $distributedSearch->addShard('shard1', 'localhost:8983/solr');
 $distributedSearch->addShard('shard2', 'localhost:7574/solr');

--- a/src/Component/Debug.php
+++ b/src/Component/Debug.php
@@ -10,7 +10,7 @@ use Solarium\Component\ResponseParser\Debug as ResponseParser;
 /**
  * Debug component.
  *
- * @see http://wiki.apache.org/solr/CommonQueryParameters#Debugging
+ * @see https://lucene.apache.org/solr/guide/common-query-parameters.html#debug-parameter
  */
 class Debug extends AbstractComponent
 {
@@ -56,6 +56,8 @@ class Debug extends AbstractComponent
 
     /**
      * Set the explainOther query.
+     *
+     * @see https://lucene.apache.org/solr/guide/common-query-parameters.html#explainother-parameter
      *
      * @param string $query
      *

--- a/src/Component/DisMax.php
+++ b/src/Component/DisMax.php
@@ -10,7 +10,7 @@ use Solarium\Exception\InvalidArgumentException;
 /**
  * DisMax component.
  *
- * @see http://wiki.apache.org/solr/DisMaxQParserPlugin
+ * @see https://lucene.apache.org/solr/guide/the-dismax-query-parser.html
  */
 class DisMax extends AbstractComponent
 {

--- a/src/Component/DistributedSearch.php
+++ b/src/Component/DistributedSearch.php
@@ -287,7 +287,7 @@ class DistributedSearch extends AbstractComponent
      *
      * @return self Provides fluent interface
      *
-     * @see https://cwiki.apache.org/confluence/display/solr/Distributed+Requests
+     * @see https://lucene.apache.org/solr/guide/distributed-requests.html
      */
     public function addReplica(string $key, string $replica): self
     {

--- a/src/Component/DistributedSearch.php
+++ b/src/Component/DistributedSearch.php
@@ -8,8 +8,8 @@ use Solarium\Component\RequestBuilder\DistributedSearch as RequestBuilder;
 /**
  * Distributed Search (sharding) component.
  *
- * @see http://wiki.apache.org/solr/DistributedSearch
- * @see http://wiki.apache.org/solr/SolrCloud/
+ * @see https://lucene.apache.org/solr/guide/distributed-search-with-index-sharding.html
+ * @see https://lucene.apache.org/solr/guide/solrcloud.html
  */
 class DistributedSearch extends AbstractComponent
 {
@@ -62,7 +62,7 @@ class DistributedSearch extends AbstractComponent
      *
      * @return self Provides fluent interface
      *
-     * @see http://wiki.apache.org/solr/DistributedSearch
+     * @see https://lucene.apache.org/solr/guide/distributed-search-with-index-sharding.html
      */
     public function addShard(string $key, string $shard): self
     {
@@ -199,7 +199,7 @@ class DistributedSearch extends AbstractComponent
      *
      * @return self Provides fluent interface
      *
-     * @see http://wiki.apache.org/solr/SolrCloud/
+     * @see https://lucene.apache.org/solr/guide/solrcloud.html
      */
     public function addCollection(string $key, string $collection): self
     {

--- a/src/Component/EdisMax.php
+++ b/src/Component/EdisMax.php
@@ -8,7 +8,7 @@ use Solarium\Component\RequestBuilder\EdisMax as RequestBuilder;
 /**
  * EdisMax component.
  *
- * @see http://wiki.apache.org/solr/ExtendedDisMax
+ * @see https://lucene.apache.org/solr/guide/the-extended-dismax-query-parser.html
  */
 class EdisMax extends DisMax
 {

--- a/src/Component/Facet/AbstractFacet.php
+++ b/src/Component/Facet/AbstractFacet.php
@@ -8,7 +8,7 @@ use Solarium\Core\Query\LocalParameters\LocalParametersTrait;
 /**
  * Facet base class.
  *
- * @see http://wiki.apache.org/solr/SimpleFacetParameters
+ * @see https://lucene.apache.org/solr/guide/faceting.html
  */
 abstract class AbstractFacet extends Configurable implements FacetInterface
 {

--- a/src/Component/Facet/AbstractField.php
+++ b/src/Component/Facet/AbstractField.php
@@ -5,7 +5,7 @@ namespace Solarium\Component\Facet;
 /**
  * Facet query.
  *
- * @see http://wiki.apache.org/solr/SimpleFacetParameters#Field_Value_Faceting_Parameters
+ * @see https://lucene.apache.org/solr/guide/faceting.html#field-value-faceting-parameters
  */
 abstract class AbstractField extends AbstractFacet
 {

--- a/src/Component/Facet/AbstractRange.php
+++ b/src/Component/Facet/AbstractRange.php
@@ -5,7 +5,7 @@ namespace Solarium\Component\Facet;
 /**
  * Facet range.
  *
- * @see http://wiki.apache.org/solr/SimpleFacetParameters#Facet_by_Range
+ * @see https://lucene.apache.org/solr/guide/faceting.html#range-faceting
  */
 abstract class AbstractRange extends AbstractFacet
 {

--- a/src/Component/Facet/FacetInterface.php
+++ b/src/Component/Facet/FacetInterface.php
@@ -5,7 +5,7 @@ namespace Solarium\Component\Facet;
 /**
  * Facet interface.
  *
- * @see http://wiki.apache.org/solr/SimpleFacetParameters
+ * @see https://lucene.apache.org/solr/guide/faceting.html
  */
 interface FacetInterface
 {

--- a/src/Component/Facet/Field.php
+++ b/src/Component/Facet/Field.php
@@ -7,7 +7,7 @@ use Solarium\Component\FacetSetInterface;
 /**
  * Facet query.
  *
- * @see http://wiki.apache.org/solr/SimpleFacetParameters#Field_Value_Faceting_Parameters
+ * @see https://lucene.apache.org/solr/guide/faceting.html#field-value-faceting-parameters
  */
 class Field extends AbstractField
 {

--- a/src/Component/Facet/Interval.php
+++ b/src/Component/Facet/Interval.php
@@ -7,7 +7,7 @@ use Solarium\Component\FacetSetInterface;
 /**
  * Facet interval.
  *
- * @see http://wiki.apache.org/solr/SimpleFacetParameters#Interval_Faceting
+ * @see https://lucene.apache.org/solr/guide/faceting.html#interval-faceting
  */
 class Interval extends AbstractFacet
 {

--- a/src/Component/Facet/JsonAggregation.php
+++ b/src/Component/Facet/JsonAggregation.php
@@ -7,7 +7,8 @@ use Solarium\Component\FacetSetInterface;
 /**
  * JSON facet aggregation.
  *
- * @see https://lucene.apache.org/solr/guide/json-facet-api.html
+ * @see https://lucene.apache.org/solr/guide/json-facet-api.html#stat-facet-example
+ * @see https://lucene.apache.org/solr/guide/json-facet-api.html#stat-facet-functions
  */
 class JsonAggregation extends AbstractFacet implements JsonFacetInterface
 {

--- a/src/Component/Facet/JsonAggregation.php
+++ b/src/Component/Facet/JsonAggregation.php
@@ -7,7 +7,7 @@ use Solarium\Component\FacetSetInterface;
 /**
  * JSON facet aggregation.
  *
- * @see https://lucene.apache.org/solr/guide/7_3/json-facet-api.html
+ * @see https://lucene.apache.org/solr/guide/json-facet-api.html
  */
 class JsonAggregation extends AbstractFacet implements JsonFacetInterface
 {

--- a/src/Component/Facet/JsonFacetInterface.php
+++ b/src/Component/Facet/JsonFacetInterface.php
@@ -3,7 +3,7 @@
 namespace Solarium\Component\Facet;
 
 /**
- * Json facets.
+ * JSON facets.
  *
  * @see https://lucene.apache.org/solr/guide/json-facet-api.html
  */

--- a/src/Component/Facet/JsonFacetInterface.php
+++ b/src/Component/Facet/JsonFacetInterface.php
@@ -5,7 +5,7 @@ namespace Solarium\Component\Facet;
 /**
  * Json facets.
  *
- * @see https://lucene.apache.org/solr/guide/7_3/json-facet-api.html
+ * @see https://lucene.apache.org/solr/guide/json-facet-api.html
  */
 interface JsonFacetInterface
 {

--- a/src/Component/Facet/JsonFacetTrait.php
+++ b/src/Component/Facet/JsonFacetTrait.php
@@ -10,7 +10,7 @@ use Solarium\Exception\InvalidArgumentException;
 /**
  * Json facets.
  *
- * @see https://lucene.apache.org/solr/guide/7_3/json-facet-api.html
+ * @see https://lucene.apache.org/solr/guide/json-facet-api.html
  */
 trait JsonFacetTrait
 {

--- a/src/Component/Facet/JsonFacetTrait.php
+++ b/src/Component/Facet/JsonFacetTrait.php
@@ -8,7 +8,7 @@ use Solarium\Core\Query\Helper;
 use Solarium\Exception\InvalidArgumentException;
 
 /**
- * Json facets.
+ * JSON facets.
  *
  * @see https://lucene.apache.org/solr/guide/json-facet-api.html
  */

--- a/src/Component/Facet/JsonQuery.php
+++ b/src/Component/Facet/JsonQuery.php
@@ -10,7 +10,7 @@ use Solarium\Core\Query\Helper;
 /**
  * Facet query.
  *
- * @see https://lucene.apache.org/solr/guide/json-facet-api.html
+ * @see https://lucene.apache.org/solr/guide/json-facet-api.html#query-facet
  */
 class JsonQuery extends AbstractFacet implements JsonFacetInterface, FacetSetInterface, QueryInterface
 {

--- a/src/Component/Facet/JsonQuery.php
+++ b/src/Component/Facet/JsonQuery.php
@@ -10,7 +10,7 @@ use Solarium\Core\Query\Helper;
 /**
  * Facet query.
  *
- * @see https://lucene.apache.org/solr/guide/7_3/json-facet-api.html
+ * @see https://lucene.apache.org/solr/guide/json-facet-api.html
  */
 class JsonQuery extends AbstractFacet implements JsonFacetInterface, FacetSetInterface, QueryInterface
 {

--- a/src/Component/Facet/JsonRange.php
+++ b/src/Component/Facet/JsonRange.php
@@ -7,7 +7,7 @@ use Solarium\Component\FacetSetInterface;
 /**
  * Facet range.
  *
- * @see http://wiki.apache.org/solr/SimpleFacetParameters#Facet_by_Range
+ * @see https://lucene.apache.org/solr/guide/json-facet-api.html#range-facet
  */
 class JsonRange extends AbstractRange implements JsonFacetInterface, FacetSetInterface
 {

--- a/src/Component/Facet/JsonTerms.php
+++ b/src/Component/Facet/JsonTerms.php
@@ -7,7 +7,7 @@ use Solarium\Component\FacetSetInterface;
 /**
  * Facet query.
  *
- * @see http://wiki.apache.org/solr/SimpleFacetParameters#Field_Value_Faceting_Parameters
+ * @see https://lucene.apache.org/solr/guide/json-facet-api.html#terms-facet
  */
 class JsonTerms extends AbstractField implements JsonFacetInterface, FacetSetInterface
 {

--- a/src/Component/Facet/Pivot.php
+++ b/src/Component/Facet/Pivot.php
@@ -8,7 +8,7 @@ use Solarium\Exception\OutOfBoundsException;
 /**
  * Facet pivot.
  *
- * @see http://wiki.apache.org/solr/SimpleFacetParameters#Pivot_.28ie_Decision_Tree.29_Faceting
+ * @see https://lucene.apache.org/solr/guide/faceting.html#pivot-decision-tree-faceting
  */
 class Pivot extends AbstractFacet
 {

--- a/src/Component/Facet/Query.php
+++ b/src/Component/Facet/Query.php
@@ -10,7 +10,7 @@ use Solarium\Core\Query\Helper;
 /**
  * Facet query.
  *
- * @see http://wiki.apache.org/solr/SimpleFacetParameters#facet.query_:_Arbitrary_Query_Faceting
+ * @see https://lucene.apache.org/solr/guide/faceting.html#general-facet-parameters
  */
 class Query extends AbstractFacet implements QueryInterface
 {

--- a/src/Component/Facet/Range.php
+++ b/src/Component/Facet/Range.php
@@ -7,7 +7,7 @@ use Solarium\Component\FacetSetInterface;
 /**
  * Facet range.
  *
- * @see http://wiki.apache.org/solr/SimpleFacetParameters#Facet_by_Range
+ * @see https://lucene.apache.org/solr/guide/faceting.html#range-faceting
  */
 class Range extends AbstractRange
 {

--- a/src/Component/Grouping.php
+++ b/src/Component/Grouping.php
@@ -15,7 +15,7 @@ use Solarium\Component\Result\Grouping\ValueGroup;
  * Also known as Result Grouping or Field Collapsing.
  * See the Solr wiki for more info about this functionality
  *
- * @see https://lucene.apache.org/solr/guide/8_1/result-grouping.html
+ * @see https://lucene.apache.org/solr/guide/result-grouping.html
  * @since 2.1.0
  */
 class Grouping extends AbstractComponent

--- a/src/Component/Highlighting/Field.php
+++ b/src/Component/Highlighting/Field.php
@@ -7,7 +7,7 @@ use Solarium\Core\Configurable;
 /**
  * Highlighting per-field settings.
  *
- * @see http://wiki.apache.org/solr/HighlightingParameters
+ * @see https://lucene.apache.org/solr/guide/highlighting.html
  */
 class Field extends Configurable
 {

--- a/src/Component/Highlighting/Highlighting.php
+++ b/src/Component/Highlighting/Highlighting.php
@@ -15,7 +15,7 @@ use Solarium\Exception\InvalidArgumentException;
 /**
  * Highlighting component.
  *
- * @see http://wiki.apache.org/solr/HighlightingParameters
+ * @see https://lucene.apache.org/solr/guide/highlighting.html
  */
 class Highlighting extends AbstractComponent implements QueryInterface
 {

--- a/src/Component/MoreLikeThis.php
+++ b/src/Component/MoreLikeThis.php
@@ -10,7 +10,7 @@ use Solarium\Component\ResponseParser\MoreLikeThis as ResponseParser;
 /**
  * MoreLikeThis component.
  *
- * @see http://wiki.apache.org/solr/MoreLikeThis
+ * @see https://lucene.apache.org/solr/guide/morelikethis.html
  */
 class MoreLikeThis extends AbstractComponent
 {
@@ -52,6 +52,8 @@ class MoreLikeThis extends AbstractComponent
      *
      * When using string input you can separate multiple fields with commas.
      *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
      * @param string|array $fields
      *
      * @return self Provides fluent interface
@@ -83,9 +85,9 @@ class MoreLikeThis extends AbstractComponent
     }
 
     /**
-     * Set the interestingTerms parameter.  Must be one of: none, list, details.
+     * Set the interestingTerms parameter. Must be one of: none, list, details.
      *
-     * @see http://wiki.apache.org/solr/MoreLikeThisHandler#Params
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
      *
      * @param string $term
      *
@@ -110,7 +112,7 @@ class MoreLikeThis extends AbstractComponent
     /**
      * Set the match.include parameter, which is either 'true' or 'false'.
      *
-     * @see http://wiki.apache.org/solr/MoreLikeThisHandler#Params
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
      *
      * @param bool $include
      *
@@ -136,7 +138,7 @@ class MoreLikeThis extends AbstractComponent
      * Set the mlt.match.offset parameter, which determines the which result from the query should be used for MLT
      * For paging of MLT use setStart / setRows.
      *
-     * @see http://wiki.apache.org/solr/MoreLikeThisHandler#Params
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
      *
      * @param int $offset
      *
@@ -164,6 +166,8 @@ class MoreLikeThis extends AbstractComponent
      * Minimum Term Frequency - the frequency below which terms will be ignored
      * in the source doc.
      *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
      * @param int $minimum
      *
      * @return self Provides fluent interface
@@ -190,6 +194,8 @@ class MoreLikeThis extends AbstractComponent
      * Minimum Document Frequency - the frequency at which words will be
      * ignored which do not occur in at least this many docs.
      *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
      * @param int $minimum
      *
      * @return self Provides fluent interface
@@ -215,6 +221,8 @@ class MoreLikeThis extends AbstractComponent
      *
      * Minimum word length below which words will be ignored.
      *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
      * @param int $minimum
      *
      * @return self Provides fluent interface
@@ -239,6 +247,8 @@ class MoreLikeThis extends AbstractComponent
      * Set maximumwordlength option.
      *
      * Maximum word length above which words will be ignored.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
      *
      * @param int $maximum
      *
@@ -266,6 +276,8 @@ class MoreLikeThis extends AbstractComponent
      * Maximum number of query terms that will be included in any generated
      * query.
      *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
      * @param int $maximum
      *
      * @return self Provides fluent interface
@@ -292,6 +304,8 @@ class MoreLikeThis extends AbstractComponent
      * Maximum number of tokens to parse in each example doc field that is not
      * stored with TermVector support.
      *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
      * @param int $maximum
      *
      * @return self Provides fluent interface
@@ -316,6 +330,8 @@ class MoreLikeThis extends AbstractComponent
      * Set boost option.
      *
      * If true the query will be boosted by the interesting term relevance.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
      *
      * @param bool $boost
      *
@@ -344,6 +360,8 @@ class MoreLikeThis extends AbstractComponent
      * DisMaxQParserPlugin. These fields must also be specified in fields.
      *
      * When using string input you can separate multiple fields with commas.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
      *
      * @param string|array $queryFields
      *
@@ -379,6 +397,8 @@ class MoreLikeThis extends AbstractComponent
      * Set count option.
      *
      * The number of similar documents to return for each result
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethiscomponent
      *
      * @param int $count
      *

--- a/src/Component/ReRankQuery.php
+++ b/src/Component/ReRankQuery.php
@@ -8,7 +8,7 @@ use Solarium\Component\RequestBuilder\ReRankQuery as RequestBuilder;
 /**
  * Rerank query.
  *
- * @see https://lucene.apache.org/solr/guide/7_3/query-re-ranking.html#rerank-query-parser
+ * @see https://lucene.apache.org/solr/guide/query-re-ranking.html#rerank-query-parser
  */
 class ReRankQuery extends AbstractComponent implements QueryInterface
 {

--- a/src/Component/Spatial.php
+++ b/src/Component/Spatial.php
@@ -8,7 +8,7 @@ use Solarium\Component\RequestBuilder\Spatial as RequestBuilder;
 /**
  * Spatial component.
  *
- * @see https://cwiki.apache.org/confluence/display/solr/Spatial+Search
+ * @see https://lucene.apache.org/solr/guide/spatial-search.html
  */
 class Spatial extends AbstractComponent
 {

--- a/src/Component/Spellcheck.php
+++ b/src/Component/Spellcheck.php
@@ -11,7 +11,7 @@ use Solarium\Component\ResponseParser\Spellcheck as ResponseParser;
 /**
  * Spellcheck component.
  *
- * @see http://wiki.apache.org/solr/SpellcheckComponent
+ * @see https://lucene.apache.org/solr/guide/spell-checking.html
  */
 class Spellcheck extends AbstractComponent implements SpellcheckInterface, QueryInterface
 {

--- a/src/Component/Stats/Stats.php
+++ b/src/Component/Stats/Stats.php
@@ -13,7 +13,7 @@ use Solarium\Exception\InvalidArgumentException;
 /**
  * Stats component.
  *
- * @see http://wiki.apache.org/solr/StatsComponent
+ * @see https://lucene.apache.org/solr/guide/the-stats-component.html
  */
 class Stats extends AbstractComponent
 {

--- a/src/Component/Suggester.php
+++ b/src/Component/Suggester.php
@@ -11,7 +11,7 @@ use Solarium\Component\ResponseParser\Suggester as ResponseParser;
 /**
  * Spellcheck component.
  *
- * @see http://wiki.apache.org/solr/SpellcheckComponent
+ * @see https://lucene.apache.org/solr/guide/suggester.html
  */
 class Suggester extends AbstractComponent implements SuggesterInterface, QueryInterface
 {

--- a/src/Core/Query/AbstractRequestBuilder.php
+++ b/src/Core/Query/AbstractRequestBuilder.php
@@ -53,7 +53,7 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
      *
      * LocalParams can be use in various Solr GET params.
      *
-     * @see http://wiki.apache.org/solr/LocalParams
+     * @see https://lucene.apache.org/solr/guide/local-parameters-in-queries.html
      *
      * @param string $value
      * @param array  $localParams in key => value format

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -379,7 +379,7 @@ class Helper
     /**
      * Render join localparams syntax.
      *
-     * @see http://wiki.apache.org/solr/Join
+     * @see https://lucene.apache.org/solr/guide/other-parsers.html#join-query-parser
      * @since 2.4.0
      *
      * @param string $from
@@ -401,7 +401,7 @@ class Helper
      *
      * This is a Solr 3.2+ feature.
      *
-     * @see http://wiki.apache.org/solr/SolrQuerySyntax#Other_built-in_useful_query_parsers
+     * @see https://lucene.apache.org/solr/guide/other-parsers.html#term-query-parser
      *
      * @param string $field
      * @param float  $weight
@@ -418,7 +418,7 @@ class Helper
      *
      * This is a Solr 3.4+ feature.
      *
-     * @see http://wiki.apache.org/solr/CommonQueryParameters#Caching_of_filters
+     * @see https://lucene.apache.org/solr/guide/common-query-parameters.html#cache-parameter
      *
      * @param bool       $useCache
      * @param float|null $cost

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -59,7 +59,7 @@ class Helper
      * If you want to use the input as a phrase please use the {@link phrase()}
      * method, because a phrase requires much less escaping.\
      *
-     * @see https://lucene.apache.org/core/7_5_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package.description
+     * @see https://lucene.apache.org/solr/guide/the-standard-query-parser.html#escaping-special-characters
      *
      * @param string $input
      *
@@ -99,7 +99,7 @@ class Helper
      * This format was derived to be standards compliant (ISO 8601)
      * A date field shall be of the form 1995-12-31T23:59:59Z The trailing "Z" designates UTC time and is mandatory
      *
-     * @see http://lucene.apache.org/solr/api/org/apache/solr/schema/DateField.html
+     * @see https://lucene.apache.org/solr/guide/working-with-dates.html#date-formatting
      *
      * @param int|string|\DateTimeInterface $input accepted formats: timestamp, date string, DateTime or
      *                                             DateTimeImmutable

--- a/src/Core/Query/LocalParameters/LocalParameters.php
+++ b/src/Core/Query/LocalParameters/LocalParameters.php
@@ -9,7 +9,7 @@ use Solarium\Exception\OutOfBoundsException;
 /**
  * Local Parameters.
  *
- * @see https://lucene.apache.org/solr/guide/8_3/local-parameters-in-queries.html
+ * @see https://lucene.apache.org/solr/guide/local-parameters-in-queries.html
  *
  * @author wicliff <wicliff.wolda@gmail.com>
  */

--- a/src/QueryType/Extract/Query.php
+++ b/src/QueryType/Extract/Query.php
@@ -16,8 +16,7 @@ use Solarium\QueryType\Update\ResponseParser as UpdateResponseParser;
  * Sends a document extract request to Solr, i.e. upload rich document content
  * such as PDF, Word or HTML, parse the file contents and add it to the index.
  *
- * The Solr server must have the {@link
- * https://lucene.apache.org/solr/guide/uploading-data-with-solr-cell-using-apache-tika.html#configuring-the-extractingrequesthandler-in-solrconfig-xml
+ * The Solr server must have the {@link https://lucene.apache.org/solr/guide/uploading-data-with-solr-cell-using-apache-tika.html#configuring-the-extractingrequesthandler-in-solrconfig-xml
  * ExtractingRequestHandler} enabled.
  */
 class Query extends BaseQuery

--- a/src/QueryType/Extract/Query.php
+++ b/src/QueryType/Extract/Query.php
@@ -16,7 +16,8 @@ use Solarium\QueryType\Update\ResponseParser as UpdateResponseParser;
  * Sends a document extract request to Solr, i.e. upload rich document content
  * such as PDF, Word or HTML, parse the file contents and add it to the index.
  *
- * The Solr server must have the {@link http://wiki.apache.org/solr/ExtractingRequestHandler
+ * The Solr server must have the {@link
+ * https://lucene.apache.org/solr/guide/uploading-data-with-solr-cell-using-apache-tika.html#configuring-the-extractingrequesthandler-in-solrconfig-xml
  * ExtractingRequestHandler} enabled.
  */
 class Query extends BaseQuery

--- a/src/QueryType/MoreLikeThis/Query.php
+++ b/src/QueryType/MoreLikeThis/Query.php
@@ -14,6 +14,8 @@ use Solarium\QueryType\Select\Result\Document;
  * Can be used to select documents and/or facets from Solr. This querytype has
  * lots of options and there are many Solarium subclasses for it.
  * See the Solr documentation and the relevant Solarium classes for more info.
+ * 
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#more-like-this-query-parser
  */
 class Query extends SelectQuery
 {
@@ -72,7 +74,7 @@ class Query extends SelectQuery
      *
      * Set to true to post query content instead of using the URL param
      *
-     * @see http://wiki.apache.org/solr/ContentStream ContentStream
+     * @see https://lucene.apache.org/solr/guide/content-streams.html
      *
      * @param bool $stream
      *
@@ -95,9 +97,9 @@ class Query extends SelectQuery
     }
 
     /**
-     * Set the interestingTerms parameter.  Must be one of: none, list, details.
+     * Set the interestingTerms parameter. Must be one of: none, list, details.
      *
-     * @see http://wiki.apache.org/solr/MoreLikeThisHandler#Params
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
      *
      * @param string $term
      *
@@ -122,7 +124,7 @@ class Query extends SelectQuery
     /**
      * Set the match.include parameter, which is either 'true' or 'false'.
      *
-     * @see http://wiki.apache.org/solr/MoreLikeThisHandler#Params
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
      *
      * @param bool $include
      *
@@ -148,7 +150,7 @@ class Query extends SelectQuery
      * Set the mlt.match.offset parameter, which determines the which result from the query should be used for MLT
      * For paging of MLT use setStart / setRows.
      *
-     * @see http://wiki.apache.org/solr/MoreLikeThisHandler#Params
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
      *
      * @param int $offset
      *
@@ -177,6 +179,8 @@ class Query extends SelectQuery
      * stored TermVector
      *
      * Separate multiple fields with commas if you use string input.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
      *
      * @param string|array $fields
      *
@@ -214,6 +218,8 @@ class Query extends SelectQuery
      * Minimum Term Frequency - the frequency below which terms will be ignored
      * in the source doc.
      *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
      * @param int $minimum
      *
      * @return self Provides fluent interface
@@ -240,6 +246,8 @@ class Query extends SelectQuery
      * Minimum Document Frequency - the frequency at which words will be
      * ignored which do not occur in at least this many docs.
      *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
      * @param int $minimum
      *
      * @return self Provides fluent interface
@@ -265,6 +273,8 @@ class Query extends SelectQuery
      *
      * Minimum word length below which words will be ignored.
      *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
      * @param int $minimum
      *
      * @return self Provides fluent interface
@@ -289,6 +299,8 @@ class Query extends SelectQuery
      * Set maximumwordlength option.
      *
      * Maximum word length above which words will be ignored.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
      *
      * @param int $maximum
      *
@@ -316,6 +328,8 @@ class Query extends SelectQuery
      * Maximum number of query terms that will be included in any generated
      * query.
      *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
      * @param int $maximum
      *
      * @return self Provides fluent interface
@@ -342,6 +356,8 @@ class Query extends SelectQuery
      * Maximum number of tokens to parse in each example doc field that is not
      * stored with TermVector support.
      *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
      * @param int $maximum
      *
      * @return self Provides fluent interface
@@ -366,6 +382,8 @@ class Query extends SelectQuery
      * Set boost option.
      *
      * If true the query will be boosted by the interesting term relevance.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
      *
      * @param bool $boost
      *
@@ -394,6 +412,8 @@ class Query extends SelectQuery
      * DisMaxQParserPlugin. These fields must also be specified in fields.
      *
      * Separate multiple fields with commas if you use string input.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
      *
      * @param string|array $queryFields
      *

--- a/src/QueryType/MoreLikeThis/Query.php
+++ b/src/QueryType/MoreLikeThis/Query.php
@@ -14,7 +14,7 @@ use Solarium\QueryType\Select\Result\Document;
  * Can be used to select documents and/or facets from Solr. This querytype has
  * lots of options and there are many Solarium subclasses for it.
  * See the Solr documentation and the relevant Solarium classes for more info.
- * 
+ *
  * @see https://lucene.apache.org/solr/guide/other-parsers.html#more-like-this-query-parser
  */
 class Query extends SelectQuery

--- a/src/QueryType/RealtimeGet/Query.php
+++ b/src/QueryType/RealtimeGet/Query.php
@@ -14,7 +14,7 @@ use Solarium\QueryType\Select\Result\Document;
  *
  * Realtime Get query for one or multiple document IDs
  *
- * @see http://wiki.apache.org/solr/RealTimeGet
+ * @see https://lucene.apache.org/solr/guide/realtime-get.html
  */
 class Query extends BaseQuery
 {

--- a/src/QueryType/Select/Query/FilterQuery.php
+++ b/src/QueryType/Select/Query/FilterQuery.php
@@ -11,7 +11,7 @@ use Solarium\Core\Query\LocalParameters\LocalParametersTrait;
 /**
  * Filterquery.
  *
- * @see http://wiki.apache.org/solr/CommonQueryParameters#fq
+ * @see https://lucene.apache.org/solr/guide/common-query-parameters.html#fq-filter-query-parameter
  */
 class FilterQuery extends Configurable implements QueryInterface
 {

--- a/src/QueryType/Server/Collections/Query/Action/ClusterStatus.php
+++ b/src/QueryType/Server/Collections/Query/Action/ClusterStatus.php
@@ -9,7 +9,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 /**
  * Class ClusterStatus.
  *
- * @see https://lucene.apache.org/solr/guide/collections-api.html#clusterstatus
+ * @see https://lucene.apache.org/solr/guide/cluster-node-management.html#clusterstatus
  */
 class ClusterStatus extends AbstractAsyncAction
 {

--- a/src/QueryType/Server/Collections/Query/Action/Create.php
+++ b/src/QueryType/Server/Collections/Query/Action/Create.php
@@ -9,7 +9,7 @@ use Solarium\QueryType\Server\Query\Action\AsyncActionInterface;
 /**
  * Class Create.
  *
- * @see https://lucene.apache.org/solr/guide/collections-api.html#create
+ * @see https://lucene.apache.org/solr/guide/collection-management.html#create
  */
 class Create extends AbstractCDRAction
 {

--- a/src/QueryType/Server/Collections/Query/Action/Delete.php
+++ b/src/QueryType/Server/Collections/Query/Action/Delete.php
@@ -8,7 +8,7 @@ use Solarium\QueryType\Server\Collections\Result\DeleteResult;
 /**
  * Class Delete.
  *
- * @see https://lucene.apache.org/solr/guide/collections-api.html#delete
+ * @see https://lucene.apache.org/solr/guide/collection-management.html#delete
  */
 class Delete extends AbstractCDRAction
 {

--- a/src/QueryType/Server/Collections/Query/Action/Reload.php
+++ b/src/QueryType/Server/Collections/Query/Action/Reload.php
@@ -8,7 +8,7 @@ use Solarium\QueryType\Server\Collections\Result\ReloadResult;
 /**
  * Class Reload for reloading a collection.
  *
- * @see https://lucene.apache.org/solr/guide/collections-api.html#reload
+ * @see https://lucene.apache.org/solr/guide/collection-management.html#reload
  */
 class Reload extends AbstractCDRAction
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Create.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Create.php
@@ -8,7 +8,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 /**
  * Class Create.
  *
- * @see https://lucene.apache.org/solr/guide/8_5/coreadmin-api.html#CoreAdminAPI-Input.1
+ * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-create
  */
 class Create extends AbstractAsyncAction implements CoreActionInterface
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/MergeIndexes.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/MergeIndexes.php
@@ -5,6 +5,11 @@ namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
 use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 
+/**
+ * Class MergeIndexes.
+ *
+ * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-mergeindexes
+ */
 class MergeIndexes extends AbstractAsyncAction implements CoreActionInterface
 {
     use CoreActionTrait;

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Reload.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Reload.php
@@ -5,6 +5,11 @@ namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
 use Solarium\QueryType\Server\Query\Action\AbstractAction;
 
+/**
+ * Class Reload.
+ *
+ * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-reload
+ */
 class Reload extends AbstractAction implements CoreActionInterface
 {
     use CoreActionTrait;

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Rename.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Rename.php
@@ -5,6 +5,11 @@ namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
 use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 
+/**
+ * Class Rename.
+ *
+ * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-rename
+ */
 class Rename extends AbstractAsyncAction implements CoreActionInterface
 {
     use CoreActionTrait;

--- a/src/QueryType/Server/CoreAdmin/Query/Action/RequestRecovery.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/RequestRecovery.php
@@ -5,6 +5,11 @@ namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
 use Solarium\QueryType\Server\Query\Action\AbstractAction;
 
+/**
+ * Class RequestRecovery.
+ *
+ * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-requestrecovery
+ */
 class RequestRecovery extends AbstractAction implements CoreActionInterface
 {
     use CoreActionTrait;

--- a/src/QueryType/Server/CoreAdmin/Query/Action/RequestStatus.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/RequestStatus.php
@@ -8,7 +8,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAction;
 /**
  * Class RequestStatus.
  *
- * @see https://lucene.apache.org/solr/guide/8_5/coreadmin-api.html#CoreAdminAPI-REQUESTSTATUS
+ * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-requeststatus
  */
 class RequestStatus extends AbstractAction
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Split.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Split.php
@@ -7,7 +7,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 
 /**
  * Class Split.
- * 
+ *
  * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-split
  */
 class Split extends AbstractAsyncAction implements CoreActionInterface

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Split.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Split.php
@@ -6,7 +6,7 @@ use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
 use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 
 /**
- * @see https://lucene.apache.org/solr/guide/8_5/coreadmin-api.html#CoreAdminAPI-SPLIT
+ * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-split
  */
 class Split extends AbstractAsyncAction implements CoreActionInterface
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Split.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Split.php
@@ -6,6 +6,8 @@ use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
 use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 
 /**
+ * Class Split.
+ * 
  * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-split
  */
 class Split extends AbstractAsyncAction implements CoreActionInterface

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Status.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Status.php
@@ -5,6 +5,11 @@ namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
 use Solarium\QueryType\Server\Query\Action\AbstractAction;
 
+/**
+ * Class Status.
+ * 
+ * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-status
+ */
 class Status extends AbstractAction implements CoreActionInterface
 {
     use CoreActionTrait;

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Status.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Status.php
@@ -7,7 +7,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAction;
 
 /**
  * Class Status.
- * 
+ *
  * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-status
  */
 class Status extends AbstractAction implements CoreActionInterface

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Swap.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Swap.php
@@ -7,7 +7,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 
 /**
  * Class Swap.
- * 
+ *
  * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-swap
  */
 class Swap extends AbstractAsyncAction implements CoreActionInterface

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Swap.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Swap.php
@@ -5,6 +5,11 @@ namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
 use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 
+/**
+ * Class Swap.
+ * 
+ * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-swap
+ */
 class Swap extends AbstractAsyncAction implements CoreActionInterface
 {
     use CoreActionTrait;

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Unload.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Unload.php
@@ -6,7 +6,7 @@ use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
 use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 
 /**
- * @see https://lucene.apache.org/solr/guide/8_5/coreadmin-api.html#CoreAdminAPI-UNLOAD
+ * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-unload
  */
 class Unload extends AbstractAsyncAction implements CoreActionInterface
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Unload.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Unload.php
@@ -7,7 +7,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 
 /**
  * Class Unload.
- * 
+ *
  * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-unload
  */
 class Unload extends AbstractAsyncAction implements CoreActionInterface

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Unload.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Unload.php
@@ -6,6 +6,8 @@ use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
 use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 
 /**
+ * Class Unload.
+ * 
  * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-unload
  */
 class Unload extends AbstractAsyncAction implements CoreActionInterface

--- a/src/QueryType/Spellcheck/Query.php
+++ b/src/QueryType/Spellcheck/Query.php
@@ -17,7 +17,7 @@ use Solarium\QueryType\Spellcheck\Result\Term;
  * Spellcheck Query.
  *
  * Can be used for an autocomplete feature.
- * 
+ *
  * @see https://lucene.apache.org/solr/guide/spell-checking.html
  */
 class Query extends BaseQuery implements SpellcheckInterface, QueryInterface

--- a/src/QueryType/Spellcheck/Query.php
+++ b/src/QueryType/Spellcheck/Query.php
@@ -16,7 +16,9 @@ use Solarium\QueryType\Spellcheck\Result\Term;
 /**
  * Spellcheck Query.
  *
- * Can be used for an autocomplete feature. See http://wiki.apache.org/solr/SpellcheckComponent for more info.
+ * Can be used for an autocomplete feature.
+ * 
+ * @see https://lucene.apache.org/solr/guide/spell-checking.html
  */
 class Query extends BaseQuery implements SpellcheckInterface, QueryInterface
 {

--- a/src/QueryType/Suggester/Query.php
+++ b/src/QueryType/Suggester/Query.php
@@ -17,7 +17,9 @@ use Solarium\QueryType\Suggester\Result\Term;
 /**
  * Suggester Query.
  *
- * Can be used for an autocomplete feature. See http://wiki.apache.org/solr/Suggester for more info.
+ * Can be used for an autocomplete feature.
+ * 
+ * @see https://lucene.apache.org/solr/guide/suggester.html
  */
 class Query extends BaseQuery implements SuggesterInterface, QueryInterface
 {

--- a/src/QueryType/Suggester/Query.php
+++ b/src/QueryType/Suggester/Query.php
@@ -18,7 +18,7 @@ use Solarium\QueryType\Suggester\Result\Term;
  * Suggester Query.
  *
  * Can be used for an autocomplete feature.
- * 
+ *
  * @see https://lucene.apache.org/solr/guide/suggester.html
  */
 class Query extends BaseQuery implements SuggesterInterface, QueryInterface

--- a/src/QueryType/Update/Query/Command/Add.php
+++ b/src/QueryType/Update/Query/Command/Add.php
@@ -9,7 +9,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query add command.
  *
- * @see http://wiki.apache.org/solr/UpdateXmlMessages#add.2BAC8-update
+ * @see https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#adding-documents
  */
 class Add extends AbstractCommand
 {

--- a/src/QueryType/Update/Query/Command/Commit.php
+++ b/src/QueryType/Update/Query/Command/Commit.php
@@ -7,7 +7,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query commit command.
  *
- * @see http://wiki.apache.org/solr/UpdateXmlMessages#A.22commit.22_and_.22optimize.22
+ * @see https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#commit-and-optimize-during-updates
  */
 class Commit extends AbstractCommand
 {

--- a/src/QueryType/Update/Query/Command/Delete.php
+++ b/src/QueryType/Update/Query/Command/Delete.php
@@ -7,7 +7,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query delete command.
  *
- * @see http://wiki.apache.org/solr/UpdateXmlMessages#A.22delete.22_by_ID_and_by_Query
+ * @see https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#delete-operations
  */
 class Delete extends AbstractCommand
 {

--- a/src/QueryType/Update/Query/Command/Optimize.php
+++ b/src/QueryType/Update/Query/Command/Optimize.php
@@ -7,7 +7,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query optimize command.
  *
- * @see http://wiki.apache.org/solr/UpdateXmlMessages#A.22commit.22_and_.22optimize.22
+ * @see https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#commit-and-optimize-during-updates
  */
 class Optimize extends AbstractCommand
 {

--- a/src/QueryType/Update/Query/Command/RawXml.php
+++ b/src/QueryType/Update/Query/Command/RawXml.php
@@ -8,7 +8,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query raw XML command.
  *
- * @see http://wiki.apache.org/solr/UpdateXmlMessages
+ * @see https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#xml-formatted-index-updates
  */
 class RawXml extends AbstractCommand
 {

--- a/src/QueryType/Update/Query/Command/Rollback.php
+++ b/src/QueryType/Update/Query/Command/Rollback.php
@@ -7,7 +7,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query rollback command.
  *
- * @see http://wiki.apache.org/solr/UpdateXmlMessages#A.22rollback.22
+ * @see https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#rollback-operations
  */
 class Rollback extends AbstractCommand
 {

--- a/src/QueryType/Update/RequestBuilder.php
+++ b/src/QueryType/Update/RequestBuilder.php
@@ -255,7 +255,7 @@ class RequestBuilder extends BaseRequestBuilder
         $xml = '';
 
         // Remove the values if 'null' or empty list is specified as the new value
-        // @see https://lucene.apache.org/solr/guide/8_1/updating-parts-of-documents.html
+        // @see https://lucene.apache.org/solr/guide/updating-parts-of-documents.html#atomic-updates
         if (Document::MODIFIER_SET === $modifier && is_array($value) && empty($value)) {
             $value = null;
         }


### PR DESCRIPTION
Replaced links to the Solr ref guide with the 'versionless' equivalent that always redirects to the latest release.

Replaced all links to the old Solr wiki with versionless links to the ref guide.

Made some related small corrections (e.g. our docs on Ping queries were obviously outdated) but this is by no means an exhaustive sanity check of the docs.

Added a note to `CONTRIBUTING` about using versionless links.