### PR TITLE
Solr Analytics component support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Raw XML from file in update query
 - Set input encoding for select and update queries
 - Create and configure Managed Resources
+- Addition of the analytic component
 
 ### Changed
 - More strict types and type hinting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the solarium library will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Added
+- Support for the analytics component
+
+
 ## [6.0.1]
 ### Added
 - Solarium\Component\Result\Facet\JsonRange::getBefore()
@@ -46,7 +51,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Raw XML from file in update query
 - Set input encoding for select and update queries
 - Create and configure Managed Resources
-- Addition of the analytic component
 
 ### Changed
 - More strict types and type hinting

--- a/docs/queries/select-query/building-a-select-query/components/analytics-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/analytics-component.md
@@ -1,4 +1,4 @@
-For a description of the Solr AnalyticsComponent see the [Solr Ref Guide](https://lucene.apache.org/solr/guide/8_3/analytics.html "wikilink").
+For a description of the Solr AnalyticsComponent see the [Solr Ref Guide](https://lucene.apache.org/solr/guide/analytics.html).
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/analytics-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/analytics-component.md
@@ -1,0 +1,61 @@
+For a description of the Solr AnalyticsComponent see the [Solr Ref Guide](https://lucene.apache.org/solr/guide/8_3/analytics.html "wikilink").
+
+Options
+-------
+
+| Name        | Type    | Default value | Description                                                                   |
+|-------------|---------|---------------|-------------------------------------------------------------------------------|
+| functions   | array   | [ ]           | One or more Variable Functions to be used throughout the rest of the request. |
+| expressions | array   | [ ]           | A list of calculations to perform over the entire result set.                 |
+| groupings   | array   | [ ]           | The list of Groupings to calculate in addition to the expressions.            |
+||
+
+Example
+-------
+
+```php
+<?php
+
+require(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($config);
+
+// get a select query instance
+$query = $client->createSelect();
+$query->setRows(0);
+
+// add analytics settings
+$analytics = $query->getAnalytics();
+$analytics
+    ->addFunction('sale()', 'mult(price,quantity)')
+    ->addExpression('max_sale', 'max(sale())')
+    ->addExpression('med_sale', 'median(sale())')
+    ->addGrouping([
+        'key' => 'sales',
+        'expressions' => [
+            'min_price' => 'min(price)',
+        ],
+        'facets' => [
+            [
+                'key' => 'category',
+                'type' => AbstractFacet::TYPE_VALUE,
+                'expression' => 'fill_missing(category, \'No Category\')',
+                'sort' => [
+                    'criteria' => [
+                        [
+                            'type' => Criterion::TYPE_EXPRESSION,
+                            'expression' => 'min_price',
+                            'direction' => 'ascending',
+                        ],
+                    ],
+                    'limit' => 10,
+                ],
+            ],
+        ],
+    ]);
+
+// this executes the query and returns the result
+$result = $client->select($query);
+$analytics = $result->getAnalytics();

--- a/src/Component/Analytics/Analytics.php
+++ b/src/Component/Analytics/Analytics.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Analytics;
+
+use Solarium\Component\AbstractComponent;
+use Solarium\Component\Analytics\Facet\ConfigurableInitTrait;
+use Solarium\Component\Analytics\Facet\ObjectTrait;
+use Solarium\Component\ComponentAwareQueryInterface;
+use Solarium\Component\RequestBuilder\Analytics as RequestBuilder;
+use Solarium\Component\RequestBuilder\ComponentRequestBuilderInterface;
+use Solarium\Component\ResponseParser\Analytics as ResponseParser;
+use Solarium\Component\ResponseParser\ComponentParserInterface;
+
+/**
+ * Analytics Component.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/8_3/analytics.html
+ */
+class Analytics extends AbstractComponent implements \JsonSerializable
+{
+    use ConfigurableInitTrait;
+    use ObjectTrait;
+
+    /**
+     * An array of functions.
+     *
+     * @var array
+     */
+    private $functions = [];
+
+    /**
+     * An array of expressions.
+     *
+     * @var array
+     */
+    private $expressions = [];
+
+    /**
+     * An array of groupings.
+     *
+     * @var \Solarium\Component\Analytics\Grouping[]
+     */
+    private $groupings = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return ComponentAwareQueryInterface::COMPONENT_ANALYTICS;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequestBuilder(): ComponentRequestBuilderInterface
+    {
+        return new RequestBuilder();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResponseParser(): ?ComponentParserInterface
+    {
+        return new ResponseParser();
+    }
+
+    /**
+     * @return array
+     */
+    public function getFunctions(): array
+    {
+        return $this->functions;
+    }
+
+    /**
+     * @param array $functions
+     *
+     * @return $this
+     */
+    public function setFunctions(array $functions): self
+    {
+        foreach ($functions as $key => $function) {
+            $this->addFunction($key, $function);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $key
+     * @param string $function
+     *
+     * @return $this
+     */
+    public function addFunction(string $key, string $function): self
+    {
+        $this->functions[$key] = $function;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getExpressions(): array
+    {
+        return $this->expressions;
+    }
+
+    /**
+     * @param array $expressions
+     *
+     * @return $this
+     */
+    public function setExpressions(array $expressions): self
+    {
+        foreach ($expressions as $key => $expression) {
+            $this->addExpression($key, $expression);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $key
+     * @param string $expression
+     *
+     * @return $this
+     */
+    public function addExpression(string $key, string $expression): self
+    {
+        $this->expressions[$key] = $expression;
+
+        return $this;
+    }
+
+    /**
+     * @return \Solarium\Component\Analytics\Grouping[]
+     */
+    public function getGroupings(): array
+    {
+        return $this->groupings;
+    }
+
+    /**
+     * @param \Solarium\Component\Analytics\Grouping[] $groupings
+     *
+     * @return $this
+     */
+    public function setGroupings(array $groupings): self
+    {
+        foreach ($groupings as $grouping) {
+            $this->addGrouping($this->ensureObject(Grouping::class, $grouping));
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param \Solarium\Component\Analytics\Grouping $grouping
+     *
+     * @return $this
+     */
+    public function addGrouping(Grouping $grouping): self
+    {
+        $this->groupings[$grouping->getKey()] = $grouping;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return array_filter([
+            'functions' => $this->functions,
+            'expressions' => $this->expressions,
+            'groupings' => $this->groupings,
+        ]);
+    }
+}

--- a/src/Component/Analytics/Analytics.php
+++ b/src/Component/Analytics/Analytics.php
@@ -18,7 +18,7 @@ use Solarium\Component\ResponseParser\ComponentParserInterface;
  *
  * @author wicliff <wicliff.wolda@gmail.com>
  *
- * @see https://lucene.apache.org/solr/guide/8_3/analytics.html
+ * @see https://lucene.apache.org/solr/guide/analytics.html
  */
 class Analytics extends AbstractComponent implements \JsonSerializable
 {

--- a/src/Component/Analytics/Facet/AbstractFacet.php
+++ b/src/Component/Analytics/Facet/AbstractFacet.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Analytics\Facet;
+
+use Solarium\Core\Configurable;
+
+/**
+ * Abstract Facet.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+abstract class AbstractFacet extends Configurable implements \JsonSerializable
+{
+    use ConfigurableInitTrait;
+
+    /**
+     * Value Facets.
+     */
+    public const TYPE_VALUE = 'value';
+
+    /**
+     * Pivot Facets.
+     */
+    public const TYPE_PIVOT = 'pivot';
+
+    /**
+     * Range Facets.
+     */
+    public const TYPE_RANGE = 'range';
+
+    /**
+     * Query Facets.
+     */
+    public const TYPE_QUERY = 'query';
+
+    /**
+     * Map types to subclasses.
+     */
+    public const CLASSMAP = [
+        self::TYPE_VALUE => ValueFacet::class,
+        self::TYPE_PIVOT => PivotFacet::class,
+        self::TYPE_RANGE => RangeFacet::class,
+        self::TYPE_QUERY => QueryFacet::class,
+    ];
+
+    /**
+     * @var string
+     */
+    private $key;
+
+    /**
+     * Get Facet type.
+     */
+    abstract public function getType(): string;
+
+    /**
+     * @return string
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return $this
+     */
+    public function setKey(string $key): self
+    {
+        $this->key = $key;
+
+        return $this;
+    }
+}

--- a/src/Component/Analytics/Facet/ConfigurableInitTrait.php
+++ b/src/Component/Analytics/Facet/ConfigurableInitTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Analytics\Facet;
+
+/**
+ * Configurable Init Trait.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+trait ConfigurableInitTrait
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function init(): void
+    {
+        foreach ($this->options as $name => $option) {
+            $setter = sprintf('set%s', ucfirst($name));
+
+            if (true === \is_callable([$this, $setter])) {
+                $this->$setter($option);
+            }
+        }
+    }
+}

--- a/src/Component/Analytics/Facet/ObjectTrait.php
+++ b/src/Component/Analytics/Facet/ObjectTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Analytics\Facet;
+
+use Solarium\Core\Configurable;
+use Solarium\Exception\InvalidArgumentException;
+
+/**
+ * ObjectTrait.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+trait ObjectTrait
+{
+    /**
+     * @param string            $class
+     * @param array|object|null $variable
+     *
+     * @return mixed
+     */
+    public function ensureObject(string $class, $variable)
+    {
+        if (null === $variable) {
+            return null;
+        }
+
+        if (true === \is_object($variable)
+            && (\get_class($variable) === $class || is_subclass_of($variable, $class))
+        ) {
+            return $variable;
+        }
+
+        try {
+            $refClass = new \ReflectionClass($class);
+        } catch (\ReflectionException $e) {
+            throw new InvalidArgumentException(sprintf('Class %s does not exists', $class));
+        }
+
+        if (true === \is_array($variable) && true === $refClass->isSubclassOf(Configurable::class)) {
+            if (false === $refClass->isAbstract()) {
+                return new $class($variable);
+            }
+
+            if (true === isset($variable['type'])
+                && (false !== $map = $refClass->getConstant('CLASSMAP'))
+                && (true === isset($map[$variable['type']]))
+            ) {
+                return new $map[$variable['type']]($variable);
+            }
+        }
+
+        throw new InvalidArgumentException(sprintf('Unable to instantiate %s with %s', $class, \gettype($variable)));
+    }
+}

--- a/src/Component/Analytics/Facet/Pivot.php
+++ b/src/Component/Analytics/Facet/Pivot.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Analytics\Facet;
+
+use Solarium\Component\Analytics\Facet\Sort\Sort;
+use Solarium\Core\Configurable;
+
+/**
+ * Pivot.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class Pivot extends Configurable implements \JsonSerializable
+{
+    use ConfigurableInitTrait;
+    use ObjectTrait;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $expression;
+
+    /**
+     * @var \Solarium\Component\Analytics\Facet\Sort\Sort|null
+     */
+    private $sort;
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return $this
+     */
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    /**
+     * @param string $expression
+     *
+     * @return $this
+     */
+    public function setExpression(string $expression): self
+    {
+        $this->expression = $expression;
+
+        return $this;
+    }
+
+    /**
+     * @return \Solarium\Component\Analytics\Facet\Sort\Sort|null
+     */
+    public function getSort(): ?Sort
+    {
+        return $this->sort;
+    }
+
+    /**
+     * @param \Solarium\Component\Analytics\Facet\Sort\Sort|array|null $sort
+     *
+     * @return $this
+     */
+    public function setSort($sort): self
+    {
+        $this->sort = $this->ensureObject(Sort::class, $sort);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return array_filter([
+            'name' => $this->name,
+            'expression' => $this->expression,
+            'sort' => $this->sort,
+        ]);
+    }
+}

--- a/src/Component/Analytics/Facet/PivotFacet.php
+++ b/src/Component/Analytics/Facet/PivotFacet.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Analytics\Facet;
+
+/**
+ * Pivot Facet.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class PivotFacet extends AbstractFacet
+{
+    use ObjectTrait;
+
+    /**
+     * @var \Solarium\Component\Analytics\Facet\Pivot[]
+     */
+    private $pivots = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return AbstractFacet::TYPE_PIVOT;
+    }
+
+    /**
+     * @return \Solarium\Component\Analytics\Facet\Pivot[]
+     */
+    public function getPivots(): array
+    {
+        return $this->pivots;
+    }
+
+    /**
+     * @param \Solarium\Component\Analytics\Facet\Pivot[]|array $pivots
+     *
+     * @return $this
+     */
+    public function setPivots(array $pivots): self
+    {
+        foreach ($pivots as $pivot) {
+            $this->addPivot($this->ensureObject(Pivot::class, $pivot));
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param \Solarium\Component\Analytics\Facet\Pivot $pivot
+     *
+     * @return $this
+     */
+    public function addPivot(Pivot $pivot): self
+    {
+        $this->pivots[] = $pivot;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return array_filter([
+            'type' => $this->getType(),
+            'pivots' => $this->pivots,
+        ]);
+    }
+}

--- a/src/Component/Analytics/Facet/QueryFacet.php
+++ b/src/Component/Analytics/Facet/QueryFacet.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Analytics\Facet;
+
+/**
+ * Query Facet.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class QueryFacet extends AbstractFacet
+{
+    /**
+     * @var array
+     */
+    private $queries = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return AbstractFacet::TYPE_QUERY;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueries(): array
+    {
+        return $this->queries;
+    }
+
+    /**
+     * @param array $queries
+     *
+     * @return QueryFacet
+     */
+    public function setQueries(array $queries): self
+    {
+        foreach ($queries as $key => $query) {
+            $this->addQuery($key, $query);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $key
+     * @param string $query
+     *
+     * @return $this
+     */
+    public function addQuery(string $key, string $query): self
+    {
+        $this->queries[$key] = $query;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return array_filter([
+            'type' => $this->getType(),
+            'queries' => $this->queries,
+        ]);
+    }
+}

--- a/src/Component/Analytics/Facet/RangeFacet.php
+++ b/src/Component/Analytics/Facet/RangeFacet.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Analytics\Facet;
+
+/**
+ * Range Facet.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class RangeFacet extends AbstractFacet
+{
+    /**
+     * All gap-based ranges include their lower bound.
+     */
+    public const INCLUDE_LOWER = 'lower';
+
+    /**
+     * All gap-based ranges include their upper bound.
+     */
+    public const INCLUDE_UPPER = 'upper';
+
+    /**
+     * The first and last gap ranges include their edge bounds (lower for the first one,
+     * upper for the last one) even if the corresponding upper/lower option is not specified.
+     */
+    public const INCLUDE_EDGE = 'edge';
+
+    /**
+     * The before and after ranges will be inclusive of their bounds,
+     * even if the first or last ranges already include those boundaries.
+     */
+    public const INCLUDE_OUTER = 'outer';
+
+    /**
+     * Includes all options: lower, upper, edge, and outer.
+     */
+    public const INCLUDE_ALL = 'all';
+
+    /**
+     * All records with field values lower then lower bound of the first range.
+     */
+    public const OTHER_BEFORE = 'before';
+
+    /**
+     * All records with field values greater then the upper bound of the last range.
+     */
+    public const OTHER_AFTER = 'after';
+
+    /**
+     * All records with field values between the lower bound
+     * of the first range and the upper bound of the last range.
+     */
+    public const OTHER_BETWEEN = 'between';
+
+    /**
+     * Include facet buckets for none of the above.
+     */
+    public const OTHER_NONE = 'none';
+
+    /**
+     * Include facet buckets for before, after and between.
+     */
+    public const OTHER_ALL = 'all';
+
+    /**
+     * Array of possible includes.
+     */
+    private const INCLUDES = [
+        self::INCLUDE_LOWER,
+        self::INCLUDE_UPPER,
+        self::INCLUDE_EDGE,
+        self::INCLUDE_OUTER,
+        self::INCLUDE_ALL,
+    ];
+
+    /**
+     * Array of possible others.
+     */
+    private const OTHERS = [
+        self::OTHER_BEFORE,
+        self::OTHER_AFTER,
+        self::OTHER_BETWEEN,
+        self::OTHER_NONE,
+        self::OTHER_ALL,
+    ];
+
+    /**
+     * @var string
+     */
+    private $field;
+
+    /**
+     * @var int
+     */
+    private $start;
+
+    /**
+     * @var int
+     */
+    private $end;
+
+    /**
+     * @var array
+     */
+    private $gap = [];
+
+    /**
+     * @var bool
+     */
+    private $hardend = false;
+
+    /**
+     * @var array
+     */
+    private $include = [];
+
+    /**
+     * @var array
+     */
+    private $others = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return AbstractFacet::TYPE_RANGE;
+    }
+
+    /**
+     * @return string
+     */
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    /**
+     * @param string $field
+     *
+     * @return $this
+     */
+    public function setField(string $field): self
+    {
+        $this->field = $field;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStart(): int
+    {
+        return $this->start;
+    }
+
+    /**
+     * @param int $start
+     *
+     * @return $this
+     */
+    public function setStart(int $start): self
+    {
+        $this->start = $start;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getEnd(): int
+    {
+        return $this->end;
+    }
+
+    /**
+     * @param int $end
+     *
+     * @return $this
+     */
+    public function setEnd(int $end): self
+    {
+        $this->end = $end;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getGap(): array
+    {
+        return $this->gap;
+    }
+
+    /**
+     * @param array $gap
+     *
+     * @return $this
+     */
+    public function setGap(array $gap): self
+    {
+        $this->gap = $gap;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHardend(): bool
+    {
+        return $this->hardend;
+    }
+
+    /**
+     * @param bool $hardend
+     *
+     * @return $this
+     */
+    public function setHardend(bool $hardend): self
+    {
+        $this->hardend = $hardend;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getInclude(): array
+    {
+        return array_values(array_intersect(self::INCLUDES, $this->include));
+    }
+
+    /**
+     * @param array $include
+     *
+     * @return $this
+     */
+    public function setInclude(array $include): self
+    {
+        $this->include = $include;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOthers(): array
+    {
+        return array_values(array_intersect(self::OTHERS, $this->others));
+    }
+
+    /**
+     * @param array $others
+     *
+     * @return $this
+     */
+    public function setOthers(array $others): self
+    {
+        $this->others = $others;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return array_filter([
+            'type' => $this->getType(),
+            'field' => $this->field,
+            'start' => $this->start,
+            'end' => $this->end,
+            'gap' => $this->gap,
+            'hardend' => $this->hardend,
+            'include' => $this->include,
+            'others' => $this->others,
+        ]);
+    }
+}

--- a/src/Component/Analytics/Facet/RangeFacet.php
+++ b/src/Component/Analytics/Facet/RangeFacet.php
@@ -286,7 +286,7 @@ class RangeFacet extends AbstractFacet
                 'others' => $this->others,
             ],
             static function ($var) {
-                return null !== $var;
+                return null !== $var && (false === is_array($var) || 0 !== count($var));
             }
         );
     }

--- a/src/Component/Analytics/Facet/RangeFacet.php
+++ b/src/Component/Analytics/Facet/RangeFacet.php
@@ -274,15 +274,20 @@ class RangeFacet extends AbstractFacet
      */
     public function jsonSerialize()
     {
-        return array_filter([
-            'type' => $this->getType(),
-            'field' => $this->field,
-            'start' => $this->start,
-            'end' => $this->end,
-            'gap' => $this->gap,
-            'hardend' => $this->hardend,
-            'include' => $this->include,
-            'others' => $this->others,
-        ]);
+        return array_filter(
+            [
+                'type' => $this->getType(),
+                'field' => $this->field,
+                'start' => $this->start,
+                'end' => $this->end,
+                'gap' => $this->gap,
+                'hardend' => $this->hardend,
+                'include' => $this->include,
+                'others' => $this->others,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
     }
 }

--- a/src/Component/Analytics/Facet/Sort/Criterion.php
+++ b/src/Component/Analytics/Facet/Sort/Criterion.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Analytics\Facet\Sort;
+
+use Solarium\Component\Analytics\Facet\ConfigurableInitTrait;
+use Solarium\Core\Configurable;
+
+/**
+ * Criterion.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class Criterion extends Configurable implements \JsonSerializable
+{
+    use ConfigurableInitTrait;
+
+    /**
+     * Sort by the value of an expression defined in the same grouping.
+     */
+    public const TYPE_EXPRESSION = 'expression';
+
+    /**
+     * Sort by the string-representation of the facet value.
+     */
+    public const TYPE_VALUE = 'facetvalue';
+
+    /**
+     * Ascending.
+     */
+    public const DIRECTION_ASCENDING = 'ascending';
+
+    /**
+     * Descending.
+     */
+    public const DIRECTION_DESCENDING = 'descending';
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $expression;
+
+    /**
+     * @var string
+     */
+    private $direction;
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return $this
+     */
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    /**
+     * @param string $expression
+     *
+     * @return $this
+     */
+    public function setExpression(string $expression): self
+    {
+        $this->expression = $expression;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDirection(): string
+    {
+        return $this->direction;
+    }
+
+    /**
+     * @param string $direction
+     *
+     * @return $this
+     */
+    public function setDirection(string $direction): self
+    {
+        $this->direction = $direction;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return array_filter([
+            'type' => $this->type,
+            'expression' => $this->expression,
+            'direction' => $this->direction,
+        ]);
+    }
+}

--- a/src/Component/Analytics/Facet/Sort/Sort.php
+++ b/src/Component/Analytics/Facet/Sort/Sort.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Analytics\Facet\Sort;
+
+use Solarium\Component\Analytics\Facet\ConfigurableInitTrait;
+use Solarium\Component\Analytics\Facet\ObjectTrait;
+use Solarium\Core\Configurable;
+
+/**
+ * Sort.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class Sort extends Configurable implements \JsonSerializable
+{
+    use ConfigurableInitTrait;
+    use ObjectTrait;
+
+    /**
+     * @var \Solarium\Component\Analytics\Facet\Sort\Criterion[]
+     */
+    private $criteria = [];
+
+    /**
+     * @var int|null
+     */
+    private $limit;
+
+    /**
+     * @var int|null
+     */
+    private $offset;
+
+    /**
+     * @return \Solarium\Component\Analytics\Facet\Sort\Criterion[]
+     */
+    public function getCriteria(): array
+    {
+        return $this->criteria;
+    }
+
+    /**
+     * @param \Solarium\Component\Analytics\Facet\Sort\Criterion[] $criteria
+     *
+     * @return $this
+     */
+    public function setCriteria(array $criteria): self
+    {
+        foreach ($criteria as $criterion) {
+            $this->addCriterion($this->ensureObject(Criterion::class, $criterion));
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param \Solarium\Component\Analytics\Facet\Sort\Criterion $criterion
+     *
+     * @return $this
+     */
+    public function addCriterion(Criterion $criterion): self
+    {
+        $this->criteria[] = $criterion;
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+
+    /**
+     * @param int|null $limit
+     *
+     * @return $this
+     */
+    public function setLimit(?int $limit): self
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getOffset(): ?int
+    {
+        return $this->offset;
+    }
+
+    /**
+     * @param int|null $offset
+     *
+     * @return $this
+     */
+    public function setOffset(?int $offset): self
+    {
+        $this->offset = $offset;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return array_filter([
+            'limit' => $this->limit,
+            'offset' => $this->offset,
+            'criteria' => $this->criteria,
+        ]);
+    }
+}

--- a/src/Component/Analytics/Facet/ValueFacet.php
+++ b/src/Component/Analytics/Facet/ValueFacet.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Analytics\Facet;
+
+use Solarium\Component\Analytics\Facet\Sort\Sort;
+
+/**
+ * Value Facet.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class ValueFacet extends AbstractFacet
+{
+    use ObjectTrait;
+
+    /**
+     * @var string
+     */
+    private $expression;
+
+    /**
+     * @var \Solarium\Component\Analytics\Facet\Sort\Sort|null
+     */
+    private $sort;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return AbstractFacet::TYPE_VALUE;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    /**
+     * @param string $expression
+     *
+     * @return $this
+     */
+    public function setExpression(string $expression): self
+    {
+        $this->expression = $expression;
+
+        return $this;
+    }
+
+    /**
+     * @return \Solarium\Component\Analytics\Facet\Sort\Sort|null
+     */
+    public function getSort(): ?Sort
+    {
+        return $this->sort;
+    }
+
+    /**
+     * @param \Solarium\Component\Analytics\Facet\Sort\Sort|array|null $sort
+     *
+     * @return $this
+     */
+    public function setSort($sort): self
+    {
+        $this->sort = $this->ensureObject(Sort::class, $sort);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return array_filter([
+            'type' => $this->getType(),
+            'expression' => $this->expression,
+            'sort' => $this->sort,
+        ]);
+    }
+}

--- a/src/Component/Analytics/Grouping.php
+++ b/src/Component/Analytics/Grouping.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Analytics;
+
+use Solarium\Component\Analytics\Facet\AbstractFacet;
+use Solarium\Component\Analytics\Facet\ConfigurableInitTrait;
+use Solarium\Component\Analytics\Facet\ObjectTrait;
+use Solarium\Core\Configurable;
+
+/**
+ * Grouping.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class Grouping extends Configurable implements \JsonSerializable
+{
+    use ConfigurableInitTrait;
+    use ObjectTrait;
+
+    /**
+     * @var string
+     */
+    private $key;
+
+    /**
+     * An array of expressions.
+     *
+     * @var array
+     */
+    private $expressions = [];
+
+    /**
+     * An array of facets.
+     *
+     * @var \Solarium\Component\Analytics\Facet\AbstractFacet[]
+     */
+    private $facets = [];
+
+    /**
+     * @return string
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return $this
+     */
+    public function setKey(string $key): self
+    {
+        $this->key = $key;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getExpressions(): array
+    {
+        return $this->expressions;
+    }
+
+    /**
+     * @param array $expressions
+     *
+     * @return $this
+     */
+    public function setExpressions(array $expressions): self
+    {
+        foreach ($expressions as $key => $expression) {
+            $this->addExpression($key, $expression);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $key
+     * @param string $expression
+     *
+     * @return $this
+     */
+    public function addExpression(string $key, string $expression): self
+    {
+        $this->expressions[$key] = $expression;
+
+        return $this;
+    }
+
+    /**
+     * @return \Solarium\Component\Analytics\Facet\AbstractFacet[]
+     */
+    public function getFacets(): array
+    {
+        return $this->facets;
+    }
+
+    /**
+     * @param array $facets
+     *
+     * @return $this
+     */
+    public function setFacets(array $facets): self
+    {
+        foreach ($facets as $facet) {
+            $this->addFacet($this->ensureObject(AbstractFacet::class, $facet));
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param \Solarium\Component\Analytics\Facet\AbstractFacet $facet
+     *
+     * @return $this
+     */
+    public function addFacet(AbstractFacet $facet): self
+    {
+        $this->facets[$facet->getKey()] = $facet;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return array_filter([
+            'expressions' => $this->expressions,
+            'facets' => $this->facets,
+        ]);
+    }
+}

--- a/src/Component/ComponentAwareQueryInterface.php
+++ b/src/Component/ComponentAwareQueryInterface.php
@@ -85,6 +85,11 @@ interface ComponentAwareQueryInterface
     const COMPONENT_RERANKQUERY = 'rerankquery';
 
     /**
+     * Query component analytics.
+     */
+    const COMPONENT_ANALYTICS = 'analytics';
+
+    /**
      * Get all registered component types.
      *
      * @return array

--- a/src/Component/QueryTraits/AnalyticsTrait.php
+++ b/src/Component/QueryTraits/AnalyticsTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\QueryTraits;
+
+use Solarium\Component\Analytics\Analytics;
+use Solarium\Component\ComponentAwareQueryInterface;
+
+/**
+ * Analytics Trait.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+trait AnalyticsTrait
+{
+    /**
+     * @return \Solarium\Component\Analytics\Analytics
+     */
+    public function getAnalytics(): Analytics
+    {
+        return $this->getComponent(ComponentAwareQueryInterface::COMPONENT_ANALYTICS, true);
+    }
+}

--- a/src/Component/RequestBuilder/Analytics.php
+++ b/src/Component/RequestBuilder/Analytics.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\RequestBuilder;
+
+use Solarium\Core\Client\Request;
+use Solarium\Core\ConfigurableInterface;
+
+/**
+ * Analytics Request Builder.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class Analytics implements ComponentRequestBuilderInterface
+{
+    /**
+     * Header name.
+     */
+    private const HEADER_NAME = 'Content-Type';
+
+    /**
+     * Content type.
+     */
+    private const HEADER_CONTENT = 'application/x-www-form-urlencoded';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \RuntimeException
+     */
+    public function buildComponent(ConfigurableInterface $component, Request $request): Request
+    {
+        $raw = sprintf('analytics=%s', json_encode($component));
+        $header = sprintf('%s: %s', self::HEADER_NAME, self::HEADER_CONTENT);
+
+        if (Request::METHOD_POST !== $request->getMethod()
+            || (null === $data = $request->getRawData())
+        ) {
+            return $request
+                ->setMethod(Request::METHOD_POST)
+                ->addHeader($header)
+                ->setRawData($raw)
+            ;
+        }
+
+        if ((null !== $currentHeader = $request->getHeader(self::HEADER_NAME))
+            && false === strpos($currentHeader, self::HEADER_CONTENT)
+        ) {
+            throw new \RuntimeException(sprintf('Unable to build analytics request. required content type is %s while current header is %s', self::HEADER_CONTENT, $header));
+        }
+
+        // merge raw data currently present in the request
+        $raw = sprintf('%s&%s', $data, $raw);
+
+        return $request
+            ->addHeader($header)
+            ->setRawData($raw)
+        ;
+    }
+}

--- a/src/Component/RequestBuilder/Analytics.php
+++ b/src/Component/RequestBuilder/Analytics.php
@@ -39,7 +39,7 @@ class Analytics implements ComponentRequestBuilderInterface
         ) {
             return $request
                 ->setMethod(Request::METHOD_POST)
-                ->addHeader($header)
+                ->replaceOrAddHeader($header)
                 ->setRawData($raw)
             ;
         }
@@ -54,7 +54,7 @@ class Analytics implements ComponentRequestBuilderInterface
         $raw = sprintf('%s&%s', $data, $raw);
 
         return $request
-            ->addHeader($header)
+            ->replaceOrAddHeader($header)
             ->setRawData($raw)
         ;
     }

--- a/src/Component/ResponseParser/Analytics.php
+++ b/src/Component/ResponseParser/Analytics.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\ResponseParser;
+
+use Solarium\Component\AbstractComponent;
+use Solarium\Component\Analytics\Grouping as ComponentGrouping;
+use Solarium\Component\ComponentAwareQueryInterface;
+use Solarium\Component\Result\Analytics\Expression;
+use Solarium\Component\Result\Analytics\Facet;
+use Solarium\Component\Result\Analytics\Grouping;
+use Solarium\Component\Result\Analytics\Result;
+
+/**
+ * Analytics.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class Analytics implements ComponentParserInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(?ComponentAwareQueryInterface $query, ?AbstractComponent $component, array $data): ?Result
+    {
+        if (false === isset($data['analytics_response']) || null === $component) {
+            return null;
+        }
+
+        $response = $data['analytics_response'];
+        $result = new Result();
+        $results = [];
+
+        /** @var \Solarium\Component\Analytics\Analytics $component */
+        foreach ($component->getExpressions() as $name => $expression) {
+            if (false === isset($response['results'][$name])) {
+                continue;
+            }
+
+            $results[] = new Expression($name, $expression, $response['results'][$name]);
+        }
+
+        $result->setResults($results);
+
+        $groupings = [];
+
+        foreach ($component->getGroupings() as $groupingName => $componentGrouping) {
+            if (false === isset($response['groupings'][$groupingName])) {
+                continue;
+            }
+
+            $grouping = new Grouping($groupingName);
+
+            foreach ($componentGrouping->getFacets() as $facetName => $componentFacet) {
+                if (false === isset($response['groupings'][$groupingName][$facetName])) {
+                    continue;
+                }
+
+                $facets = [];
+
+                foreach ($response['groupings'][$groupingName][$facetName] as $facet) {
+                    $facets[] = $this->facet($componentGrouping, $facet);
+                }
+
+                $grouping->addFacets($facetName, $facets);
+            }
+
+            $groupings[] = $grouping;
+        }
+
+        $result->setGroupings($groupings);
+
+        return $result;
+    }
+
+    /**
+     * @param \Solarium\Component\Analytics\Grouping $grouping
+     * @param array                                  $result
+     *
+     * @return \Solarium\Component\Result\Analytics\Facet
+     */
+    private function facet(ComponentGrouping $grouping, array $result): Facet
+    {
+        $facet = new Facet($result['value'], $result['pivot'] ?? null);
+
+        foreach ($grouping->getExpressions() as $expressionName => $expression) {
+            if (false === isset($result['results'][$expressionName])) {
+                continue;
+            }
+
+            $facet->addResult(new Expression($expressionName, $expression, $result['results'][$expressionName]));
+        }
+
+        if (false === isset($result['children'])) {
+            return $facet;
+        }
+
+        foreach ($result['children'] as $child) {
+            $facet->addChild($this->facet($grouping, $child));
+        }
+
+        return $facet;
+    }
+}

--- a/src/Component/Result/Analytics/Expression.php
+++ b/src/Component/Result/Analytics/Expression.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Result\Analytics;
+
+/**
+ * Expression.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class Expression
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $expression;
+
+    /**
+     * @var float
+     */
+    private $value;
+
+    /**
+     * @param string $name
+     * @param string $expression
+     * @param float  $value
+     */
+    public function __construct(string $name, string $expression, float $value)
+    {
+        $this->name = $name;
+        $this->expression = $expression;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    /**
+     * @return float
+     */
+    public function getValue(): float
+    {
+        return $this->value;
+    }
+}

--- a/src/Component/Result/Analytics/Facet.php
+++ b/src/Component/Result/Analytics/Facet.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Result\Analytics;
+
+/**
+ * Facet response.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class Facet implements \IteratorAggregate, \Countable
+{
+    /**
+     * @var string|null
+     */
+    private $pivot;
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @var \Solarium\Component\Result\Analytics\Expression[]
+     */
+    private $results;
+
+    /**
+     * @var \Solarium\Component\Result\Analytics\Facet[]
+     */
+    private $children = [];
+
+    /**
+     * @param string|null $pivot
+     * @param string      $value
+     */
+    public function __construct(string $value, ?string $pivot = null)
+    {
+        $this->value = $value;
+        $this->pivot = $pivot;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPivot(): ?string
+    {
+        return $this->pivot;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return \Solarium\Component\Result\Analytics\Expression[]
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+
+    /**
+     * @param \Solarium\Component\Result\Analytics\Expression $expression
+     *
+     * @return $this
+     */
+    public function addResult(Expression $expression): self
+    {
+        $this->results[$expression->getName()] = $expression;
+
+        return $this;
+    }
+
+    /**
+     * @return \Solarium\Component\Result\Analytics\Facet[]
+     */
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    /**
+     * @param \Solarium\Component\Result\Analytics\Facet $facet
+     *
+     * @return $this
+     */
+    public function addChild(self $facet): self
+    {
+        $this->children[] = $facet;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->results);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return \count($this->results);
+    }
+}

--- a/src/Component/Result/Analytics/Grouping.php
+++ b/src/Component/Result/Analytics/Grouping.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Result\Analytics;
+
+/**
+ * Grouping result.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class Grouping
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var array
+     */
+    private $facets = [];
+
+    /**
+     * @param string $name
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string                                       $name
+     * @param \Solarium\Component\Result\Analytics\Facet[] $facets
+     *
+     * @return $this
+     */
+    public function addFacets(string $name, array $facets): self
+    {
+        $this->facets[$name] = $facets;
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return array|null
+     */
+    public function getFacets(string $name): ?array
+    {
+        return $this->facets[$name] ?? null;
+    }
+}

--- a/src/Component/Result/Analytics/Result.php
+++ b/src/Component/Result/Analytics/Result.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Component\Result\Analytics;
+
+/**
+ * Analytics result.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class Result implements \IteratorAggregate, \Countable
+{
+    /**
+     * @var \Solarium\Component\Result\Analytics\Expression[]
+     */
+    private $results = [];
+
+    /**
+     * @var \Solarium\Component\Result\Analytics\Grouping[]
+     */
+    private $groupings = [];
+
+    /**
+     * @param \Solarium\Component\Result\Analytics\Expression[] $results
+     *
+     * @return $this
+     */
+    public function setResults(array $results): self
+    {
+        foreach ($results as $result) {
+            $this->addResult($result);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param \Solarium\Component\Result\Analytics\Expression $result
+     *
+     * @return $this
+     */
+    public function addResult(Expression $result): self
+    {
+        $this->results[$result->getName()] = $result;
+
+        return $this;
+    }
+
+    /**
+     * @return \Solarium\Component\Result\Analytics\Expression[]
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return \Solarium\Component\Result\Analytics\Expression|null
+     */
+    public function getResult(string $name): ?Expression
+    {
+        return $this->results[$name] ?? null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->results);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return \count($this->results);
+    }
+
+    /**
+     * @return \Solarium\Component\Result\Analytics\Grouping[]
+     */
+    public function getGroupings(): array
+    {
+        return $this->groupings;
+    }
+
+    /**
+     * @param array $groupings
+     *
+     * @return $this
+     */
+    public function setGroupings(array $groupings): self
+    {
+        foreach ($groupings as $grouping) {
+            $this->addGrouping($grouping);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return \Solarium\Component\Result\Analytics\Grouping|null
+     */
+    public function getGrouping(string $name): ?Grouping
+    {
+        return $this->groupings[$name] ?? null;
+    }
+
+    /**
+     * @param \Solarium\Component\Result\Analytics\Grouping $grouping
+     *
+     * @return $this
+     */
+    public function addGrouping(Grouping $grouping): self
+    {
+        $this->groupings[$grouping->getName()] = $grouping;
+
+        return $this;
+    }
+}

--- a/src/Core/Client/Request.php
+++ b/src/Core/Client/Request.php
@@ -175,7 +175,6 @@ class Request extends Configurable implements RequestParamsInterface
     /**
      * Set the file to upload via "multipart/form-data" POST request.
      *
-     *
      * @param string $filename Name of file to upload
      *
      * @throws RuntimeException
@@ -204,6 +203,24 @@ class Request extends Configurable implements RequestParamsInterface
     }
 
     /**
+     * @param string $headerName
+     *
+     * @return string|null
+     */
+    public function getHeader(string $headerName): ?string
+    {
+        foreach ($this->headers as $header) {
+            list($name) = explode(':', $header);
+
+            if ($name === $headerName) {
+                return $header;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Set request headers.
      *
      * @param array $headers
@@ -219,15 +236,24 @@ class Request extends Configurable implements RequestParamsInterface
     }
 
     /**
-     * Add a request header.
+     * Add request header;
+     * Overwrites previously set of the same type.
      *
-     * @param string|array $value
+     * @param string $header
      *
-     * @return self Provides fluent interface
+     * @return $this
      */
-    public function addHeader($value): self
+    public function addHeader(string $header): self
     {
-        $this->headers[] = $value;
+        list($name) = explode(':', $header);
+
+        if ((null !== $current = $this->getHeader($name)) &&
+            false !== $key = array_search($current, $this->headers, true)
+        ) {
+            $this->headers[$key] = $header;
+        } else {
+            $this->headers[] = $header;
+        }
 
         return $this;
     }
@@ -351,6 +377,14 @@ class Request extends Configurable implements RequestParamsInterface
     }
 
     /**
+     * @return string
+     */
+    public function getHash(): string
+    {
+        return spl_object_hash($this);
+    }
+
+    /**
      * Initialization hook.
      */
     protected function init()
@@ -375,13 +409,5 @@ class Request extends Configurable implements RequestParamsInterface
                     }
             }
         }
-    }
-
-    /**
-     * @return string
-     */
-    public function getHash(): string
-    {
-        return spl_object_hash($this);
     }
 }

--- a/src/Core/Client/Request.php
+++ b/src/Core/Client/Request.php
@@ -236,14 +236,27 @@ class Request extends Configurable implements RequestParamsInterface
     }
 
     /**
-     * Add request header;
-     * Overwrites previously set of the same type.
+     * Add a request header.
+     *
+     * @param string|array $value
+     *
+     * @return self Provides fluent interface
+     */
+    public function addHeader($value): self
+    {
+        $this->headers[] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Replace header if previously set else add it.
      *
      * @param string $header
      *
      * @return $this
      */
-    public function addHeader(string $header): self
+    public function replaceOrAddHeader(string $header): self
     {
         list($name) = explode(':', $header);
 

--- a/src/Plugin/CustomizeRequest/CustomizeRequest.php
+++ b/src/Plugin/CustomizeRequest/CustomizeRequest.php
@@ -3,7 +3,7 @@
 namespace Solarium\Plugin\CustomizeRequest;
 
 use Solarium\Core\Event\Events;
-use Solarium\Core\Event\postCreateRequest;
+use Solarium\Core\Event\PostCreateRequest;
 use Solarium\Core\Plugin\AbstractPlugin;
 use Solarium\Exception\InvalidArgumentException;
 use Solarium\Exception\RuntimeException;

--- a/src/QueryType/Select/Query/Query.php
+++ b/src/QueryType/Select/Query/Query.php
@@ -2,6 +2,7 @@
 
 namespace Solarium\QueryType\Select\Query;
 
+use Solarium\Component\Analytics\Analytics;
 use Solarium\Component\ComponentAwareQueryInterface;
 use Solarium\Component\ComponentAwareQueryTrait;
 use Solarium\Component\Debug;
@@ -15,6 +16,7 @@ use Solarium\Component\MoreLikeThis;
 use Solarium\Component\QueryElevation;
 use Solarium\Component\QueryInterface;
 use Solarium\Component\QueryTrait;
+use Solarium\Component\QueryTraits\AnalyticsTrait;
 use Solarium\Component\QueryTraits\DebugTrait;
 use Solarium\Component\QueryTraits\DisMaxTrait;
 use Solarium\Component\QueryTraits\DistributedSearchTrait;
@@ -70,6 +72,7 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface, Query
     use QueryElevationTrait;
     use ReRankQueryTrait;
     use QueryTrait;
+    use AnalyticsTrait;
 
     /**
      * Solr sort mode descending.
@@ -152,6 +155,7 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface, Query
             ComponentAwareQueryInterface::COMPONENT_STATS => Stats::class,
             ComponentAwareQueryInterface::COMPONENT_QUERYELEVATION => QueryElevation::class,
             ComponentAwareQueryInterface::COMPONENT_RERANKQUERY => ReRankQuery::class,
+            ComponentAwareQueryInterface::COMPONENT_ANALYTICS => Analytics::class,
         ];
 
         parent::__construct($options);

--- a/src/QueryType/Select/Result/Result.php
+++ b/src/QueryType/Select/Result/Result.php
@@ -3,6 +3,7 @@
 namespace Solarium\QueryType\Select\Result;
 
 use Solarium\Component\ComponentAwareQueryInterface;
+use Solarium\Component\Result\Analytics\Result as AnalyticsResult;
 use Solarium\Component\Result\Debug\Result as DebugResult;
 use Solarium\Component\Result\FacetSet as FacetSetResult;
 use Solarium\Component\Result\Grouping\Result as GroupingResult;
@@ -322,5 +323,17 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     public function getDebug(): ?DebugResult
     {
         return $this->getComponent(ComponentAwareQueryInterface::COMPONENT_DEBUG);
+    }
+
+    /**
+     * Get analytics component result.
+     *
+     * This is a convenience method that maps presets to getComponent
+     *
+     * @return \Solarium\Component\Result\Analytics\Result|null
+     */
+    public function getAnalytics(): ?AnalyticsResult
+    {
+        return $this->getComponent(ComponentAwareQueryInterface::COMPONENT_ANALYTICS);
     }
 }

--- a/tests/Component/Analytics/AnalyticsTest.php
+++ b/tests/Component/Analytics/AnalyticsTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Tests\Component\Analytics;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Component\Analytics\Analytics;
+use Solarium\Component\Analytics\Facet\AbstractFacet;
+use Solarium\Component\Analytics\Facet\QueryFacet;
+use Solarium\Component\Analytics\Facet\Sort\Criterion;
+use Solarium\Component\Analytics\Facet\Sort\Sort;
+use Solarium\Component\Analytics\Facet\ValueFacet;
+use Solarium\Component\Analytics\Grouping;
+use Solarium\Component\ComponentAwareQueryInterface;
+use Solarium\Component\RequestBuilder\Analytics as RequestBuilder;
+use Solarium\Component\ResponseParser\Analytics as ResponseParser;
+
+/**
+ * Analytics Test.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class AnalyticsTest extends TestCase
+{
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testTypeAndRequestBuilder(): void
+    {
+        $component = new Analytics();
+
+        $this->assertSame(ComponentAwareQueryInterface::COMPONENT_ANALYTICS, $component->getType());
+        $this->assertInstanceOf(RequestBuilder::class, $component->getRequestBuilder());
+        $this->assertInstanceOf(ResponseParser::class, $component->getResponseParser());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testFunctions(): void
+    {
+        $options = [
+            'functions' => [
+                'clothing_sale()' => 'filter(mult(price,quantity),equal(category,\'Clothing\'))',
+            ],
+        ];
+
+        $component = new Analytics($options);
+
+        $this->assertSame($options['functions'], $component->getFunctions());
+        $this->assertArrayNotHasKey('expressions', $component->jsonSerialize());
+        $this->assertArrayNotHasKey('groupings', $component->jsonSerialize());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testExpressions(): void
+    {
+        $options = [
+            'functions' => [
+                'clothing_sale()' => 'filter(mult(price,quantity),equal(category,\'Clothing\'))',
+            ],
+            'expressions' => [
+                'max_clothing_sale' => 'max(clothing_sale())',
+                'med_clothing_sale' => 'median(clothing_sale())',
+            ],
+            'groupings' => [],
+        ];
+
+        $component = new Analytics($options);
+
+        $this->assertSame($options['expressions'], $component->getExpressions());
+        $this->assertSame($options['functions'], $component->getFunctions());
+        $this->assertArrayNotHasKey('groupings', $component->jsonSerialize());
+    }
+
+    public function testGroupings(): void
+    {
+        $facetOptions = [
+            'key' => 'key',
+            'expression' => 'fillmissing(category,\'No Category\')',
+        ];
+
+        $groupingOptions = [
+            'key' => 'sales_numbers',
+            'expressions' => [
+                'max_sale' => 'max(sale())',
+                'med_sale' => 'median(sale())',
+            ],
+            'facets' => [
+                new ValueFacet($facetOptions),
+            ],
+        ];
+
+        $options = [
+            'functions' => [
+                'sale()' => 'mult(price,quantity)',
+            ],
+            'groupings' => [
+                new Grouping($groupingOptions),
+            ],
+        ];
+
+        $component = new Analytics($options);
+
+        $this->assertSame($options['functions'], $component->getFunctions());
+        $this->assertArrayNotHasKey('expressions', $component->jsonSerialize());
+
+        $grouping = $component->getGroupings()[$groupingOptions['key']];
+
+        $this->assertSame($groupingOptions['key'], $grouping->getKey());
+        $this->assertSame($groupingOptions['expressions'], $grouping->getExpressions());
+        $this->assertSame($groupingOptions['facets'][0], $grouping->getFacets()[$facetOptions['key']]);
+        $this->assertArrayNotHasKey('key', $grouping->jsonSerialize());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testMapArrayToObjects(): void
+    {
+        $options = [
+            'functions' => [
+                'clothing_sale()' => 'filter(mult(price,quantity),equal(category,\'Clothing\'))',
+            ],
+            'expressions' => [
+                'max_clothing_sale' => 'max(clothing_sale())',
+                'med_clothing_sale' => 'median(clothing_sale())',
+            ],
+            'groupings' => [
+                [
+                    'key' => 'sales',
+                    'expressions' => [
+                        'stddev_sale' => 'stddev(sale())',
+                        'min_price' => 'min(price)',
+                        'max_quantity' => 'max(quantity)',
+                    ],
+                    'facets' => [
+                        [
+                            'key' => 'category',
+                            'type' => AbstractFacet::TYPE_VALUE,
+                            'expression' => 'fill_missing(category, \'No Category\')',
+                            'sort' => [
+                                'criteria' => [
+                                    [
+                                        'type' => Criterion::TYPE_EXPRESSION,
+                                        'expression' => 'min_price',
+                                        'direction' => 'ascending',
+                                    ],
+                                    [
+                                        'type' => Criterion::TYPE_VALUE,
+                                        'direction' => 'descending',
+                                    ],
+                                ],
+                                'limit' => 10,
+                            ],
+                        ],
+                        [
+                            'key' => 'temps',
+                            'type' => AbstractFacet::TYPE_QUERY,
+                            'queries' => [
+                                'hot' => 'temp:[90 TO *]',
+                                'cold' => 'temp:[* TO 50]',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $component = new Analytics($options);
+        $grouping = $component->getGroupings()['sales'];
+
+        $this->assertInstanceOf(Grouping::class, $grouping);
+
+        $facets = $grouping->getFacets();
+
+        $this->assertInstanceOf(ValueFacet::class, $facets['category']);
+        $this->assertInstanceOf(QueryFacet::class, $facets['temps']);
+
+        $sort = $facets['category']->getSort();
+
+        $this->assertInstanceOf(Sort::class, $sort);
+        $this->assertInstanceOf(Criterion::class, $sort->getCriteria()[0]);
+    }
+}

--- a/tests/Component/Analytics/Facet/AnalyticsFacetTest.php
+++ b/tests/Component/Analytics/Facet/AnalyticsFacetTest.php
@@ -39,7 +39,7 @@ class AnalyticsFacetTest extends TestCase
 
         $this->assertSame($options['key'], $facet->getKey());
         $this->assertSame($options['expression'], $facet->getExpression());
-        $this->assertSame($options['sort'], $facet->getSort());
+        $this->assertNull($facet->getSort());
         $this->assertArrayNotHasKey('sort', $facet->jsonSerialize());
     }
 
@@ -69,7 +69,7 @@ class AnalyticsFacetTest extends TestCase
         $this->assertSame($options['start'], $facet->getStart());
         $this->assertSame($options['end'], $facet->getEnd());
         $this->assertSame($options['gap'], $facet->getGap());
-        $this->assertSame($options['hardend'], $facet->isHardend());
+        $this->assertTrue($facet->isHardend());
         $this->assertSame($options['include'], $facet->getInclude());
         $this->assertSame($options['others'], $facet->getOthers());
         $this->assertArrayNotHasKey('others', $facet->jsonSerialize());
@@ -127,7 +127,7 @@ class AnalyticsFacetTest extends TestCase
 
         $this->assertSame($pivotOptions['name'], $pivot->getName());
         $this->assertSame($pivotOptions['expression'], $pivot->getExpression());
-        $this->assertSame($pivotOptions['sort'], $pivot->getSort());
+        $this->assertNull($pivot->getSort());
         $this->assertArrayNotHasKey('sort', $pivot->jsonSerialize());
     }
 
@@ -153,7 +153,7 @@ class AnalyticsFacetTest extends TestCase
 
         $sort = new Sort($options);
 
-        $this->assertSame($options['limit'], $sort->getLimit());
+        $this->assertNull($sort->getLimit());
         $this->assertSame($options['offset'], $sort->getOffset());
         $this->assertArrayNotHasKey('limit', $sort->jsonSerialize());
 

--- a/tests/Component/Analytics/Facet/AnalyticsFacetTest.php
+++ b/tests/Component/Analytics/Facet/AnalyticsFacetTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Tests\Component\Analytics\Facet;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Component\Analytics\Facet\AbstractFacet;
+use Solarium\Component\Analytics\Facet\Pivot;
+use Solarium\Component\Analytics\Facet\PivotFacet;
+use Solarium\Component\Analytics\Facet\QueryFacet;
+use Solarium\Component\Analytics\Facet\RangeFacet;
+use Solarium\Component\Analytics\Facet\Sort\Criterion;
+use Solarium\Component\Analytics\Facet\Sort\Sort;
+use Solarium\Component\Analytics\Facet\ValueFacet;
+
+/**
+ * Analytics Facet Test.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class AnalyticsFacetTest extends TestCase
+{
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testValueFacet(): void
+    {
+        $options = [
+            'key' => 'key',
+            'expression' => 'fillmissing(category,\'No Category\')',
+            'sort' => null,
+        ];
+
+        $facet = new ValueFacet($options);
+
+        $this->assertSame(AbstractFacet::TYPE_VALUE, $facet->getType());
+
+        $this->assertSame($options['key'], $facet->getKey());
+        $this->assertSame($options['expression'], $facet->getExpression());
+        $this->assertSame($options['sort'], $facet->getSort());
+        $this->assertArrayNotHasKey('sort', $facet->jsonSerialize());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testRangeFacet(): void
+    {
+        $options = [
+            'key' => 'key',
+            'field' => 'price',
+            'start' => 0,
+            'end' => 100,
+            'gap' => [5, 10, 10, 25],
+            'hardend' => true,
+            'include' => [RangeFacet::INCLUDE_LOWER, RangeFacet::INCLUDE_UPPER],
+            'others' => [],
+        ];
+
+        $facet = new RangeFacet($options);
+
+        $this->assertSame(AbstractFacet::TYPE_RANGE, $facet->getType());
+
+        $this->assertSame($options['key'], $facet->getKey());
+        $this->assertSame($options['field'], $facet->getField());
+        $this->assertSame($options['start'], $facet->getStart());
+        $this->assertSame($options['end'], $facet->getEnd());
+        $this->assertSame($options['gap'], $facet->getGap());
+        $this->assertSame($options['hardend'], $facet->isHardend());
+        $this->assertSame($options['include'], $facet->getInclude());
+        $this->assertSame($options['others'], $facet->getOthers());
+        $this->assertArrayNotHasKey('others', $facet->jsonSerialize());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testQueryFacet(): void
+    {
+        $options = [
+            'key' => 'key',
+            'queries' => [
+                'high_quantity' => 'quantity:[ 5 TO 14 ] AND price:[ 100 TO * ]',
+                'low_quantity' => 'quantity:[ 1 TO 4 ] AND price:[ 100 TO * ]',
+            ],
+        ];
+
+        $facet = new QueryFacet($options);
+
+        $this->assertSame(AbstractFacet::TYPE_QUERY, $facet->getType());
+
+        $this->assertSame($options['key'], $facet->getKey());
+        $this->assertSame($options['queries'], $facet->getQueries());
+        $this->assertArrayNotHasKey('key', $facet->jsonSerialize());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \PHPUnit\Framework\Exception
+     */
+    public function testPivotFacet(): void
+    {
+        $pivotOptions = [
+            'name' => 'state',
+            'expression' => 'fillmissing(state, fillmissing(providence, territory))',
+            'sort' => null,
+        ];
+
+        $options = [
+            'key' => 'key',
+            'pivots' => [
+                new Pivot($pivotOptions),
+            ],
+        ];
+
+        $facet = new PivotFacet($options);
+
+        $this->assertSame(AbstractFacet::TYPE_PIVOT, $facet->getType());
+        $this->assertSame($options['key'], $facet->getKey());
+        $this->assertArrayNotHasKey('key', $facet->jsonSerialize());
+
+        $pivot = $facet->getPivots()[0];
+
+        $this->assertSame($pivotOptions['name'], $pivot->getName());
+        $this->assertSame($pivotOptions['expression'], $pivot->getExpression());
+        $this->assertSame($pivotOptions['sort'], $pivot->getSort());
+        $this->assertArrayNotHasKey('sort', $pivot->jsonSerialize());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \PHPUnit\Framework\Exception
+     */
+    public function testSort(): void
+    {
+        $criterionOptions = [
+            'type' => Criterion::TYPE_EXPRESSION,
+            'expression' => 'max_sale',
+            'direction' => Criterion::DIRECTION_ASCENDING,
+        ];
+
+        $options = [
+            'limit' => null,
+            'offset' => 5,
+            'criteria' => [
+                new Criterion($criterionOptions),
+            ],
+        ];
+
+        $sort = new Sort($options);
+
+        $this->assertSame($options['limit'], $sort->getLimit());
+        $this->assertSame($options['offset'], $sort->getOffset());
+        $this->assertArrayNotHasKey('limit', $sort->jsonSerialize());
+
+        $criterion = $sort->getCriteria()[0];
+
+        $this->assertSame($criterionOptions['type'], $criterion->getType());
+        $this->assertSame($criterionOptions['expression'], $criterion->getExpression());
+        $this->assertSame($criterionOptions['direction'], $criterion->getDirection());
+
+        unset($criterionOptions['direction']);
+
+        $criterion = new Criterion($criterionOptions);
+        $this->assertArrayNotHasKey('direction', $criterion->jsonSerialize());
+    }
+}

--- a/tests/Component/Analytics/Facet/ObjectTraitTest.php
+++ b/tests/Component/Analytics/Facet/ObjectTraitTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Tests\Component\Analytics\Facet;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Component\Analytics\Facet\AbstractFacet;
+use Solarium\Component\Analytics\Facet\ObjectTrait;
+use Solarium\Component\Analytics\Facet\PivotFacet;
+use Solarium\Component\Analytics\Facet\Sort\Sort;
+use Solarium\Exception\InvalidArgumentException;
+
+/**
+ * Object Trait Test.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class ObjectTraitTest extends TestCase
+{
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testNullReturn(): void
+    {
+        $mock = $this->getMockForTrait(ObjectTrait::class);
+
+        $this->assertNull($mock->ensureObject(AbstractFacet::class, null));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testReturnVariable(): void
+    {
+        $mock = $this->getMockForTrait(ObjectTrait::class);
+
+        $this->assertInstanceOf(PivotFacet::class, $mock->ensureObject(AbstractFacet::class, new PivotFacet()));
+    }
+
+    /**
+     * Test non existing class.
+     */
+    public function testNonExistingClass(): void
+    {
+        $mock = $this->getMockForTrait(ObjectTrait::class);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $mock->ensureObject('Foo\Bar', new PivotFacet());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testFromArray(): void
+    {
+        $mock = $this->getMockForTrait(ObjectTrait::class);
+
+        $this->assertInstanceOf(Sort::class, $mock->ensureObject(Sort::class, []));
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testFromClassMap(): void
+    {
+        $mock = $this->getMockForTrait(ObjectTrait::class);
+
+        $this->assertInstanceOf(PivotFacet::class, $mock->ensureObject(AbstractFacet::class, ['type' => AbstractFacet::TYPE_PIVOT]));
+    }
+
+    /**
+     * Test invalid variable type.
+     */
+    public function testInvalidVariableType(): void
+    {
+        $mock = $this->getMockForTrait(ObjectTrait::class);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $mock->ensureObject(PivotFacet::class, true);
+    }
+
+    /**
+     * Test invalid mapping type.
+     */
+    public function testInvalidMappingType(): void
+    {
+        $mock = $this->getMockForTrait(ObjectTrait::class);
+
+        $this->expectException(InvalidArgumentException::class);
+        $mock->ensureObject(AbstractFacet::class, ['type' => 'foo']);
+    }
+}

--- a/tests/Component/RequestBuilder/AnalyticsTest.php
+++ b/tests/Component/RequestBuilder/AnalyticsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Tests\Component\RequestBuilder;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Component\Analytics\Analytics as Component;
+use Solarium\Component\RequestBuilder\Analytics as RequestBuilder;
+use Solarium\Core\Client\Request;
+
+/**
+ * AnalyticsTest.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class AnalyticsTest extends TestCase
+{
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \RuntimeException
+     */
+    public function testBuildComponent(): void
+    {
+        $builder = new RequestBuilder();
+        $request = new Request();
+
+        $component = new Component();
+        $component->addFunction('sale()', 'mult(price,quantity)');
+
+        $request = $builder->buildComponent($component, $request);
+
+        $this->assertSame(Request::METHOD_POST, $request->getMethod());
+        parse_str($request->getRawData(), $data);
+
+        $this->assertArrayHasKey('analytics', $data);
+        $analytics = json_decode($data['analytics'], true);
+        $this->assertArrayHasKey('functions', $analytics);
+        $this->assertArrayHasKey('sale()', $analytics['functions']);
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \RuntimeException
+     */
+    public function testMergingPostData(): void
+    {
+        $builder = new RequestBuilder();
+        $request = new Request();
+        $request
+            ->setMethod(Request::METHOD_POST)
+            ->setRawData('json='.json_encode([
+                'query' => '*:*',
+                'rows' => '1',
+            ]))
+        ;
+
+        $component = new Component();
+        $component->addFunction('sale()', 'mult(price,quantity)');
+
+        $request = $builder->buildComponent($component, $request);
+
+        $this->assertSame(Request::METHOD_POST, $request->getMethod());
+        parse_str($request->getRawData(), $data);
+
+        $this->assertArrayHasKey('analytics', $data);
+        $this->assertArrayHasKey('json', $data);
+
+        $analytics = json_decode($data['analytics'], true);
+
+        $this->assertArrayHasKey('functions', $analytics);
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    public function testInvalidContentType(): void
+    {
+        $builder = new RequestBuilder();
+        $request = new Request();
+        $request
+            ->setMethod(Request::METHOD_POST)
+            ->addHeader('Content-Type: application/xml, charset=utf-8')
+            ->setRawData(json_encode([
+                'query' => '*:*',
+                'rows' => '1',
+            ]))
+        ;
+
+        $component = new Component();
+        $component->addFunction('sale()', 'mult(price,quantity)');
+
+        $this->expectException(\RuntimeException::class);
+        $builder->buildComponent($component, $request);
+    }
+}

--- a/tests/Component/ResponseParser/AnalyticsTest.php
+++ b/tests/Component/ResponseParser/AnalyticsTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Tests\Component\ResponseParser;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Component\Analytics\Analytics;
+use Solarium\Component\Analytics\Facet\AbstractFacet;
+use Solarium\Component\Analytics\Grouping;
+use Solarium\Component\ResponseParser\Analytics as ResponseParser;
+use Solarium\Component\Result\Analytics\Expression;
+use Solarium\Component\Result\Analytics\Grouping as ResultGrouping;
+use Solarium\Component\Result\Analytics\Result as AnalyticsResult;
+
+/**
+ * Analytics Test.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class AnalyticsTest extends TestCase
+{
+    public function testParseData(): void
+    {
+        $grouping = new Grouping([
+            'key' => 'geo_sales',
+            'expressions' => [
+                'max_sale' => 'max(sale())',
+                'med_sale' => 'median(sale())',
+            ],
+            'facets' => [
+                [
+                    'key' => 'category',
+                    'type' => AbstractFacet::TYPE_PIVOT,
+                    'pivots' => [
+                        [
+                            'name' => 'country',
+                            'expression' => 'country',
+                        ],
+                        [
+                            'name' => 'state',
+                            'expression' => 'fillmissing(state, fillmissing(providence, territory))',
+                        ],
+                        [
+                            'name' => 'city',
+                            'expression' => 'fillmissing(city, \'N/A\')',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $component = new Analytics();
+        $component
+            ->addExpression('max_sale', 'max(sale())')
+            ->addExpression('med_sale', 'median(sale())')
+            ->addGrouping($grouping);
+
+        $data = [
+            'analytics_response' => [
+                'results' => [
+                    'max_sale' => 50.0,
+                    'med_sale' => 31.0,
+                ],
+                'groupings' => [
+                    'geo_sales' => [
+                        'category' => [
+                            [
+                                'pivot' => 'country',
+                                'value' => 'usa',
+                                'results' => [
+                                    'max_sale' => 103.75,
+                                    'med_sale' => 15.5,
+                                ],
+                                'children' => [
+                                    [
+                                        'pivot' => 'state',
+                                        'value' => 'texas',
+                                        'results' => [
+                                            'max_sale' => 99.2,
+                                            'med_sale' => 20.35,
+                                        ],
+                                        'children' => [
+                                            [
+                                                'pivot' => 'city',
+                                                'value' => 'austin',
+                                                'results' => [
+                                                    'max_sale' => 94.34,
+                                                    'med_sale' => 17.60,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $parser = new ResponseParser();
+        $result = $parser->parse(null, $component, $data);
+
+        $this->assertCount(\count($result->getResults()), $result);
+        $this->assertCount(\count($result->getIterator()), $result);
+        $this->assertArrayHasKey('geo_sales', $result->getGroupings());
+
+        $this->assertInstanceOf(AnalyticsResult::class, $result);
+        $expression = $result->getResult('max_sale');
+
+        $this->assertInstanceOf(Expression::class, $expression);
+        $this->assertEquals('max(sale())', $expression->getExpression());
+        $this->assertEquals(50.0, $expression->getValue());
+
+        $grouping = $result->getGrouping('geo_sales');
+
+        $this->assertInstanceOf(ResultGrouping::class, $grouping);
+
+        $facets = $grouping->getFacets('category');
+
+        $this->assertCount(1, $facets);
+        $this->assertSame('country', $facets[0]->getPivot());
+        $this->assertSame('usa', $facets[0]->getValue());
+
+        $this->assertCount(\count($facets[0]->getResults()), $facets[0]);
+        $this->assertCount(\count($facets[0]->getIterator()), $facets[0]);
+
+        $this->assertCount(1, $facets[0]->getChildren());
+        $this->assertCount(1, $facets[0]->getChildren()[0]->getChildren());
+    }
+
+    public function testNullResponse(): void
+    {
+        $component = new Analytics();
+        $component
+            ->addExpression('max_sale', 'max(sale())')
+            ->addExpression('med_sale', 'median(sale())');
+
+        $data = [
+            'analytics_response' => [
+                'results' => [
+                    'max_sale' => 50.0,
+                    'med_sale' => 31.0,
+                ],
+            ],
+        ];
+
+        $parser = new ResponseParser();
+
+        $this->assertNull($parser->parse(null, $component, []));
+        $this->assertNull($parser->parse(null, null, $data));
+    }
+
+    public function testNotReturnedExpressionsAndFacets(): void
+    {
+        $grouping = new Grouping([
+            'key' => 'geo_sales',
+            'expressions' => [
+                'max_sale' => 'max(sale())',
+                'med_sale' => 'median(sale())',
+                'min_sale' => 'min(sale())',
+            ],
+            'facets' => [
+                [
+                    'key' => 'category',
+                    'type' => AbstractFacet::TYPE_PIVOT,
+                    'pivots' => [
+                        [
+                            'name' => 'country',
+                            'expression' => 'country',
+                        ],
+                        [
+                            'name' => 'state',
+                            'expression' => 'fillmissing(state, fillmissing(providence, territory))',
+                        ],
+                        [
+                            'name' => 'city',
+                            'expression' => 'fillmissing(city, \'N/A\')',
+                        ],
+                    ],
+                ],
+                [
+                    'key' => 'bar',
+                    'type' => AbstractFacet::TYPE_VALUE,
+                ],
+            ],
+        ]);
+
+        $component = new Analytics();
+        $component
+            ->addExpression('max_sale', 'max(sale())')
+            ->addExpression('med_sale', 'median(sale())')
+            ->addExpression('min_sale', 'min(sale())')
+            ->addGrouping($grouping)
+            ->addGrouping(new Grouping(['key' => 'foo']))
+        ;
+
+        $data = [
+            'analytics_response' => [
+                'results' => [
+                    'max_sale' => 50.0,
+                    'med_sale' => 31.0,
+                ],
+                'groupings' => [
+                    'geo_sales' => [
+                        'category' => [
+                            [
+                                'pivot' => 'country',
+                                'value' => 'usa',
+                                'results' => [
+                                    'max_sale' => 103.75,
+                                    'med_sale' => 15.5,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $parser = new ResponseParser();
+        $result = $parser->parse(null, $component, $data);
+
+        $this->assertNull($result->getResult('min_sale'));
+        $this->assertNull($result->getGrouping('foo'));
+
+        $grouping = $result->getGrouping('geo_sales');
+        $this->assertNull($grouping->getFacets('bar'));
+    }
+}

--- a/tests/Core/Client/RequestTest.php
+++ b/tests/Core/Client/RequestTest.php
@@ -381,6 +381,23 @@ class RequestTest extends TestCase
         );
     }
 
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testReplaceHeaders(): void
+    {
+        $original = 'Content-Type: application/xml';
+        $replacement = 'Content-Type: application/json';
+
+        $this->request->addHeader($original);
+
+        $this->assertSame($original, $this->request->getHeader('Content-Type'));
+
+        $this->request->addHeader($replacement);
+
+        $this->assertSame($replacement, $this->request->getHeader('Content-Type'));
+    }
+
     public function testClearHeaders()
     {
         $headers = [

--- a/tests/Core/Client/RequestTest.php
+++ b/tests/Core/Client/RequestTest.php
@@ -389,11 +389,11 @@ class RequestTest extends TestCase
         $original = 'Content-Type: application/xml';
         $replacement = 'Content-Type: application/json';
 
-        $this->request->addHeader($original);
+        $this->request->replaceOrAddHeader($original);
 
         $this->assertSame($original, $this->request->getHeader('Content-Type'));
 
-        $this->request->addHeader($replacement);
+        $this->request->replaceOrAddHeader($replacement);
 
         $this->assertSame($replacement, $this->request->getHeader('Content-Type'));
     }

--- a/tests/QueryType/Select/Query/AbstractQueryTest.php
+++ b/tests/QueryType/Select/Query/AbstractQueryTest.php
@@ -3,6 +3,7 @@
 namespace Solarium\Tests\QueryType\Select\Query;
 
 use PHPUnit\Framework\TestCase;
+use Solarium\Component\Analytics\Analytics;
 use Solarium\Component\MoreLikeThis;
 use Solarium\Core\Client\Client;
 use Solarium\Exception\InvalidArgumentException;
@@ -690,6 +691,11 @@ abstract class AbstractQueryTest extends TestCase
             'Solarium\Component\ReRankQuery',
             \get_class($reRankQuery)
         );
+    }
+
+    public function testGetAnalytics(): void
+    {
+        $this->assertInstanceOf(Analytics::class, $this->query->getAnalytics());
     }
 
     public function testAddTag()

--- a/tests/QueryType/Select/Result/AbstractResultTest.php
+++ b/tests/QueryType/Select/Result/AbstractResultTest.php
@@ -34,6 +34,8 @@ abstract class AbstractResultTest extends TestCase
 
     protected $debug;
 
+    protected $analytics;
+
     protected $spellcheck;
 
     public function setUp(): void
@@ -54,6 +56,7 @@ abstract class AbstractResultTest extends TestCase
         $this->spellcheck = null;
         $this->stats = null;
         $this->debug = null;
+        $this->analytics = null;
 
         $this->components = [
             ComponentAwareQueryInterface::COMPONENT_FACETSET => $this->facetSet,
@@ -63,6 +66,7 @@ abstract class AbstractResultTest extends TestCase
             ComponentAwareQueryInterface::COMPONENT_SPELLCHECK => $this->spellcheck,
             ComponentAwareQueryInterface::COMPONENT_STATS => $this->stats,
             ComponentAwareQueryInterface::COMPONENT_DEBUG => $this->debug,
+            ComponentAwareQueryInterface::COMPONENT_ANALYTICS => $this->analytics,
         ];
 
         $this->result = new SelectDummy(1, 12, $this->numFound, $this->maxScore, $this->docs, $this->components);
@@ -90,7 +94,7 @@ abstract class AbstractResultTest extends TestCase
 
     public function testCount()
     {
-        $this->assertCount(count($this->docs), $this->result);
+        $this->assertCount(\count($this->docs), $this->result);
     }
 
     public function testGetComponents()
@@ -158,6 +162,14 @@ abstract class AbstractResultTest extends TestCase
         $this->assertSame(
             $this->components[ComponentAwareQueryInterface::COMPONENT_DEBUG],
             $this->result->getDebug()
+        );
+    }
+
+    public function testGetAnalytics()
+    {
+        $this->assertSame(
+            $this->components[ComponentAwareQueryInterface::COMPONENT_ANALYTICS],
+            $this->result->getAnalytics()
         );
     }
 


### PR DESCRIPTION
replaces https://github.com/solariumphp/solarium/pull/731 & fixes #727 

implementation to support the solr analytics component with solarium.
@ see https://lucene.apache.org/solr/guide/analytics.html for more info on this component