### PR TITLE
move function classes to analytics namespace

### DIFF
--- a/src/Builder/Analytics/ExpressionBuilder.php
+++ b/src/Builder/Analytics/ExpressionBuilder.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Solarium\Builder\Analytics;
 
 use Solarium\Builder\ExpressionInterface;
-use Solarium\Builder\MappingFunction;
-use Solarium\Builder\ReductionFunction;
 
 /**
  * Expression Builder.

--- a/src/Builder/Analytics/MappingFunction.php
+++ b/src/Builder/Analytics/MappingFunction.php
@@ -2,7 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Solarium\Builder;
+namespace Solarium\Builder\Analytics;
+
+use Solarium\Builder\AbstractExpressionVisitor;
+use Solarium\Builder\ExpressionInterface;
+use Solarium\Builder\FunctionInterface;
 
 /**
  * Mapping Function.

--- a/src/Builder/Analytics/ReductionFunction.php
+++ b/src/Builder/Analytics/ReductionFunction.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Solarium\Builder;
+namespace Solarium\Builder\Analytics;
 
+use Solarium\Builder\AbstractExpressionVisitor;
+use Solarium\Builder\ExpressionInterface;
+use Solarium\Builder\FunctionInterface;
 use Solarium\Exception\RuntimeException;
 
 /**

--- a/tests/Builder/Analytics/FunctionBuilderTest.php
+++ b/tests/Builder/Analytics/FunctionBuilderTest.php
@@ -55,7 +55,8 @@ class FunctionBuilderTest extends TestCase
         FunctionBuilder::create()
             ->where($expr->count(
                 $expr->missing('foo')
-            ));
+            ))
+        ;
     }
 
     /**


### PR DESCRIPTION
apologies for the early refactor of this one; 
after trying to get my head around how to best implement the streaming function builder i realised having the function classes in the builder namespace root might end up being messy.

as no release has been tagged including the function builder, i assume this is no problem