### PR TITLE
symfony coding standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /vendor
 .idea
 /.phpunit.result.cache
-.php_cs.cache
+/.php_cs.cache
+/.phpcs-cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,5 +1,12 @@
 <?php
 
+$header = <<<'EOF'
+This file is part of the Solarium package.
+
+For the full copyright and license information, please view the COPYING
+file that was distributed with this source code.
+EOF;
+
 return PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)
     ->setRules([
@@ -9,9 +16,9 @@ return PhpCsFixer\Config::create()
        'array_syntax' => ['syntax' => 'short'],
        'class_attributes_separation' => ['elements' => ['const', 'method', 'property']],
        'combine_consecutive_unsets' => true,
-        // one should use PHPUnit methods to set up expected exception instead of annotations
        'general_phpdoc_annotation_remove' => ['expectedException', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp'],
        'heredoc_to_nowdoc' => true,
+       'header_comment' => ['header' => $header],
        'list_syntax' => ['syntax' => 'long'],
        'method_argument_space' => ['keep_multiple_spaces_after_comma' => false],
        'no_extra_consecutive_blank_lines' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block'],
@@ -21,12 +28,9 @@ return PhpCsFixer\Config::create()
        'no_useless_return' => true,
        'ordered_class_elements' => true,
        'ordered_imports' => true,
-       // 'php_unit_strict' => true,
-       // 'php_unit_test_class_requires_covers' => true,
        'phpdoc_add_missing_param_annotation' => true,
        'phpdoc_order' => true,
        'semicolon_after_instruction' => true,
-       // 'strict_comparison' => true,
        'strict_param' => true,
        'implode_call' => true,
        'no_superfluous_phpdoc_tags' => false,
@@ -35,6 +39,5 @@ return PhpCsFixer\Config::create()
         PhpCsFixer\Finder::create()
             ->exclude('vendor/')
             ->in('src')
-            ->in('tests')
     )
 ;

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -9,7 +9,6 @@ disabled:
     - blank_line_before_break
     - blank_line_before_continue
     - blank_line_before_declare
-    - blank_line_before_return
     - blank_line_before_throw
     - blank_line_before_try
 

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "symfony/contracts": "^1.0 || ^2.0"
     },
     "require-dev": {
+        "escapestudios/symfony2-coding-standard": "^3.11",
         "guzzlehttp/guzzle": "^6.5",
         "nyholm/psr7": "^1.2",
         "php-http/guzzle6-adapter": "^2.0",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <config name="installed_paths" value="vendor/escapestudios/symfony2-coding-standard" />
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+
+    <rule ref="Symfony"/>
+
+    <file>src/</file>
+
+</ruleset>

--- a/src/Builder/AbstractExpressionVisitor.php
+++ b/src/Builder/AbstractExpressionVisitor.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Builder;
 
 use Solarium\Exception\RuntimeException;
@@ -57,7 +64,7 @@ abstract class AbstractExpressionVisitor
             case $expr instanceof CompositeComparison:
                 return $this->walkCompositeExpression($expr);
             default:
-                throw new RuntimeException('Unknown Expression '.\get_class($expr));
+                throw new RuntimeException(sprintf('Unknown Expression %s', \get_class($expr)));
         }
     }
 }

--- a/src/Builder/Analytics/AnalyticsExpressionVisitor.php
+++ b/src/Builder/Analytics/AnalyticsExpressionVisitor.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Builder\Analytics;
 
 use Solarium\Builder\AbstractExpressionVisitor;
@@ -30,7 +37,7 @@ class AnalyticsExpressionVisitor extends AbstractExpressionVisitor
             return $this->walkExpression($expr);
         }
 
-        throw new RuntimeException('Unknown Expression '.\get_class($expr));
+        throw new RuntimeException(sprintf('Unknown Expression %s', \get_class($expr)));
     }
 
     /**

--- a/src/Builder/Analytics/ExpressionBuilder.php
+++ b/src/Builder/Analytics/ExpressionBuilder.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Builder\Analytics;
 
 use Solarium\Builder\ExpressionInterface;

--- a/src/Builder/Analytics/FunctionBuilder.php
+++ b/src/Builder/Analytics/FunctionBuilder.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Builder\Analytics;
 
 use Solarium\Builder\ExpressionInterface;

--- a/src/Builder/Analytics/MappingFunction.php
+++ b/src/Builder/Analytics/MappingFunction.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Builder\Analytics;
 
 use Solarium\Builder\AbstractExpressionVisitor;

--- a/src/Builder/Analytics/ReductionFunction.php
+++ b/src/Builder/Analytics/ReductionFunction.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Solarium\Builder;
 namespace Solarium\Builder\Analytics;
 
 use Solarium\Builder\AbstractExpressionVisitor;

--- a/src/Builder/Analytics/ReductionFunction.php
+++ b/src/Builder/Analytics/ReductionFunction.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Builder;
 namespace Solarium\Builder\Analytics;
 
 use Solarium\Builder\AbstractExpressionVisitor;

--- a/src/Builder/Comparison.php
+++ b/src/Builder/Comparison.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Builder;
 
 /**

--- a/src/Builder/CompositeComparison.php
+++ b/src/Builder/CompositeComparison.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Builder;
 
 use Solarium\Exception\RuntimeException;

--- a/src/Builder/ExpressionInterface.php
+++ b/src/Builder/ExpressionInterface.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Builder;
 
 /**

--- a/src/Builder/FunctionInterface.php
+++ b/src/Builder/FunctionInterface.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Builder;
 
 /**

--- a/src/Builder/Value.php
+++ b/src/Builder/Value.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Builder;
 
 /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium;
 
 use Solarium\Core\Client\Client as CoreClient;
@@ -66,7 +73,7 @@ class Client extends CoreClient
      */
     public static function checkExact(string $version): bool
     {
-        return substr(self::VERSION, 0, strlen($version)) == $version;
+        return 0 === strpos(self::VERSION, $version);
     }
 
     /**

--- a/src/Component/AbstractComponent.php
+++ b/src/Component/AbstractComponent.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\RequestBuilder\ComponentRequestBuilderInterface;
@@ -34,6 +41,8 @@ abstract class AbstractComponent extends Configurable
 
     /**
      * This component has no response parser...
+     *
+     * @return \Solarium\Component\ResponseParser\ComponentParserInterface|null
      */
     public function getResponseParser(): ?ComponentParserInterface
     {

--- a/src/Component/Analytics/Analytics.php
+++ b/src/Component/Analytics/Analytics.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Analytics;
 
 use Solarium\Component\AbstractComponent;

--- a/src/Component/Analytics/Facet/AbstractFacet.php
+++ b/src/Component/Analytics/Facet/AbstractFacet.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Analytics\Facet;
 
 use Solarium\Core\Configurable;

--- a/src/Component/Analytics/Facet/ConfigurableInitTrait.php
+++ b/src/Component/Analytics/Facet/ConfigurableInitTrait.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Analytics\Facet;
 
 /**

--- a/src/Component/Analytics/Facet/ObjectTrait.php
+++ b/src/Component/Analytics/Facet/ObjectTrait.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Analytics\Facet;
 
 use Solarium\Core\Configurable;
@@ -47,7 +54,9 @@ trait ObjectTrait
                 && (false !== $map = $refClass->getConstant('CLASSMAP'))
                 && (true === isset($map[$variable['type']]))
             ) {
-                return new $map[$variable['type']]($variable);
+                $class = $map[$variable['type']];
+
+                return new $class($variable);
             }
         }
 

--- a/src/Component/Analytics/Facet/Pivot.php
+++ b/src/Component/Analytics/Facet/Pivot.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Analytics\Facet;
 
 use Solarium\Component\Analytics\Facet\Sort\Sort;

--- a/src/Component/Analytics/Facet/PivotFacet.php
+++ b/src/Component/Analytics/Facet/PivotFacet.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Analytics\Facet;
 
 /**

--- a/src/Component/Analytics/Facet/QueryFacet.php
+++ b/src/Component/Analytics/Facet/QueryFacet.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Analytics\Facet;
 
 /**

--- a/src/Component/Analytics/Facet/RangeFacet.php
+++ b/src/Component/Analytics/Facet/RangeFacet.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Analytics\Facet;
 
 /**
@@ -286,7 +293,7 @@ class RangeFacet extends AbstractFacet
                 'others' => $this->others,
             ],
             static function ($var) {
-                return null !== $var && (false === is_array($var) || 0 !== count($var));
+                return null !== $var && (false === \is_array($var) || 0 !== \count($var));
             }
         );
     }

--- a/src/Component/Analytics/Facet/Sort/Criterion.php
+++ b/src/Component/Analytics/Facet/Sort/Criterion.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Analytics\Facet\Sort;
 
 use Solarium\Component\Analytics\Facet\ConfigurableInitTrait;

--- a/src/Component/Analytics/Facet/Sort/Sort.php
+++ b/src/Component/Analytics/Facet/Sort/Sort.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Analytics\Facet\Sort;
 
 use Solarium\Component\Analytics\Facet\ConfigurableInitTrait;

--- a/src/Component/Analytics/Facet/ValueFacet.php
+++ b/src/Component/Analytics/Facet/ValueFacet.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Analytics\Facet;
 
 use Solarium\Component\Analytics\Facet\Sort\Sort;

--- a/src/Component/Analytics/Grouping.php
+++ b/src/Component/Analytics/Grouping.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Analytics;
 
 use Solarium\Component\Analytics\Facet\AbstractFacet;

--- a/src/Component/ComponentAwareQueryInterface.php
+++ b/src/Component/ComponentAwareQueryInterface.php
@@ -111,7 +111,7 @@ interface ComponentAwareQueryInterface
      *
      * @return self Provides fluent interface
      */
-    public function registerComponentType(string $key, string $component);
+    public function registerComponentType(string $key, string $component): self;
 
     /**
      * Get all registered components.

--- a/src/Component/ComponentAwareQueryInterface.php
+++ b/src/Component/ComponentAwareQueryInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Exception\OutOfBoundsException;
@@ -118,7 +125,6 @@ interface ComponentAwareQueryInterface
      *
      * You can optionally supply an autoload class to create a new component
      * instance if there is no registered component for the given key yet.
-     *
      *
      * @param string      $key      Use one of the constants
      * @param string|bool $autoload Class to autoload if component needs to be created

--- a/src/Component/ComponentAwareQueryInterface.php
+++ b/src/Component/ComponentAwareQueryInterface.php
@@ -101,7 +101,7 @@ interface ComponentAwareQueryInterface
      *
      * @return array
      */
-    public function getComponentTypes();
+    public function getComponentTypes(): array;
 
     /**
      * Register a component type.
@@ -111,7 +111,7 @@ interface ComponentAwareQueryInterface
      *
      * @return self Provides fluent interface
      */
-    public function registerComponentType(string $key, string $component): self;
+    public function registerComponentType(string $key, string $component);
 
     /**
      * Get all registered components.

--- a/src/Component/ComponentAwareQueryTrait.php
+++ b/src/Component/ComponentAwareQueryTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Exception\OutOfBoundsException;
@@ -41,7 +48,7 @@ trait ComponentAwareQueryTrait
      *
      * @return self Provides fluent interface
      */
-    public function registerComponentType(string $key, string $component): ComponentAwareQueryInterface
+    public function registerComponentType(string $key, string $component): self
     {
         $this->componentTypes[$key] = $component;
 
@@ -64,7 +71,6 @@ trait ComponentAwareQueryTrait
      * You can optionally supply an autoload class to create a new component
      * instance if there is no registered component for the given key yet.
      *
-     *
      * @param string      $key      Use one of the constants
      * @param string|bool $autoload Class to autoload if component needs to be created
      * @param array|null  $config   Configuration to use for autoload
@@ -81,7 +87,7 @@ trait ComponentAwareQueryTrait
 
         if (true === $autoload) {
             if (!isset($this->componentTypes[$key])) {
-                throw new OutOfBoundsException('Cannot autoload unknown component: '.$key);
+                throw new OutOfBoundsException(sprintf('Cannot autoload unknown component: %s', $key));
             }
 
             $className = $this->componentTypes[$key];
@@ -124,7 +130,7 @@ trait ComponentAwareQueryTrait
      */
     public function removeComponent($component): ComponentAwareQueryInterface
     {
-        if (is_object($component)) {
+        if (\is_object($component)) {
             foreach ($this->components as $key => $instance) {
                 if ($instance === $component) {
                     unset($this->components[$key]);

--- a/src/Component/ComponentAwareQueryTrait.php
+++ b/src/Component/ComponentAwareQueryTrait.php
@@ -48,7 +48,7 @@ trait ComponentAwareQueryTrait
      *
      * @return self Provides fluent interface
      */
-    public function registerComponentType(string $key, string $component): self
+    public function registerComponentType(string $key, string $component)
     {
         $this->componentTypes[$key] = $component;
 

--- a/src/Component/ComponentAwareQueryTrait.php
+++ b/src/Component/ComponentAwareQueryTrait.php
@@ -35,7 +35,7 @@ trait ComponentAwareQueryTrait
      *
      * @return array
      */
-    public function getComponentTypes()
+    public function getComponentTypes(): array
     {
         return $this->componentTypes;
     }

--- a/src/Component/ComponentTraits/SpellcheckTrait.php
+++ b/src/Component/ComponentTraits/SpellcheckTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ComponentTraits;
 
 use Solarium\Component\SpellcheckInterface;
@@ -75,9 +82,10 @@ trait SpellcheckTrait
      */
     public function setDictionary($dictionary): SpellcheckInterface
     {
-        if (is_string($dictionary)) {
+        if (\is_string($dictionary)) {
             $dictionary = [$dictionary];
         }
+
         return $this->setOption('dictionary', $dictionary);
     }
 

--- a/src/Component/ComponentTraits/SuggesterTrait.php
+++ b/src/Component/ComponentTraits/SuggesterTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ComponentTraits;
 
 use Solarium\Component\SuggesterInterface;
@@ -20,9 +27,10 @@ trait SuggesterTrait
      */
     public function setDictionary($dictionary): SuggesterInterface
     {
-        if (is_string($dictionary)) {
+        if (\is_string($dictionary)) {
             $dictionary = [$dictionary];
         }
+
         return $this->setOption('dictionary', $dictionary);
     }
 

--- a/src/Component/ComponentTraits/TermsTrait.php
+++ b/src/Component/ComponentTraits/TermsTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ComponentTraits;
 
 use Solarium\Component\TermsInterface;
@@ -25,7 +32,7 @@ trait TermsTrait
      */
     public function setFields($value): TermsInterface
     {
-        if (is_string($value)) {
+        if (\is_string($value)) {
             $value = explode(',', $value);
             $value = array_map('trim', $value);
         }
@@ -191,7 +198,7 @@ trait TermsTrait
      */
     public function setRegexFlags($value): TermsInterface
     {
-        if (is_string($value)) {
+        if (\is_string($value)) {
             $value = explode(',', $value);
             $value = array_map('trim', $value);
         }

--- a/src/Component/Debug.php
+++ b/src/Component/Debug.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\RequestBuilder\ComponentRequestBuilderInterface;
@@ -66,6 +73,7 @@ class Debug extends AbstractComponent
     public function setExplainOther(string $query): self
     {
         $this->setOption('explainother', $query);
+
         return $this;
     }
 }

--- a/src/Component/DisMax.php
+++ b/src/Component/DisMax.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\DisMax\BoostQuery;
@@ -64,6 +71,7 @@ class DisMax extends AbstractComponent
     public function setQueryAlternative($queryAlternative): self
     {
         $this->setOption('queryalternative', $queryAlternative);
+
         return $this;
     }
 
@@ -92,6 +100,7 @@ class DisMax extends AbstractComponent
     public function setQueryFields(string $queryFields): self
     {
         $this->setOption('queryfields', $queryFields);
+
         return $this;
     }
 
@@ -118,6 +127,7 @@ class DisMax extends AbstractComponent
     public function setMinimumMatch(string $minimumMatch): self
     {
         $this->setOption('minimummatch', $minimumMatch);
+
         return $this;
     }
 
@@ -146,6 +156,7 @@ class DisMax extends AbstractComponent
     public function setPhraseFields(string $phraseFields): self
     {
         $this->setOption('phrasefields', $phraseFields);
+
         return $this;
     }
 
@@ -172,6 +183,7 @@ class DisMax extends AbstractComponent
     public function setPhraseSlop(int $phraseSlop): self
     {
         $this->setOption('phraseslop', $phraseSlop);
+
         return $this;
     }
 
@@ -198,6 +210,7 @@ class DisMax extends AbstractComponent
     public function setQueryPhraseSlop(int $queryPhraseSlop): self
     {
         $this->setOption('queryphraseslop', $queryPhraseSlop);
+
         return $this;
     }
 
@@ -223,6 +236,7 @@ class DisMax extends AbstractComponent
     public function setTie(float $tie): self
     {
         $this->setOption('tie', $tie);
+
         return  $this;
     }
 
@@ -264,7 +278,7 @@ class DisMax extends AbstractComponent
     public function getBoostQuery(string $key = null): ?string
     {
         if (null !== $key) {
-            if (array_key_exists($key, $this->boostQueries)) {
+            if (\array_key_exists($key, $this->boostQueries)) {
                 return $this->boostQueries[$key]->getQuery();
             }
         } elseif (!empty($this->boostQueries)) {
@@ -272,7 +286,7 @@ class DisMax extends AbstractComponent
             $boostQueries = array_values($this->boostQueries);
 
             return $boostQueries[0]->getQuery();
-        } elseif (array_key_exists('boostquery', $this->options)) {
+        } elseif (\array_key_exists('boostquery', $this->options)) {
             return $this->options['boostquery'];
         }
 
@@ -285,7 +299,6 @@ class DisMax extends AbstractComponent
      * Supports a boostquery instance or a config array, in that case a new
      * boostquery instance wil be created based on the options.
      *
-     *
      * @param BoostQuery|array $boostQuery
      *
      * @throws InvalidArgumentException
@@ -294,18 +307,18 @@ class DisMax extends AbstractComponent
      */
     public function addBoostQuery($boostQuery): self
     {
-        if (is_array($boostQuery)) {
+        if (\is_array($boostQuery)) {
             $boostQuery = new BoostQuery($boostQuery);
         }
 
         $key = $boostQuery->getKey();
 
-        if (0 === strlen($key)) {
+        if (0 === \strlen($key)) {
             throw new InvalidArgumentException('A boostquery must have a key value');
         }
 
         //double add calls for the same BQ are ignored, but non-unique keys cause an exception
-        if (array_key_exists($key, $this->boostQueries) && $this->boostQueries[$key] !== $boostQuery) {
+        if (\array_key_exists($key, $this->boostQueries) && $this->boostQueries[$key] !== $boostQuery) {
             throw new InvalidArgumentException('A boostquery must have a unique key value within a query');
         }
 
@@ -325,7 +338,7 @@ class DisMax extends AbstractComponent
     {
         foreach ($boostQueries as $key => $boostQuery) {
             // in case of a config array: add key to config
-            if (is_array($boostQuery) && !isset($boostQuery['key'])) {
+            if (\is_array($boostQuery) && !isset($boostQuery['key'])) {
                 $boostQuery['key'] = $key;
             }
 
@@ -356,7 +369,7 @@ class DisMax extends AbstractComponent
      */
     public function removeBoostQuery($boostQuery): self
     {
-        if (is_object($boostQuery)) {
+        if (\is_object($boostQuery)) {
             $boostQuery = $boostQuery->getKey();
         }
 
@@ -411,6 +424,7 @@ class DisMax extends AbstractComponent
     public function setBoostFunctions(string $boostFunctions): self
     {
         $this->setOption('boostfunctions', $boostFunctions);
+
         return $this;
     }
 
@@ -438,6 +452,7 @@ class DisMax extends AbstractComponent
     public function setQueryParser(string $parser): self
     {
         $this->setOption('queryparser', $parser);
+
         return $this;
     }
 

--- a/src/Component/DisMax/BoostQuery.php
+++ b/src/Component/DisMax/BoostQuery.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\DisMax;
 
 use Solarium\Component\QueryInterface;
@@ -34,6 +41,7 @@ class BoostQuery extends Configurable implements QueryInterface
     public function setKey(string $value): self
     {
         $this->setOption('key', $value);
+
         return $this;
     }
 

--- a/src/Component/DistributedSearch.php
+++ b/src/Component/DistributedSearch.php
@@ -222,7 +222,7 @@ class DistributedSearch extends AbstractComponent
      *
      * @return self Provides fluent interface
      */
-    public function addCollections(array $collections)
+    public function addCollections(array $collections): self
     {
         foreach ($collections as $key => $collection) {
             $this->addCollection($key, $collection);

--- a/src/Component/DistributedSearch.php
+++ b/src/Component/DistributedSearch.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\RequestBuilder\ComponentRequestBuilderInterface;

--- a/src/Component/EdisMax.php
+++ b/src/Component/EdisMax.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\RequestBuilder\ComponentRequestBuilderInterface;
@@ -56,6 +63,7 @@ class EdisMax extends DisMax
     public function setBoostFunctionsMult(string $boostFunctionsMult): self
     {
         $this->setOption('boostfunctionsmult', $boostFunctionsMult);
+
         return $this;
     }
 
@@ -84,6 +92,7 @@ class EdisMax extends DisMax
     public function setPhraseBigramFields(string $phraseBigramFields): self
     {
         $this->setOption('phrasebigramfields', $phraseBigramFields);
+
         return $this;
     }
 
@@ -110,6 +119,7 @@ class EdisMax extends DisMax
     public function setPhraseBigramSlop(int $phraseBigramSlop): self
     {
         $this->setOption('phrasebigramslop', $phraseBigramSlop);
+
         return $this;
     }
 
@@ -138,6 +148,7 @@ class EdisMax extends DisMax
     public function setPhraseTrigramFields(string $phraseTrigramFields): self
     {
         $this->setOption('phrasetrigramfields', $phraseTrigramFields);
+
         return $this;
     }
 
@@ -164,6 +175,7 @@ class EdisMax extends DisMax
     public function setPhraseTrigramSlop(int $phraseTrigramSlop): self
     {
         $this->setOption('phrasetrigramslop', $phraseTrigramSlop);
+
         return $this;
     }
 
@@ -195,6 +207,7 @@ class EdisMax extends DisMax
     public function setUserFields(string $userFields): self
     {
         $this->setOption('userfields', $userFields);
+
         return $this;
     }
 

--- a/src/Component/Facet/AbstractFacet.php
+++ b/src/Component/Facet/AbstractFacet.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 use Solarium\Core\Configurable;

--- a/src/Component/Facet/AbstractField.php
+++ b/src/Component/Facet/AbstractField.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 /**
@@ -38,6 +45,7 @@ abstract class AbstractField extends AbstractFacet
     public function setField(string $field): self
     {
         $this->setOption('field', $field);
+
         return $this;
     }
 
@@ -63,6 +71,7 @@ abstract class AbstractField extends AbstractFacet
     public function setSort(string $sort): self
     {
         $this->setOption('sort', $sort);
+
         return $this;
     }
 
@@ -86,6 +95,7 @@ abstract class AbstractField extends AbstractFacet
     public function setPrefix(string $prefix): self
     {
         $this->setOption('prefix', $prefix);
+
         return $this;
     }
 
@@ -109,6 +119,7 @@ abstract class AbstractField extends AbstractFacet
     public function setLimit(int $limit): self
     {
         $this->setOption('limit', $limit);
+
         return $this;
     }
 
@@ -132,6 +143,7 @@ abstract class AbstractField extends AbstractFacet
     public function setOffset(int $offset): self
     {
         $this->setOption('offset', $offset);
+
         return $this;
     }
 
@@ -155,6 +167,7 @@ abstract class AbstractField extends AbstractFacet
     public function setMinCount(int $minCount): self
     {
         $this->setOption('mincount', $minCount);
+
         return $this;
     }
 
@@ -178,6 +191,7 @@ abstract class AbstractField extends AbstractFacet
     public function setMissing(bool $missing): self
     {
         $this->setOption('missing', $missing);
+
         return $this;
     }
 
@@ -203,6 +217,7 @@ abstract class AbstractField extends AbstractFacet
     public function setMethod(string $method): self
     {
         $this->setOption('method', $method);
+
         return $this;
     }
 

--- a/src/Component/Facet/AbstractRange.php
+++ b/src/Component/Facet/AbstractRange.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 /**

--- a/src/Component/Facet/AbstractRange.php
+++ b/src/Component/Facet/AbstractRange.php
@@ -272,7 +272,7 @@ abstract class AbstractRange extends AbstractFacet
      *
      * @return \Solarium\Core\Configurable
      */
-    public function setPivot($pivot)
+    public function setPivot($pivot): \Solarium\Core\Configurable
     {
         return $this->setOption('pivot', $pivot);
     }

--- a/src/Component/Facet/AbstractRange.php
+++ b/src/Component/Facet/AbstractRange.php
@@ -9,6 +9,8 @@
 
 namespace Solarium\Component\Facet;
 
+use Solarium\Core\Configurable;
+
 /**
  * Facet range.
  *
@@ -272,7 +274,7 @@ abstract class AbstractRange extends AbstractFacet
      *
      * @return \Solarium\Core\Configurable
      */
-    public function setPivot($pivot): \Solarium\Core\Configurable
+    public function setPivot($pivot): Configurable
     {
         return $this->setOption('pivot', $pivot);
     }

--- a/src/Component/Facet/FacetInterface.php
+++ b/src/Component/Facet/FacetInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 /**

--- a/src/Component/Facet/Field.php
+++ b/src/Component/Facet/Field.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 use Solarium\Component\FacetSetInterface;

--- a/src/Component/Facet/Interval.php
+++ b/src/Component/Facet/Interval.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 use Solarium\Component\FacetSetInterface;

--- a/src/Component/Facet/JsonAggregation.php
+++ b/src/Component/Facet/JsonAggregation.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 use Solarium\Component\FacetSetInterface;
@@ -34,6 +41,7 @@ class JsonAggregation extends AbstractFacet implements JsonFacetInterface
     public function setFunction(string $function): self
     {
         $this->setOption('function', $function);
+
         return $this;
     }
 
@@ -61,6 +69,7 @@ class JsonAggregation extends AbstractFacet implements JsonFacetInterface
     public function setMin(int $min): self
     {
         $this->setOption('min', $min);
+
         return $this;
     }
 

--- a/src/Component/Facet/JsonFacetInterface.php
+++ b/src/Component/Facet/JsonFacetInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 /**

--- a/src/Component/Facet/JsonFacetTrait.php
+++ b/src/Component/Facet/JsonFacetTrait.php
@@ -1,9 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 use Solarium\Component\FacetSetInterface;
 use Solarium\Component\FacetSetTrait;
+use Solarium\Core\Configurable;
 use Solarium\Core\Query\Helper;
 use Solarium\Exception\InvalidArgumentException;
 
@@ -40,6 +48,7 @@ trait JsonFacetTrait
     public function getDomainFilter()
     {
         $domain = $this->getOption('domain');
+
         return $domain['filter'] ?? null;
     }
 
@@ -51,9 +60,9 @@ trait JsonFacetTrait
      * @param string $query
      * @param array  $bind  Bind values for placeholders in the query string
      *
-     * @return self Provides fluent interface
+     * @return \Solarium\Core\Configurable
      */
-    public function setDomainFilterQuery(string $query, array $bind = null): FacetSetInterface
+    public function setDomainFilterQuery(string $query, array $bind = null): Configurable
     {
         if (null !== $bind) {
             $helper = new Helper();
@@ -61,20 +70,22 @@ trait JsonFacetTrait
         }
 
         $filter = $this->getDomainFilter();
-        if (!$filter || is_string($filter)) {
+        if (!$filter || \is_string($filter)) {
             return $this->setOption('domain', ['filter' => $query]);
         }
 
-        foreach ($filter as &$param_or_query) {
-            if (is_string($param_or_query)) {
-                $param_or_query = $query;
+        foreach ($filter as &$paramOrQuery) {
+            if (\is_string($paramOrQuery)) {
+                $paramOrQuery = $query;
+
                 return $this->setOption('domain', ['filter' => $filter]);
             }
         }
-        unset($param_or_query);
+        unset($paramOrQuery);
 
         /* @noinspection UnsupportedStringOffsetOperationsInspection */
         $filter[] = $query;
+
         return $this->setOption('domain', ['filter' => $filter]);
     }
 
@@ -92,19 +103,20 @@ trait JsonFacetTrait
             return $this->setOption('domain', ['filter' => ['param' => $param]]);
         }
 
-        if (is_string($filter) || 1 == count($filter)) {
+        if (\is_string($filter) || 1 === \count($filter)) {
             return $this->setOption('domain', ['filter' => [$filter, ['param' => $param]]]);
         }
 
-        foreach ($filter as &$param_or_query) {
-            if (is_array($param_or_query) && $param_or_query['param'] == $param) {
+        foreach ($filter as &$paramOrQuery) {
+            if (\is_array($paramOrQuery) && $paramOrQuery['param'] === $param) {
                 return $this;
             }
         }
-        unset($param_or_query);
+        unset($paramOrQuery);
 
         /* @noinspection UnsupportedStringOffsetOperationsInspection */
         $filter[] = ['param' => $param];
+
         return $this->setOption('domain', ['filter' => $filter]);
     }
 
@@ -137,7 +149,6 @@ trait JsonFacetTrait
 
     /**
      * Add a facet.
-     *
      *
      * @param FacetInterface|array $facet
      *

--- a/src/Component/Facet/JsonFacetTrait.php
+++ b/src/Component/Facet/JsonFacetTrait.php
@@ -11,7 +11,6 @@ namespace Solarium\Component\Facet;
 
 use Solarium\Component\FacetSetInterface;
 use Solarium\Component\FacetSetTrait;
-use Solarium\Core\Configurable;
 use Solarium\Core\Query\Helper;
 use Solarium\Exception\InvalidArgumentException;
 
@@ -60,9 +59,9 @@ trait JsonFacetTrait
      * @param string $query
      * @param array  $bind  Bind values for placeholders in the query string
      *
-     * @return \Solarium\Core\Configurable
+     * @return \Solarium\Component\FacetSetInterface
      */
-    public function setDomainFilterQuery(string $query, array $bind = null): Configurable
+    public function setDomainFilterQuery(string $query, array $bind = null): FacetSetInterface
     {
         if (null !== $bind) {
             $helper = new Helper();

--- a/src/Component/Facet/JsonQuery.php
+++ b/src/Component/Facet/JsonQuery.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 use Solarium\Component\FacetSetInterface;
@@ -48,11 +55,15 @@ class JsonQuery extends AbstractFacet implements JsonFacetInterface, FacetSetInt
         return new Helper();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function serialize()
     {
         $options = $this->jsonFacetTraitSerialize();
         $options['q'] = $options['query'];
         unset($options['query']);
+
         return $options;
     }
 }

--- a/src/Component/Facet/JsonRange.php
+++ b/src/Component/Facet/JsonRange.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 use Solarium\Component\FacetSetInterface;

--- a/src/Component/Facet/JsonTerms.php
+++ b/src/Component/Facet/JsonTerms.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 use Solarium\Component\FacetSetInterface;
@@ -67,6 +74,7 @@ class JsonTerms extends AbstractField implements JsonFacetInterface, FacetSetInt
     public function setRefine(bool $refine): self
     {
         $this->setOption('refine', $refine);
+
         return $this;
     }
 
@@ -92,6 +100,7 @@ class JsonTerms extends AbstractField implements JsonFacetInterface, FacetSetInt
     public function setOverRequest(int $overrequest): self
     {
         $this->setOption('overrequest', $overrequest);
+
         return $this;
     }
 
@@ -118,6 +127,7 @@ class JsonTerms extends AbstractField implements JsonFacetInterface, FacetSetInt
     public function setNumBuckets(bool $numBuckets): self
     {
         $this->setOption('numBuckets', $numBuckets);
+
         return $this;
     }
 
@@ -145,6 +155,7 @@ class JsonTerms extends AbstractField implements JsonFacetInterface, FacetSetInt
     public function setAllBuckets(bool $allBuckets): self
     {
         $this->setOption('allBuckets', $allBuckets);
+
         return $this;
     }
 

--- a/src/Component/Facet/MultiQuery.php
+++ b/src/Component/Facet/MultiQuery.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 use Solarium\Component\Facet\Query as FacetQuery;

--- a/src/Component/Facet/Pivot.php
+++ b/src/Component/Facet/Pivot.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 use Solarium\Component\FacetSetInterface;

--- a/src/Component/Facet/Query.php
+++ b/src/Component/Facet/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 use Solarium\Component\FacetSetInterface;

--- a/src/Component/Facet/Range.php
+++ b/src/Component/Facet/Range.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Facet;
 
 use Solarium\Component\FacetSetInterface;

--- a/src/Component/FacetSet.php
+++ b/src/Component/FacetSet.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\Facet\FacetInterface;
@@ -84,6 +91,7 @@ class FacetSet extends AbstractComponent implements FacetSetInterface
     public function setExtractFromResponse(bool $extract): self
     {
         $this->setOption('extractfromresponse', $extract);
+
         return $this;
     }
 
@@ -109,6 +117,7 @@ class FacetSet extends AbstractComponent implements FacetSetInterface
     public function setPrefix(string $prefix): self
     {
         $this->setOption('prefix', $prefix);
+
         return $this;
     }
 
@@ -136,6 +145,7 @@ class FacetSet extends AbstractComponent implements FacetSetInterface
     public function setContains(string $contains): self
     {
         $this->setOption('contains', $contains);
+
         return $this;
     }
 
@@ -163,6 +173,7 @@ class FacetSet extends AbstractComponent implements FacetSetInterface
     public function setContainsIgnoreCase(bool $containsIgnoreCase): self
     {
         $this->setOption('containsignorecase', $containsIgnoreCase);
+
         return $this;
     }
 
@@ -250,6 +261,7 @@ class FacetSet extends AbstractComponent implements FacetSetInterface
     public function setSort(string $sort): self
     {
         $this->setOption('sort', $sort);
+
         return $this;
     }
 
@@ -277,6 +289,7 @@ class FacetSet extends AbstractComponent implements FacetSetInterface
     public function setLimit(int $limit): self
     {
         $this->setOption('limit', $limit);
+
         return $this;
     }
 
@@ -304,6 +317,7 @@ class FacetSet extends AbstractComponent implements FacetSetInterface
     public function setMinCount(int $minCount): self
     {
         $this->setOption('mincount', $minCount);
+
         return $this;
     }
 
@@ -331,6 +345,7 @@ class FacetSet extends AbstractComponent implements FacetSetInterface
     public function setMissing(bool $missing): self
     {
         $this->setOption('missing', $missing);
+
         return $this;
     }
 

--- a/src/Component/FacetSetInterface.php
+++ b/src/Component/FacetSetInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\Facet\FacetInterface;
@@ -135,7 +142,6 @@ interface FacetSetInterface
      *
      * When no key is supplied the facet cannot be added, in that case you will need to add it manually
      * after setting the key, by using the addFacet method.
-     *
      *
      * @param string            $type
      * @param array|object|null $options

--- a/src/Component/FacetSetTrait.php
+++ b/src/Component/FacetSetTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\Facet\FacetInterface;
@@ -166,7 +173,7 @@ trait FacetSetTrait
         $type = strtolower($type);
 
         if (!isset($this->facetTypes[$type])) {
-            throw new OutOfBoundsException('Facettype unknown: '.$type);
+            throw new OutOfBoundsException(sprintf('Facettype unknown: %s', $type));
         }
 
         $class = $this->facetTypes[$type];

--- a/src/Component/Grouping.php
+++ b/src/Component/Grouping.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\RequestBuilder\ComponentRequestBuilderInterface;
@@ -16,7 +23,6 @@ use Solarium\Component\Result\Grouping\ValueGroup;
  * See the Solr wiki for more info about this functionality
  *
  * @see https://lucene.apache.org/solr/guide/result-grouping.html
- * @since 2.1.0
  */
 class Grouping extends AbstractComponent
 {
@@ -118,7 +124,7 @@ class Grouping extends AbstractComponent
      */
     public function addFields($fields): self
     {
-        if (is_string($fields)) {
+        if (\is_string($fields)) {
             $fields = explode(',', $fields);
             $fields = array_map('trim', $fields);
         }
@@ -192,7 +198,7 @@ class Grouping extends AbstractComponent
      */
     public function addQueries($queries): self
     {
-        if (!is_array($queries)) {
+        if (!\is_array($queries)) {
             $queries = [$queries];
         }
 
@@ -252,6 +258,7 @@ class Grouping extends AbstractComponent
     public function setLimit(int $limit): self
     {
         $this->setOption('limit', $limit);
+
         return $this;
     }
 
@@ -277,6 +284,7 @@ class Grouping extends AbstractComponent
     public function setOffset(int $offset): self
     {
         $this->setOption('offset', $offset);
+
         return $this;
     }
 
@@ -302,6 +310,7 @@ class Grouping extends AbstractComponent
     public function setSort(string $sort): self
     {
         $this->setOption('sort', $sort);
+
         return $this;
     }
 
@@ -328,6 +337,7 @@ class Grouping extends AbstractComponent
     public function setMainResult(bool $value): self
     {
         $this->setOption('mainresult', $value);
+
         return $this;
     }
 
@@ -353,6 +363,7 @@ class Grouping extends AbstractComponent
     public function setNumberOfGroups(bool $value): self
     {
         $this->setOption('numberofgroups', $value);
+
         return $this;
     }
 
@@ -383,6 +394,7 @@ class Grouping extends AbstractComponent
     public function setCachePercentage(int $value): self
     {
         $this->setOption('cachepercentage', $value);
+
         return $this;
     }
 
@@ -409,6 +421,7 @@ class Grouping extends AbstractComponent
     public function setTruncate(bool $value): self
     {
         $this->setOption('truncate', $value);
+
         return $this;
     }
 
@@ -434,6 +447,7 @@ class Grouping extends AbstractComponent
     public function setFunction(string $value): self
     {
         $this->setOption('function', $value);
+
         return $this;
     }
 
@@ -461,6 +475,7 @@ class Grouping extends AbstractComponent
     public function setFacet(bool $value): self
     {
         $this->setOption('facet', $value);
+
         return $this;
     }
 
@@ -487,6 +502,7 @@ class Grouping extends AbstractComponent
     public function setFormat(string $value): self
     {
         $this->setOption('format', $value);
+
         return $this;
     }
 
@@ -510,6 +526,7 @@ class Grouping extends AbstractComponent
     public function setResultQueryGroupClass(string $value): self
     {
         $this->setOption('resultquerygroupclass', $value);
+
         return $this;
     }
 
@@ -535,6 +552,7 @@ class Grouping extends AbstractComponent
     public function setResultValueGroupClass(string $value): self
     {
         $this->setOption('resultvaluegroupclass', $value);
+
         return  $this;
     }
 

--- a/src/Component/Highlighting/Field.php
+++ b/src/Component/Highlighting/Field.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Highlighting;
 
 use Solarium\Core\Configurable;
@@ -41,6 +48,7 @@ class Field extends Configurable
     public function setName(string $name): self
     {
         $this->setOption('name', $name);
+
         return $this;
     }
 
@@ -56,6 +64,7 @@ class Field extends Configurable
     public function setSnippets(int $maximum): self
     {
         $this->setOption('snippets', $maximum);
+
         return $this;
     }
 
@@ -81,6 +90,7 @@ class Field extends Configurable
     public function setFragSize(int $size): self
     {
         $this->setOption('fragsize', $size);
+
         return $this;
     }
 
@@ -106,6 +116,7 @@ class Field extends Configurable
     public function setMergeContiguous(bool $merge): self
     {
         $this->setOption('mergecontiguous', $merge);
+
         return $this;
     }
 
@@ -129,6 +140,7 @@ class Field extends Configurable
     public function setAlternateField(string $field): self
     {
         $this->setOption('alternatefield', $field);
+
         return $this;
     }
 
@@ -152,6 +164,7 @@ class Field extends Configurable
     public function setPreserveMulti(bool $preservemulti): self
     {
         $this->setOption('preservemulti', $preservemulti);
+
         return $this;
     }
 
@@ -175,6 +188,7 @@ class Field extends Configurable
     public function setFormatter(string $formatter = 'simple'): self
     {
         $this->setOption('formatter', $formatter);
+
         return $this;
     }
 
@@ -200,6 +214,7 @@ class Field extends Configurable
     public function setSimplePrefix(string $prefix): self
     {
         $this->setOption('simpleprefix', $prefix);
+
         return $this;
     }
 
@@ -227,6 +242,7 @@ class Field extends Configurable
     public function setSimplePostfix(string $postfix): self
     {
         $this->setOption('simplepostfix', $postfix);
+
         return $this;
     }
 
@@ -254,6 +270,7 @@ class Field extends Configurable
     public function setFragmenter(string $fragmenter): self
     {
         $this->setOption('fragmenter', $fragmenter);
+
         return $this;
     }
 
@@ -277,6 +294,7 @@ class Field extends Configurable
     public function setUseFastVectorHighlighter(bool $use): self
     {
         $this->setOption('usefastvectorhighlighter', $use);
+
         return $this;
     }
 

--- a/src/Component/Highlighting/Field.php
+++ b/src/Component/Highlighting/Field.php
@@ -33,7 +33,7 @@ class Field extends Configurable
      *
      * @return string|null
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->getOption('name');
     }

--- a/src/Component/Highlighting/Highlighting.php
+++ b/src/Component/Highlighting/Highlighting.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Highlighting;
 
 use Solarium\Component\AbstractComponent;
@@ -104,6 +111,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
 
         if ($autocreate) {
             $this->addField($name);
+
             return $this->fields[$name];
         }
 
@@ -112,7 +120,6 @@ class Highlighting extends AbstractComponent implements QueryInterface
 
     /**
      * Add a field for highlighting.
-     *
      *
      * @param string|array|Field $field
      *
@@ -123,9 +130,9 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function addField($field): self
     {
         // autocreate object for string input
-        if (is_string($field)) {
+        if (\is_string($field)) {
             $field = new Field(['name' => $field]);
-        } elseif (is_array($field)) {
+        } elseif (\is_array($field)) {
             $field = new Field($field);
         }
 
@@ -149,14 +156,14 @@ class Highlighting extends AbstractComponent implements QueryInterface
      */
     public function addFields($fields): self
     {
-        if (is_string($fields)) {
+        if (\is_string($fields)) {
             $fields = explode(',', $fields);
             $fields = array_map('trim', $fields);
         }
 
         foreach ($fields as $key => $field) {
             // in case of a config array without key: add key to config
-            if (is_array($field) && !isset($field['name'])) {
+            if (\is_array($field) && !isset($field['name'])) {
                 $field['name'] = $key;
             }
 
@@ -234,6 +241,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setSnippets(int $maximum): self
     {
         $this->setOption('snippets', $maximum);
+
         return $this;
     }
 
@@ -259,6 +267,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setFragSize(int $size): self
     {
         $this->setOption('fragsize', $size);
+
         return $this;
     }
 
@@ -284,6 +293,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setMergeContiguous(bool $merge): self
     {
         $this->setOption('mergecontiguous', $merge);
+
         return $this;
     }
 
@@ -307,6 +317,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setRequireFieldMatch(bool $require): self
     {
         $this->setOption('requirefieldmatch', $require);
+
         return $this;
     }
 
@@ -332,6 +343,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setMaxAnalyzedChars(int $chars): self
     {
         $this->setOption('maxanalyzedchars', $chars);
+
         return $this;
     }
 
@@ -355,6 +367,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setAlternateField(string $field): self
     {
         $this->setOption('alternatefield', $field);
+
         return $this;
     }
 
@@ -378,6 +391,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setMaxAlternateFieldLength(int $length): self
     {
         $this->setOption('maxalternatefieldlength', $length);
+
         return $this;
     }
 
@@ -401,6 +415,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setPreserveMulti(bool $preservemulti): self
     {
         $this->setOption('preservemulti', $preservemulti);
+
         return $this;
     }
 
@@ -424,6 +439,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setFormatter(string $formatter = 'simple'): self
     {
         $this->setOption('formatter', $formatter);
+
         return $this;
     }
 
@@ -449,6 +465,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setSimplePrefix(string $prefix): self
     {
         $this->setOption('simpleprefix', $prefix);
+
         return $this;
     }
 
@@ -476,6 +493,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setSimplePostfix(string $postfix): self
     {
         $this->setOption('simplepostfix', $postfix);
+
         return $this;
     }
 
@@ -503,6 +521,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setTagPrefix(string $prefix): self
     {
         $this->setOption('tagprefix', $prefix);
+
         return $this;
     }
 
@@ -530,6 +549,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setTagPostfix(string $postfix): self
     {
         $this->setOption('tagpostfix', $postfix);
+
         return $this;
     }
 
@@ -557,6 +577,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setFragmenter(string $fragmenter): self
     {
         $this->setOption('fragmenter', $fragmenter);
+
         return $this;
     }
 
@@ -580,6 +601,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setFragListBuilder(string $builder): self
     {
         $this->setOption('fraglistbuilder', $builder);
+
         return $this;
     }
 
@@ -603,6 +625,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setFragmentsBuilder(string $builder): self
     {
         $this->setOption('fragmentsbuilder', $builder);
+
         return $this;
     }
 
@@ -626,6 +649,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setUseFastVectorHighlighter(bool $use): self
     {
         $this->setOption('usefastvectorhighlighter', $use);
+
         return $this;
     }
 
@@ -649,6 +673,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setUsePhraseHighlighter(bool $use): self
     {
         $this->setOption('usephrasehighlighter', $use);
+
         return $this;
     }
 
@@ -672,6 +697,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setHighlightMultiTerm(bool $highlight): self
     {
         $this->setOption('highlightmultiterm', $highlight);
+
         return $this;
     }
 
@@ -695,6 +721,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setRegexSlop(float $slop): self
     {
         $this->setOption('regexslop', $slop);
+
         return $this;
     }
 
@@ -718,6 +745,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setRegexPattern(string $pattern): self
     {
         $this->setOption('regexpattern', $pattern);
+
         return $this;
     }
 
@@ -741,6 +769,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setRegexMaxAnalyzedChars(int $chars): self
     {
         $this->setOption('regexmaxanalyzedchars', $chars);
+
         return $this;
     }
 
@@ -764,6 +793,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setPhraseLimit(int $maximum): self
     {
         $this->setOption('phraselimit', $maximum);
+
         return $this;
     }
 
@@ -787,6 +817,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setMultiValuedSeparatorChar(string $separator): self
     {
         $this->setOption('multivaluedseparatorchar', $separator);
+
         return $this;
     }
 
@@ -810,6 +841,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setBoundaryScannerMaxScan(int $maximum): self
     {
         $this->setOption('boundaryscannermaxscan', $maximum);
+
         return $this;
     }
 
@@ -833,6 +865,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setBoundaryScannerChars(string $chars): self
     {
         $this->setOption('boundaryscannerchars', $chars);
+
         return $this;
     }
 
@@ -856,6 +889,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setBoundaryScannerType(string $type): self
     {
         $this->setOption('boundaryscannertype', $type);
+
         return $this;
     }
 
@@ -879,6 +913,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setBoundaryScannerLanguage(string $language): self
     {
         $this->setOption('boundaryscannerlanguage', $language);
+
         return $this;
     }
 
@@ -902,6 +937,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function setBoundaryScannerCountry(string $country): self
     {
         $this->setOption('boundaryscannercountry', $country);
+
         return $this;
     }
 

--- a/src/Component/MoreLikeThis.php
+++ b/src/Component/MoreLikeThis.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\RequestBuilder\ComponentRequestBuilderInterface;
@@ -60,12 +67,13 @@ class MoreLikeThis extends AbstractComponent
      */
     public function setFields($fields): self
     {
-        if (is_string($fields)) {
+        if (\is_string($fields)) {
             $fields = explode(',', $fields);
             $fields = array_map('trim', $fields);
         }
 
         $this->setOption('fields', $fields);
+
         return $this;
     }
 
@@ -96,6 +104,7 @@ class MoreLikeThis extends AbstractComponent
     public function setInterestingTerms(string $term): self
     {
         $this->setOption('interestingTerms', $term);
+
         return $this;
     }
 
@@ -121,6 +130,7 @@ class MoreLikeThis extends AbstractComponent
     public function setMatchInclude(bool $include): self
     {
         $this->setOption('matchinclude', $include);
+
         return $this;
     }
 
@@ -147,6 +157,7 @@ class MoreLikeThis extends AbstractComponent
     public function setMatchOffset(int $offset): self
     {
         $this->setOption('matchoffset', $offset);
+
         return $this;
     }
 
@@ -175,6 +186,7 @@ class MoreLikeThis extends AbstractComponent
     public function setMinimumTermFrequency(int $minimum): self
     {
         $this->setOption('minimumtermfrequency', $minimum);
+
         return $this;
     }
 
@@ -203,6 +215,7 @@ class MoreLikeThis extends AbstractComponent
     public function setMinimumDocumentFrequency(int $minimum): self
     {
         $this->setOption('minimumdocumentfrequency', $minimum);
+
         return $this;
     }
 
@@ -230,6 +243,7 @@ class MoreLikeThis extends AbstractComponent
     public function setMinimumWordLength(int $minimum): self
     {
         $this->setOption('minimumwordlength', $minimum);
+
         return $this;
     }
 
@@ -257,6 +271,7 @@ class MoreLikeThis extends AbstractComponent
     public function setMaximumWordLength(int $maximum): self
     {
         $this->setOption('maximumwordlength', $maximum);
+
         return $this;
     }
 
@@ -285,6 +300,7 @@ class MoreLikeThis extends AbstractComponent
     public function setMaximumQueryTerms(int $maximum): self
     {
         $this->setOption('maximumqueryterms', $maximum);
+
         return $this;
     }
 
@@ -313,6 +329,7 @@ class MoreLikeThis extends AbstractComponent
     public function setMaximumNumberOfTokens(int $maximum): self
     {
         $this->setOption('maximumnumberoftokens', $maximum);
+
         return $this;
     }
 
@@ -340,6 +357,7 @@ class MoreLikeThis extends AbstractComponent
     public function setBoost(bool $boost): self
     {
         $this->setOption('boost', $boost);
+
         return $this;
     }
 
@@ -369,12 +387,13 @@ class MoreLikeThis extends AbstractComponent
      */
     public function setQueryFields($queryFields): self
     {
-        if (is_string($queryFields)) {
+        if (\is_string($queryFields)) {
             $queryFields = explode(',', $queryFields);
             $queryFields = array_map('trim', $queryFields);
         }
 
         $this->setOption('queryfields', $queryFields);
+
         return $this;
     }
 
@@ -407,6 +426,7 @@ class MoreLikeThis extends AbstractComponent
     public function setCount(int $count): self
     {
         $this->setOption('count', $count);
+
         return $this;
     }
 

--- a/src/Component/QueryElevation.php
+++ b/src/Component/QueryElevation.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\RequestBuilder\ComponentRequestBuilderInterface;
@@ -73,7 +80,7 @@ class QueryElevation extends AbstractComponent
      */
     public function addTransformers($transformers): self
     {
-        if (is_string($transformers)) {
+        if (\is_string($transformers)) {
             $transformers = explode(',', $transformers);
             $transformers = array_map('trim', $transformers);
         }
@@ -150,6 +157,7 @@ class QueryElevation extends AbstractComponent
     public function setEnableElevation(bool $enable): self
     {
         $this->setOption('enableElevation', $enable);
+
         return $this;
     }
 
@@ -173,6 +181,7 @@ class QueryElevation extends AbstractComponent
     public function setForceElevation(bool $force): self
     {
         $this->setOption('forceElevation', $force);
+
         return $this;
     }
 
@@ -196,6 +205,7 @@ class QueryElevation extends AbstractComponent
     public function setExclusive(bool $exclusive): self
     {
         $this->setOption('exclusive', $exclusive);
+
         return $this;
     }
 
@@ -219,6 +229,7 @@ class QueryElevation extends AbstractComponent
     public function setUseConfiguredElevatedOrder(bool $useConfiguredElevatedOrder): self
     {
         $this->setOption('useConfiguredElevatedOrder', $useConfiguredElevatedOrder);
+
         return $this;
     }
 
@@ -248,6 +259,7 @@ class QueryElevation extends AbstractComponent
         }
 
         $this->setOption('markExcludes', $mark);
+
         return $this;
     }
 
@@ -270,12 +282,13 @@ class QueryElevation extends AbstractComponent
      */
     public function setElevateIds($ids): self
     {
-        if (is_string($ids)) {
+        if (\is_string($ids)) {
             $ids = explode(',', $ids);
             $ids = array_map('trim', $ids);
         }
 
         $this->setOption('elevateIds', $ids);
+
         return $this;
     }
 
@@ -298,12 +311,13 @@ class QueryElevation extends AbstractComponent
      */
     public function setExcludeIds($ids): self
     {
-        if (is_string($ids)) {
+        if (\is_string($ids)) {
             $ids = explode(',', $ids);
             $ids = array_map('trim', $ids);
         }
 
         $this->setOption('excludeIds', $ids);
+
         return $this;
     }
 

--- a/src/Component/QueryInterface.php
+++ b/src/Component/QueryInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 /**

--- a/src/Component/QueryTrait.php
+++ b/src/Component/QueryTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 /**

--- a/src/Component/QueryTraits/AnalyticsTrait.php
+++ b/src/Component/QueryTraits/AnalyticsTrait.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\Analytics\Analytics;

--- a/src/Component/QueryTraits/DebugTrait.php
+++ b/src/Component/QueryTraits/DebugTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/DisMaxTrait.php
+++ b/src/Component/QueryTraits/DisMaxTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/DistributedSearchTrait.php
+++ b/src/Component/QueryTraits/DistributedSearchTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/EDisMaxTrait.php
+++ b/src/Component/QueryTraits/EDisMaxTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/FacetSetTrait.php
+++ b/src/Component/QueryTraits/FacetSetTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/GroupingTrait.php
+++ b/src/Component/QueryTraits/GroupingTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/HighlightingTrait.php
+++ b/src/Component/QueryTraits/HighlightingTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/MoreLikeThisTrait.php
+++ b/src/Component/QueryTraits/MoreLikeThisTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/QueryElevationTrait.php
+++ b/src/Component/QueryTraits/QueryElevationTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/ReRankQueryTrait.php
+++ b/src/Component/QueryTraits/ReRankQueryTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/SpatialTrait.php
+++ b/src/Component/QueryTraits/SpatialTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/SpellcheckTrait.php
+++ b/src/Component/QueryTraits/SpellcheckTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/StatsTrait.php
+++ b/src/Component/QueryTraits/StatsTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/SuggesterTrait.php
+++ b/src/Component/QueryTraits/SuggesterTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/QueryTraits/TermsTrait.php
+++ b/src/Component/QueryTraits/TermsTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\QueryTraits;
 
 use Solarium\Component\ComponentAwareQueryInterface;

--- a/src/Component/ReRankQuery.php
+++ b/src/Component/ReRankQuery.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\RequestBuilder\ComponentRequestBuilderInterface;
@@ -54,6 +61,7 @@ class ReRankQuery extends AbstractComponent implements QueryInterface
     public function setDocs(int $value): self
     {
         $this->setOption('docs', $value);
+
         return $this;
     }
 
@@ -77,6 +85,7 @@ class ReRankQuery extends AbstractComponent implements QueryInterface
     public function setWeight(float $value): self
     {
         $this->setOption('weight', $value);
+
         return $this;
     }
 }

--- a/src/Component/RequestBuilder/Analytics.php
+++ b/src/Component/RequestBuilder/Analytics.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Core\Client\Request;

--- a/src/Component/RequestBuilder/ComponentRequestBuilderInterface.php
+++ b/src/Component/RequestBuilder/ComponentRequestBuilderInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Core\Client\Request;

--- a/src/Component/RequestBuilder/Debug.php
+++ b/src/Component/RequestBuilder/Debug.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Component\Debug as DebugComponent;

--- a/src/Component/RequestBuilder/DisMax.php
+++ b/src/Component/RequestBuilder/DisMax.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Component\DisMax as DismaxComponent;
@@ -34,7 +41,7 @@ class DisMax implements ComponentRequestBuilderInterface
 
         // add boostqueries to request
         $boostQueries = $component->getBoostQueries();
-        if (0 !== count($boostQueries)) {
+        if (0 !== \count($boostQueries)) {
             foreach ($boostQueries as $boostQuery) {
                 $request->addParam('bq', $boostQuery->getQuery());
             }

--- a/src/Component/RequestBuilder/DistributedSearch.php
+++ b/src/Component/RequestBuilder/DistributedSearch.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Component\DistributedSearch as DistributedSearchComponent;
@@ -23,13 +30,13 @@ class DistributedSearch implements ComponentRequestBuilderInterface
     {
         // add shards to request
         $shards = array_values($component->getShards());
-        if (count($shards)) {
+        if (\count($shards)) {
             $request->addParam('shards', implode(',', $shards));
         }
 
         $replicas = array_values($component->getReplicas());
 
-        if (count($replicas)) {
+        if (\count($replicas)) {
             $value = ($request->getParam('shards')) ? $request->getParam('shards').','.implode('|', $replicas) : implode('|', $replicas);
 
             $request->addParam('shards', $value, true);
@@ -39,7 +46,7 @@ class DistributedSearch implements ComponentRequestBuilderInterface
 
         // add collections to request
         $collections = array_values($component->getCollections());
-        if (count($collections)) {
+        if (\count($collections)) {
             $request->addParam('collection', implode(',', $collections));
         }
 

--- a/src/Component/RequestBuilder/EdisMax.php
+++ b/src/Component/RequestBuilder/EdisMax.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Component\EdisMax as EdismaxComponent;
@@ -38,7 +45,7 @@ class EdisMax implements ComponentRequestBuilderInterface
 
         // add boostqueries to request
         $boostQueries = $component->getBoostQueries();
-        if (0 !== count($boostQueries)) {
+        if (0 !== \count($boostQueries)) {
             foreach ($boostQueries as $boostQuery) {
                 $request->addParam('bq', $boostQuery->getQuery());
             }

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Component\Facet\Field as FacetField;
@@ -9,7 +16,6 @@ use Solarium\Component\Facet\MultiQuery as FacetMultiQuery;
 use Solarium\Component\Facet\Pivot as FacetPivot;
 use Solarium\Component\Facet\Query as FacetQuery;
 use Solarium\Component\Facet\Range as FacetRange;
-use Solarium\Component\FacetSet as FacetsetComponent;
 use Solarium\Component\FacetSetInterface;
 use Solarium\Core\Client\Request;
 use Solarium\Core\ConfigurableInterface;
@@ -24,74 +30,78 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
     /**
      * Add request settings for FacetSet.
      *
-     * @param FacetsetComponent $component
-     * @param Request           $request
+     * @param \Solarium\Core\ConfigurableInterface $component
+     * @param Request                              $request
      *
-     * @throws UnexpectedValueException
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return Request
      */
     public function buildComponent(ConfigurableInterface $component, Request $request): Request
     {
         $facets = $component->getFacets();
+
         if (0 !== \count($facets)) {
-            $non_json = false;
-            $json_facets = [];
+            $nonJson = false;
+            $jsonFacets = [];
 
             // create a list of facet fields
             // 1) filter for FACET_FIELD
             // 2) get field name
             // 3) count occurence
-            $facet_fields = array_count_values(array_map(function ($value) {
-                return $value->getField();
-            }, array_filter($facets, function ($value) {
-                return FacetSetInterface::FACET_FIELD == $value->getType();
-            })));
+            $facetFields = array_count_values(array_map(
+                static function ($value) {
+                    return $value->getField();
+                },
+                array_filter($facets, static function ($value) {
+                    return FacetSetInterface::FACET_FIELD === $value->getType();
+                })
+            ));
             foreach ($facets as $key => $facet) {
                 switch ($facet->getType()) {
                     case FacetSetInterface::FACET_FIELD:
                         /* @var FacetField $facet */
-                        $this->addFacetField($request, $facet, (1 < $facet_fields[$facet->getField()]));
-                        $non_json = true;
+                        $this->addFacetField($request, $facet, (1 < $facetFields[$facet->getField()]));
+                        $nonJson = true;
                         break;
                     case FacetSetInterface::FACET_QUERY:
                         /* @var FacetQuery $facet */
                         $this->addFacetQuery($request, $facet);
-                        $non_json = true;
+                        $nonJson = true;
                         break;
                     case FacetSetInterface::FACET_MULTIQUERY:
                         /* @var FacetMultiQuery $facet */
                         $this->addFacetMultiQuery($request, $facet);
-                        $non_json = true;
+                        $nonJson = true;
                         break;
                     case FacetSetInterface::FACET_RANGE:
                         /* @var FacetRange $facet */
                         $this->addFacetRange($request, $facet);
-                        $non_json = true;
+                        $nonJson = true;
                         break;
                     case FacetSetInterface::FACET_PIVOT:
                         /* @var FacetPivot $facet */
                         $this->addFacetPivot($request, $facet);
-                        $non_json = true;
+                        $nonJson = true;
                         break;
                     case FacetSetInterface::FACET_INTERVAL:
                         /* @var FacetInterval $facet */
                         $this->addFacetInterval($request, $facet);
-                        $non_json = true;
+                        $nonJson = true;
                         break;
                     case FacetSetInterface::JSON_FACET_TERMS:
                     case FacetSetInterface::JSON_FACET_QUERY:
                     case FacetSetInterface::JSON_FACET_RANGE:
                     case FacetSetInterface::JSON_FACET_AGGREGATION:
                         /* @var JsonFacetInterface $facet */
-                        $json_facets[$key] = $facet->serialize();
+                        $jsonFacets[$key] = $facet->serialize();
                         break;
                     default:
                         throw new UnexpectedValueException('Unknown facet type');
                 }
             }
 
-            if ($non_json) {
+            if ($nonJson) {
                 // enable non-json faceting
                 $request->addParam('facet', 'true');
 
@@ -107,8 +117,8 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
                 $request->addParam('facet.limit', $component->getLimit());
             }
 
-            if ($json_facets) {
-                $request->addParam('json.facet', json_encode($json_facets));
+            if ($jsonFacets) {
+                $request->addParam('json.facet', json_encode($jsonFacets));
             }
         }
 
@@ -120,14 +130,14 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
      *
      * @param Request    $request
      * @param FacetField $facet
-     * @param bool       $use_local_params TRUE, if local params instead of global field params should be used. Must be set if the same field is used in different facets. Default is keeping the global field params (https://issues.apache.org/jira/browse/SOLR-6193)
+     * @param bool       $useLocalParams TRUE, if local params instead of global field params should be used. Must be set if the same field is used in different facets. Default is keeping the global field params (https://issues.apache.org/jira/browse/SOLR-6193)
      */
-    public function addFacetField(Request $request, FacetField $facet, bool $use_local_params = false)
+    public function addFacetField(Request $request, FacetField $facet, bool $useLocalParams = false)
     {
         $field = $facet->getField();
 
-        if ($use_local_params) {
-            $local_params = ['key' => $facet->getKey(),
+        if ($useLocalParams) {
+            $localParams = ['key' => $facet->getKey(),
                 'ex' => $facet->getLocalParameters()->getExcludes(),
                 'facet.limit' => $facet->getLimit(),
                 'facet.sort' => $facet->getSort(),
@@ -146,7 +156,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
                 'facet.field',
                 $this->renderLocalParams(
                     $field,
-                    $local_params
+                    $localParams
                 )
             );
         } else {

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -132,7 +132,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
      * @param FacetField $facet
      * @param bool       $useLocalParams TRUE, if local params instead of global field params should be used. Must be set if the same field is used in different facets. Default is keeping the global field params (https://issues.apache.org/jira/browse/SOLR-6193)
      */
-    public function addFacetField(Request $request, FacetField $facet, bool $useLocalParams = false)
+    public function addFacetField(Request $request, FacetField $facet, bool $useLocalParams = false): void
     {
         $field = $facet->getField();
 
@@ -185,7 +185,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
      * @param Request    $request
      * @param FacetQuery $facet
      */
-    public function addFacetQuery($request, $facet)
+    public function addFacetQuery($request, $facet): void
     {
         $request->addParam(
             'facet.query',
@@ -199,7 +199,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
      * @param Request         $request
      * @param FacetMultiQuery $facet
      */
-    public function addFacetMultiQuery($request, $facet)
+    public function addFacetMultiQuery($request, $facet): void
     {
         foreach ($facet->getQueries() as $facetQuery) {
             $this->addFacetQuery($request, $facetQuery);
@@ -212,7 +212,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
      * @param Request    $request
      * @param FacetRange $facet
      */
-    public function addFacetRange($request, $facet)
+    public function addFacetRange($request, $facet): void
     {
         $field = $facet->getField();
 
@@ -249,7 +249,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
      * @param Request    $request
      * @param FacetPivot $facet
      */
-    public function addFacetPivot($request, $facet)
+    public function addFacetPivot($request, $facet): void
     {
         $stats = $facet->getStats();
 
@@ -276,7 +276,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
      * @param Request       $request
      * @param FacetInterval $facet
      */
-    public function addFacetInterval($request, $facet)
+    public function addFacetInterval($request, $facet): void
     {
         $field = $facet->getField();
 

--- a/src/Component/RequestBuilder/Grouping.php
+++ b/src/Component/RequestBuilder/Grouping.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Component\Grouping as GroupingComponent;

--- a/src/Component/RequestBuilder/Highlighting.php
+++ b/src/Component/RequestBuilder/Highlighting.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Component\Highlighting\Field as HighlightingField;
@@ -26,7 +33,7 @@ class Highlighting implements ComponentRequestBuilderInterface
         $request->addParam('hl', 'true');
 
         // set global highlighting params
-        if (count($component->getFields()) > 0) {
+        if (\count($component->getFields()) > 0) {
             $request->addParam('hl.fl', implode(',', array_keys($component->getFields())));
         }
         $request->addParam('hl.snippets', $component->getSnippets());

--- a/src/Component/RequestBuilder/MoreLikeThis.php
+++ b/src/Component/RequestBuilder/MoreLikeThis.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Component\MoreLikeThis as MoreLikeThisComponent;
@@ -27,7 +34,7 @@ class MoreLikeThis implements ComponentRequestBuilderInterface
         $request->addParam('mlt.interestingTerms', $component->getInterestingTerms());
         $request->addParam('mlt.match.include', $component->getMatchInclude());
         $request->addParam('mlt.match.offset', $component->getMatchOffset());
-        $request->addParam('mlt.fl', count($component->getFields()) ? implode(',', $component->getFields()) : null);
+        $request->addParam('mlt.fl', \count($component->getFields()) ? implode(',', $component->getFields()) : null);
         $request->addParam('mlt.mintf', $component->getMinimumTermFrequency());
         $request->addParam('mlt.mindf', $component->getMinimumDocumentFrequency());
         $request->addParam('mlt.minwl', $component->getMinimumWordLength());
@@ -37,7 +44,7 @@ class MoreLikeThis implements ComponentRequestBuilderInterface
         $request->addParam('mlt.boost', $component->getBoost());
         $request->addParam(
             'mlt.qf',
-            count($component->getQueryFields()) ? $component->getQueryFields() : null
+            \count($component->getQueryFields()) ? $component->getQueryFields() : null
         );
         $request->addParam('mlt.count', $component->getCount());
 

--- a/src/Component/RequestBuilder/QueryElevation.php
+++ b/src/Component/RequestBuilder/QueryElevation.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Component\QueryElevation as QueryelevationComponent;

--- a/src/Component/RequestBuilder/ReRankQuery.php
+++ b/src/Component/RequestBuilder/ReRankQuery.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Component\ReRankQuery as ReRankQueryComponent;

--- a/src/Component/RequestBuilder/RequestParamsInterface.php
+++ b/src/Component/RequestBuilder/RequestParamsInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 /**

--- a/src/Component/RequestBuilder/RequestParamsTrait.php
+++ b/src/Component/RequestBuilder/RequestParamsTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 /**
@@ -75,7 +82,7 @@ trait RequestParamsTrait
     {
         if (null !== $value && [] !== $value) {
             if (!$overwrite && isset($this->params[$key])) {
-                if (!is_array($this->params[$key])) {
+                if (!\is_array($this->params[$key])) {
                     $this->params[$key] = [$this->params[$key]];
                 }
                 $this->params[$key][] = $value;
@@ -149,7 +156,7 @@ trait RequestParamsTrait
     public function getQueryString(string $separator = '&'): string
     {
         $queryString = '';
-        if (count($this->params) > 0) {
+        if (\count($this->params) > 0) {
             $queryString = http_build_query($this->params, null, $separator);
             $queryString = preg_replace(
                 '/%5B(?:\d|[1-9]\d+)%5D=/',

--- a/src/Component/RequestBuilder/Spatial.php
+++ b/src/Component/RequestBuilder/Spatial.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Component\Spatial as SpatialComponent;

--- a/src/Component/RequestBuilder/Spellcheck.php
+++ b/src/Component/RequestBuilder/Spellcheck.php
@@ -1,10 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
+use Solarium\Component\SpellcheckInterface;
 use Solarium\Core\Client\Request;
 use Solarium\Core\ConfigurableInterface;
-use Solarium\Component\SpellcheckInterface;
 
 /**
  * Add select component Spellcheck to the request.

--- a/src/Component/RequestBuilder/Stats.php
+++ b/src/Component/RequestBuilder/Stats.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Component\Stats\Stats as StatsComponent;
@@ -28,7 +35,7 @@ class Stats implements ComponentRequestBuilderInterface
         foreach ($component->getFields() as $field) {
             $pivots = $field->getPivots();
 
-            $prefix = (count($pivots) > 0) ? '{!tag='.implode(',', $pivots).'}' : '';
+            $prefix = (\count($pivots) > 0) ? '{!tag='.implode(',', $pivots).'}' : '';
             $request->addParam('stats.field', $prefix.$field->getKey());
 
             // add field specific facet stats

--- a/src/Component/RequestBuilder/SubRequest.php
+++ b/src/Component/RequestBuilder/SubRequest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 /**

--- a/src/Component/RequestBuilder/Suggester.php
+++ b/src/Component/RequestBuilder/Suggester.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Core\Client\Request;

--- a/src/Component/RequestBuilder/Terms.php
+++ b/src/Component/RequestBuilder/Terms.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\RequestBuilder;
 
 use Solarium\Component\TermsInterface;

--- a/src/Component/ResponseParser/Analytics.php
+++ b/src/Component/ResponseParser/Analytics.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ResponseParser;
 
 use Solarium\Component\AbstractComponent;

--- a/src/Component/ResponseParser/ComponentParserInterface.php
+++ b/src/Component/ResponseParser/ComponentParserInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ResponseParser;
 
 use Solarium\Component\AbstractComponent;

--- a/src/Component/ResponseParser/Debug.php
+++ b/src/Component/ResponseParser/Debug.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ResponseParser;
 
 use Solarium\Component\AbstractComponent;
@@ -40,14 +47,14 @@ class Debug implements ComponentParserInterface
             $otherQuery = $debug['otherQuery'] ?? '';
 
             // parse explain data
-            if (isset($debug['explain']) && is_array($debug['explain'])) {
+            if (isset($debug['explain']) && \is_array($debug['explain'])) {
                 $explain = $this->parseDocumentSet($debug['explain']);
             } else {
                 $explain = new DocumentSet([]);
             }
 
             // parse explainOther data
-            if (isset($debug['explainOther']) && is_array($debug['explainOther'])) {
+            if (isset($debug['explainOther']) && \is_array($debug['explainOther'])) {
                 $explainOther = $this->parseDocumentSet($debug['explainOther']);
             } else {
                 $explainOther = new DocumentSet([]);
@@ -55,7 +62,7 @@ class Debug implements ComponentParserInterface
 
             // parse timing data
             $timing = null;
-            if (isset($debug['timing']) && is_array($debug['timing'])) {
+            if (isset($debug['timing']) && \is_array($debug['timing'])) {
                 $time = null;
                 $timingPhases = [];
                 foreach ($debug['timing'] as $key => $timingData) {
@@ -63,7 +70,7 @@ class Debug implements ComponentParserInterface
                         case 'time':
                             $time = $timingData;
                             break;
-                        case is_array($timingData):
+                        case \is_array($timingData):
                             $timingPhases[$key] = $this->parseTimingPhase($key, $timingData);
                             break;
                     }
@@ -100,7 +107,7 @@ class Debug implements ComponentParserInterface
         $docs = [];
         foreach ($data as $key => $documentData) {
             $details = [];
-            if (isset($documentData['details']) && is_array($documentData['details'])) {
+            if (isset($documentData['details']) && \is_array($documentData['details'])) {
                 foreach ($documentData['details'] as $detailData) {
                     $detail = new Detail(
                         $detailData['match'],
@@ -108,7 +115,7 @@ class Debug implements ComponentParserInterface
                         $detailData['description']
                     );
 
-                    if (isset($detailData['details']) && is_array($detailData['details'])) {
+                    if (isset($detailData['details']) && \is_array($detailData['details'])) {
                         $detail->setSubDetails($detailData['details']);
                     }
                     $details[] = $detail;

--- a/src/Component/ResponseParser/FacetSet.php
+++ b/src/Component/ResponseParser/FacetSet.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ResponseParser;
 
 use Solarium\Component\AbstractComponent;
@@ -9,18 +16,18 @@ use Solarium\Component\Facet\Field as QueryFacetField;
 use Solarium\Component\Facet\Interval as QueryFacetInterval;
 use Solarium\Component\Facet\JsonAggregation;
 use Solarium\Component\Facet\JsonFacetInterface;
+use Solarium\Component\Facet\JsonRange as QueryFacetJsonRange;
 use Solarium\Component\Facet\MultiQuery as QueryFacetMultiQuery;
 use Solarium\Component\Facet\Query as QueryFacetQuery;
 use Solarium\Component\Facet\Range as QueryFacetRange;
-use Solarium\Component\Facet\JsonRange as QueryFacetJsonRange;
 use Solarium\Component\FacetSet as QueryFacetSet;
 use Solarium\Component\FacetSetInterface;
 use Solarium\Component\Result\Facet\Aggregation;
 use Solarium\Component\Result\Facet\Bucket;
 use Solarium\Component\Result\Facet\Buckets;
-use Solarium\Component\Result\Facet\JsonRange as ResultFacetJsonRange;
 use Solarium\Component\Result\Facet\Field as ResultFacetField;
 use Solarium\Component\Result\Facet\Interval as ResultFacetInterval;
+use Solarium\Component\Result\Facet\JsonRange as ResultFacetJsonRange;
 use Solarium\Component\Result\Facet\MultiQuery as ResultFacetMultiQuery;
 use Solarium\Component\Result\Facet\Pivot\Pivot as ResultFacetPivot;
 use Solarium\Component\Result\Facet\Pivot\PivotItem;
@@ -140,15 +147,16 @@ class FacetSet extends ResponseParserAbstract implements ComponentParserInterfac
     /**
      * Parse JSON facets.
      *
-     * @param array            $facet_data
+     * @param array            $facetData
      * @param FacetInterface[] $facets
      *
      * @return array
      */
-    protected function parseJsonFacetSet(array $facet_data, array $facets): array
+    protected function parseJsonFacetSet(array $facetData, array $facets): array
     {
-        $buckets_and_aggregations = [];
-        foreach ($facet_data as $key => $values) {
+        $bucketsAndAggregations = [];
+
+        foreach ($facetData as $key => $values) {
             if (\is_array($values)) {
                 if (isset($values['buckets'])) {
                     $buckets = [];
@@ -184,12 +192,12 @@ class FacetSet extends ResponseParserAbstract implements ComponentParserInterfac
                         } else {
                             $between = null;
                         }
-                        $buckets_and_aggregations[$key] = new ResultFacetJsonRange($buckets, $before, $after, $between);
+                        $bucketsAndAggregations[$key] = new ResultFacetJsonRange($buckets, $before, $after, $between);
                     } elseif ($buckets || $numBuckets) {
-                        $buckets_and_aggregations[$key] = new Buckets($buckets, $numBuckets);
+                        $bucketsAndAggregations[$key] = new Buckets($buckets, $numBuckets);
                     }
                 } else {
-                    $buckets_and_aggregations[$key] = new ResultFacetSet($this->parseJsonFacetSet(
+                    $bucketsAndAggregations[$key] = new ResultFacetSet($this->parseJsonFacetSet(
                         $values,
                         (isset($facets[$key]) && $facets[$key] instanceof JsonFacetInterface) ? $facets[$key]->getFacets() : []
                     ));
@@ -201,11 +209,11 @@ class FacetSet extends ResponseParserAbstract implements ComponentParserInterfac
                         continue;
                     }
                 }
-                $buckets_and_aggregations[$key] = new Aggregation($values);
+                $bucketsAndAggregations[$key] = new Aggregation($values);
             }
         }
 
-        return $buckets_and_aggregations;
+        return $bucketsAndAggregations;
     }
 
     /**

--- a/src/Component/ResponseParser/Grouping.php
+++ b/src/Component/ResponseParser/Grouping.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ResponseParser;
 
 use Solarium\Component\AbstractComponent;
@@ -23,9 +30,9 @@ class Grouping implements ComponentParserInterface
      * @param GroupingComponent|AbstractComponent $grouping
      * @param array                               $data
      *
-     * @return Result
-     *
      * @throws InvalidArgumentException
+     *
+     * @return Result
      */
     public function parse(?ComponentAwareQueryInterface $query, ?AbstractComponent $grouping, array $data): Result
     {
@@ -85,7 +92,7 @@ class Grouping implements ComponentParserInterface
                 // create document instances
                 $documentClass = $query->getOption('documentclass');
                 $documents = [];
-                if (isset($result['doclist']['docs']) && is_array($result['doclist']['docs'])) {
+                if (isset($result['doclist']['docs']) && \is_array($result['doclist']['docs'])) {
                     foreach ($result['doclist']['docs'] as $doc) {
                         $documents[] = new $documentClass($doc);
                     }
@@ -120,7 +127,7 @@ class Grouping implements ComponentParserInterface
         // create document instances
         $documents = [];
         if (isset($valueGroupResult['doclist']['docs']) &&
-            is_array($valueGroupResult['doclist']['docs'])) {
+            \is_array($valueGroupResult['doclist']['docs'])) {
             foreach ($valueGroupResult['doclist']['docs'] as $doc) {
                 $documents[] = new $documentClass($doc);
             }

--- a/src/Component/ResponseParser/Highlighting.php
+++ b/src/Component/ResponseParser/Highlighting.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ResponseParser;
 
 use Solarium\Component\AbstractComponent;

--- a/src/Component/ResponseParser/MoreLikeThis.php
+++ b/src/Component/ResponseParser/MoreLikeThis.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ResponseParser;
 
 use Solarium\Component\AbstractComponent;
@@ -23,9 +30,9 @@ class MoreLikeThis extends AbstractResponseParser implements ComponentParserInte
      * @param MoreLikeThisComponent $moreLikeThis
      * @param array                 $data
      *
-     * @return MoreLikeThisResult
-     *
      * @throws InvalidArgumentException
+     *
+     * @return MoreLikeThisResult
      */
     public function parse(?ComponentAwareQueryInterface $query, ?AbstractComponent $moreLikeThis, array $data): MoreLikeThisResult
     {

--- a/src/Component/ResponseParser/Spellcheck.php
+++ b/src/Component/ResponseParser/Spellcheck.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ResponseParser;
 
 use Solarium\Component\AbstractComponent;
@@ -7,7 +14,6 @@ use Solarium\Component\ComponentAwareQueryInterface;
 use Solarium\Component\Result\Spellcheck\Collation;
 use Solarium\Component\Result\Spellcheck\Result;
 use Solarium\Component\Result\Spellcheck\Suggestion;
-use Solarium\Component\Spellcheck as SpellcheckComponent;
 use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
 
@@ -19,9 +25,9 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
     /**
      * Parse result data into result objects.
      *
-     * @param AbstractQuery       $query
-     * @param SpellcheckComponent $spellcheck
-     * @param array               $data
+     * @param \Solarium\Component\ComponentAwareQueryInterface|null $query
+     * @param \Solarium\Component\AbstractComponent|null            $spellcheck
+     * @param array                                                 $data
      *
      * @return Result|null
      */
@@ -33,11 +39,11 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
             $correctlySpelled = false;
 
             if (isset($data['spellcheck']['suggestions']) &&
-                is_array($data['spellcheck']['suggestions']) &&
-                count($data['spellcheck']['suggestions']) > 0
+                \is_array($data['spellcheck']['suggestions']) &&
+                \count($data['spellcheck']['suggestions']) > 0
             ) {
                 $spellcheckResults = $data['spellcheck']['suggestions'];
-                if ($query && $query->getResponseWriter() == $query::WT_JSON) {
+                if ($query && $query->getResponseWriter() === $query::WT_JSON) {
                     $spellcheckResults = $this->convertToKeyValueArray($spellcheckResults);
                 }
 
@@ -50,7 +56,7 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
                             $collations = $this->parseCollation($query, $value);
                             break;
                         default:
-                            if (array_key_exists(0, $value)) {
+                            if (\array_key_exists(0, $value)) {
                                 foreach ($value as $currentValue) {
                                     $suggestions[] = $this->parseSuggestion($currentValue, $key);
                                 }
@@ -67,7 +73,7 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
              * directly under spellcheck.
              */
             if (isset($data['spellcheck']['collations']) &&
-                is_array($data['spellcheck']['collations'])
+                \is_array($data['spellcheck']['collations'])
             ) {
                 $collations = [$collations];
                 foreach ($this->convertToKeyValueArray($data['spellcheck']['collations']) as $collationResult) {
@@ -83,6 +89,7 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
 
             return new Result($suggestions, $collations, $correctlySpelled);
         }
+
         return null;
     }
 
@@ -97,24 +104,24 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
     protected function parseCollation(?AbstractQuery $queryObject, $values): array
     {
         $collations = [];
-        if (is_string($values)) {
+        if (\is_string($values)) {
             $collations[] = new Collation($values, null, []);
-        } elseif (is_array($values) && isset($values[0]) && is_string($values[0]) && 'collationQuery' !== $values[0]) {
+        } elseif (\is_array($values) && isset($values[0]) && \is_string($values[0]) && 'collationQuery' !== $values[0]) {
             foreach ($values as $value) {
                 $collations[] = new Collation($value, null, []);
             }
         } else {
             if ($queryObject && $queryObject->getResponseWriter() === $queryObject::WT_JSON) {
-                if (is_array(current($values))) {
+                if (\is_array(current($values))) {
                     foreach ($values as $key => $value) {
-                        if (array_key_exists('collationQuery', $value)) {
+                        if (\array_key_exists('collationQuery', $value)) {
                             $values[$key] = $value;
                         } else {
                             $values[$key] = $this->convertToKeyValueArray($value);
                         }
                     }
                 } else {
-                    if (array_key_exists('collationQuery', $values)) {
+                    if (\array_key_exists('collationQuery', $values)) {
                         $values = [$values];
                     } else {
                         $values = [$this->convertToKeyValueArray($values)];
@@ -175,9 +182,9 @@ class Spellcheck extends ResponseParserAbstract implements ComponentParserInterf
         $originalFrequency = (isset($value['origFreq'])) ? $value['origFreq'] : null;
 
         $words = [];
-        if (isset($value['suggestion']) && is_array($value['suggestion'])) {
+        if (isset($value['suggestion']) && \is_array($value['suggestion'])) {
             foreach ($value['suggestion'] as $suggestion) {
-                if (is_string($suggestion)) {
+                if (\is_string($suggestion)) {
                     $suggestion = [
                         'word' => $suggestion,
                         'freq' => null,

--- a/src/Component/ResponseParser/Stats.php
+++ b/src/Component/ResponseParser/Stats.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ResponseParser;
 
 use Solarium\Component\AbstractComponent;

--- a/src/Component/ResponseParser/Suggester.php
+++ b/src/Component/ResponseParser/Suggester.php
@@ -1,12 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ResponseParser;
 
 use Solarium\Component\AbstractComponent;
 use Solarium\Component\ComponentAwareQueryInterface;
 use Solarium\Component\Result\Suggester\Result;
-use Solarium\Component\Suggester as SuggesterComponent;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractResponseParser;
 use Solarium\QueryType\Suggester\Result\Dictionary;
 use Solarium\QueryType\Suggester\Result\Term;
@@ -19,9 +24,9 @@ class Suggester extends AbstractResponseParser implements ComponentParserInterfa
     /**
      * Parse result data into result objects.
      *
-     * @param AbstractQuery      $query
-     * @param SuggesterComponent $suggester
-     * @param array              $data
+     * @param \Solarium\Component\ComponentAwareQueryInterface|null $query
+     * @param \Solarium\Component\AbstractComponent|null            $suggester
+     * @param array                                                 $data
      *
      * @return Result|null
      */
@@ -30,7 +35,7 @@ class Suggester extends AbstractResponseParser implements ComponentParserInterfa
         $dictionaries = [];
         $allSuggestions = [];
 
-        if (isset($data['suggest']) && is_array($data['suggest'])) {
+        if (isset($data['suggest']) && \is_array($data['suggest'])) {
             foreach ($data['suggest'] as $dictionary => $dictionaryResults) {
                 $terms = [];
                 foreach ($dictionaryResults as $term => $termData) {
@@ -46,6 +51,11 @@ class Suggester extends AbstractResponseParser implements ComponentParserInterfa
         return null;
     }
 
+    /**
+     * @param array $terms
+     *
+     * @return \Solarium\QueryType\Suggester\Result\Dictionary
+     */
     private function createDictionary(array $terms): Dictionary
     {
         return new Dictionary(
@@ -53,6 +63,11 @@ class Suggester extends AbstractResponseParser implements ComponentParserInterfa
         );
     }
 
+    /**
+     * @param array $termData
+     *
+     * @return \Solarium\QueryType\Suggester\Result\Term
+     */
     private function createTerm(array $termData): Term
     {
         return new Term(

--- a/src/Component/ResponseParser/Terms.php
+++ b/src/Component/ResponseParser/Terms.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\ResponseParser;
 
 use Solarium\Component\AbstractComponent;
@@ -28,7 +35,7 @@ class Terms extends AbstractResponseParser implements ComponentParserInterface
     {
         $allTerms = [];
 
-        if (isset($data['terms']) && is_array($data['terms'])) {
+        if (isset($data['terms']) && \is_array($data['terms'])) {
             $terms = [];
             foreach ($data['terms'] as $field => $termData) {
                 // There seems to be a bug in Solr that json.nl=flat is ignored in a distributed search on Solr

--- a/src/Component/Result/Analytics/Expression.php
+++ b/src/Component/Result/Analytics/Expression.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Analytics;
 
 /**

--- a/src/Component/Result/Analytics/Facet.php
+++ b/src/Component/Result/Analytics/Facet.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Analytics;
 
 /**
@@ -32,8 +39,8 @@ class Facet implements \IteratorAggregate, \Countable
     private $children = [];
 
     /**
-     * @param string|null $pivot
      * @param string      $value
+     * @param string|null $pivot
      */
     public function __construct(string $value, ?string $pivot = null)
     {

--- a/src/Component/Result/Analytics/Grouping.php
+++ b/src/Component/Result/Analytics/Grouping.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Analytics;
 
 /**

--- a/src/Component/Result/Analytics/Result.php
+++ b/src/Component/Result/Analytics/Result.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Analytics;
 
 /**

--- a/src/Component/Result/Debug/Detail.php
+++ b/src/Component/Result/Debug/Detail.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Debug;
 
 /**
@@ -85,6 +92,7 @@ class Detail
     public function setSubDetails(array $subDetails): self
     {
         $this->subDetails = $subDetails;
+
         return $this;
     }
 

--- a/src/Component/Result/Debug/Document.php
+++ b/src/Component/Result/Debug/Document.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Debug;
 
 /**
@@ -74,6 +81,6 @@ class Document extends Detail implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->details);
+        return \count($this->details);
     }
 }

--- a/src/Component/Result/Debug/DocumentSet.php
+++ b/src/Component/Result/Debug/DocumentSet.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Debug;
 
 /**
@@ -63,6 +70,6 @@ class DocumentSet implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->docs);
+        return \count($this->docs);
     }
 }

--- a/src/Component/Result/Debug/Result.php
+++ b/src/Component/Result/Debug/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Debug;
 
 /**
@@ -167,6 +174,6 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->explain);
+        return \count($this->explain);
     }
 }

--- a/src/Component/Result/Debug/Timing.php
+++ b/src/Component/Result/Debug/Timing.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Debug;
 
 /**
@@ -82,6 +89,6 @@ class Timing implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->phases);
+        return \count($this->phases);
     }
 }

--- a/src/Component/Result/Debug/TimingPhase.php
+++ b/src/Component/Result/Debug/TimingPhase.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Debug;
 
 /**
@@ -91,6 +98,6 @@ class TimingPhase implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->timings);
+        return \count($this->timings);
     }
 }

--- a/src/Component/Result/Facet/Aggregation.php
+++ b/src/Component/Result/Facet/Aggregation.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Facet;
 
 /**

--- a/src/Component/Result/Facet/Bucket.php
+++ b/src/Component/Result/Facet/Bucket.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Facet;
 
 use Solarium\Component\Facet\FacetInterface;
@@ -106,6 +113,6 @@ class Bucket implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->facetSet->getFacets());
+        return \count($this->facetSet->getFacets());
     }
 }

--- a/src/Component/Result/Facet/Buckets.php
+++ b/src/Component/Result/Facet/Buckets.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Facet;
 
 /**
@@ -64,7 +71,7 @@ class Buckets implements FacetResultInterface, \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->buckets);
+        return \count($this->buckets);
     }
 
     /**

--- a/src/Component/Result/Facet/FacetResultInterface.php
+++ b/src/Component/Result/Facet/FacetResultInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Facet;
 
 /**

--- a/src/Component/Result/Facet/Field.php
+++ b/src/Component/Result/Facet/Field.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Facet;
 
 /**
@@ -55,6 +62,6 @@ class Field implements FacetResultInterface, \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->values);
+        return \count($this->values);
     }
 }

--- a/src/Component/Result/Facet/Interval.php
+++ b/src/Component/Result/Facet/Interval.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Facet;
 
 /**

--- a/src/Component/Result/Facet/JsonRange.php
+++ b/src/Component/Result/Facet/JsonRange.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Facet;
 
 /**

--- a/src/Component/Result/Facet/MultiQuery.php
+++ b/src/Component/Result/Facet/MultiQuery.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Facet;
 
 /**

--- a/src/Component/Result/Facet/Pivot/Pivot.php
+++ b/src/Component/Result/Facet/Pivot/Pivot.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Facet\Pivot;
 
 use Solarium\Component\Result\Facet\FacetResultInterface;
@@ -55,6 +62,6 @@ class Pivot implements FacetResultInterface, \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->pivot);
+        return \count($this->pivot);
     }
 }

--- a/src/Component/Result/Facet/Pivot/PivotItem.php
+++ b/src/Component/Result/Facet/Pivot/PivotItem.php
@@ -1,9 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Facet\Pivot;
 
-use Solarium\Component\Result\Stats\Stats;
 use Solarium\Component\Result\Facet\Range;
+use Solarium\Component\Result\Stats\Stats;
 
 /**
  * Select field pivot result.

--- a/src/Component/Result/Facet/Query.php
+++ b/src/Component/Result/Facet/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Facet;
 
 /**

--- a/src/Component/Result/Facet/Range.php
+++ b/src/Component/Result/Facet/Range.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Facet;
 
 use Solarium\Component\Result\Facet\Pivot\Pivot;

--- a/src/Component/Result/FacetSet.php
+++ b/src/Component/Result/FacetSet.php
@@ -60,7 +60,7 @@ class FacetSet implements \IteratorAggregate, \Countable, FacetResultInterface
      *
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->facets);
     }

--- a/src/Component/Result/FacetSet.php
+++ b/src/Component/Result/FacetSet.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result;
 
 use Solarium\Component\Result\Facet\FacetResultInterface;
@@ -65,6 +72,6 @@ class FacetSet implements \IteratorAggregate, \Countable, FacetResultInterface
      */
     public function count()
     {
-        return count($this->facets);
+        return \count($this->facets);
     }
 }

--- a/src/Component/Result/Grouping/FieldGroup.php
+++ b/src/Component/Result/Grouping/FieldGroup.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Grouping;
 
 /**
@@ -93,6 +100,6 @@ class FieldGroup implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->valueGroups);
+        return \count($this->valueGroups);
     }
 }

--- a/src/Component/Result/Grouping/QueryGroup.php
+++ b/src/Component/Result/Grouping/QueryGroup.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Grouping;
 
 use Solarium\Core\Query\AbstractQuery;
@@ -138,6 +145,6 @@ class QueryGroup implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->getDocuments());
+        return \count($this->getDocuments());
     }
 }

--- a/src/Component/Result/Grouping/Result.php
+++ b/src/Component/Result/Grouping/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Grouping;
 
 /**
@@ -67,6 +74,6 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->groups);
+        return \count($this->groups);
     }
 }

--- a/src/Component/Result/Grouping/ValueGroup.php
+++ b/src/Component/Result/Grouping/ValueGroup.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Grouping;
 
 use Solarium\Core\Query\AbstractQuery;
@@ -138,6 +145,6 @@ class ValueGroup implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->getDocuments());
+        return \count($this->getDocuments());
     }
 }

--- a/src/Component/Result/Highlighting/Highlighting.php
+++ b/src/Component/Result/Highlighting/Highlighting.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Highlighting;
 
 /**
@@ -63,6 +70,6 @@ class Highlighting implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->results);
+        return \count($this->results);
     }
 }

--- a/src/Component/Result/Highlighting/Result.php
+++ b/src/Component/Result/Highlighting/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Highlighting;
 
 /**
@@ -67,6 +74,6 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->fields);
+        return \count($this->fields);
     }
 }

--- a/src/Component/Result/MoreLikeThis/MoreLikeThis.php
+++ b/src/Component/Result/MoreLikeThis/MoreLikeThis.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\MoreLikeThis;
 
 /**
@@ -63,6 +70,6 @@ class MoreLikeThis implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->results);
+        return \count($this->results);
     }
 }

--- a/src/Component/Result/MoreLikeThis/Result.php
+++ b/src/Component/Result/MoreLikeThis/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\MoreLikeThis;
 
 use Solarium\Core\Query\DocumentInterface;
@@ -96,6 +103,6 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->documents);
+        return \count($this->documents);
     }
 }

--- a/src/Component/Result/Spellcheck/Collation.php
+++ b/src/Component/Result/Spellcheck/Collation.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Spellcheck;
 
 /**
@@ -97,6 +104,6 @@ class Collation implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->corrections);
+        return \count($this->corrections);
     }
 }

--- a/src/Component/Result/Spellcheck/Result.php
+++ b/src/Component/Result/Spellcheck/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Spellcheck;
 
 /**
@@ -51,8 +58,8 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function getCollation(?int $key = null): ?Collation
     {
-        $nrOfCollations = count($this->collations);
-        if (0 == $nrOfCollations) {
+        $nrOfCollations = \count($this->collations);
+        if (0 === $nrOfCollations) {
             return null;
         }
 
@@ -124,6 +131,6 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->suggestions);
+        return \count($this->suggestions);
     }
 }

--- a/src/Component/Result/Spellcheck/Suggestion.php
+++ b/src/Component/Result/Spellcheck/Suggestion.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Spellcheck;
 
 /**

--- a/src/Component/Result/Stats/FacetValue.php
+++ b/src/Component/Result/Stats/FacetValue.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Stats;
 
 /**

--- a/src/Component/Result/Stats/Result.php
+++ b/src/Component/Result/Stats/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Stats;
 
 /**

--- a/src/Component/Result/Stats/Stats.php
+++ b/src/Component/Result/Stats/Stats.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Stats;
 
 /**
@@ -76,6 +83,6 @@ class Stats implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->results);
+        return \count($this->results);
     }
 }

--- a/src/Component/Result/Suggester/Result.php
+++ b/src/Component/Result/Suggester/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Suggester;
 
 use Solarium\QueryType\Suggester\Result\Dictionary;
@@ -84,6 +91,6 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->results);
+        return \count($this->results);
     }
 }

--- a/src/Component/Result/Terms/Field.php
+++ b/src/Component/Result/Terms/Field.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Terms;
 
 /**
@@ -51,6 +58,6 @@ class Field implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->terms);
+        return \count($this->terms);
     }
 }

--- a/src/Component/Result/Terms/Result.php
+++ b/src/Component/Result/Terms/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Result\Terms;
 
 /**
@@ -82,6 +89,6 @@ class Result implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->results);
+        return \count($this->results);
     }
 }

--- a/src/Component/Spatial.php
+++ b/src/Component/Spatial.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\RequestBuilder\ComponentRequestBuilderInterface;
@@ -40,6 +47,7 @@ class Spatial extends AbstractComponent
     public function setField(string $sfield): self
     {
         $this->setOption('sfield', $sfield);
+
         return $this;
     }
 
@@ -51,6 +59,7 @@ class Spatial extends AbstractComponent
     public function setDistance(int $distance): self
     {
         $this->setOption('d', $distance);
+
         return $this;
     }
 
@@ -63,6 +72,7 @@ class Spatial extends AbstractComponent
     public function setPoint(string $point)
     {
         $this->setOption('pt', $point);
+
         return $this;
     }
 

--- a/src/Component/Spatial.php
+++ b/src/Component/Spatial.php
@@ -69,7 +69,7 @@ class Spatial extends AbstractComponent
      *
      * @return self Provides fluent interface
      */
-    public function setPoint(string $point)
+    public function setPoint(string $point): self
     {
         $this->setOption('pt', $point);
 

--- a/src/Component/Spellcheck.php
+++ b/src/Component/Spellcheck.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\ComponentTraits\SpellcheckTrait;

--- a/src/Component/SpellcheckInterface.php
+++ b/src/Component/SpellcheckInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Core\ConfigurableInterface;

--- a/src/Component/Stats/FacetsTrait.php
+++ b/src/Component/Stats/FacetsTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Stats;
 
 /**
@@ -38,7 +45,7 @@ trait FacetsTrait
      */
     public function addFacets($facets): self
     {
-        if (is_string($facets)) {
+        if (\is_string($facets)) {
             $facets = explode(',', $facets);
             $facets = array_map('trim', $facets);
         }

--- a/src/Component/Stats/Field.php
+++ b/src/Component/Stats/Field.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Stats;
 
 use Solarium\Core\Configurable;
@@ -38,6 +45,7 @@ class Field extends Configurable
     public function setKey(string $value): self
     {
         $this->setOption('key', $value);
+
         return $this;
     }
 
@@ -65,7 +73,7 @@ class Field extends Configurable
      */
     public function addPivots($pivots): self
     {
-        if (is_string($pivots)) {
+        if (\is_string($pivots)) {
             $pivots = explode(',', $pivots);
             $pivots = array_map('trim', $pivots);
         }

--- a/src/Component/Stats/Stats.php
+++ b/src/Component/Stats/Stats.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component\Stats;
 
 use Solarium\Component\AbstractComponent;
@@ -72,7 +79,7 @@ class Stats extends AbstractComponent
      */
     public function createField($options = null): Field
     {
-        if (is_string($options)) {
+        if (\is_string($options)) {
             $fq = new Field();
             $fq->setKey($options);
         } else {
@@ -92,7 +99,6 @@ class Stats extends AbstractComponent
      * Supports a field instance or a config array, in that case a new
      * field instance wil be created based on the options.
      *
-     *
      * @param Field|array $field
      *
      * @throws InvalidArgumentException
@@ -101,18 +107,18 @@ class Stats extends AbstractComponent
      */
     public function addField($field): self
     {
-        if (is_array($field)) {
+        if (\is_array($field)) {
             $field = new Field($field);
         }
 
         $key = $field->getKey();
 
-        if (0 === strlen($key)) {
+        if (0 === \strlen($key)) {
             throw new InvalidArgumentException('A field must have a key value');
         }
 
         // Double add calls for the same field are ignored, but non-unique keys cause an exception.
-        if (array_key_exists($key, $this->fields) && $this->fields[$key] !== $field) {
+        if (\array_key_exists($key, $this->fields) && $this->fields[$key] !== $field) {
             throw new InvalidArgumentException('A field must have a unique key value');
         }
 
@@ -132,7 +138,7 @@ class Stats extends AbstractComponent
     {
         foreach ($fields as $key => $field) {
             // in case of a config array: add key to config
-            if (is_array($field) && !isset($field['key'])) {
+            if (\is_array($field) && !isset($field['key'])) {
                 $field['key'] = $key;
             }
 
@@ -175,7 +181,7 @@ class Stats extends AbstractComponent
      */
     public function removeField($field): self
     {
-        if (is_object($field)) {
+        if (\is_object($field)) {
             $field = $field->getKey();
         }
 

--- a/src/Component/Suggester.php
+++ b/src/Component/Suggester.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\ComponentTraits\SuggesterTrait;

--- a/src/Component/SuggesterInterface.php
+++ b/src/Component/SuggesterInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Core\ConfigurableInterface;

--- a/src/Component/Terms.php
+++ b/src/Component/Terms.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Component\ComponentTraits\TermsTrait;

--- a/src/Component/TermsInterface.php
+++ b/src/Component/TermsInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Component;
 
 use Solarium\Core\ConfigurableInterface;

--- a/src/Core/Client/Adapter/AdapterHelper.php
+++ b/src/Core/Client/Adapter/AdapterHelper.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client\Adapter;
 
 use Solarium\Core\Client\Endpoint;
@@ -16,9 +23,9 @@ class AdapterHelper
      * @param Request  $request
      * @param Endpoint $endpoint
      *
-     * @return string
-     *
      * @throws HttpException
+     *
+     * @return string
      */
     public static function buildUri(Request $request, Endpoint $endpoint): string
     {
@@ -30,6 +37,7 @@ class AdapterHelper
             } else {
                 $baseUri = $endpoint->getBaseUri();
             }
+
             return $baseUri.$request->getUri();
         } catch (UnexpectedValueException $e) {
             // Backward compatibility: getBaseUri() now throws an UnexpectedValueException and we don't send a request.

--- a/src/Core/Client/Adapter/AdapterInterface.php
+++ b/src/Core/Client/Adapter/AdapterInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client\Adapter;
 
 use Solarium\Core\Client\Endpoint;

--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client\Adapter;
 
 use Solarium\Core\Client\Endpoint;
@@ -61,7 +68,6 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
     /**
      * Create curl handle for a request.
      *
-     *
      * @param Request  $request
      * @param Endpoint $endpoint
      *
@@ -79,7 +85,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
         $handler = curl_init();
         curl_setopt($handler, CURLOPT_URL, $uri);
         curl_setopt($handler, CURLOPT_RETURNTRANSFER, true);
-        if (!(function_exists('ini_get') && ini_get('open_basedir'))) {
+        if (!(\function_exists('ini_get') && ini_get('open_basedir'))) {
             curl_setopt($handler, CURLOPT_FOLLOWLOCATION, true);
         }
         curl_setopt($handler, CURLOPT_TIMEOUT, $options['timeout']);
@@ -92,7 +98,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
         if (!isset($options['headers']['Content-Type'])) {
             $charset = $request->getParam('ie') ?? 'utf-8';
 
-            if (Request::METHOD_GET == $method) {
+            if (Request::METHOD_GET === $method) {
                 $options['headers']['Content-Type'] = 'application/x-www-form-urlencoded; charset='.$charset;
             } else {
                 $options['headers']['Content-Type'] = 'application/xml; charset='.$charset;
@@ -110,7 +116,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
             curl_setopt($handler, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
         }
 
-        if (count($options['headers'])) {
+        if (\count($options['headers'])) {
             $headers = [];
             foreach ($options['headers'] as $key => $value) {
                 $headers[] = $key.': '.$value;
@@ -118,7 +124,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
             curl_setopt($handler, CURLOPT_HTTPHEADER, $headers);
         }
 
-        if (Request::METHOD_POST == $method) {
+        if (Request::METHOD_POST === $method) {
             curl_setopt($handler, CURLOPT_POST, true);
 
             if ($request->getFileUpload()) {
@@ -127,13 +133,13 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
             } else {
                 curl_setopt($handler, CURLOPT_POSTFIELDS, $request->getRawData());
             }
-        } elseif (Request::METHOD_GET == $method) {
+        } elseif (Request::METHOD_GET === $method) {
             curl_setopt($handler, CURLOPT_HTTPGET, true);
-        } elseif (Request::METHOD_HEAD == $method) {
+        } elseif (Request::METHOD_HEAD === $method) {
             curl_setopt($handler, CURLOPT_CUSTOMREQUEST, 'HEAD');
-        } elseif (Request::METHOD_DELETE == $method) {
+        } elseif (Request::METHOD_DELETE === $method) {
             curl_setopt($handler, CURLOPT_CUSTOMREQUEST, 'DELETE');
-        } elseif (Request::METHOD_PUT == $method) {
+        } elseif (Request::METHOD_PUT === $method) {
             curl_setopt($handler, CURLOPT_CUSTOMREQUEST, 'PUT');
 
             if ($request->getFileUpload()) {
@@ -152,7 +158,6 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
     /**
      * Check result of a request.
      *
-     *
      * @param string   $data
      * @param array    $headers
      * @param resource $handle
@@ -163,8 +168,8 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
     {
         // if there is no data and there are no headers it's a total failure,
         // a connection to the host was impossible.
-        if (empty($data) && 0 == count($headers)) {
-            throw new HttpException('HTTP request failed, '.curl_error($handle));
+        if (empty($data) && 0 === \count($headers)) {
+            throw new HttpException(sprintf('HTTP request failed, %s', curl_error($handle)));
         }
     }
 
@@ -193,7 +198,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
      */
     protected function init()
     {
-        if (!function_exists('curl_init')) {
+        if (!\function_exists('curl_init')) {
             throw new RuntimeException('cURL is not available, install it to use the CurlHttp adapter');
         }
 
@@ -214,7 +219,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
             'timeout' => $this->timeout,
         ];
         foreach ($request->getHeaders() as $headerLine) {
-            [$header, $value] = explode(':', $headerLine);
+            list($header, $value) = explode(':', $headerLine);
             if ($header = trim($header)) {
                 $options['headers'][$header] = trim($value);
             }

--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -164,7 +164,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
      *
      * @throws HttpException
      */
-    public function check($data, $headers, $handle)
+    public function check($data, $headers, $handle): void
     {
         // if there is no data and there are no headers it's a total failure,
         // a connection to the host was impossible.

--- a/src/Core/Client/Adapter/Http.php
+++ b/src/Core/Client/Adapter/Http.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client\Adapter;
 
 use Solarium\Core\Client\Endpoint;
@@ -17,7 +24,6 @@ class Http implements AdapterInterface, TimeoutAwareInterface
     /**
      * Handle Solr communication.
      *
-     *
      * @param Request  $request
      * @param Endpoint $endpoint
      *
@@ -30,7 +36,7 @@ class Http implements AdapterInterface, TimeoutAwareInterface
         $context = $this->createContext($request, $endpoint);
         $uri = AdapterHelper::buildUri($request, $endpoint);
 
-        [$data, $headers] = $this->getData($uri, $context);
+        list($data, $headers) = $this->getData($uri, $context);
 
         $this->check($data, $headers);
 
@@ -39,7 +45,6 @@ class Http implements AdapterInterface, TimeoutAwareInterface
 
     /**
      * Check result of a request.
-     *
      *
      * @param string $data
      * @param array  $headers
@@ -50,7 +55,7 @@ class Http implements AdapterInterface, TimeoutAwareInterface
     {
         // if there is no data and there are no headers it's a total failure,
         // a connection to the host was impossible.
-        if (false === $data && 0 == count($headers)) {
+        if (false === $data && 0 === \count($headers)) {
             throw new HttpException('HTTP request failed');
         }
     }
@@ -88,12 +93,12 @@ class Http implements AdapterInterface, TimeoutAwareInterface
             );
         }
 
-        if (Request::METHOD_POST == $method) {
+        if (Request::METHOD_POST === $method) {
             if ($request->getFileUpload()) {
                 $data = AdapterHelper::buildUploadBodyFromRequest($request);
 
-                $content_length = strlen($data);
-                $request->addHeader("Content-Length: $content_length\r\n");
+                $contentLength = \strlen($data);
+                $request->addHeader("Content-Length: $contentLength\r\n");
                 stream_context_set_option(
                     $context,
                     'http',
@@ -114,7 +119,7 @@ class Http implements AdapterInterface, TimeoutAwareInterface
                     $request->addHeader('Content-Type: text/xml; charset='.$charset);
                 }
             }
-        } elseif (Request::METHOD_PUT == $method) {
+        } elseif (Request::METHOD_PUT === $method) {
             $data = $request->getRawData();
             if (null !== $data) {
                 stream_context_set_option(
@@ -130,7 +135,7 @@ class Http implements AdapterInterface, TimeoutAwareInterface
         }
 
         $headers = $request->getHeaders();
-        if (count($headers) > 0) {
+        if (\count($headers) > 0) {
             stream_context_set_option(
                 $context,
                 'http',

--- a/src/Core/Client/Adapter/Http.php
+++ b/src/Core/Client/Adapter/Http.php
@@ -51,7 +51,7 @@ class Http implements AdapterInterface, TimeoutAwareInterface
      *
      * @throws HttpException
      */
-    public function check($data, $headers)
+    public function check($data, $headers): void
     {
         // if there is no data and there are no headers it's a total failure,
         // a connection to the host was impossible.

--- a/src/Core/Client/Adapter/Psr18Adapter.php
+++ b/src/Core/Client/Adapter/Psr18Adapter.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client\Adapter;
 
 use Psr\Http\Client\ClientExceptionInterface;
@@ -13,6 +20,9 @@ use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
 use Solarium\Exception\HttpException;
 
+/**
+ * Psr18 Adapter.
+ */
 final class Psr18Adapter implements AdapterInterface
 {
     /**
@@ -30,16 +40,26 @@ final class Psr18Adapter implements AdapterInterface
      */
     private $streamFactory;
 
-    public function __construct(
-        ClientInterface $httpClient,
-        RequestFactoryInterface $requestFactory,
-        StreamFactoryInterface $streamFactory
-    ) {
+    /**
+     * @param \Psr\Http\Client\ClientInterface          $httpClient
+     * @param \Psr\Http\Message\RequestFactoryInterface $requestFactory
+     * @param \Psr\Http\Message\StreamFactoryInterface  $streamFactory
+     */
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, StreamFactoryInterface $streamFactory)
+    {
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;
         $this->streamFactory = $streamFactory;
     }
 
+    /**
+     * @param \Solarium\Core\Client\Request  $request
+     * @param \Solarium\Core\Client\Endpoint $endpoint
+     *
+     * @throws \Solarium\Exception\HttpException
+     *
+     * @return \Solarium\Core\Client\Response
+     */
     public function execute(Request $request, Endpoint $endpoint): Response
     {
         try {
@@ -49,6 +69,14 @@ final class Psr18Adapter implements AdapterInterface
         }
     }
 
+    /**
+     * @param \Solarium\Core\Client\Request  $request
+     * @param \Solarium\Core\Client\Endpoint $endpoint
+     *
+     * @throws \Solarium\Exception\HttpException
+     *
+     * @return \Psr\Http\Message\RequestInterface
+     */
     private function createPsr7Request(Request $request, Endpoint $endpoint): RequestInterface
     {
         $uri = AdapterHelper::buildUri($request, $endpoint);
@@ -71,6 +99,11 @@ final class Psr18Adapter implements AdapterInterface
         return $psr7Request;
     }
 
+    /**
+     * @param \Psr\Http\Message\ResponseInterface $psr7Response
+     *
+     * @return \Solarium\Core\Client\Response
+     */
     private function createResponse(ResponseInterface $psr7Response): Response
     {
         $headerLines = [
@@ -89,9 +122,14 @@ final class Psr18Adapter implements AdapterInterface
         return new Response((string) $psr7Response->getBody(), $headerLines);
     }
 
+    /**
+     * @param \Solarium\Core\Client\Request $request
+     *
+     * @return string|null
+     */
     private function getRequestBody(Request $request): ?string
     {
-        if (Request::METHOD_PUT == $request->getMethod()) {
+        if (Request::METHOD_PUT === $request->getMethod()) {
             return $request->getRawData();
         }
 
@@ -106,12 +144,18 @@ final class Psr18Adapter implements AdapterInterface
         return $request->getRawData();
     }
 
+    /**
+     * @param \Solarium\Core\Client\Request  $request
+     * @param \Solarium\Core\Client\Endpoint $endpoint
+     *
+     * @return array
+     */
     private function getRequestHeaders(Request $request, Endpoint $endpoint): array
     {
         $headers = [];
 
         foreach ($request->getHeaders() as $headerLine) {
-            [$header, $value] = explode(':', $headerLine);
+            list($header, $value) = explode(':', $headerLine);
             if ($header = trim($header)) {
                 $headers[$header][] = $value;
             }
@@ -120,7 +164,7 @@ final class Psr18Adapter implements AdapterInterface
         if (!isset($headers['Content-Type'])) {
             $charset = $request->getParam('ie') ?? 'utf-8';
 
-            if (Request::METHOD_GET == $request->getMethod()) {
+            if (Request::METHOD_GET === $request->getMethod()) {
                 $headers['Content-Type'] = ['application/x-www-form-urlencoded; charset='.$charset];
             } else {
                 $headers['Content-Type'] = ['application/xml; charset='.$charset];

--- a/src/Core/Client/Adapter/TimeoutAwareInterface.php
+++ b/src/Core/Client/Adapter/TimeoutAwareInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client\Adapter;
 
 /**
@@ -12,7 +19,13 @@ interface TimeoutAwareInterface
      */
     public const DEFAULT_TIMEOUT = 5;
 
+    /**
+     * @param int $timeoutInSeconds
+     */
     public function setTimeout(int $timeoutInSeconds): void;
 
+    /**
+     * @return int
+     */
     public function getTimeout(): int;
 }

--- a/src/Core/Client/Adapter/TimeoutAwareTrait.php
+++ b/src/Core/Client/Adapter/TimeoutAwareTrait.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client\Adapter;
 
 /**
@@ -12,11 +19,17 @@ trait TimeoutAwareTrait
      */
     private $timeout = TimeoutAwareInterface::DEFAULT_TIMEOUT;
 
+    /**
+     * {@inheritdoc}
+     */
     public function setTimeout(int $timeoutInSeconds): void
     {
         $this->timeout = $timeoutInSeconds;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getTimeout(): int
     {
         return $this->timeout;

--- a/src/Core/Client/Client.php
+++ b/src/Core/Client/Client.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -385,7 +392,7 @@ class Client extends Configurable implements ClientInterface
         }
 
         if (!isset($this->endpoints[$key])) {
-            throw new OutOfBoundsException('Endpoint '.$key.' not available');
+            throw new OutOfBoundsException(sprintf('Endpoint %s not available', $key));
         }
 
         return $this->endpoints[$key];
@@ -471,7 +478,7 @@ class Client extends Configurable implements ClientInterface
         }
 
         if (!isset($this->endpoints[$endpoint])) {
-            throw new OutOfBoundsException('Unknown endpoint '.$endpoint.' cannot be set as default');
+            throw new OutOfBoundsException(sprintf('Unknown endpoint %s cannot be set as default', $endpoint));
         }
 
         $this->defaultEndpoint = $endpoint;
@@ -670,7 +677,7 @@ class Client extends Configurable implements ClientInterface
                 return $this->pluginInstances[$key];
             }
 
-            throw new OutOfBoundsException('Cannot autoload plugin of unknown type: '.$key);
+            throw new OutOfBoundsException(sprintf('Cannot autoload plugin of unknown type: %s', $key));
         }
 
         return null;
@@ -722,7 +729,7 @@ class Client extends Configurable implements ClientInterface
 
         $requestBuilder = $query->getRequestBuilder();
         if (!$requestBuilder || !($requestBuilder instanceof RequestBuilderInterface)) {
-            throw new UnexpectedValueException('No requestbuilder returned by query type: '.$query->getType());
+            throw new UnexpectedValueException(sprintf('No requestbuilder returned by query type: %s', $query->getType()));
         }
 
         $request = $requestBuilder->build($query);
@@ -1061,7 +1068,7 @@ class Client extends Configurable implements ClientInterface
         }
 
         if (!isset($this->queryTypes[$type])) {
-            throw new InvalidArgumentException('Unknown query type: '.$type);
+            throw new InvalidArgumentException(sprintf('Unknown query type: %s', $type));
         }
 
         $class = $this->queryTypes[$type];

--- a/src/Core/Client/ClientInterface.php
+++ b/src/Core/Client/ClientInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client;
 
 use Psr\EventDispatcher\EventDispatcherInterface;

--- a/src/Core/Client/Endpoint.php
+++ b/src/Core/Client/Endpoint.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client;
 
 use Solarium\Core\Configurable;
@@ -63,6 +70,7 @@ class Endpoint extends Configurable
     public function setKey(string $value): self
     {
         $this->setOption('key', $value);
+
         return $this;
     }
 
@@ -76,6 +84,7 @@ class Endpoint extends Configurable
     public function setHost(string $host): self
     {
         $this->setOption('host', $host);
+
         return $this;
     }
 
@@ -99,6 +108,7 @@ class Endpoint extends Configurable
     public function setPort(int $port): self
     {
         $this->setOption('port', $port);
+
         return $this;
     }
 
@@ -128,6 +138,7 @@ class Endpoint extends Configurable
         }
 
         $this->setOption('path', $path);
+
         return $this;
     }
 
@@ -151,6 +162,7 @@ class Endpoint extends Configurable
     public function setCollection(string $collection): self
     {
         $this->setOption('collection', $collection);
+
         return $this;
     }
 
@@ -174,6 +186,7 @@ class Endpoint extends Configurable
     public function setCore(string $core): self
     {
         $this->setOption('core', $core);
+
         return $this;
     }
 
@@ -197,6 +210,7 @@ class Endpoint extends Configurable
     public function setScheme(string $scheme): self
     {
         $this->setOption('scheme', $scheme);
+
         return $this;
     }
 
@@ -215,9 +229,9 @@ class Endpoint extends Configurable
      *
      * Based on host, path, port and collection options.
      *
-     * @return string
-     *
      * @throws UnexpectedValueException
+     *
+     * @return string
      */
     public function getCollectionBaseUri(): string
     {
@@ -238,9 +252,9 @@ class Endpoint extends Configurable
      *
      * Based on host, path, port and core options.
      *
-     * @return string
-     *
      * @throws UnexpectedValueException
+     *
+     * @return string
      */
     public function getCoreBaseUri(): string
     {
@@ -260,9 +274,9 @@ class Endpoint extends Configurable
     /**
      * Get the base url for all V1 API requests.
      *
-     * @return string
-     *
      * @throws UnexpectedValueException
+     *
+     * @return string
      */
     public function getBaseUri(): string
     {
@@ -280,9 +294,9 @@ class Endpoint extends Configurable
     /**
      * Get the base url for all V1 API requests.
      *
-     * @return string
-     *
      * @throws UnexpectedValueException
+     *
+     * @return string
      */
     public function getV1BaseUri(): string
     {
@@ -292,9 +306,9 @@ class Endpoint extends Configurable
     /**
      * Get the base url for all V2 API requests.
      *
-     * @return string
-     *
      * @throws UnexpectedValueException
+     *
+     * @return string
      */
     public function getV2BaseUri(): string
     {
@@ -352,6 +366,7 @@ class Endpoint extends Configurable
     public function setLeader(bool $leader): self
     {
         $this->setOption('leader', $leader);
+
         return $this;
     }
 

--- a/src/Core/Client/Request.php
+++ b/src/Core/Client/Request.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client;
 
 use Solarium\Component\RequestBuilder\RequestParamsInterface;

--- a/src/Core/Client/Response.php
+++ b/src/Core/Client/Response.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client;
 
 use Solarium\Exception\HttpException;
@@ -94,12 +101,11 @@ class Response
     /**
      * Set headers.
      *
-     *
      * @param array $headers
      *
-     * @return self Provides fluent interface
-     *
      * @throws HttpException
+     *
+     * @return self Provides fluent interface
      */
     public function setHeaders(array $headers): self
     {
@@ -108,7 +114,7 @@ class Response
         // get the status header
         $statusHeader = null;
         foreach ($headers as $header) {
-            if ('HTTP' == substr($header, 0, 4)) {
+            if (0 === strpos($header, 'HTTP')) {
                 $statusHeader = $header;
                 break;
             }

--- a/src/Core/Client/State/AbstractState.php
+++ b/src/Core/Client/State/AbstractState.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client\State;
 
 /**

--- a/src/Core/Client/State/AbstractState.php
+++ b/src/Core/Client/State/AbstractState.php
@@ -34,7 +34,7 @@ abstract class AbstractState implements StateInterface
     /**
      * {@inheritdoc}
      */
-    public function update(array $state, array $liveNodes)
+    public function update(array $state, array $liveNodes): void
     {
         $this->stateRaw = $state;
         $this->liveNodes = $liveNodes;
@@ -49,11 +49,7 @@ abstract class AbstractState implements StateInterface
      */
     public function getStateProp(string $name, $defaultValue = null)
     {
-        if (isset($this->stateRaw[$name])) {
-            return $this->stateRaw[$name];
-        }
-
-        return $defaultValue;
+        return $this->stateRaw[$name] ?? $defaultValue;
     }
 
     /**

--- a/src/Core/Client/State/AbstractState.php
+++ b/src/Core/Client/State/AbstractState.php
@@ -14,10 +14,14 @@ namespace Solarium\Core\Client\State;
  */
 abstract class AbstractState implements StateInterface
 {
-    /** @var array List of live nodes */
+    /**
+     * @var array List of live nodes
+     */
     protected $liveNodes;
 
-    /** @var array State array retrieved by ZkStateReader */
+    /**
+     * @var array State array retrieved by ZkStateReader
+     */
     protected $stateRaw;
 
     /**

--- a/src/Core/Client/State/ClusterState.php
+++ b/src/Core/Client/State/ClusterState.php
@@ -1,9 +1,19 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client\State;
 
 use Solarium\Exception\RuntimeException;
 
+/**
+ * Cluster State.
+ */
 class ClusterState
 {
     const ALIASES_PROP = 'aliases';
@@ -121,9 +131,9 @@ class ClusterState
     /**
      * @param string $collectionName
      *
-     * @return CollectionState
-     *
      * @throws RuntimeException
+     *
+     * @return CollectionState
      */
     public function getCollectionState(string $collectionName): CollectionState
     {

--- a/src/Core/Client/State/CollectionState.php
+++ b/src/Core/Client/State/CollectionState.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client\State;
 
 use Solarium\Exception\RuntimeException;
@@ -16,16 +23,6 @@ class CollectionState extends AbstractState
     protected $shards;
 
     /**
-     * Name of the collection.
-     *
-     * @return string
-     */
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    /**
      * Magic method enables a object to be transformed to a string.
      *
      * Get a summary showing significant variables in the object
@@ -38,6 +35,16 @@ class CollectionState extends AbstractState
     }
 
     /**
+     * Name of the collection.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
      * @return bool
      */
     public function isAutoAddReplicas(): bool
@@ -45,6 +52,9 @@ class CollectionState extends AbstractState
         return $this->getState()[ClusterState::AUTO_ADD_REPLICAS] ?? false;
     }
 
+    /**
+     * @return bool
+     */
     public function isAutoCreated(): bool
     {
         return $this->getState()[ClusterState::AUTO_CREATED] ?? false;
@@ -141,9 +151,9 @@ class CollectionState extends AbstractState
     /**
      * Array with node names as keys and base URIs as values.
      *
-     * @return string[]
-     *
      * @throws RuntimeException
+     *
+     * @return string[]
      */
     public function getNodesBaseUris(): array
     {
@@ -162,11 +172,17 @@ class CollectionState extends AbstractState
         return $uris;
     }
 
+    /**
+     * @return string
+     */
     public function getTlogReplicas(): string
     {
         return $this->getState()[ClusterState::TLOG_REPLICAS];
     }
 
+    /**
+     * @return string
+     */
     public function getZnodeVersion(): string
     {
         return $this->getState()[ClusterState::ZNODE_VERSION];
@@ -182,15 +198,22 @@ class CollectionState extends AbstractState
         return $this->stateRaw[$this->name];
     }
 
+    /**
+     * Clear and set shards.
+     */
     protected function setShards()
     {
         // Clear shards first
         $this->shards = [];
+
         foreach ($this->getState()[ClusterState::SHARDS_PROP] as $shardName => $shardState) {
             $this->shards[$shardName] = new ShardState([$shardName => $shardState], $this->liveNodes);
         }
     }
 
+    /**
+     * init.
+     */
     protected function init()
     {
         $this->name = key($this->stateRaw);

--- a/src/Core/Client/State/CollectionState.php
+++ b/src/Core/Client/State/CollectionState.php
@@ -16,10 +16,14 @@ use Solarium\Exception\RuntimeException;
  */
 class CollectionState extends AbstractState
 {
-    /** @var string Name of the collection */
+    /**
+     * @var string Name of the collection
+     */
     protected $name;
 
-    /** @var ShardState[] */
+    /**
+     * @var ShardState[]
+     */
     protected $shards;
 
     /**

--- a/src/Core/Client/State/ReplicaState.php
+++ b/src/Core/Client/State/ReplicaState.php
@@ -34,22 +34,34 @@ class ReplicaState extends AbstractState
      */
     const RECOVERY_FAILED = 'recovery_failed';
 
-    /** @var string Name of the replica */
+    /**
+     * @var string Name of the replica
+     */
     protected $name = '';
 
-    /** @var string Name of the core */
+    /**
+     * @var string Name of the core
+     */
     protected $core = '';
 
-    /** @var string Base uri of shard replica */
+    /**
+     * @var string Base uri of shard replica
+     */
     protected $baseUri = '';
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $nodeName = '';
 
-    /** @var bool Whether or not this replica is a shard leader */
+    /**
+     * @var bool Whether or not this replica is a shard leader
+     */
     protected $leader = false;
 
-    /** @var string Replica state, one of the following: active, down, recovering or recovery_failed */
+    /**
+     * @var string Replica state, one of the following: active, down, recovering or recovery_failed
+     */
     protected $state;
 
     /**

--- a/src/Core/Client/State/ReplicaState.php
+++ b/src/Core/Client/State/ReplicaState.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client\State;
 
 /**
@@ -7,24 +14,6 @@ namespace Solarium\Core\Client\State;
  */
 class ReplicaState extends AbstractState
 {
-    /** @var string Name of the replica */
-    protected $name = '';
-
-    /** @var string Name of the core */
-    protected $core = '';
-
-    /** @var string Base uri of shard replica */
-    protected $baseUri = '';
-
-    /** @var string */
-    protected $nodeName = '';
-
-    /** @var bool Whether or not this replica is a shard leader */
-    protected $leader = false;
-
-    /** @var string Replica state, one of the following: active, down, recovering or recovery_failed */
-    protected $state;
-
     /**
      * The replica is ready to receive updates and queries.
      */
@@ -44,6 +33,24 @@ class ReplicaState extends AbstractState
      * Recovery attempts have not worked, something is not right.
      */
     const RECOVERY_FAILED = 'recovery_failed';
+
+    /** @var string Name of the replica */
+    protected $name = '';
+
+    /** @var string Name of the core */
+    protected $core = '';
+
+    /** @var string Base uri of shard replica */
+    protected $baseUri = '';
+
+    /** @var string */
+    protected $nodeName = '';
+
+    /** @var bool Whether or not this replica is a shard leader */
+    protected $leader = false;
+
+    /** @var string Replica state, one of the following: active, down, recovering or recovery_failed */
+    protected $state;
 
     /**
      * @return string
@@ -103,6 +110,9 @@ class ReplicaState extends AbstractState
         return self::ACTIVE === $this->state;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function init()
     {
         $this->name = key($this->stateRaw);

--- a/src/Core/Client/State/ShardState.php
+++ b/src/Core/Client/State/ShardState.php
@@ -40,22 +40,34 @@ class ShardState extends AbstractState
      */
     const RECOVERY_FAILED = 'recovery_failed';
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $name;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $range;
 
-    /** @var ReplicaState[] */
+    /**
+     * @var ReplicaState[]
+     */
     protected $replicas;
 
-    /** @var string Id of the shard leader */
+    /**
+     * @var string Id of the shard leader
+     */
     protected $shardLeader;
 
-    /** @var string[] An array of all ids of the active replicas */
+    /**
+     * @var string[] An array of all ids of the active replicas
+     */
     protected $activeReplicas;
 
-    /** @var string Shard is active or inactive */
+    /**
+     * @var string Shard is active or inactive
+     */
     protected $state;
 
     /**

--- a/src/Core/Client/State/ShardState.php
+++ b/src/Core/Client/State/ShardState.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client\State;
 
 /**
@@ -7,24 +14,6 @@ namespace Solarium\Core\Client\State;
  */
 class ShardState extends AbstractState
 {
-    /** @var string */
-    protected $name;
-
-    /** @var string */
-    protected $range;
-
-    /** @var ReplicaState[] */
-    protected $replicas;
-
-    /** @var string Id of the shard leader */
-    protected $shardLeader;
-
-    /** @var string[] An array of all ids of the active replicas */
-    protected $activeReplicas;
-
-    /** @var string Shard is active or inactive */
-    protected $state;
-
     /** The normal/default state of a shard. */
     const ACTIVE = 'active';
 
@@ -50,6 +39,24 @@ class ShardState extends AbstractState
      * session id).
      */
     const RECOVERY_FAILED = 'recovery_failed';
+
+    /** @var string */
+    protected $name;
+
+    /** @var string */
+    protected $range;
+
+    /** @var ReplicaState[] */
+    protected $replicas;
+
+    /** @var string Id of the shard leader */
+    protected $shardLeader;
+
+    /** @var string[] An array of all ids of the active replicas */
+    protected $activeReplicas;
+
+    /** @var string Shard is active or inactive */
+    protected $state;
 
     /**
      * Returns the name of the shard.
@@ -149,6 +156,9 @@ class ShardState extends AbstractState
         return $replicas;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function init()
     {
         $this->name = key($this->stateRaw);

--- a/src/Core/Client/State/StateInterface.php
+++ b/src/Core/Client/State/StateInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Client\State;
 
 /**

--- a/src/Core/Configurable.php
+++ b/src/Core/Configurable.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core;
 
 use Solarium\Exception\InvalidArgumentException;

--- a/src/Core/ConfigurableInterface.php
+++ b/src/Core/ConfigurableInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core;
 
 use Solarium\Exception\InvalidArgumentException;
@@ -24,9 +31,9 @@ interface ConfigurableInterface
      * @param bool               $overwrite True for overwriting existing options, false
      *                                      for merging (new values overwrite old ones if needed)
      *
-     * @return self
-     *
      * @throws InvalidArgumentException
+     *
+     * @return self
      */
     public function setOptions($options, bool $overwrite = false): self;
 

--- a/src/Core/Event/Events.php
+++ b/src/Core/Event/Events.php
@@ -1,11 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Event;
 
 /**
  * Event definitions.
  */
-interface Events
+class Events
 {
     /**
      * The preCreateRequest event is thrown just before a request is created based on a query object, using the
@@ -102,4 +109,11 @@ interface Events
      * @var string
      */
     public const POST_CREATE_QUERY = PostCreateQuery::class;
+
+    /**
+     * Not instantiable.
+     */
+    private function __construct()
+    {
+    }
 }

--- a/src/Core/Event/Events.php
+++ b/src/Core/Event/Events.php
@@ -11,6 +11,8 @@ namespace Solarium\Core\Event;
 
 /**
  * Event definitions.
+ *
+ * @codeCoverageIgnore
  */
 class Events
 {

--- a/src/Core/Event/PostCreateQuery.php
+++ b/src/Core/Event/PostCreateQuery.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Event;
 
 use Solarium\Core\Query\QueryInterface;

--- a/src/Core/Event/PostCreateRequest.php
+++ b/src/Core/Event/PostCreateRequest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Event;
 
 use Solarium\Core\Client\Request;

--- a/src/Core/Event/PostCreateResult.php
+++ b/src/Core/Event/PostCreateResult.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Event;
 
 use Solarium\Core\Client\Response;

--- a/src/Core/Event/PostExecute.php
+++ b/src/Core/Event/PostExecute.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Event;
 
 use Solarium\Core\Query\QueryInterface;

--- a/src/Core/Event/PostExecuteRequest.php
+++ b/src/Core/Event/PostExecuteRequest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Event;
 
 use Solarium\Core\Client\Endpoint;

--- a/src/Core/Event/PreCreateQuery.php
+++ b/src/Core/Event/PreCreateQuery.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Event;
 
 use Solarium\Core\Query\QueryInterface;
@@ -11,7 +18,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 class PreCreateQuery extends Event
 {
     /**
-     * @var null|QueryInterface
+     * @var QueryInterface|null
      */
     protected $query;
 

--- a/src/Core/Event/PreCreateRequest.php
+++ b/src/Core/Event/PreCreateRequest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Event;
 
 use Solarium\Core\Client\Request;
@@ -53,13 +60,14 @@ class PreCreateRequest extends Event
     public function setRequest(Request $request): self
     {
         $this->request = $request;
+
         return $this;
     }
 
     /**
      * Get the result.
      *
-     * @return null|Request
+     * @return Request|null
      */
     public function getRequest(): ?Request
     {

--- a/src/Core/Event/PreCreateResult.php
+++ b/src/Core/Event/PreCreateResult.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Event;
 
 use Solarium\Core\Client\Response;
@@ -79,6 +86,7 @@ class PreCreateResult extends Event
     public function setResult(ResultInterface $result): self
     {
         $this->result = $result;
+
         return $this;
     }
 }

--- a/src/Core/Event/PreExecute.php
+++ b/src/Core/Event/PreExecute.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Event;
 
 use Solarium\Core\Query\QueryInterface;
@@ -61,6 +68,7 @@ class PreExecute extends Event
     public function setResult(ResultInterface $result): self
     {
         $this->result = $result;
+
         return $this;
     }
 }

--- a/src/Core/Event/PreExecuteRequest.php
+++ b/src/Core/Event/PreExecuteRequest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Event;
 
 use Solarium\Core\Client\Endpoint;
@@ -69,6 +76,7 @@ class PreExecuteRequest extends Event
     public function setRequest(Request $request): self
     {
         $this->request = $request;
+
         return $this;
     }
 
@@ -92,6 +100,7 @@ class PreExecuteRequest extends Event
     public function setResponse(Response $response): self
     {
         $this->response = $response;
+
         return $this;
     }
 }

--- a/src/Core/Plugin/AbstractPlugin.php
+++ b/src/Core/Plugin/AbstractPlugin.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Plugin;
 
 use Solarium\Core\Client\ClientInterface;

--- a/src/Core/Plugin/PluginInterface.php
+++ b/src/Core/Plugin/PluginInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Plugin;
 
 use Solarium\Core\Client\ClientInterface;

--- a/src/Core/Query/AbstractDocument.php
+++ b/src/Core/Query/AbstractDocument.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query;
 
 /**
@@ -14,6 +21,12 @@ abstract class AbstractDocument implements DocumentInterface, \IteratorAggregate
      */
     protected $fields;
 
+    /**
+     * @param $name
+     * @param $value
+     *
+     * @return \Solarium\Core\Query\DocumentInterface
+     */
     abstract public function __set($name, $value): DocumentInterface;
 
     /**
@@ -73,7 +86,7 @@ abstract class AbstractDocument implements DocumentInterface, \IteratorAggregate
      */
     public function count(): int
     {
-        return count($this->fields);
+        return \count($this->fields);
     }
 
     /**

--- a/src/Core/Query/AbstractDocument.php
+++ b/src/Core/Query/AbstractDocument.php
@@ -95,7 +95,7 @@ abstract class AbstractDocument implements DocumentInterface, \IteratorAggregate
      * @param mixed $offset
      * @param mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->__set($offset, $value);
     }
@@ -107,7 +107,7 @@ abstract class AbstractDocument implements DocumentInterface, \IteratorAggregate
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return null !== $this->__get($offset);
     }
@@ -117,7 +117,7 @@ abstract class AbstractDocument implements DocumentInterface, \IteratorAggregate
      *
      * @param mixed $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->__set($offset, null);
     }

--- a/src/Core/Query/AbstractDocument.php
+++ b/src/Core/Query/AbstractDocument.php
@@ -22,8 +22,8 @@ abstract class AbstractDocument implements DocumentInterface, \IteratorAggregate
     protected $fields;
 
     /**
-     * @param $name
-     * @param $value
+     * @param mixed $name
+     * @param mixed $value
      *
      * @return \Solarium\Core\Query\DocumentInterface
      */

--- a/src/Core/Query/AbstractQuery.php
+++ b/src/Core/Query/AbstractQuery.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query;
 
 use Solarium\Core\Configurable;

--- a/src/Core/Query/AbstractRequestBuilder.php
+++ b/src/Core/Query/AbstractRequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query;
 
 use Solarium\Core\Client\Request;
@@ -68,7 +75,7 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
                 continue;
             }
 
-            if (is_array($paramValue)) {
+            if (\is_array($paramValue)) {
                 $paramValue = implode(',', $paramValue);
             }
 

--- a/src/Core/Query/AbstractResponseParser.php
+++ b/src/Core/Query/AbstractResponseParser.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query;
 
 /**
@@ -21,12 +28,12 @@ abstract class AbstractResponseParser
         // key counter to convert values to arrays when keys are re-used
         $keys = [];
 
-        $dataCount = count($data);
+        $dataCount = \count($data);
         $result = [];
         for ($i = 0; $i < $dataCount; $i += 2) {
             $key = $data[$i];
             $value = $data[$i + 1];
-            if (array_key_exists($key, $keys)) {
+            if (\array_key_exists($key, $keys)) {
                 if (1 === $keys[$key]) {
                     $result[$key] = [$result[$key]];
                 }

--- a/src/Core/Query/DocumentInterface.php
+++ b/src/Core/Query/DocumentInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query;
 
 /**

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query;
 
 use Solarium\Exception\InvalidArgumentException;
@@ -114,10 +121,10 @@ class Helper
                 $input = clone $input;
                 break;
             // input of timestamp or date/time string
-            case is_string($input) || is_numeric($input):
-
+            case \is_string($input):
+            case is_numeric($input):
                 // if date/time string: convert to timestamp first
-                if (is_string($input)) {
+                if (\is_string($input)) {
                     $input = strtotime($input);
                 }
 
@@ -297,7 +304,7 @@ class Helper
             }
 
             foreach ($params as $paramKey => $paramValue) {
-                if (is_int($paramKey) || $forceKeys) {
+                if (\is_int($paramKey) || $forceKeys) {
                     ++$this->derefencedParamsLastKey;
                     $derefKey = 'deref_'.$this->derefencedParamsLastKey;
                 } else {
@@ -310,7 +317,7 @@ class Helper
 
         $output = '{!'.$name;
         foreach ($params as $key => $value) {
-            if (!$dereferenced || $forceKeys || is_int($key)) {
+            if (!$dereferenced || $forceKeys || \is_int($key)) {
                 $output .= ' '.$key.'='.$value;
             }
         }
@@ -380,7 +387,6 @@ class Helper
      * Render join localparams syntax.
      *
      * @see https://lucene.apache.org/solr/guide/other-parsers.html#join-query-parser
-     * @since 2.4.0
      *
      * @param string $from
      * @param string $to
@@ -493,7 +499,7 @@ class Helper
         if (isset($this->assembleParts[$partNumber - 1])) {
             $value = $this->assembleParts[$partNumber - 1];
         } else {
-            throw new InvalidArgumentException('No value supplied for part #'.$partNumber.' in query assembler');
+            throw new InvalidArgumentException(sprintf('No value supplied for part #%d in query assembler', $partNumber));
         }
 
         switch ($partMode) {

--- a/src/Core/Query/LocalParameters/LocalParameter.php
+++ b/src/Core/Query/LocalParameters/LocalParameter.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query\LocalParameters;
 
 /**

--- a/src/Core/Query/LocalParameters/LocalParameterInterface.php
+++ b/src/Core/Query/LocalParameters/LocalParameterInterface.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query\LocalParameters;
 
 /**

--- a/src/Core/Query/LocalParameters/LocalParameters.php
+++ b/src/Core/Query/LocalParameters/LocalParameters.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query\LocalParameters;
 
 use Solarium\Exception\OutOfBoundsException;
@@ -440,6 +447,13 @@ class LocalParameters implements \ArrayAccess
         return $this->addValue(LocalParameter::TYPE_STAT, $stat);
     }
 
+    /**
+     * @param array $stats
+     *
+     * @throws \Solarium\Exception\OutOfBoundsException
+     *
+     * @return $this
+     */
     public function setStats(array $stats): self
     {
         return $this->setValues(LocalParameter::TYPE_STAT, $stats);

--- a/src/Core/Query/LocalParameters/LocalParametersTrait.php
+++ b/src/Core/Query/LocalParameters/LocalParametersTrait.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query\LocalParameters;
 
 use Solarium\Exception\OutOfBoundsException;

--- a/src/Core/Query/QueryInterface.php
+++ b/src/Core/Query/QueryInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query;
 
 use Solarium\Core\ConfigurableInterface;

--- a/src/Core/Query/RequestBuilderInterface.php
+++ b/src/Core/Query/RequestBuilderInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query;
 
 use Solarium\Core\Client\Request;

--- a/src/Core/Query/ResponseParserInterface.php
+++ b/src/Core/Query/ResponseParserInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query;
 
 use Solarium\Core\Query\Result\ResultInterface;

--- a/src/Core/Query/Result/QueryType.php
+++ b/src/Core/Query/Result/QueryType.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query\Result;
 
 use Solarium\Core\Query\ResponseParserInterface;
@@ -29,7 +36,7 @@ class QueryType extends Result
         if (!$this->parsed) {
             $responseParser = $this->query->getResponseParser();
             if (!$responseParser || !($responseParser instanceof ResponseParserInterface)) {
-                throw new UnexpectedValueException('No responseparser returned by querytype: '.$this->query->getType());
+                throw new UnexpectedValueException(sprintf('No responseparser returned by querytype: %s', $this->query->getType()));
             }
 
             $this->mapData($responseParser->parse($this));

--- a/src/Core/Query/Result/Result.php
+++ b/src/Core/Query/Result/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query\Result;
 
 use Solarium\Core\Client\Response;
@@ -41,7 +48,6 @@ class Result implements ResultInterface
 
     /**
      * Constructor.
-     *
      *
      * @param AbstractQuery $query
      * @param Response      $response
@@ -102,7 +108,7 @@ class Result implements ResultInterface
                     $this->data = json_decode($this->response->getBody(), true);
                     break;
                 default:
-                    throw new RuntimeException('Responseparser cannot handle '.$this->query->getResponseWriter());
+                    throw new RuntimeException(sprintf('Responseparser cannot handle %s', $this->query->getResponseWriter()));
             }
 
             if (null === $this->data) {

--- a/src/Core/Query/Result/ResultInterface.php
+++ b/src/Core/Query/Result/ResultInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Core\Query\Result;
 
 use Solarium\Core\Client\Response;

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Exception;
 
 /**

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Exception;
 
 /**

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Exception;
 
 /**

--- a/src/Exception/LogicExceptionInterface.php
+++ b/src/Exception/LogicExceptionInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Exception;
 
 /**

--- a/src/Exception/OutOfBoundsException.php
+++ b/src/Exception/OutOfBoundsException.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Exception;
 
 /**

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Exception;
 
 /**

--- a/src/Exception/RuntimeExceptionInterface.php
+++ b/src/Exception/RuntimeExceptionInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Exception;
 
 /**

--- a/src/Exception/StreamException.php
+++ b/src/Exception/StreamException.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Exception;
 
 /**

--- a/src/Exception/StreamException.php
+++ b/src/Exception/StreamException.php
@@ -24,7 +24,7 @@ class StreamException extends \UnexpectedValueException implements RuntimeExcept
      *
      * @param string $expression
      */
-    public function setExpression(string $expression)
+    public function setExpression(string $expression): void
     {
         $this->expression = $expression;
     }

--- a/src/Exception/UnexpectedValueException.php
+++ b/src/Exception/UnexpectedValueException.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Exception;
 
 /**

--- a/src/Plugin/BufferedAdd/BufferedAdd.php
+++ b/src/Plugin/BufferedAdd/BufferedAdd.php
@@ -1,15 +1,22 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\BufferedAdd;
 
 use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Plugin\AbstractPlugin;
+use Solarium\Core\Query\DocumentInterface;
 use Solarium\Plugin\BufferedAdd\Event\AddDocument as AddDocumentEvent;
 use Solarium\Plugin\BufferedAdd\Event\PostCommit as PostCommitEvent;
 use Solarium\Plugin\BufferedAdd\Event\PostFlush as PostFlushEvent;
 use Solarium\Plugin\BufferedAdd\Event\PreCommit as PreCommitEvent;
 use Solarium\Plugin\BufferedAdd\Event\PreFlush as PreFlushEvent;
-use Solarium\Core\Query\DocumentInterface;
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 use Solarium\QueryType\Update\Result as UpdateResult;
 
@@ -54,6 +61,7 @@ class BufferedAdd extends AbstractPlugin
     public function setEndpoint(Endpoint $endpoint): self
     {
         $this->setOption('endpoint', $endpoint);
+
         return $this;
     }
 
@@ -77,6 +85,7 @@ class BufferedAdd extends AbstractPlugin
     public function setBufferSize(int $size): self
     {
         $this->setOption('buffersize', $size);
+
         return $this;
     }
 
@@ -100,6 +109,7 @@ class BufferedAdd extends AbstractPlugin
     public function setCommitWithin(int $time): self
     {
         $this->setOption('commitwithin', $time);
+
         return $this;
     }
 
@@ -123,6 +133,7 @@ class BufferedAdd extends AbstractPlugin
     public function setOverwrite(bool $value): self
     {
         $this->setOption('overwrite', $value);
+
         return $this;
     }
 
@@ -166,7 +177,7 @@ class BufferedAdd extends AbstractPlugin
         $event = new AddDocumentEvent($document);
         $this->client->getEventDispatcher()->dispatch($event);
 
-        if (count($this->buffer) == $this->options['buffersize']) {
+        if (\count($this->buffer) === $this->options['buffersize']) {
             $this->flush();
         }
 
@@ -224,7 +235,7 @@ class BufferedAdd extends AbstractPlugin
      */
     public function flush(?bool $overwrite = null, ?int $commitWithin = null)
     {
-        if (0 == count($this->buffer)) {
+        if (0 === \count($this->buffer)) {
             // nothing to do
             return false;
         }

--- a/src/Plugin/BufferedAdd/BufferedAdd.php
+++ b/src/Plugin/BufferedAdd/BufferedAdd.php
@@ -268,7 +268,7 @@ class BufferedAdd extends AbstractPlugin
      *
      * @return UpdateResult
      */
-    public function commit(?bool $overwrite = null, ?bool $softCommit = null, ?bool $waitSearcher = null, ?bool $expungeDeletes = null)
+    public function commit(?bool $overwrite = null, ?bool $softCommit = null, ?bool $waitSearcher = null, ?bool $expungeDeletes = null): UpdateResult
     {
         $overwrite = $overwrite ?? $this->getOverwrite();
 
@@ -292,7 +292,7 @@ class BufferedAdd extends AbstractPlugin
      * This is an extension point for plugin implementations.
      * Will be called as soon as $this->client and options have been set.
      */
-    protected function initPluginType()
+    protected function initPluginType(): void
     {
         $this->updateQuery = $this->client->createUpdate();
     }

--- a/src/Plugin/BufferedAdd/Event/AddDocument.php
+++ b/src/Plugin/BufferedAdd/Event/AddDocument.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\BufferedAdd\Event;
 
 use Solarium\Core\Query\DocumentInterface;

--- a/src/Plugin/BufferedAdd/Event/Events.php
+++ b/src/Plugin/BufferedAdd/Event/Events.php
@@ -2,12 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\BufferedAdd\Event;
 
 /**
  * Event definitions.
  */
-interface Events
+class Events
 {
     /**
      * This event is called before a buffer flush.
@@ -53,4 +60,11 @@ interface Events
      * @var string
      */
     public const ADD_DOCUMENT = AddDocument::class;
+
+    /**
+     * Not instantiable.
+     */
+    private function __construct()
+    {
+    }
 }

--- a/src/Plugin/BufferedAdd/Event/Events.php
+++ b/src/Plugin/BufferedAdd/Event/Events.php
@@ -13,6 +13,8 @@ namespace Solarium\Plugin\BufferedAdd\Event;
 
 /**
  * Event definitions.
+ *
+ * @codeCoverageIgnore
  */
 class Events
 {

--- a/src/Plugin/BufferedAdd/Event/PostCommit.php
+++ b/src/Plugin/BufferedAdd/Event/PostCommit.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\BufferedAdd\Event;
 
 use Solarium\QueryType\Update\Result;

--- a/src/Plugin/BufferedAdd/Event/PostFlush.php
+++ b/src/Plugin/BufferedAdd/Event/PostFlush.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\BufferedAdd\Event;
 
 use Solarium\QueryType\Update\Result;

--- a/src/Plugin/BufferedAdd/Event/PreCommit.php
+++ b/src/Plugin/BufferedAdd/Event/PreCommit.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\BufferedAdd\Event;
 
 use Solarium\Core\Query\DocumentInterface;

--- a/src/Plugin/BufferedAdd/Event/PreFlush.php
+++ b/src/Plugin/BufferedAdd/Event/PreFlush.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\BufferedAdd\Event;
 
 use Solarium\Core\Query\DocumentInterface;

--- a/src/Plugin/CustomizeRequest/Customization.php
+++ b/src/Plugin/CustomizeRequest/Customization.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\CustomizeRequest;
 
 use Solarium\Core\Configurable;

--- a/src/Plugin/CustomizeRequest/CustomizeRequest.php
+++ b/src/Plugin/CustomizeRequest/CustomizeRequest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\CustomizeRequest;
 
 use Solarium\Core\Event\Events;
@@ -39,7 +46,7 @@ class CustomizeRequest extends AbstractPlugin
      */
     public function createCustomization($options = null): Customization
     {
-        if (is_string($options)) {
+        if (\is_string($options)) {
             $fq = new Customization();
             $fq->setKey($options);
         } else {
@@ -59,7 +66,6 @@ class CustomizeRequest extends AbstractPlugin
      * Supports a Customization instance or a config array, in that case a new
      * Customization instance wil be created based on the options.
      *
-     *
      * @param Customization|array $customization
      *
      * @throws InvalidArgumentException
@@ -68,19 +74,19 @@ class CustomizeRequest extends AbstractPlugin
      */
     public function addCustomization($customization): self
     {
-        if (is_array($customization)) {
+        if (\is_array($customization)) {
             $customization = new Customization($customization);
         }
 
         $key = $customization->getKey();
 
         // check for non-empty key
-        if (0 === strlen($key)) {
+        if (0 === \strlen($key)) {
             throw new InvalidArgumentException('A Customization must have a key value');
         }
 
         // check for a unique key
-        if (array_key_exists($key, $this->customizations)) {
+        if (\array_key_exists($key, $this->customizations)) {
             //double add calls for the same customization are ignored, others cause an exception
             if ($this->customizations[$key] !== $customization) {
                 throw new InvalidArgumentException('A Customization must have a unique key value');
@@ -103,7 +109,7 @@ class CustomizeRequest extends AbstractPlugin
     {
         foreach ($customizations as $key => $customization) {
             // in case of a config array: add key to config
-            if (is_array($customization) && !isset($customization['key'])) {
+            if (\is_array($customization) && !isset($customization['key'])) {
                 $customization['key'] = $key;
             }
 
@@ -146,7 +152,7 @@ class CustomizeRequest extends AbstractPlugin
      */
     public function removeCustomization($customization): self
     {
-        if (is_object($customization)) {
+        if (\is_object($customization)) {
             $customization = $customization->getKey();
         }
 
@@ -182,6 +188,7 @@ class CustomizeRequest extends AbstractPlugin
     {
         $this->clearCustomizations();
         $this->addCustomizations($customizations);
+
         return $this;
     }
 
@@ -202,7 +209,7 @@ class CustomizeRequest extends AbstractPlugin
         foreach ($this->getCustomizations() as $key => $customization) {
             // first validate
             if (!$customization->isValid()) {
-                throw new RuntimeException('Request customization with key "'.$key.'" is invalid');
+                throw new RuntimeException(sprintf('Request customization with key "%s" is invalid', $key));
             }
 
             // apply to request, depending on type

--- a/src/Plugin/Loadbalancer/Event/EndpointFailure.php
+++ b/src/Plugin/Loadbalancer/Event/EndpointFailure.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\Loadbalancer\Event;
 
 use Solarium\Core\Client\Endpoint;

--- a/src/Plugin/Loadbalancer/Event/Events.php
+++ b/src/Plugin/Loadbalancer/Event/Events.php
@@ -11,6 +11,8 @@ namespace Solarium\Plugin\Loadbalancer\Event;
 
 /**
  * Event definitions.
+ *
+ * @codeCoverageIgnore
  */
 class Events
 {

--- a/src/Plugin/Loadbalancer/Event/Events.php
+++ b/src/Plugin/Loadbalancer/Event/Events.php
@@ -1,11 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\Loadbalancer\Event;
 
 /**
  * Event definitions.
  */
-interface Events
+class Events
 {
     /**
      * This event is called after and endpoint has failed.
@@ -15,4 +22,11 @@ interface Events
      * @var string
      */
     public const ENDPOINT_FAILURE = EndpointFailure::class;
+
+    /**
+     * Not instantiable.
+     */
+    private function __construct()
+    {
+    }
 }

--- a/src/Plugin/Loadbalancer/Loadbalancer.php
+++ b/src/Plugin/Loadbalancer/Loadbalancer.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\Loadbalancer;
 
 use Solarium\Core\Client\Client;
@@ -62,7 +69,7 @@ class Loadbalancer extends AbstractPlugin
      *
      * The value can be null if no queries have been executed, or if the last executed query didn't use loadbalancing.
      *
-     * @var null|string
+     * @var string|null
      */
     protected $lastEndpoint;
 
@@ -114,6 +121,7 @@ class Loadbalancer extends AbstractPlugin
     public function setFailoverEnabled(bool $value): self
     {
         $this->setOption('failoverenabled', $value);
+
         return $this;
     }
 
@@ -137,6 +145,7 @@ class Loadbalancer extends AbstractPlugin
     public function setFailoverMaxRetries(int $value): self
     {
         $this->setOption('failovermaxretries', $value);
+
         return $this;
     }
 
@@ -153,7 +162,6 @@ class Loadbalancer extends AbstractPlugin
     /**
      * Add an endpoint to the loadbalacing 'pool'.
      *
-     *
      * @param Endpoint|string $endpoint
      * @param int             $weight   Must be a positive number
      *
@@ -163,11 +171,11 @@ class Loadbalancer extends AbstractPlugin
      */
     public function addEndpoint($endpoint, int $weight = 1): self
     {
-        if (!is_string($endpoint)) {
+        if (!\is_string($endpoint)) {
             $endpoint = $endpoint->getKey();
         }
 
-        if (array_key_exists($endpoint, $this->endpoints)) {
+        if (\array_key_exists($endpoint, $this->endpoints)) {
             throw new InvalidArgumentException('An endpoint for the loadbalancer plugin must have a unique key');
         }
 
@@ -226,7 +234,7 @@ class Loadbalancer extends AbstractPlugin
      */
     public function removeEndpoint($endpoint): self
     {
-        if (!is_string($endpoint)) {
+        if (!\is_string($endpoint)) {
             $endpoint = $endpoint->getKey();
         }
 
@@ -250,6 +258,7 @@ class Loadbalancer extends AbstractPlugin
     {
         $this->clearEndpoints();
         $this->addEndpoints($endpoints);
+
         return $this;
     }
 
@@ -262,8 +271,7 @@ class Loadbalancer extends AbstractPlugin
      * If the next query cannot be loadbalanced (for instance based on the querytype) this setting is ignored
      * but will still be reset.
      *
-     *
-     * @param string|null|Endpoint $endpoint
+     * @param string|Endpoint|null $endpoint
      *
      * @throws OutOfBoundsException
      *
@@ -271,11 +279,11 @@ class Loadbalancer extends AbstractPlugin
      */
     public function setForcedEndpointForNextQuery($endpoint): self
     {
-        if (!is_string($endpoint)) {
+        if (!\is_string($endpoint)) {
             $endpoint = $endpoint->getKey();
         }
 
-        if (null !== $endpoint && !array_key_exists($endpoint, $this->endpoints)) {
+        if (null !== $endpoint && !\array_key_exists($endpoint, $this->endpoints)) {
             throw new OutOfBoundsException('Unknown endpoint forced for next query');
         }
 
@@ -330,7 +338,7 @@ class Loadbalancer extends AbstractPlugin
      */
     public function addBlockedQueryType(string $type): self
     {
-        if (!array_key_exists($type, $this->blockedQueryTypes)) {
+        if (!\array_key_exists($type, $this->blockedQueryTypes)) {
             $this->blockedQueryTypes[$type] = true;
         }
 
@@ -364,9 +372,10 @@ class Loadbalancer extends AbstractPlugin
      */
     public function removeBlockedQueryType(string $type): self
     {
-        if (array_key_exists($type, $this->blockedQueryTypes)) {
+        if (\array_key_exists($type, $this->blockedQueryTypes)) {
             unset($this->blockedQueryTypes[$type]);
         }
+
         return $this;
     }
 
@@ -378,6 +387,7 @@ class Loadbalancer extends AbstractPlugin
     public function clearBlockedQueryTypes(): self
     {
         $this->blockedQueryTypes = [];
+
         return $this;
     }
 
@@ -405,6 +415,7 @@ class Loadbalancer extends AbstractPlugin
         // We need to accept event proxies or decoraters.
         /* @var PreCreateRequest $event */
         $this->queryType = $event->getQuery()->getType();
+
         return $this;
     }
 
@@ -427,7 +438,7 @@ class Loadbalancer extends AbstractPlugin
         }
 
         // check querytype: is loadbalancing allowed?
-        if (!array_key_exists($this->queryType, $this->blockedQueryTypes)) {
+        if (!\array_key_exists($this->queryType, $this->blockedQueryTypes)) {
             $response = $this->getLoadbalancedResponse($event->getRequest());
         } else {
             $endpoint = $this->client->getEndpoint($this->defaultEndpoint);
@@ -444,7 +455,6 @@ class Loadbalancer extends AbstractPlugin
 
     /**
      * Execute a request using the adapter.
-     *
      *
      * @param Request $request
      *

--- a/src/Plugin/Loadbalancer/SolrCloudLoadbalancer.php
+++ b/src/Plugin/Loadbalancer/SolrCloudLoadbalancer.php
@@ -1,7 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\Loadbalancer;
 
+/**
+ * SolrCloud Loadbalancer.
+ */
 class SolrCloudLoadbalancer
 {
 }

--- a/src/Plugin/Loadbalancer/WeightedRandomChoice.php
+++ b/src/Plugin/Loadbalancer/WeightedRandomChoice.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\Loadbalancer;
 
 use Solarium\Exception\InvalidArgumentException;
@@ -36,7 +43,6 @@ class WeightedRandomChoice
     /**
      * Constructor.
      *
-     *
      * @param array $choices
      *
      * @throws InvalidArgumentException
@@ -60,7 +66,6 @@ class WeightedRandomChoice
     /**
      * Get a (weighted) random entry.
      *
-     *
      * @param array $excludes Keys to exclude
      *
      * @throws RuntimeException
@@ -69,7 +74,7 @@ class WeightedRandomChoice
      */
     public function getRandom(array $excludes = []): string
     {
-        if (count($excludes) == count($this->values)) {
+        if (\count($excludes) === \count($this->values)) {
             throw new RuntimeException('No more server entries available');
         }
 
@@ -77,7 +82,7 @@ class WeightedRandomChoice
         $result = null;
         while (1) {
             $result = $this->values[$this->getKey()];
-            if (!in_array($result, $excludes, true)) {
+            if (!\in_array($result, $excludes, true)) {
                 break;
             }
         }
@@ -95,7 +100,7 @@ class WeightedRandomChoice
         // We don't need cryptographically secure values, therefore mt_rand is the better choice over random_int().
         /** @noinspection RandomApiMigrationInspection */
         $random = mt_rand(1, $this->totalWeight);
-        $high = count($this->lookup) - 1;
+        $high = \count($this->lookup) - 1;
         $low = 0;
 
         while ($low < $high) {

--- a/src/Plugin/MinimumScoreFilter/Document.php
+++ b/src/Plugin/MinimumScoreFilter/Document.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\MinimumScoreFilter;
 
 use Solarium\Core\Query\DocumentInterface;
@@ -85,9 +92,9 @@ class Document implements DocumentInterface, \IteratorAggregate, \Countable, \Ar
      * @param string $name
      * @param string $value
      *
-     * @return self
-     *
      * @throws RuntimeException
+     *
+     * @return self
      */
     public function __set($name, $value): self
     {

--- a/src/Plugin/MinimumScoreFilter/Document.php
+++ b/src/Plugin/MinimumScoreFilter/Document.php
@@ -148,7 +148,7 @@ class Document implements DocumentInterface, \IteratorAggregate, \Countable, \Ar
      *
      * @param mixed $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->document->offsetUnset($offset);
     }
@@ -171,7 +171,7 @@ class Document implements DocumentInterface, \IteratorAggregate, \Countable, \Ar
      * @param mixed $offset
      * @param mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->__set($offset, $value);
     }

--- a/src/Plugin/MinimumScoreFilter/Filter.php
+++ b/src/Plugin/MinimumScoreFilter/Filter.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\MinimumScoreFilter;
 
 use Solarium\Exception\OutOfBoundsException;
@@ -37,7 +44,7 @@ class Filter
                 }
                 break;
             default:
-                throw new OutOfBoundsException('Unknown filter mode in query: '.$mode);
+                throw new OutOfBoundsException(sprintf('Unknown filter mode in query: %s', $mode));
                 break;
         }
 

--- a/src/Plugin/MinimumScoreFilter/MinimumScoreFilter.php
+++ b/src/Plugin/MinimumScoreFilter/MinimumScoreFilter.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\MinimumScoreFilter;
 
 use Solarium\Core\Plugin\AbstractPlugin;

--- a/src/Plugin/MinimumScoreFilter/Query.php
+++ b/src/Plugin/MinimumScoreFilter/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\MinimumScoreFilter;
 
 use Solarium\Component\AbstractComponent;
@@ -50,6 +57,7 @@ class Query extends SelectQuery
     public function setFilterMode(string $mode): self
     {
         $this->setOption('filter_mode', $mode);
+
         return $this;
     }
 
@@ -75,6 +83,7 @@ class Query extends SelectQuery
     public function setFilterRatio(float $value): self
     {
         $this->setOption('filterratio', $value);
+
         return $this;
     }
 
@@ -96,7 +105,7 @@ class Query extends SelectQuery
     public function getFields(): array
     {
         $fields = parent::getFields();
-        if (!in_array('score', $fields, true)) {
+        if (!\in_array('score', $fields, true)) {
             $fields[] = 'score';
         }
 

--- a/src/Plugin/MinimumScoreFilter/QueryGroupResult.php
+++ b/src/Plugin/MinimumScoreFilter/QueryGroupResult.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\MinimumScoreFilter;
 
 use Solarium\Component\Result\Grouping\QueryGroup as StandardQueryGroupResult;

--- a/src/Plugin/MinimumScoreFilter/Result.php
+++ b/src/Plugin/MinimumScoreFilter/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\MinimumScoreFilter;
 
 use Solarium\QueryType\Select\Result\Result as SelectResult;

--- a/src/Plugin/MinimumScoreFilter/ValueGroupResult.php
+++ b/src/Plugin/MinimumScoreFilter/ValueGroupResult.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\MinimumScoreFilter;
 
 use Solarium\Component\Result\Grouping\ValueGroup as StandardValueGroup;

--- a/src/Plugin/ParallelExecution/Event/Events.php
+++ b/src/Plugin/ParallelExecution/Event/Events.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\ParallelExecution\Event;
 
 /**
@@ -7,7 +14,7 @@ namespace Solarium\Plugin\ParallelExecution\Event;
  *
  * @codeCoverageIgnore
  */
-interface Events
+class Events
 {
     /**
      * This event is called just before parallel HTTP request execution, but after init work.
@@ -24,4 +31,11 @@ interface Events
      * @var string
      */
     public const EXECUTE_END = ExecuteEnd::class;
+
+    /**
+     * Not instantiable.
+     */
+    private function __construct()
+    {
+    }
 }

--- a/src/Plugin/ParallelExecution/Event/ExecuteEnd.php
+++ b/src/Plugin/ParallelExecution/Event/ExecuteEnd.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\ParallelExecution\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;

--- a/src/Plugin/ParallelExecution/Event/ExecuteStart.php
+++ b/src/Plugin/ParallelExecution/Event/ExecuteStart.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\ParallelExecution\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;

--- a/src/Plugin/ParallelExecution/ParallelExecution.php
+++ b/src/Plugin/ParallelExecution/ParallelExecution.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin\ParallelExecution;
 
 use Solarium\Component\QueryInterface;
@@ -45,13 +52,13 @@ class ParallelExecution extends AbstractPlugin
      *
      * @param string               $key
      * @param QueryInterface       $query
-     * @param null|string|Endpoint $endpoint
+     * @param string|Endpoint|null $endpoint
      *
      * @return self Provides fluent interface
      */
     public function addQuery(string $key, QueryInterface $query, $endpoint = null)
     {
-        if (is_object($endpoint)) {
+        if (\is_object($endpoint)) {
             $endpoint = $endpoint->getKey();
         }
 
@@ -94,9 +101,9 @@ class ParallelExecution extends AbstractPlugin
     /**
      * Execute queries parallel.
      *
-     * @return \Solarium\Core\Query\Result\Result[]
-     *
      * @throws RuntimeException
+     *
+     * @return \Solarium\Core\Query\Result\Result[]
      */
     public function execute(): array
     {
@@ -121,17 +128,17 @@ class ParallelExecution extends AbstractPlugin
 
         do {
             $mrc = curl_multi_exec($multiHandle, $active);
-        } while (CURLM_CALL_MULTI_PERFORM == $mrc);
+        } while (CURLM_CALL_MULTI_PERFORM === $mrc);
 
         $timeout = $this->getOption('curlmultiselecttimeout');
-        while ($active && CURLM_OK == $mrc) {
+        while ($active && CURLM_OK === $mrc) {
             if (-1 === curl_multi_select($multiHandle, $timeout)) {
                 usleep(100);
             }
 
             do {
                 $mrc = curl_multi_exec($multiHandle, $active);
-            } while (CURLM_CALL_MULTI_PERFORM == $mrc);
+            } while (CURLM_CALL_MULTI_PERFORM === $mrc);
         }
 
         $event = new ExecuteEndEvent();

--- a/src/Plugin/PostBigRequest.php
+++ b/src/Plugin/PostBigRequest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin;
 
 use Solarium\Core\Client\Request;
@@ -38,6 +45,7 @@ class PostBigRequest extends AbstractPlugin
     public function setMaxQueryStringLength(int $value): self
     {
         $this->setOption('maxquerystringlength', $value);
+
         return $this;
     }
 
@@ -65,8 +73,8 @@ class PostBigRequest extends AbstractPlugin
         $request = $event->getRequest();
         $queryString = $request->getQueryString();
 
-        if (Request::METHOD_GET == $request->getMethod() &&
-            strlen($queryString) > $this->getMaxQueryStringLength()) {
+        if (Request::METHOD_GET === $request->getMethod() &&
+            \strlen($queryString) > $this->getMaxQueryStringLength()) {
             $charset = $request->getParam('ie') ?? 'utf-8';
 
             $request->setMethod(Request::METHOD_POST);
@@ -74,6 +82,7 @@ class PostBigRequest extends AbstractPlugin
             $request->clearParams();
             $request->addHeader('Content-Type: application/x-www-form-urlencoded; charset='.$charset);
         }
+
         return $this;
     }
 

--- a/src/Plugin/PrefetchIterator.php
+++ b/src/Plugin/PrefetchIterator.php
@@ -169,7 +169,7 @@ class PrefetchIterator extends AbstractPlugin implements \Iterator, \Countable
     /**
      * Iterator implementation.
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
 
@@ -208,7 +208,7 @@ class PrefetchIterator extends AbstractPlugin implements \Iterator, \Countable
     /**
      * Iterator implementation.
      */
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }

--- a/src/Plugin/PrefetchIterator.php
+++ b/src/Plugin/PrefetchIterator.php
@@ -1,11 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Plugin;
 
 use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Plugin\AbstractPlugin;
-use Solarium\QueryType\Select\Query\Query as SelectQuery;
 use Solarium\Core\Query\DocumentInterface;
+use Solarium\QueryType\Select\Query\Query as SelectQuery;
 use Solarium\QueryType\Select\Result\Result as SelectResult;
 
 /**
@@ -79,6 +86,7 @@ class PrefetchIterator extends AbstractPlugin implements \Iterator, \Countable
         $this->resetData();
 
         $this->setOption('prefetch', $value);
+
         return $this;
     }
 
@@ -129,6 +137,7 @@ class PrefetchIterator extends AbstractPlugin implements \Iterator, \Countable
     public function setEndpoint($endpoint): self
     {
         $this->setOption('endpoint', $endpoint);
+
         return $this;
     }
 

--- a/src/QueryType/Analysis/Query/AbstractQuery.php
+++ b/src/QueryType/Analysis/Query/AbstractQuery.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Analysis\Query;
 
 use Solarium\Component\QueryInterface;
@@ -23,6 +30,7 @@ abstract class AbstractQuery extends BaseQuery implements QueryInterface
     public function setShowMatch(bool $show): self
     {
         $this->setOption('showmatch', $show);
+
         return $this;
     }
 

--- a/src/QueryType/Analysis/Query/Document.php
+++ b/src/QueryType/Analysis/Query/Document.php
@@ -1,15 +1,22 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Analysis\Query;
 
 use Solarium\Core\Client\Client;
+use Solarium\Core\Query\DocumentInterface;
 use Solarium\Core\Query\RequestBuilderInterface;
 use Solarium\Core\Query\ResponseParserInterface;
 use Solarium\Exception\RuntimeException;
 use Solarium\QueryType\Analysis\RequestBuilder\Document as RequestBuilder;
 use Solarium\QueryType\Analysis\ResponseParser\Document as ResponseParser;
 use Solarium\QueryType\Analysis\Result\Document as ResultDocument;
-use Solarium\Core\Query\DocumentInterface;
 
 /**
  * Analysis document query.

--- a/src/QueryType/Analysis/Query/Field.php
+++ b/src/QueryType/Analysis/Query/Field.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Analysis\Query;
 
 use Solarium\Core\Client\Client;
@@ -66,6 +73,7 @@ class Field extends AbstractQuery
     public function setFieldValue(string $value): self
     {
         $this->setOption('fieldvalue', $value);
+
         return  $this;
     }
 
@@ -91,6 +99,7 @@ class Field extends AbstractQuery
     public function setFieldType(string $type): self
     {
         $this->setOption('fieldtype', $type);
+
         return $this;
     }
 
@@ -116,6 +125,7 @@ class Field extends AbstractQuery
     public function setFieldName(string $name): self
     {
         $this->setOption('fieldname', $name);
+
         return $this;
     }
 

--- a/src/QueryType/Analysis/RequestBuilder/Document.php
+++ b/src/QueryType/Analysis/RequestBuilder/Document.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Analysis\RequestBuilder;
 
 use Solarium\Core\Client\Request;
@@ -44,7 +51,7 @@ class Document extends BaseRequestBuilder
             $xml .= '<doc>';
 
             foreach ($doc->getFields() as $name => $value) {
-                if (is_array($value)) {
+                if (\is_array($value)) {
                     foreach ($value as $multival) {
                         $xml .= $this->buildFieldXml($name, $multival);
                     }

--- a/src/QueryType/Analysis/RequestBuilder/Field.php
+++ b/src/QueryType/Analysis/RequestBuilder/Field.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Analysis\RequestBuilder;
 
 use Solarium\Core\Client\Request;

--- a/src/QueryType/Analysis/RequestBuilder/RequestBuilder.php
+++ b/src/QueryType/Analysis/RequestBuilder/RequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Analysis\RequestBuilder;
 
 use Solarium\Core\Client\Request;

--- a/src/QueryType/Analysis/ResponseParser/Document.php
+++ b/src/QueryType/Analysis/ResponseParser/Document.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Analysis\ResponseParser;
 
 use Solarium\Core\Query\Result\ResultInterface;

--- a/src/QueryType/Analysis/ResponseParser/Field.php
+++ b/src/QueryType/Analysis/ResponseParser/Field.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Analysis\ResponseParser;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
@@ -70,9 +77,9 @@ class Field extends ResponseParserAbstract implements ResponseParserInterface
         foreach ($data as $fieldKey => $fieldData) {
             $types = [];
             foreach ($fieldData as $typeKey => $typeData) {
-                if ($query->getResponseWriter() == $query::WT_JSON) {
+                if ($query->getResponseWriter() === $query::WT_JSON) {
                     // fix for extra level for key fields
-                    if (1 == count($typeData)) {
+                    if (1 === \count($typeData)) {
                         $typeData = current($typeData);
                     }
                     $typeData = $this->convertToKeyValueArray($typeData);
@@ -80,7 +87,7 @@ class Field extends ResponseParserAbstract implements ResponseParserInterface
 
                 $classes = [];
                 foreach ($typeData as $class => $analysis) {
-                    if (is_string($analysis)) {
+                    if (\is_string($analysis)) {
                         $item = new Item(
                             [
                                 'text' => $analysis,

--- a/src/QueryType/Analysis/Result/Document.php
+++ b/src/QueryType/Analysis/Result/Document.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Analysis\Result;
 
 use Solarium\Core\Query\Result\QueryType as BaseResult;
@@ -95,7 +102,7 @@ class Document extends BaseResult implements \IteratorAggregate, \Countable
     {
         $this->parseResponse();
 
-        return count($this->items);
+        return \count($this->items);
     }
 
     /**

--- a/src/QueryType/Analysis/Result/Field.php
+++ b/src/QueryType/Analysis/Result/Field.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Analysis\Result;
 
 use Solarium\Core\Query\Result\QueryType as BaseResult;
@@ -95,6 +102,6 @@ class Field extends BaseResult implements \IteratorAggregate, \Countable
     {
         $this->parseResponse();
 
-        return count($this->items);
+        return \count($this->items);
     }
 }

--- a/src/QueryType/Analysis/Result/Item.php
+++ b/src/QueryType/Analysis/Result/Item.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Analysis\Result;
 
 /**
@@ -145,7 +152,7 @@ class Item
      */
     public function getPositionHistory(): array
     {
-        if (is_array($this->positionHistory)) {
+        if (\is_array($this->positionHistory)) {
             return $this->positionHistory;
         }
 

--- a/src/QueryType/Analysis/Result/ResultList.php
+++ b/src/QueryType/Analysis/Result/ResultList.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Analysis\Result;
 
 /**
@@ -70,6 +77,6 @@ class ResultList implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->items);
+        return \count($this->items);
     }
 }

--- a/src/QueryType/Analysis/Result/Types.php
+++ b/src/QueryType/Analysis/Result/Types.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Analysis\Result;
 
 /**
@@ -26,6 +33,7 @@ class Types extends ResultList
                 return $item;
             }
         }
+
         return null;
     }
 
@@ -41,6 +49,7 @@ class Types extends ResultList
                 return $item;
             }
         }
+
         return null;
     }
 }

--- a/src/QueryType/Extract/Query.php
+++ b/src/QueryType/Extract/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Extract;
 
 use Solarium\Core\Client\Client;

--- a/src/QueryType/Extract/RequestBuilder.php
+++ b/src/QueryType/Extract/RequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Extract;
 
 use Solarium\Core\Client\Request;
@@ -15,7 +22,6 @@ class RequestBuilder extends BaseRequestBuilder
 {
     /**
      * Build the request.
-     *
      *
      * @param Query|QueryInterface $query
      *

--- a/src/QueryType/Extract/Result.php
+++ b/src/QueryType/Extract/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Extract;
 
 use Solarium\QueryType\Update\Result as UpdateResult;

--- a/src/QueryType/Graph/Query.php
+++ b/src/QueryType/Graph/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Graph;
 
 use Solarium\Core\Client\Client;
@@ -45,6 +52,8 @@ class Query extends AbstractQuery
 
     /**
      * No response parser required since we pass through GraphML.
+     *
+     * @return \Solarium\Core\Query\ResponseParserInterface|null
      */
     public function getResponseParser(): ?ResponseParserInterface
     {
@@ -61,6 +70,7 @@ class Query extends AbstractQuery
     public function setExpression(string $expr): self
     {
         $this->setOption('expr', $expr);
+
         return $this;
     }
 

--- a/src/QueryType/Graph/Result.php
+++ b/src/QueryType/Graph/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Graph;
 
 use Solarium\Core\Query\Result\Result as BaseResult;

--- a/src/QueryType/ManagedResources/Query/AbstractCommand.php
+++ b/src/QueryType/ManagedResources/Query/AbstractCommand.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query;
 
 use Solarium\Core\Configurable;

--- a/src/QueryType/ManagedResources/Query/InitArgsInterface.php
+++ b/src/QueryType/ManagedResources/Query/InitArgsInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query;
 
 /**

--- a/src/QueryType/ManagedResources/Query/Resources.php
+++ b/src/QueryType/ManagedResources/Query/Resources.php
@@ -1,24 +1,27 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query;
 
 use Solarium\Core\Client\Client;
+use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\RequestBuilderInterface;
 use Solarium\Core\Query\ResponseParserInterface;
 use Solarium\QueryType\ManagedResources\RequestBuilder\Resources as RequestBuilder;
 use Solarium\QueryType\ManagedResources\ResponseParser\Resources as ResponseParser;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\QueryType\ManagedResources\Result\Resources\ResourceList;
 
+/**
+ * Resources.
+ */
 class Resources extends AbstractQuery
 {
-    /**
-     * Fixed name for resources.
-     *
-     * @var string
-     */
-    private $name = 'resources';
-
     /**
      * Default options.
      *
@@ -29,6 +32,13 @@ class Resources extends AbstractQuery
         'resultclass' => ResourceList::class,
         'omitheader' => true,
     ];
+
+    /**
+     * Fixed name for resources.
+     *
+     * @var string
+     */
+    private $name = 'resources';
 
     /**
      * Get the name of resources.

--- a/src/QueryType/ManagedResources/Query/Stopwords.php
+++ b/src/QueryType/ManagedResources/Query/Stopwords.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query;
 
 use Solarium\Core\Client\Client;
@@ -17,6 +24,9 @@ use Solarium\QueryType\ManagedResources\RequestBuilder\Stopwords as RequestBuild
 use Solarium\QueryType\ManagedResources\ResponseParser\Stopwords as ResponseParser;
 use Solarium\QueryType\ManagedResources\Result\Stopwords\WordSet;
 
+/**
+ * Stopwords.
+ */
 class Stopwords extends BaseQuery
 {
     /**
@@ -138,6 +148,7 @@ class Stopwords extends BaseQuery
     public function setName(string $name): self
     {
         $this->name = $name;
+
         return $this;
     }
 
@@ -156,7 +167,7 @@ class Stopwords extends BaseQuery
         $type = strtolower($type);
 
         if (!isset($this->commandTypes[$type])) {
-            throw new InvalidArgumentException('Stopwords commandtype unknown: '.$type);
+            throw new InvalidArgumentException(sprintf('Stopwords commandtype unknown: %s', $type));
         }
 
         $class = $this->commandTypes[$type];

--- a/src/QueryType/ManagedResources/Query/Stopwords/Command/Add.php
+++ b/src/QueryType/ManagedResources/Query/Stopwords/Command/Add.php
@@ -1,11 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Stopwords\Command;
 
 use Solarium\Core\Client\Request;
 use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\Stopwords;
 
+/**
+ * Add.
+ */
 class Add extends AbstractCommand
 {
     /**
@@ -55,6 +65,7 @@ class Add extends AbstractCommand
     public function setStopwords(array $stopwords): self
     {
         $this->stopwords = $stopwords;
+
         return $this;
     }
 

--- a/src/QueryType/ManagedResources/Query/Stopwords/Command/Config.php
+++ b/src/QueryType/ManagedResources/Query/Stopwords/Command/Config.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Stopwords\Command;
 
 use Solarium\Core\Client\Request;
@@ -7,6 +14,9 @@ use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\InitArgsInterface;
 use Solarium\QueryType\ManagedResources\Query\Stopwords;
 
+/**
+ * Config.
+ */
 class Config extends AbstractCommand
 {
     /**
@@ -56,6 +66,7 @@ class Config extends AbstractCommand
     public function setInitArgs(InitArgsInterface $initArgs): self
     {
         $this->initArgs = $initArgs;
+
         return $this;
     }
 

--- a/src/QueryType/ManagedResources/Query/Stopwords/Command/Create.php
+++ b/src/QueryType/ManagedResources/Query/Stopwords/Command/Create.php
@@ -1,11 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Stopwords\Command;
 
 use Solarium\Core\Client\Request;
 use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\Stopwords;
 
+/**
+ * Create.
+ */
 class Create extends AbstractCommand
 {
     /**
@@ -30,6 +40,8 @@ class Create extends AbstractCommand
 
     /**
      * Returns the raw data to be sent to Solr.
+     *
+     * @return string
      */
     public function getRawData(): string
     {

--- a/src/QueryType/ManagedResources/Query/Stopwords/Command/Delete.php
+++ b/src/QueryType/ManagedResources/Query/Stopwords/Command/Delete.php
@@ -1,11 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Stopwords\Command;
 
 use Solarium\Core\Client\Request;
 use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\Stopwords;
 
+/**
+ * Delete.
+ */
 class Delete extends AbstractCommand
 {
     /**
@@ -65,6 +75,7 @@ class Delete extends AbstractCommand
     public function setTerm(string $term): self
     {
         $this->term = $term;
+
         return $this;
     }
 }

--- a/src/QueryType/ManagedResources/Query/Stopwords/Command/Exists.php
+++ b/src/QueryType/ManagedResources/Query/Stopwords/Command/Exists.php
@@ -1,11 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Stopwords\Command;
 
 use Solarium\Core\Client\Request;
 use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\Stopwords;
 
+/**
+ * Exists.
+ */
 class Exists extends AbstractCommand
 {
     /**
@@ -65,6 +75,7 @@ class Exists extends AbstractCommand
     public function setTerm(string $term): self
     {
         $this->term = $term;
+
         return $this;
     }
 }

--- a/src/QueryType/ManagedResources/Query/Stopwords/Command/Remove.php
+++ b/src/QueryType/ManagedResources/Query/Stopwords/Command/Remove.php
@@ -1,11 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Stopwords\Command;
 
 use Solarium\Core\Client\Request;
 use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\Stopwords;
 
+/**
+ * Remove.
+ */
 class Remove extends AbstractCommand
 {
     /**
@@ -30,6 +40,8 @@ class Remove extends AbstractCommand
 
     /**
      * Returns the raw data to be sent to Solr.
+     *
+     * @return string
      */
     public function getRawData(): string
     {

--- a/src/QueryType/ManagedResources/Query/Stopwords/InitArgs.php
+++ b/src/QueryType/ManagedResources/Query/Stopwords/InitArgs.php
@@ -1,9 +1,19 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Stopwords;
 
 use Solarium\QueryType\ManagedResources\Query\InitArgsInterface;
 
+/**
+ * InitArgs.
+ */
 class InitArgs implements InitArgsInterface
 {
     /**
@@ -23,6 +33,7 @@ class InitArgs implements InitArgsInterface
     public function setIgnoreCase(bool $ignoreCase): InitArgsInterface
     {
         $this->ignoreCase = $ignoreCase;
+
         return $this;
     }
 

--- a/src/QueryType/ManagedResources/Query/Stopwords/Stopword.php
+++ b/src/QueryType/ManagedResources/Query/Stopwords/Stopword.php
@@ -1,7 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Stopwords;
 
+/**
+ * Stopword.
+ */
 class Stopword
 {
     /**
@@ -29,6 +39,7 @@ class Stopword
     public function setTerm(string $term): self
     {
         $this->term = $term;
+
         return $this;
     }
 }

--- a/src/QueryType/ManagedResources/Query/Synonyms.php
+++ b/src/QueryType/ManagedResources/Query/Synonyms.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query;
 
 use Solarium\Core\Client\Client;
@@ -17,6 +24,9 @@ use Solarium\QueryType\ManagedResources\RequestBuilder\Synonyms as RequestBuilde
 use Solarium\QueryType\ManagedResources\ResponseParser\Synonyms as ResponseParser;
 use Solarium\QueryType\ManagedResources\Result\Synonyms\SynonymMappings;
 
+/**
+ * Synonyms.
+ */
 class Synonyms extends BaseQuery
 {
     /**
@@ -181,7 +191,7 @@ class Synonyms extends BaseQuery
         $type = strtolower($type);
 
         if (!isset($this->commandTypes[$type])) {
-            throw new InvalidArgumentException('Synonyms commandtype unknown: '.$type);
+            throw new InvalidArgumentException(sprintf('Synonyms commandtype unknown: %s', $type));
         }
 
         $class = $this->commandTypes[$type];

--- a/src/QueryType/ManagedResources/Query/Synonyms/Command/Add.php
+++ b/src/QueryType/ManagedResources/Query/Synonyms/Command/Add.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Synonyms\Command;
 
 use Solarium\Core\Client\Request;
@@ -7,6 +14,9 @@ use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\Synonyms;
 use Solarium\QueryType\ManagedResources\Query\Synonyms\Synonyms as SynonymsData;
 
+/**
+ * Add.
+ */
 class Add extends AbstractCommand
 {
     /**
@@ -54,11 +64,14 @@ class Add extends AbstractCommand
     public function setSynonyms(SynonymsData $synonyms): self
     {
         $this->synonyms = $synonyms;
+
         return $this;
     }
 
     /**
      * Returns the raw data to be sent to Solr.
+     *
+     * @return string
      */
     public function getRawData(): string
     {

--- a/src/QueryType/ManagedResources/Query/Synonyms/Command/Config.php
+++ b/src/QueryType/ManagedResources/Query/Synonyms/Command/Config.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Synonyms\Command;
 
 use Solarium\Core\Client\Request;
@@ -7,6 +14,9 @@ use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\InitArgsInterface;
 use Solarium\QueryType\ManagedResources\Query\Synonyms;
 
+/**
+ * Config.
+ */
 class Config extends AbstractCommand
 {
     /**
@@ -56,6 +66,7 @@ class Config extends AbstractCommand
     public function setInitArgs(InitArgsInterface $initArgs): self
     {
         $this->initArgs = $initArgs;
+
         return $this;
     }
 

--- a/src/QueryType/ManagedResources/Query/Synonyms/Command/Create.php
+++ b/src/QueryType/ManagedResources/Query/Synonyms/Command/Create.php
@@ -1,11 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Synonyms\Command;
 
 use Solarium\Core\Client\Request;
 use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\Synonyms;
 
+/**
+ * Create.
+ */
 class Create extends AbstractCommand
 {
     /**
@@ -30,6 +40,8 @@ class Create extends AbstractCommand
 
     /**
      * Returns the raw data to be sent to Solr.
+     *
+     * @return string
      */
     public function getRawData(): string
     {

--- a/src/QueryType/ManagedResources/Query/Synonyms/Command/Delete.php
+++ b/src/QueryType/ManagedResources/Query/Synonyms/Command/Delete.php
@@ -1,11 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Synonyms\Command;
 
 use Solarium\Core\Client\Request;
 use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\Synonyms;
 
+/**
+ * Delete.
+ */
 class Delete extends AbstractCommand
 {
     /**
@@ -65,6 +75,7 @@ class Delete extends AbstractCommand
     public function setTerm(string $term): self
     {
         $this->term = $term;
+
         return $this;
     }
 }

--- a/src/QueryType/ManagedResources/Query/Synonyms/Command/Exists.php
+++ b/src/QueryType/ManagedResources/Query/Synonyms/Command/Exists.php
@@ -1,11 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Synonyms\Command;
 
 use Solarium\Core\Client\Request;
 use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\Synonyms;
 
+/**
+ * Exists.
+ */
 class Exists extends AbstractCommand
 {
     /**
@@ -65,6 +75,7 @@ class Exists extends AbstractCommand
     public function setTerm(string $term): self
     {
         $this->term = $term;
+
         return $this;
     }
 }

--- a/src/QueryType/ManagedResources/Query/Synonyms/Command/Remove.php
+++ b/src/QueryType/ManagedResources/Query/Synonyms/Command/Remove.php
@@ -1,11 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Synonyms\Command;
 
 use Solarium\Core\Client\Request;
 use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\Synonyms;
 
+/**
+ * Remove.
+ */
 class Remove extends AbstractCommand
 {
     /**
@@ -30,6 +40,8 @@ class Remove extends AbstractCommand
 
     /**
      * Returns the raw data to be sent to Solr.
+     *
+     * @return string
      */
     public function getRawData(): string
     {

--- a/src/QueryType/ManagedResources/Query/Synonyms/InitArgs.php
+++ b/src/QueryType/ManagedResources/Query/Synonyms/InitArgs.php
@@ -1,10 +1,20 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Synonyms;
 
 use Solarium\Exception\UnexpectedValueException;
 use Solarium\QueryType\ManagedResources\Query\InitArgsInterface;
 
+/**
+ * InitArgs.
+ */
 class InitArgs implements InitArgsInterface
 {
     /**
@@ -45,6 +55,7 @@ class InitArgs implements InitArgsInterface
     public function setIgnoreCase(bool $ignoreCase): InitArgsInterface
     {
         $this->ignoreCase = $ignoreCase;
+
         return $this;
     }
 
@@ -74,6 +85,7 @@ class InitArgs implements InitArgsInterface
         }
 
         $this->format = $this->formats[$format];
+
         return $this;
     }
 

--- a/src/QueryType/ManagedResources/Query/Synonyms/Synonyms.php
+++ b/src/QueryType/ManagedResources/Query/Synonyms/Synonyms.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Query\Synonyms;
 
 /**
@@ -37,6 +44,7 @@ class Synonyms
     public function setTerm(string $term): self
     {
         $this->term = $term;
+
         return $this;
     }
 
@@ -58,6 +66,7 @@ class Synonyms
     public function setSynonyms(array $synonyms): self
     {
         $this->synonyms = $synonyms;
+
         return $this;
     }
 }

--- a/src/QueryType/ManagedResources/RequestBuilder/Resources.php
+++ b/src/QueryType/ManagedResources/RequestBuilder/Resources.php
@@ -1,9 +1,19 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\RequestBuilder;
 
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 
+/**
+ * Resources.
+ */
 class Resources extends BaseRequestBuilder
 {
 }

--- a/src/QueryType/ManagedResources/RequestBuilder/Stopwords.php
+++ b/src/QueryType/ManagedResources/RequestBuilder/Stopwords.php
@@ -1,21 +1,32 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\RequestBuilder;
 
 use Solarium\Core\Client\Request;
 use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
-use Solarium\Core\Query\QueryInterface;
 use Solarium\Exception\RuntimeException;
 use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\Stopwords as StopwordsQuery;
 
+/**
+ * Stopwords.
+ */
 class Stopwords extends BaseRequestBuilder
 {
     /**
      * Build request for a stopwords query.
      *
-     * @param QueryInterface|StopwordsQuery $query
+     * @param \Solarium\Core\Query\AbstractQuery $query
+     *
+     * @throws \Solarium\Exception\RuntimeException
      *
      * @return Request
      */

--- a/src/QueryType/ManagedResources/RequestBuilder/Synonyms.php
+++ b/src/QueryType/ManagedResources/RequestBuilder/Synonyms.php
@@ -1,21 +1,32 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\RequestBuilder;
 
 use Solarium\Core\Client\Request;
 use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
-use Solarium\Core\Query\QueryInterface;
 use Solarium\Exception\RuntimeException;
 use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\Synonyms as SynonymsQuery;
 
+/**
+ * Synonyms.
+ */
 class Synonyms extends BaseRequestBuilder
 {
     /**
      * Build request for a synonyms query.
      *
-     * @param QueryInterface|SynonymsQuery $query
+     * @param \Solarium\Core\Query\AbstractQuery $query
+     *
+     * @throws \Solarium\Exception\RuntimeException
      *
      * @return Request
      */

--- a/src/QueryType/ManagedResources/ResponseParser/Resources.php
+++ b/src/QueryType/ManagedResources/ResponseParser/Resources.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\ResponseParser;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
@@ -7,6 +14,9 @@ use Solarium\Core\Query\ResponseParserInterface;
 use Solarium\Core\Query\Result\ResultInterface;
 use Solarium\QueryType\ManagedResources\Result\Resources\Resource;
 
+/**
+ * Resources.
+ */
 class Resources extends ResponseParserAbstract implements ResponseParserInterface
 {
     /**

--- a/src/QueryType/ManagedResources/ResponseParser/Stopwords.php
+++ b/src/QueryType/ManagedResources/ResponseParser/Stopwords.php
@@ -1,11 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\ResponseParser;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
 use Solarium\Core\Query\ResponseParserInterface;
 use Solarium\Core\Query\Result\ResultInterface;
 
+/**
+ * Stopwords.
+ */
 class Stopwords extends ResponseParserAbstract implements ResponseParserInterface
 {
     /**

--- a/src/QueryType/ManagedResources/ResponseParser/Synonyms.php
+++ b/src/QueryType/ManagedResources/ResponseParser/Synonyms.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\ResponseParser;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
@@ -7,6 +14,9 @@ use Solarium\Core\Query\ResponseParserInterface;
 use Solarium\Core\Query\Result\ResultInterface;
 use Solarium\Exception\RuntimeException;
 
+/**
+ * Synonyms.
+ */
 class Synonyms extends ResponseParserAbstract implements ResponseParserInterface
 {
     /**

--- a/src/QueryType/ManagedResources/Result/Resources/Resource.php
+++ b/src/QueryType/ManagedResources/Result/Resources/Resource.php
@@ -1,9 +1,29 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Result\Resources;
 
+/**
+ * Resource.
+ */
 class Resource
 {
+    /**
+     * Resource type stopwords.
+     */
+    const TYPE_STOPWORDS = 'stopwords';
+
+    /**
+     * Resource type synonyms.
+     */
+    const TYPE_SYNONYMS = 'synonyms';
+
     /**
      * @var string
      */
@@ -18,16 +38,6 @@ class Resource
      * @var string
      */
     protected $class;
-
-    /**
-     * Resource type stopwords.
-     */
-    const TYPE_STOPWORDS = 'stopwords';
-
-    /**
-     * Resource type synonyms.
-     */
-    const TYPE_SYNONYMS = 'synonyms';
 
     /**
      * Resource constructor.
@@ -57,6 +67,7 @@ class Resource
     public function setResourceId(string $resourceId): self
     {
         $this->resourceId = $resourceId;
+
         return $this;
     }
 
@@ -76,6 +87,7 @@ class Resource
     public function setNumObservers(int $numObservers): self
     {
         $this->numObservers = $numObservers;
+
         return $this;
     }
 
@@ -95,6 +107,7 @@ class Resource
     public function setClass(string $class): self
     {
         $this->class = $class;
+
         return $this;
     }
 
@@ -105,9 +118,9 @@ class Resource
      */
     public function getType(): string
     {
-        if (0 === strncmp($this->resourceId, '/schema/analysis/stopwords', strlen('/schema/analysis/stopwords'))) {
+        if (0 === strncmp($this->resourceId, '/schema/analysis/stopwords', \strlen('/schema/analysis/stopwords'))) {
             return self::TYPE_STOPWORDS;
-        } elseif (0 === strncmp($this->resourceId, '/schema/analysis/synonyms', strlen('/schema/analysis/synonyms'))) {
+        } elseif (0 === strncmp($this->resourceId, '/schema/analysis/synonyms', \strlen('/schema/analysis/synonyms'))) {
             return self::TYPE_SYNONYMS;
         }
 

--- a/src/QueryType/ManagedResources/Result/Resources/ResourceList.php
+++ b/src/QueryType/ManagedResources/Result/Resources/ResourceList.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Result\Resources;
 
 use Solarium\Core\Client\Response;
@@ -7,6 +14,9 @@ use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\Result\QueryType as BaseResult;
 use Solarium\Core\Query\Result\Result;
 
+/**
+ * ResourceList.
+ */
 class ResourceList extends BaseResult implements \IteratorAggregate, \Countable
 {
     /**
@@ -52,6 +62,7 @@ class ResourceList extends BaseResult implements \IteratorAggregate, \Countable
     public function getItems(): array
     {
         $this->parseResponse();
+
         return $this->items;
     }
 
@@ -63,6 +74,7 @@ class ResourceList extends BaseResult implements \IteratorAggregate, \Countable
     public function getIterator(): \ArrayIterator
     {
         $this->parseResponse();
+
         return new \ArrayIterator($this->items);
     }
 
@@ -74,6 +86,7 @@ class ResourceList extends BaseResult implements \IteratorAggregate, \Countable
     public function count(): int
     {
         $this->parseResponse();
+
         return \count($this->items);
     }
 }

--- a/src/QueryType/ManagedResources/Result/Stopwords/WordSet.php
+++ b/src/QueryType/ManagedResources/Result/Stopwords/WordSet.php
@@ -1,12 +1,22 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Result\Stopwords;
 
 use Solarium\Core\Client\Response;
 use Solarium\Core\Query\AbstractQuery;
-use Solarium\Core\Query\Result\Result;
 use Solarium\Core\Query\Result\QueryType as BaseResult;
+use Solarium\Core\Query\Result\Result;
 
+/**
+ * WordSet.
+ */
 class WordSet extends BaseResult implements \IteratorAggregate, \Countable
 {
     /**
@@ -74,6 +84,7 @@ class WordSet extends BaseResult implements \IteratorAggregate, \Countable
     public function getItems(): array
     {
         $this->parseResponse();
+
         return $this->items;
     }
 
@@ -85,6 +96,7 @@ class WordSet extends BaseResult implements \IteratorAggregate, \Countable
     public function getIterator(): \ArrayIterator
     {
         $this->parseResponse();
+
         return new \ArrayIterator($this->items);
     }
 
@@ -96,7 +108,8 @@ class WordSet extends BaseResult implements \IteratorAggregate, \Countable
     public function count(): int
     {
         $this->parseResponse();
-        return count($this->items);
+
+        return \count($this->items);
     }
 
     /**
@@ -105,6 +118,7 @@ class WordSet extends BaseResult implements \IteratorAggregate, \Countable
     public function isIgnoreCase(): ?bool
     {
         $this->parseResponse();
+
         return $this->ignoreCase;
     }
 
@@ -114,6 +128,7 @@ class WordSet extends BaseResult implements \IteratorAggregate, \Countable
     public function getInitializedOn(): string
     {
         $this->parseResponse();
+
         return $this->initializedOn;
     }
 
@@ -123,6 +138,7 @@ class WordSet extends BaseResult implements \IteratorAggregate, \Countable
     public function getUpdatedSinceInit(): ?string
     {
         $this->parseResponse();
+
         return $this->updatedSinceInit;
     }
 }

--- a/src/QueryType/ManagedResources/Result/Synonyms/SynonymMappings.php
+++ b/src/QueryType/ManagedResources/Result/Synonyms/SynonymMappings.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Result\Synonyms;
 
 use Solarium\Core\Client\Response;
@@ -7,6 +14,9 @@ use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\Result\QueryType as BaseResult;
 use Solarium\Core\Query\Result\Result;
 
+/**
+ * SynonymMappings.
+ */
 class SynonymMappings extends BaseResult implements \IteratorAggregate, \Countable
 {
     /**
@@ -87,6 +97,7 @@ class SynonymMappings extends BaseResult implements \IteratorAggregate, \Countab
     public function getItems(): array
     {
         $this->parseResponse();
+
         return $this->items;
     }
 
@@ -98,6 +109,7 @@ class SynonymMappings extends BaseResult implements \IteratorAggregate, \Countab
     public function getIterator(): \ArrayIterator
     {
         $this->parseResponse();
+
         return new \ArrayIterator($this->items);
     }
 
@@ -109,6 +121,7 @@ class SynonymMappings extends BaseResult implements \IteratorAggregate, \Countab
     public function count(): int
     {
         $this->parseResponse();
+
         return \count($this->items);
     }
 
@@ -118,6 +131,7 @@ class SynonymMappings extends BaseResult implements \IteratorAggregate, \Countab
     public function getResourceId(): string
     {
         $this->parseResponse();
+
         return $this->resourceId;
     }
 
@@ -127,6 +141,7 @@ class SynonymMappings extends BaseResult implements \IteratorAggregate, \Countab
     public function isIgnoreCase(): ?bool
     {
         $this->parseResponse();
+
         return $this->ignoreCase;
     }
 
@@ -136,6 +151,7 @@ class SynonymMappings extends BaseResult implements \IteratorAggregate, \Countab
     public function getFormat(): ?string
     {
         $this->parseResponse();
+
         return $this->format;
     }
 
@@ -145,6 +161,7 @@ class SynonymMappings extends BaseResult implements \IteratorAggregate, \Countab
     public function getInitializedOn(): string
     {
         $this->parseResponse();
+
         return $this->initializedOn;
     }
 
@@ -154,6 +171,7 @@ class SynonymMappings extends BaseResult implements \IteratorAggregate, \Countab
     public function getUpdatedSinceInit(): ?string
     {
         $this->parseResponse();
+
         return $this->updatedSinceInit;
     }
 }

--- a/src/QueryType/ManagedResources/Result/Synonyms/Synonyms.php
+++ b/src/QueryType/ManagedResources/Result/Synonyms/Synonyms.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\ManagedResources\Result\Synonyms;
 
 /**
@@ -49,6 +56,7 @@ class Synonyms
     public function setTerm(string $term): self
     {
         $this->term = $term;
+
         return $this;
     }
 
@@ -72,6 +80,7 @@ class Synonyms
     public function setSynonyms(array $synonyms): self
     {
         $this->synonyms = $synonyms;
+
         return $this;
     }
 }

--- a/src/QueryType/MoreLikeThis/Query.php
+++ b/src/QueryType/MoreLikeThis/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\MoreLikeThis;
 
 use Solarium\Core\Client\Client;
@@ -83,6 +90,7 @@ class Query extends SelectQuery
     public function setQueryStream(bool $stream): self
     {
         $this->setOption('stream', $stream);
+
         return $this;
     }
 
@@ -108,6 +116,7 @@ class Query extends SelectQuery
     public function setInterestingTerms(string $term): self
     {
         $this->setOption('interestingTerms', $term);
+
         return $this;
     }
 
@@ -133,6 +142,7 @@ class Query extends SelectQuery
     public function setMatchInclude(bool $include): self
     {
         $this->setOption('matchinclude', $include);
+
         return $this;
     }
 
@@ -159,6 +169,7 @@ class Query extends SelectQuery
     public function setMatchOffset(int $offset): self
     {
         $this->setOption('matchoffset', $offset);
+
         return $this;
     }
 
@@ -188,12 +199,13 @@ class Query extends SelectQuery
      */
     public function setMltFields($fields): self
     {
-        if (is_string($fields)) {
+        if (\is_string($fields)) {
             $fields = explode(',', $fields);
             $fields = array_map('trim', $fields);
         }
 
         $this->setOption('mltfields', $fields);
+
         return $this;
     }
 
@@ -227,6 +239,7 @@ class Query extends SelectQuery
     public function setMinimumTermFrequency(int $minimum): self
     {
         $this->setOption('minimumtermfrequency', $minimum);
+
         return $this;
     }
 
@@ -255,6 +268,7 @@ class Query extends SelectQuery
     public function setMinimumDocumentFrequency(int $minimum): self
     {
         $this->setOption('minimumdocumentfrequency', $minimum);
+
         return $this;
     }
 
@@ -282,6 +296,7 @@ class Query extends SelectQuery
     public function setMinimumWordLength(int $minimum): self
     {
         $this->setOption('minimumwordlength', $minimum);
+
         return $this;
     }
 
@@ -309,6 +324,7 @@ class Query extends SelectQuery
     public function setMaximumWordLength(int $maximum): self
     {
         $this->setOption('maximumwordlength', $maximum);
+
         return $this;
     }
 
@@ -337,6 +353,7 @@ class Query extends SelectQuery
     public function setMaximumQueryTerms(int $maximum): self
     {
         $this->setOption('maximumqueryterms', $maximum);
+
         return $this;
     }
 
@@ -365,6 +382,7 @@ class Query extends SelectQuery
     public function setMaximumNumberOfTokens(int $maximum): self
     {
         $this->setOption('maximumnumberoftokens', $maximum);
+
         return $this;
     }
 
@@ -392,6 +410,7 @@ class Query extends SelectQuery
     public function setBoost(bool $boost): self
     {
         $this->setOption('boost', $boost);
+
         return $this;
     }
 
@@ -421,12 +440,13 @@ class Query extends SelectQuery
      */
     public function setQueryFields($queryFields): self
     {
-        if (is_string($queryFields)) {
+        if (\is_string($queryFields)) {
             $queryFields = explode(',', $queryFields);
             $queryFields = array_map('trim', $queryFields);
         }
 
         $this->setOption('queryfields', $queryFields);
+
         return $this;
     }
 

--- a/src/QueryType/MoreLikeThis/RequestBuilder.php
+++ b/src/QueryType/MoreLikeThis/RequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\MoreLikeThis;
 
 use Solarium\Core\Client\Request;

--- a/src/QueryType/MoreLikeThis/ResponseParser.php
+++ b/src/QueryType/MoreLikeThis/ResponseParser.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\MoreLikeThis;
 
 use Solarium\Core\Query\Result\ResultInterface;
@@ -27,7 +34,7 @@ class ResponseParser extends SelectResponseParser
         if (isset($data['interestingTerms']) && 'none' !== $query->getInterestingTerms()) {
             $terms = $data['interestingTerms'];
             if ('details' === $query->getInterestingTerms()) {
-                if ($query->getResponseWriter() == $query::WT_JSON) {
+                if ($query->getResponseWriter() === $query::WT_JSON) {
                     $terms = $this->convertToKeyValueArray($terms);
                 }
             }

--- a/src/QueryType/MoreLikeThis/Result.php
+++ b/src/QueryType/MoreLikeThis/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\MoreLikeThis;
 
 use Solarium\Exception\UnexpectedValueException;
@@ -50,7 +57,7 @@ class Result extends SelectResult
     public function getInterestingTerms()
     {
         $query = $this->getQuery();
-        if ('none' == $query->getInterestingTerms()) {
+        if ('none' === $query->getInterestingTerms()) {
             throw new UnexpectedValueException('interestingterms is none');
         }
         $this->parseResponse();

--- a/src/QueryType/MoreLikeThis/Result.php
+++ b/src/QueryType/MoreLikeThis/Result.php
@@ -54,7 +54,7 @@ class Result extends SelectResult
      *
      * @return array
      */
-    public function getInterestingTerms(): array
+    public function getInterestingTerms()
     {
         $query = $this->getQuery();
         if ('none' === $query->getInterestingTerms()) {
@@ -74,7 +74,7 @@ class Result extends SelectResult
      *
      * @return ReadOnlyDocument
      */
-    public function getMatch(): ReadOnlyDocument
+    public function getMatch()
     {
         $query = $this->getQuery();
         if (true !== $query->getMatchInclude()) {

--- a/src/QueryType/MoreLikeThis/Result.php
+++ b/src/QueryType/MoreLikeThis/Result.php
@@ -54,7 +54,7 @@ class Result extends SelectResult
      *
      * @return array
      */
-    public function getInterestingTerms()
+    public function getInterestingTerms(): array
     {
         $query = $this->getQuery();
         if ('none' === $query->getInterestingTerms()) {
@@ -74,7 +74,7 @@ class Result extends SelectResult
      *
      * @return ReadOnlyDocument
      */
-    public function getMatch()
+    public function getMatch(): ReadOnlyDocument
     {
         $query = $this->getQuery();
         if (true !== $query->getMatchInclude()) {

--- a/src/QueryType/Ping/Query.php
+++ b/src/QueryType/Ping/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Ping;
 
 use Solarium\Core\Client\Client;
@@ -49,6 +56,8 @@ class Query extends BaseQuery
 
     /**
      * The ping query has no response parser so we return a null value.
+     *
+     * @return \Solarium\Core\Query\ResponseParserInterface|null
      */
     public function getResponseParser(): ?ResponseParserInterface
     {

--- a/src/QueryType/Ping/RequestBuilder.php
+++ b/src/QueryType/Ping/RequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Ping;
 
 use Solarium\Core\Client\Request;

--- a/src/QueryType/Ping/Result.php
+++ b/src/QueryType/Ping/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Ping;
 
 use Solarium\Core\Query\Result\Result as BaseResult;

--- a/src/QueryType/RealtimeGet/Query.php
+++ b/src/QueryType/RealtimeGet/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\RealtimeGet;
 
 use Solarium\Core\Client\Client;
@@ -90,7 +97,7 @@ class Query extends BaseQuery
      */
     public function addIds($ids): self
     {
-        if (is_string($ids)) {
+        if (\is_string($ids)) {
             $ids = explode(',', $ids);
             $ids = array_map('trim', $ids);
         }
@@ -169,6 +176,7 @@ class Query extends BaseQuery
     public function setDocumentClass(string $value): self
     {
         $this->setOption('documentclass', $value);
+
         return $this;
     }
 

--- a/src/QueryType/RealtimeGet/RequestBuilder.php
+++ b/src/QueryType/RealtimeGet/RequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\RealtimeGet;
 
 use Solarium\Core\Client\Request;

--- a/src/QueryType/RealtimeGet/Result.php
+++ b/src/QueryType/RealtimeGet/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\RealtimeGet;
 
 use Solarium\Core\Query\DocumentInterface;

--- a/src/QueryType/Select/Query/FilterQuery.php
+++ b/src/QueryType/Select/Query/FilterQuery.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Select\Query;
 
 use Solarium\Component\QueryInterface;

--- a/src/QueryType/Select/Query/Query.php
+++ b/src/QueryType/Select/Query/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Select\Query;
 
 use Solarium\Component\Analytics\Analytics;
@@ -138,7 +145,10 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface, Query
      */
     protected $filterQueries = [];
 
-    public function __construct($options = null)
+    /**
+     * @param array|null $options
+     */
+    public function __construct(array $options = null)
     {
         $this->componentTypes = [
             ComponentAwareQueryInterface::COMPONENT_MORELIKETHIS => MoreLikeThis::class,

--- a/src/QueryType/Select/RequestBuilder.php
+++ b/src/QueryType/Select/RequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Select;
 
 use Solarium\Core\Client\Request;

--- a/src/QueryType/Select/ResponseParser.php
+++ b/src/QueryType/Select/ResponseParser.php
@@ -1,14 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Select;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
+use Solarium\Core\Query\DocumentInterface;
 use Solarium\Core\Query\ResponseParserInterface;
 use Solarium\Core\Query\Result\ResultInterface;
 use Solarium\Exception\RuntimeException;
 use Solarium\QueryType\Select\Query\Query;
 use Solarium\QueryType\Select\Result\Result;
-use Solarium\Core\Query\DocumentInterface;
 
 /**
  * Parse select response data.
@@ -34,7 +41,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         // create document instances
         $documentClass = $query->getOption('documentclass');
         $classes = class_implements($documentClass);
-        if (!in_array(DocumentInterface::class, $classes, true)) {
+        if (!\in_array(DocumentInterface::class, $classes, true)) {
             throw new RuntimeException('The result document class must implement a document interface');
         }
 

--- a/src/QueryType/Select/Result/Document.php
+++ b/src/QueryType/Select/Result/Document.php
@@ -1,10 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Select\Result;
 
-use Solarium\Exception\RuntimeException;
 use Solarium\Core\Query\AbstractDocument;
 use Solarium\Core\Query\DocumentInterface;
+use Solarium\Exception\RuntimeException;
 
 /**
  * Read-only Solr document.

--- a/src/QueryType/Select/Result/Result.php
+++ b/src/QueryType/Select/Result/Result.php
@@ -227,6 +227,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * @param string $key
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return mixed
      */
     public function getComponent(string $key)

--- a/src/QueryType/Select/Result/Result.php
+++ b/src/QueryType/Select/Result/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Select\Result;
 
 use Solarium\Component\ComponentAwareQueryInterface;
@@ -10,8 +17,8 @@ use Solarium\Component\Result\Grouping\Result as GroupingResult;
 use Solarium\Component\Result\Highlighting\Highlighting;
 use Solarium\Component\Result\MoreLikeThis\MoreLikeThis;
 use Solarium\Component\Result\Spellcheck\Result as SpellcheckResult;
-use Solarium\Component\Result\Suggester\Result as SuggesterResult;
 use Solarium\Component\Result\Stats\Stats;
+use Solarium\Component\Result\Suggester\Result as SuggesterResult;
 use Solarium\Core\Query\DocumentInterface;
 use Solarium\Core\Query\Result\QueryType as BaseResult;
 
@@ -200,7 +207,7 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     {
         $this->parseResponse();
 
-        return count($this->documents);
+        return \count($this->documents);
     }
 
     /**

--- a/src/QueryType/Server/AbstractServerQuery.php
+++ b/src/QueryType/Server/AbstractServerQuery.php
@@ -56,7 +56,7 @@ abstract class AbstractServerQuery extends AbstractQuery implements ActionInterf
     /**
      * @param ActionInterface $action
      */
-    public function setAction(ActionInterface $action)
+    public function setAction(ActionInterface $action): void
     {
         $this->action = $action;
     }

--- a/src/QueryType/Server/AbstractServerQuery.php
+++ b/src/QueryType/Server/AbstractServerQuery.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server;
 
 use Solarium\Core\Query\AbstractQuery;
@@ -38,7 +45,7 @@ abstract class AbstractServerQuery extends AbstractQuery implements ActionInterf
     public function createAction($type, $options = null): ActionInterface
     {
         if (!isset($this->actionTypes[$type])) {
-            throw new InvalidArgumentException('Action unknown: '.$type);
+            throw new InvalidArgumentException(sprintf('Action unknown: %s', $type));
         }
 
         $class = $this->actionTypes[$type];

--- a/src/QueryType/Server/Api/Query.php
+++ b/src/QueryType/Server/Api/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Api;
 
 use Solarium\Core\Client\Client;
@@ -45,6 +52,7 @@ class Query extends AbstractQuery
     public function setVersion(string $version): self
     {
         $this->setOption('version', $version);
+
         return $this;
     }
 
@@ -68,6 +76,7 @@ class Query extends AbstractQuery
     public function setMethod(string $method): self
     {
         $this->setOption('method', $method);
+
         return $this;
     }
 
@@ -91,6 +100,7 @@ class Query extends AbstractQuery
     public function setAccept(string $accept): self
     {
         $this->setOption('accept', $accept);
+
         return $this;
     }
 
@@ -114,6 +124,7 @@ class Query extends AbstractQuery
     public function setContentType(string $contentType): self
     {
         $this->setOption('contenttype', $contentType);
+
         return $this;
     }
 
@@ -137,6 +148,7 @@ class Query extends AbstractQuery
     public function setRawData(string $rawData): self
     {
         $this->setOption('rawdata', $rawData);
+
         return $this;
     }
 

--- a/src/QueryType/Server/Api/RequestBuilder.php
+++ b/src/QueryType/Server/Api/RequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Api;
 
 use Solarium\Core\Client\Request;

--- a/src/QueryType/Server/Api/ResponseParser.php
+++ b/src/QueryType/Server/Api/ResponseParser.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Api;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
@@ -23,6 +30,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
     {
         $data = $result->getData();
         $data = $this->addHeaderInfo($data, $data);
+
         return $data;
     }
 }

--- a/src/QueryType/Server/Collections/Query/Action/AbstractCDRAction.php
+++ b/src/QueryType/Server/Collections/Query/Action/AbstractCDRAction.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Collections\Query\Action;
 
 use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;

--- a/src/QueryType/Server/Collections/Query/Action/ClusterStatus.php
+++ b/src/QueryType/Server/Collections/Query/Action/ClusterStatus.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Collections\Query\Action;
 
 use Solarium\QueryType\Server\Collections\Query\Query as CollectionsQuery;
@@ -34,6 +41,7 @@ class ClusterStatus extends AbstractAsyncAction
     public function setCollection(string $collection): self
     {
         $this->setOption('collection', $collection);
+
         return $this;
     }
 
@@ -57,6 +65,7 @@ class ClusterStatus extends AbstractAsyncAction
     public function setShard(string $shard): self
     {
         $this->setOption('shard', $shard);
+
         return $this;
     }
 
@@ -81,6 +90,7 @@ class ClusterStatus extends AbstractAsyncAction
     public function setRoute(string $route): self
     {
         $this->setOption('_route_', $route);
+
         return $this;
     }
 

--- a/src/QueryType/Server/Collections/Query/Action/Create.php
+++ b/src/QueryType/Server/Collections/Query/Action/Create.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Collections\Query\Action;
 
 use Solarium\QueryType\Server\Collections\Query\Query as CollectionsQuery;
@@ -34,6 +41,7 @@ class Create extends AbstractCDRAction
     public function setRouterName(string $routerName): self
     {
         $this->setOption('router.name', $routerName);
+
         return $this;
     }
 
@@ -58,6 +66,7 @@ class Create extends AbstractCDRAction
     public function setNumShards(int $numShards): self
     {
         $this->setOption('numShards', $numShards);
+
         return $this;
     }
 
@@ -82,6 +91,7 @@ class Create extends AbstractCDRAction
     public function setShards(string $shards): self
     {
         $this->setOption('shards', $shards);
+
         return $this;
     }
 
@@ -105,6 +115,7 @@ class Create extends AbstractCDRAction
     public function setReplicationFactor(int $replicationFactor): self
     {
         $this->setOption('replicationFactor', $replicationFactor);
+
         return $this;
     }
 
@@ -118,6 +129,7 @@ class Create extends AbstractCDRAction
     public function setNrtReplicas(int $nrtReplicas): self
     {
         $this->setOption('nrtReplicas', $nrtReplicas);
+
         return $this;
     }
 
@@ -131,6 +143,7 @@ class Create extends AbstractCDRAction
     public function setTlogReplicas(int $tlogReplicas): self
     {
         $this->setOption('tlogReplicas', $tlogReplicas);
+
         return $this;
     }
 
@@ -144,6 +157,7 @@ class Create extends AbstractCDRAction
     public function setPullReplicas(int $pullReplicas): self
     {
         $this->setOption('pullReplicas', $pullReplicas);
+
         return $this;
     }
 
@@ -158,6 +172,7 @@ class Create extends AbstractCDRAction
     public function setMaxShardsPerNode(int $maxShardsPerNode): self
     {
         $this->setOption('maxShardsPerNode', $maxShardsPerNode);
+
         return $this;
     }
 
@@ -172,6 +187,7 @@ class Create extends AbstractCDRAction
     public function setCreateNodeSet(string $createNodeSet): self
     {
         $this->setOption('createNodeSet', $createNodeSet);
+
         return $this;
     }
 
@@ -187,6 +203,7 @@ class Create extends AbstractCDRAction
     public function setCreateNodeSetShuffle(bool $shuffle): self
     {
         $this->setOption('createNodeSet.shuffle', $shuffle);
+
         return $this;
     }
 
@@ -200,6 +217,7 @@ class Create extends AbstractCDRAction
     public function setCollectionConfigName(string $configName): self
     {
         $this->setOption('collection.configName', $configName);
+
         return $this;
     }
 
@@ -225,6 +243,7 @@ class Create extends AbstractCDRAction
     public function setRouterField(string $routerField): self
     {
         $this->setOption('router.field', $routerField);
+
         return $this;
     }
 
@@ -239,6 +258,7 @@ class Create extends AbstractCDRAction
     public function setProperty(string $name, string $value): self
     {
         $this->setOption('property.'.$name, $value);
+
         return $this;
     }
 
@@ -266,6 +286,7 @@ class Create extends AbstractCDRAction
     public function setAutoAddReplicas(bool $autoAddReplicas): self
     {
         $this->setOption('autoAddReplicas', $autoAddReplicas);
+
         return $this;
     }
 
@@ -279,6 +300,7 @@ class Create extends AbstractCDRAction
     public function setAsync(string $id): AsyncActionInterface
     {
         $this->setOption('async', $id);
+
         return $this;
     }
 
@@ -292,6 +314,7 @@ class Create extends AbstractCDRAction
     public function setRule(string $rule): self
     {
         $this->setOption('rule', $rule);
+
         return $this;
     }
 
@@ -305,6 +328,7 @@ class Create extends AbstractCDRAction
     public function setSnitch(string $snitch): self
     {
         $this->setOption('snitch', $snitch);
+
         return $this;
     }
 
@@ -318,6 +342,7 @@ class Create extends AbstractCDRAction
     public function setPolicy(string $policy): self
     {
         $this->setOption('policy', $policy);
+
         return $this;
     }
 
@@ -333,6 +358,7 @@ class Create extends AbstractCDRAction
     public function setWaitForFinalState(bool $waitForFinalState): self
     {
         $this->setOption('waitForFinalState', $waitForFinalState);
+
         return $this;
     }
 
@@ -347,6 +373,7 @@ class Create extends AbstractCDRAction
     public function setWithCollection(string $withCollection): self
     {
         $this->setOption('withCollection', $withCollection);
+
         return $this;
     }
 

--- a/src/QueryType/Server/Collections/Query/Action/Delete.php
+++ b/src/QueryType/Server/Collections/Query/Action/Delete.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Collections\Query\Action;
 
 use Solarium\QueryType\Server\Collections\Query\Query as CollectionsQuery;

--- a/src/QueryType/Server/Collections/Query/Action/Reload.php
+++ b/src/QueryType/Server/Collections/Query/Action/Reload.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Collections\Query\Action;
 
 use Solarium\QueryType\Server\Collections\Query\Query as CollectionsQuery;

--- a/src/QueryType/Server/Collections/Query/Query.php
+++ b/src/QueryType/Server/Collections/Query/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Collections\Query;
 
 use Solarium\Core\Client\Client;

--- a/src/QueryType/Server/Collections/ResponseParser.php
+++ b/src/QueryType/Server/Collections/ResponseParser.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Collections;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
@@ -24,6 +31,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         $data = $result->getData();
         $data = $this->parseStatus($data, $result);
         $data = $this->addHeaderInfo($data, $data);
+
         return $data;
     }
 

--- a/src/QueryType/Server/Collections/ResponseParser/ClusterStatus.php
+++ b/src/QueryType/Server/Collections/ResponseParser/ClusterStatus.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Collections\ResponseParser;
 
 use Solarium\Core\Query\Result\ResultInterface;
@@ -23,6 +30,7 @@ class ClusterStatus extends ResponseParser
         $data = $result->getData();
 
         $data = $this->addHeaderInfo($data, $data);
+
         return $data;
     }
 }

--- a/src/QueryType/Server/Collections/Result/AbstractResult.php
+++ b/src/QueryType/Server/Collections/Result/AbstractResult.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Collections\Result;
 
 use Solarium\Core\Query\Result\QueryType as BaseResult;
@@ -25,6 +32,7 @@ abstract class AbstractResult extends BaseResult
     public function getWasSuccessful(): bool
     {
         $this->parseResponse();
+
         return $this->wasSuccessful;
     }
 
@@ -34,6 +42,7 @@ abstract class AbstractResult extends BaseResult
     public function getStatusMessage(): string
     {
         $this->parseResponse();
+
         return $this->statusMessage;
     }
 }

--- a/src/QueryType/Server/Collections/Result/ClusterStatusResult.php
+++ b/src/QueryType/Server/Collections/Result/ClusterStatusResult.php
@@ -1,9 +1,19 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Collections\Result;
 
 use Solarium\Core\Client\State\ClusterState;
 
+/**
+ * ClusterStatusResult.
+ */
 class ClusterStatusResult extends AbstractResult
 {
     /**

--- a/src/QueryType/Server/Collections/Result/CreateResult.php
+++ b/src/QueryType/Server/Collections/Result/CreateResult.php
@@ -1,7 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Collections\Result;
 
+/**
+ * CreateResult.
+ */
 class CreateResult extends AbstractResult
 {
     /**
@@ -12,6 +22,7 @@ class CreateResult extends AbstractResult
     public function getStatus(): array
     {
         $this->parseResponse();
+
         return $this->getData();
     }
 }

--- a/src/QueryType/Server/Collections/Result/DeleteResult.php
+++ b/src/QueryType/Server/Collections/Result/DeleteResult.php
@@ -1,7 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Collections\Result;
 
+/**
+ * DeleteResult.
+ */
 class DeleteResult extends AbstractResult
 {
     /**
@@ -12,6 +22,7 @@ class DeleteResult extends AbstractResult
     public function getStatus(): array
     {
         $this->parseResponse();
+
         return $this->getData();
     }
 }

--- a/src/QueryType/Server/Collections/Result/ReloadResult.php
+++ b/src/QueryType/Server/Collections/Result/ReloadResult.php
@@ -1,7 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Collections\Result;
 
+/**
+ * ReloadResult.
+ */
 class ReloadResult extends AbstractResult
 {
     /**
@@ -12,6 +22,7 @@ class ReloadResult extends AbstractResult
     public function getStatus(): array
     {
         $this->parseResponse();
+
         return $this->getData();
     }
 }

--- a/src/QueryType/Server/CoreAdmin/Query/Action/CoreActionInterface.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/CoreActionInterface.php
@@ -1,9 +1,19 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 
 use Solarium\QueryType\Server\Query\Action\ActionInterface;
 
+/**
+ * CoreActionInterface.
+ */
 interface CoreActionInterface extends ActionInterface
 {
     /**

--- a/src/QueryType/Server/CoreAdmin/Query/Action/CoreActionTrait.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/CoreActionTrait.php
@@ -1,7 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 
+/**
+ * CoreActionTrait.
+ */
 trait CoreActionTrait
 {
     /**
@@ -14,6 +24,7 @@ trait CoreActionTrait
     public function setCore(string $core): CoreActionInterface
     {
         $this->setOption('core', $core);
+
         return $this;
     }
 

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Create.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Create.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
@@ -33,6 +40,7 @@ class Create extends AbstractAsyncAction implements CoreActionInterface
     {
         // for some reason the core is called "name" in the create action
         $this->setOption('name', $core);
+
         return $this;
     }
 
@@ -57,6 +65,7 @@ class Create extends AbstractAsyncAction implements CoreActionInterface
     public function setInstanceDir(string $instanceDir): self
     {
         $this->setOption('instanceDir', $instanceDir);
+
         return $this;
     }
 
@@ -80,6 +89,7 @@ class Create extends AbstractAsyncAction implements CoreActionInterface
     public function setConfig(string $config): self
     {
         $this->setOption('config', $config);
+
         return $this;
     }
 
@@ -103,6 +113,7 @@ class Create extends AbstractAsyncAction implements CoreActionInterface
     public function setSchema(string $schema): self
     {
         $this->setOption('schema', $schema);
+
         return $this;
     }
 
@@ -126,6 +137,7 @@ class Create extends AbstractAsyncAction implements CoreActionInterface
     public function setDataDir(string $dataDir): self
     {
         $this->setOption('dataDir', $dataDir);
+
         return $this;
     }
 
@@ -149,6 +161,7 @@ class Create extends AbstractAsyncAction implements CoreActionInterface
     public function setConfigSet(string $configSet): self
     {
         $this->setOption('configSet', $configSet);
+
         return $this;
     }
 
@@ -172,6 +185,7 @@ class Create extends AbstractAsyncAction implements CoreActionInterface
     public function setCollection(string $collection): self
     {
         $this->setOption('collection', $collection);
+
         return $this;
     }
 
@@ -195,6 +209,7 @@ class Create extends AbstractAsyncAction implements CoreActionInterface
     public function setShard($shard): self
     {
         $this->setOption('shard', $shard);
+
         return $this;
     }
 
@@ -220,17 +235,21 @@ class Create extends AbstractAsyncAction implements CoreActionInterface
     {
         $option = 'property.'.$name;
         $this->setOption($option, $value);
+
         return $this;
     }
 
     /**
      * Get a previously added core property.
      *
+     * @param mixed $name
+     *
      * @return string
      */
     public function getCoreProperty($name): string
     {
         $option = 'property.'.$name;
+
         return $this->getOption($option);
     }
 }

--- a/src/QueryType/Server/CoreAdmin/Query/Action/MergeIndexes.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/MergeIndexes.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
@@ -34,6 +41,7 @@ class MergeIndexes extends AbstractAsyncAction implements CoreActionInterface
     public function setIndexDir(array $indexDir): self
     {
         $this->setOption('indexDir', $indexDir);
+
         return $this;
     }
 
@@ -57,6 +65,7 @@ class MergeIndexes extends AbstractAsyncAction implements CoreActionInterface
     public function setSrcCore(array $srcCore): self
     {
         $this->setOption('srcCore', $srcCore);
+
         return $this;
     }
 

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Reload.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Reload.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Rename.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Rename.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
@@ -34,6 +41,7 @@ class Rename extends AbstractAsyncAction implements CoreActionInterface
     public function setOther($other): self
     {
         $this->setOption('other', $other);
+
         return $this;
     }
 

--- a/src/QueryType/Server/CoreAdmin/Query/Action/RequestRecovery.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/RequestRecovery.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;

--- a/src/QueryType/Server/CoreAdmin/Query/Action/RequestStatus.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/RequestStatus.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
@@ -32,6 +39,7 @@ class RequestStatus extends AbstractAction
     public function setRequestId($requestId): self
     {
         $this->setOption('requestid', $requestId);
+
         return $this;
     }
 

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Split.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Split.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
@@ -34,6 +41,7 @@ class Split extends AbstractAsyncAction implements CoreActionInterface
     public function setPath(array $path): self
     {
         $this->setOption('path', $path);
+
         return $this;
     }
 
@@ -57,6 +65,7 @@ class Split extends AbstractAsyncAction implements CoreActionInterface
     public function setTargetCore(array $targetCore): self
     {
         $this->setOption('targetCore', $targetCore);
+
         return $this;
     }
 
@@ -80,6 +89,7 @@ class Split extends AbstractAsyncAction implements CoreActionInterface
     public function setRanges(string $ranges): self
     {
         $this->setOption('ranges', $ranges);
+
         return $this;
     }
 
@@ -103,6 +113,7 @@ class Split extends AbstractAsyncAction implements CoreActionInterface
     public function setSplitKey(string $splitKey): self
     {
         $this->setOption('split.key', $splitKey);
+
         return $this;
     }
 

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Status.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Status.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
@@ -35,6 +42,7 @@ class Status extends AbstractAction implements CoreActionInterface
     public function setIndexInfo(bool $indexInfo): self
     {
         $this->setOption('indexInfo', $indexInfo);
+
         return $this;
     }
 

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Swap.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Swap.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
@@ -34,6 +41,7 @@ class Swap extends AbstractAsyncAction implements CoreActionInterface
     public function setOther($other): self
     {
         $this->setOption('other', $other);
+
         return $this;
     }
 

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Unload.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Unload.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Query\Action;
 
 use Solarium\QueryType\Server\CoreAdmin\Query\Query as CoreAdminQuery;
@@ -34,6 +41,7 @@ class Unload extends AbstractAsyncAction implements CoreActionInterface
     public function setDeleteIndex(bool $deleteIndex): self
     {
         $this->setOption('deleteIndex', $deleteIndex);
+
         return $this;
     }
 
@@ -57,6 +65,7 @@ class Unload extends AbstractAsyncAction implements CoreActionInterface
     public function setDeleteDataDir(bool $deleteDataDir): self
     {
         $this->setOption('deleteDataDir', $deleteDataDir);
+
         return $this;
     }
 
@@ -80,6 +89,7 @@ class Unload extends AbstractAsyncAction implements CoreActionInterface
     public function setDeleteInstanceDir(bool $deleteInstanceDir): self
     {
         $this->setOption('deleteInstanceDir', $deleteInstanceDir);
+
         return $this;
     }
 

--- a/src/QueryType/Server/CoreAdmin/Query/Query.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Query.php
@@ -186,7 +186,7 @@ class Query extends AbstractServerQuery
      *
      * @return RequestRecovery|ActionInterface
      */
-    public function createRequestRecovery($options = [])
+    public function createRequestRecovery($options = []): RequestRecovery
     {
         return $this->createAction(self::ACTION_REQUEST_RECOVERY, $options);
     }

--- a/src/QueryType/Server/CoreAdmin/Query/Query.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Query;
 
 use Solarium\Core\Client\Client;

--- a/src/QueryType/Server/CoreAdmin/ResponseParser.php
+++ b/src/QueryType/Server/CoreAdmin/ResponseParser.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
@@ -20,15 +27,16 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
      *
      * @param Result|ResultInterface $result
      *
-     * @return array
-     *
      * @throws \Exception
+     *
+     * @return array
      */
     public function parse(ResultInterface $result): array
     {
         $data = $result->getData();
         $data = $this->parseStatus($data, $result);
         $data = $this->addHeaderInfo($data, $data);
+
         return $data;
     }
 
@@ -36,9 +44,9 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
      * @param array  $data
      * @param Result $result
      *
-     * @return array
-     *
      * @throws \Exception
+     *
+     * @return array
      */
     protected function parseStatus(array $data, Result $result): array
     {
@@ -55,7 +63,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
             return $data;
         }
 
-        if (!is_array($data['status'])) {
+        if (!\is_array($data['status'])) {
             return $data;
         }
 

--- a/src/QueryType/Server/CoreAdmin/Result/Result.php
+++ b/src/QueryType/Server/CoreAdmin/Result/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Result;
 
 use Solarium\Core\Query\Result\QueryType as BaseResult;
@@ -39,6 +46,7 @@ class Result extends BaseResult
     public function getWasSuccessful(): bool
     {
         $this->parseResponse();
+
         return $this->wasSuccessful;
     }
 
@@ -48,6 +56,7 @@ class Result extends BaseResult
     public function getStatusMessage(): string
     {
         $this->parseResponse();
+
         return $this->statusMessage;
     }
 
@@ -59,6 +68,7 @@ class Result extends BaseResult
     public function getStatusResults(): ?array
     {
         $this->parseResponse();
+
         return $this->statusResults;
     }
 
@@ -70,13 +80,14 @@ class Result extends BaseResult
     public function getStatusResult(): ?StatusResult
     {
         $this->parseResponse();
+
         return $this->statusResult;
     }
 
     /**
      * @param string $coreName
      *
-     * @return null|StatusResult
+     * @return StatusResult|null
      */
     public function getStatusResultByCoreName(string $coreName): ?StatusResult
     {

--- a/src/QueryType/Server/CoreAdmin/Result/Result.php
+++ b/src/QueryType/Server/CoreAdmin/Result/Result.php
@@ -41,6 +41,8 @@ class Result extends BaseResult
     protected $statusMessage = 'ERROR';
 
     /**
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return bool
      */
     public function getWasSuccessful(): bool
@@ -51,6 +53,8 @@ class Result extends BaseResult
     }
 
     /**
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return string
      */
     public function getStatusMessage(): string
@@ -63,6 +67,8 @@ class Result extends BaseResult
     /**
      * Returns the status result objects for all requested core statuses.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return StatusResult[]|null
      */
     public function getStatusResults(): ?array
@@ -74,6 +80,8 @@ class Result extends BaseResult
 
     /**
      * Retrives the status of the core, only available when the core was filtered to a core in the status action.
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return StatusResult|null
      */

--- a/src/QueryType/Server/CoreAdmin/Result/StatusResult.php
+++ b/src/QueryType/Server/CoreAdmin/Result/StatusResult.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\CoreAdmin\Result;
 
 /**
@@ -53,6 +60,7 @@ class StatusResult
     public function setCoreName(string $coreName): self
     {
         $this->coreName = $coreName;
+
         return $this;
     }
 
@@ -72,6 +80,7 @@ class StatusResult
     public function setNumberOfDocuments(int $numberOfDocuments): self
     {
         $this->numberOfDocuments = $numberOfDocuments;
+
         return $this;
     }
 
@@ -91,6 +100,7 @@ class StatusResult
     public function setUptime(int $uptime): self
     {
         $this->uptime = $uptime;
+
         return $this;
     }
 
@@ -110,6 +120,7 @@ class StatusResult
     public function setVersion(int $version): self
     {
         $this->version = $version;
+
         return $this;
     }
 
@@ -129,6 +140,7 @@ class StatusResult
     public function setStartTime(?\DateTime $startTime): self
     {
         $this->startTime = $startTime;
+
         return $this;
     }
 
@@ -148,6 +160,7 @@ class StatusResult
     public function setLastModified(?\DateTime $lastModified): self
     {
         $this->lastModified = $lastModified;
+
         return $this;
     }
 }

--- a/src/QueryType/Server/Query/Action/AbstractAction.php
+++ b/src/QueryType/Server/Query/Action/AbstractAction.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Query\Action;
 
 use Solarium\Core\Configurable;

--- a/src/QueryType/Server/Query/Action/AbstractAsyncAction.php
+++ b/src/QueryType/Server/Query/Action/AbstractAsyncAction.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Query\Action;
 
 /**
@@ -7,12 +14,19 @@ namespace Solarium\QueryType\Server\Query\Action;
  */
 abstract class AbstractAsyncAction extends AbstractAction implements AsyncActionInterface
 {
+    /**
+     * {@inheritdoc}
+     */
     public function setAsync(string $requestId): AsyncActionInterface
     {
         $this->setOption('async', $requestId);
+
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getAsync(): string
     {
         return (string) $this->getOption('async');

--- a/src/QueryType/Server/Query/Action/ActionInterface.php
+++ b/src/QueryType/Server/Query/Action/ActionInterface.php
@@ -1,9 +1,19 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Query\Action;
 
 use Solarium\Core\ConfigurableInterface;
 
+/**
+ * ActionInterface.
+ */
 interface ActionInterface extends ConfigurableInterface
 {
     /**

--- a/src/QueryType/Server/Query/Action/AsyncActionInterface.php
+++ b/src/QueryType/Server/Query/Action/AsyncActionInterface.php
@@ -1,7 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Query\Action;
 
+/**
+ * AsyncActionInterface.
+ */
 interface AsyncActionInterface extends ActionInterface
 {
     /**

--- a/src/QueryType/Server/Query/RequestBuilder.php
+++ b/src/QueryType/Server/Query/RequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Server\Query;
 
 use Solarium\Core\Client\Request;
@@ -26,6 +33,7 @@ class RequestBuilder extends BaseRequestBuilder
         $request = parent::build($query);
         $request->setMethod(Request::METHOD_GET);
         $request = $this->addOptionsFromAction($query->getAction(), $request);
+
         return $request;
     }
 
@@ -40,6 +48,7 @@ class RequestBuilder extends BaseRequestBuilder
         $options = ['action' => $action->getType()];
         $options = array_merge($options, $action->getOptions());
         $request->addParams($options);
+
         return $request;
     }
 }

--- a/src/QueryType/Server/Query/RequestBuilder.php
+++ b/src/QueryType/Server/Query/RequestBuilder.php
@@ -12,8 +12,6 @@ namespace Solarium\QueryType\Server\Query;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
-use Solarium\Core\Query\QueryInterface;
-use Solarium\QueryType\Server\AbstractServerQuery;
 use Solarium\QueryType\Server\Query\Action\ActionInterface;
 
 /**
@@ -24,7 +22,7 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build request for an API query.
      *
-     * @param QueryInterface|AbstractServerQuery $query
+     * @param \Solarium\Core\Query\AbstractQuery $query
      *
      * @return Request
      */

--- a/src/QueryType/Spellcheck/Query.php
+++ b/src/QueryType/Spellcheck/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Spellcheck;
 
 use Solarium\Component\ComponentTraits\SpellcheckTrait;

--- a/src/QueryType/Spellcheck/RequestBuilder.php
+++ b/src/QueryType/Spellcheck/RequestBuilder.php
@@ -13,7 +13,6 @@ use Solarium\Component\RequestBuilder\Spellcheck;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
-use Solarium\Core\Query\QueryInterface;
 
 /**
  * Build a Spellcheck query request.
@@ -23,7 +22,7 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build request for a Spellcheck query.
      *
-     * @param QueryInterface|Query $query
+     * @param \Solarium\Core\Query\AbstractQuery $query
      *
      * @return Request
      */

--- a/src/QueryType/Spellcheck/RequestBuilder.php
+++ b/src/QueryType/Spellcheck/RequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Spellcheck;
 
 use Solarium\Component\RequestBuilder\Spellcheck;

--- a/src/QueryType/Spellcheck/ResponseParser.php
+++ b/src/QueryType/Spellcheck/ResponseParser.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Spellcheck;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
@@ -15,7 +22,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
     /**
      * Get result data for the response.
      *
-     * @param Result $result
+     * @param \Solarium\Core\Query\Result\ResultInterface $result
      *
      * @return array
      */
@@ -28,11 +35,11 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         $allSuggestions = [];
         $collation = null;
 
-        if (isset($data['spellcheck']['suggestions']) && is_array($data['spellcheck']['suggestions'])) {
+        if (isset($data['spellcheck']['suggestions']) && \is_array($data['spellcheck']['suggestions'])) {
             $suggestResults = $data['spellcheck']['suggestions'];
             $termClass = $query->getOption('termclass');
 
-            if ($query->getResponseWriter() == $query::WT_JSON) {
+            if ($query->getResponseWriter() === $query::WT_JSON) {
                 $suggestResults = $this->convertToKeyValueArray($suggestResults);
             }
 
@@ -40,14 +47,14 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
                 if ('collation' === $term) {
                     $collation = $termData;
                 } else {
-                    if (!array_key_exists(0, $termData)) {
+                    if (!\array_key_exists(0, $termData)) {
                         $termData = [$termData];
                     }
 
                     foreach ($termData as $currentTermData) {
                         $allSuggestions[] = $this->createTerm($termClass, $currentTermData);
 
-                        if (!array_key_exists($term, $suggestions)) {
+                        if (!\array_key_exists($term, $suggestions)) {
                             $suggestions[$term] = $this->createTerm($termClass, $currentTermData);
                         }
                     }
@@ -65,6 +72,12 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         );
     }
 
+    /**
+     * @param $termClass
+     * @param array $termData
+     *
+     * @return mixed
+     */
     private function createTerm($termClass, array $termData)
     {
         return new $termClass(

--- a/src/QueryType/Spellcheck/ResponseParser.php
+++ b/src/QueryType/Spellcheck/ResponseParser.php
@@ -73,8 +73,8 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
     }
 
     /**
-     * @param $termClass
-     * @param array $termData
+     * @param string $termClass
+     * @param array  $termData
      *
      * @return mixed
      */

--- a/src/QueryType/Spellcheck/Result/Result.php
+++ b/src/QueryType/Spellcheck/Result/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Spellcheck\Result;
 
 use Solarium\Core\Query\Result\QueryType as BaseResult;
@@ -137,13 +144,13 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     {
         $this->parseResponse();
 
-        return count($this->results);
+        return \count($this->results);
     }
 
     /**
      * Get collation.
      *
-     * @return null|string
+     * @return string|null
      */
     public function getCollation(): ?string
     {

--- a/src/QueryType/Spellcheck/Result/Result.php
+++ b/src/QueryType/Spellcheck/Result/Result.php
@@ -61,6 +61,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * This is not the HTTP status code! The normal value for success is 0.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return int
      */
     public function getStatus(): int
@@ -76,6 +78,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      * This doesn't include things like the HTTP responsetime. Purely the Solr
      * query execution time.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return int
      */
     public function getQueryTime(): int
@@ -88,6 +92,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     /**
      * Get all results.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return array
      */
     public function getResults(): array
@@ -99,6 +105,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
     /**
      * Get flat results.
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return array
      */
@@ -114,6 +122,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * @param string $term
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return array
      */
     public function getTerm(string $term): ?Term
@@ -125,6 +135,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
     /**
      * IteratorAggregate implementation.
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return \ArrayIterator
      */
@@ -138,6 +150,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     /**
      * Countable implementation.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return int
      */
     public function count(): int
@@ -149,6 +163,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
     /**
      * Get collation.
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return string|null
      */

--- a/src/QueryType/Spellcheck/Result/Term.php
+++ b/src/QueryType/Spellcheck/Result/Term.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Spellcheck\Result;
 
 /**
@@ -108,6 +115,6 @@ class Term implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->suggestions);
+        return \count($this->suggestions);
     }
 }

--- a/src/QueryType/Stream/Expression.php
+++ b/src/QueryType/Stream/Expression.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Stream;
 
 /**

--- a/src/QueryType/Stream/ExpressionBuilder.php
+++ b/src/QueryType/Stream/ExpressionBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Stream;
 
 use Solarium\Exception\InvalidArgumentException;
@@ -244,17 +251,17 @@ class ExpressionBuilder
      * @param string $name
      * @param array  $arguments
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
+     *
+     * @return string
      */
     public function __call(string $name, array $arguments): string
     {
         return $name.'('.implode(', ', array_filter($arguments, function ($value) {
-            if (is_array($value) || (is_object($value) && !method_exists($value, '__toString'))) {
+            if (\is_array($value) || (\is_object($value) && !method_exists($value, '__toString'))) {
                 throw new InvalidArgumentException('An expression argument must be a scalar value or an object that provides a __toString() method.');
             }
-            if (is_string($value)) {
+            if (\is_string($value)) {
                 $value = trim($value);
             }
             // Eliminate empty string arguments.
@@ -271,29 +278,30 @@ class ExpressionBuilder
      */
     public static function indent(string $expression): string
     {
-        $current_indentation = 0;
-        $indentation_step = 2;
-        $indented_expression = '';
-        $len = strlen($expression);
+        $currentIndentation = 0;
+        $indentationStep = 2;
+        $indentedExpression = '';
+        $len = \strlen($expression);
         for ($c = 0; $c < $len; ++$c) {
             if ('(' === $expression[$c]) {
-                $indented_expression .= $expression[$c].PHP_EOL;
-                $current_indentation += $indentation_step;
-                $indented_expression .= str_pad('', $current_indentation);
+                $indentedExpression .= $expression[$c].PHP_EOL;
+                $currentIndentation += $indentationStep;
+                $indentedExpression .= str_pad('', $currentIndentation);
             } elseif (')' === $expression[$c]) {
-                $current_indentation -= $indentation_step;
-                $indented_expression .= PHP_EOL;
-                $indented_expression .= str_pad('', $current_indentation).$expression[$c];
+                $currentIndentation -= $indentationStep;
+                $indentedExpression .= PHP_EOL;
+                $indentedExpression .= str_pad('', $currentIndentation).$expression[$c];
             } elseif (',' === $expression[$c]) {
-                $indented_expression .= $expression[$c].PHP_EOL.str_pad('', $current_indentation);
+                $indentedExpression .= $expression[$c].PHP_EOL.str_pad('', $currentIndentation);
                 // swallow space if any
                 if (' ' === @$expression[$c + 1]) {
                     ++$c;
                 }
             } else {
-                $indented_expression .= $expression[$c];
+                $indentedExpression .= $expression[$c];
             }
         }
-        return $indented_expression;
+
+        return $indentedExpression;
     }
 }

--- a/src/QueryType/Stream/Query.php
+++ b/src/QueryType/Stream/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Stream;
 
 use Solarium\Core\Client\Client;
@@ -64,6 +71,7 @@ class Query extends AbstractQuery
     public function setExpression(string $expr): self
     {
         $this->setOption('expr', $expr);
+
         return $this;
     }
 
@@ -89,6 +97,7 @@ class Query extends AbstractQuery
     public function setDocumentClass(string $value): self
     {
         $this->setOption('documentclass', $value);
+
         return $this;
     }
 

--- a/src/QueryType/Stream/RequestBuilder.php
+++ b/src/QueryType/Stream/RequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Stream;
 
 use Solarium\Core\Client\Request;

--- a/src/QueryType/Stream/RequestBuilder.php
+++ b/src/QueryType/Stream/RequestBuilder.php
@@ -11,7 +11,6 @@ namespace Solarium\QueryType\Stream;
 
 use Solarium\Core\Client\Request;
 use Solarium\Core\Query\AbstractQuery;
-use Solarium\Core\Query\QueryInterface;
 use Solarium\Core\Query\RequestBuilderInterface;
 
 /**
@@ -22,7 +21,7 @@ class RequestBuilder implements RequestBuilderInterface
     /**
      * Build request for a stream query.
      *
-     * @param QueryInterface|Query $query
+     * @param \Solarium\Core\Query\AbstractQuery $query
      *
      * @return Request
      */

--- a/src/QueryType/Stream/ResponseParser.php
+++ b/src/QueryType/Stream/ResponseParser.php
@@ -27,7 +27,9 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
      *
      * @param Result|ResultInterface $result
      *
-     * @throws RuntimeException
+     * @throws \Solarium\Exception\RuntimeException
+     * @throws \Solarium\Exception\StreamException
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return array
      */

--- a/src/QueryType/Stream/ResponseParser.php
+++ b/src/QueryType/Stream/ResponseParser.php
@@ -1,14 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Stream;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
+use Solarium\Core\Query\DocumentInterface;
 use Solarium\Core\Query\ResponseParserInterface as ResponseParserInterface;
 use Solarium\Core\Query\Result\ResultInterface;
 use Solarium\Exception\RuntimeException;
 use Solarium\Exception\StreamException;
 use Solarium\QueryType\Select\Result\Result;
-use Solarium\Core\Query\DocumentInterface;
 
 /**
  * Parse streaming expression response data.
@@ -34,7 +41,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         // create document instances
         $documentClass = $query->getOption('documentclass');
         $classes = class_implements($documentClass);
-        if (!in_array(DocumentInterface::class, $classes, true)) {
+        if (!\in_array(DocumentInterface::class, $classes, true)) {
             throw new RuntimeException('The result document class must implement DocumentInterface');
         }
 
@@ -70,7 +77,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         return $this->addHeaderInfo(
             $data,
             [
-                'numfound' => count($documents),
+                'numfound' => \count($documents),
                 'documents' => $documents,
             ]
         );

--- a/src/QueryType/Stream/Result.php
+++ b/src/QueryType/Stream/Result.php
@@ -55,6 +55,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * This is not the HTTP status code! The normal value for success is 0.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return int
      */
     public function getStatus(): int
@@ -70,6 +72,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      * This doesn't include things like the HTTP responsetime. Purely the Solr
      * query execution time.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return int
      */
     public function getQueryTime(): int
@@ -84,6 +88,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * Returns the total number of documents found by Solr (this is NOT the
      * number of document fetched from Solr!)
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return int
      */
@@ -107,6 +113,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     /**
      * Get all documents.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return DocumentInterface[]
      */
     public function getDocuments(): array
@@ -119,6 +127,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     /**
      * IteratorAggregate implementation.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return \ArrayIterator
      */
     public function getIterator(): \ArrayIterator
@@ -130,6 +140,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
     /**
      * Countable implementation.
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return int
      */

--- a/src/QueryType/Stream/Result.php
+++ b/src/QueryType/Stream/Result.php
@@ -1,9 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Stream;
 
-use Solarium\Core\Query\Result\QueryType as BaseResult;
 use Solarium\Core\Query\DocumentInterface;
+use Solarium\Core\Query\Result\QueryType as BaseResult;
 
 /**
  * Stream query result.
@@ -130,7 +137,7 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     {
         $this->parseResponse();
 
-        return count($this->documents);
+        return \count($this->documents);
     }
 
     /**

--- a/src/QueryType/Suggester/Query.php
+++ b/src/QueryType/Suggester/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Suggester;
 
 use Solarium\Component\ComponentTraits\SuggesterTrait;

--- a/src/QueryType/Suggester/RequestBuilder.php
+++ b/src/QueryType/Suggester/RequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Suggester;
 
 use Solarium\Component\RequestBuilder\Suggester;

--- a/src/QueryType/Suggester/ResponseParser.php
+++ b/src/QueryType/Suggester/ResponseParser.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Suggester;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
@@ -27,7 +34,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         $dictionaries = [];
         $allSuggestions = [];
 
-        if (isset($data['suggest']) && is_array($data['suggest'])) {
+        if (isset($data['suggest']) && \is_array($data['suggest'])) {
             $dictionaryClass = $query->getOption('dictionaryclass');
             $termClass = $query->getOption('termclass');
 
@@ -50,6 +57,12 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         );
     }
 
+    /**
+     * @param string $dictionaryClass
+     * @param array  $terms
+     *
+     * @return mixed
+     */
     private function createDictionary($dictionaryClass, array $terms)
     {
         return new $dictionaryClass(
@@ -57,6 +70,12 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         );
     }
 
+    /**
+     * @param string $termClass
+     * @param array  $termData
+     *
+     * @return mixed
+     */
     private function createTerm($termClass, array $termData)
     {
         return new $termClass(

--- a/src/QueryType/Suggester/Result/Dictionary.php
+++ b/src/QueryType/Suggester/Result/Dictionary.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Suggester\Result;
 
 /**
@@ -63,6 +70,6 @@ class Dictionary implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->terms);
+        return \count($this->terms);
     }
 }

--- a/src/QueryType/Suggester/Result/Result.php
+++ b/src/QueryType/Suggester/Result/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Suggester\Result;
 
 use Solarium\Core\Query\Result\QueryType as BaseResult;
@@ -128,6 +135,6 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     {
         $this->parseResponse();
 
-        return count($this->results);
+        return \count($this->results);
     }
 }

--- a/src/QueryType/Suggester/Result/Result.php
+++ b/src/QueryType/Suggester/Result/Result.php
@@ -52,6 +52,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * This is not the HTTP status code! The normal value for success is 0.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return int
      */
     public function getStatus(): int
@@ -67,6 +69,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      * This doesn't include things like the HTTP responsetime. Purely the Solr
      * query execution time.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return int
      */
     public function getQueryTime(): int
@@ -79,6 +83,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     /**
      * Get all results.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return array
      */
     public function getResults(): array
@@ -90,6 +96,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
     /**
      * Get flat results.
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return array
      */
@@ -105,6 +113,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * @param string $dictionary
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return Dictionary|null
      */
     public function getDictionary($dictionary): ?Dictionary
@@ -117,6 +127,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     /**
      * IteratorAggregate implementation.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return \ArrayIterator
      */
     public function getIterator(): \ArrayIterator
@@ -128,6 +140,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
     /**
      * Countable implementation.
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return int
      */

--- a/src/QueryType/Suggester/Result/Term.php
+++ b/src/QueryType/Suggester/Result/Term.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Suggester\Result;
 
 /**
@@ -70,6 +77,6 @@ class Term implements \IteratorAggregate, \Countable
      */
     public function count(): int
     {
-        return count($this->suggestions);
+        return \count($this->suggestions);
     }
 }

--- a/src/QueryType/Terms/Query.php
+++ b/src/QueryType/Terms/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Terms;
 
 use Solarium\Component\ComponentTraits\TermsTrait;

--- a/src/QueryType/Terms/RequestBuilder.php
+++ b/src/QueryType/Terms/RequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Terms;
 
 use Solarium\Component\RequestBuilder\Terms;

--- a/src/QueryType/Terms/ResponseParser.php
+++ b/src/QueryType/Terms/ResponseParser.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Terms;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
@@ -14,7 +21,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
     /**
      * Get result data for the response.
      *
-     * @param Result $result
+     * @param \Solarium\Core\Query\Result\ResultInterface $result
      *
      * @return array
      */
@@ -35,7 +42,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
                 // There seems to be a bug in Solr that json.nl=flat is ignored in a distributed search on Solr
                 // Cloud. In that case the "map" format is returned which doesn't need to be converted. But we don't
                 // use it in general because it has limitations for some components.
-                if (isset($terms[0]) && $query->getResponseWriter() == $query::WT_JSON) {
+                if (isset($terms[0]) && $query->getResponseWriter() === $query::WT_JSON) {
                     // We have a "flat" json result.
                     $terms = $this->convertToKeyValueArray($terms);
                 }

--- a/src/QueryType/Terms/Result.php
+++ b/src/QueryType/Terms/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Terms;
 
 use Solarium\Core\Query\Result\QueryType as BaseResult;
@@ -113,6 +120,6 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     {
         $this->parseResponse();
 
-        return count($this->results);
+        return \count($this->results);
     }
 }

--- a/src/QueryType/Terms/Result.php
+++ b/src/QueryType/Terms/Result.php
@@ -45,6 +45,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      *
      * This is not the HTTP status code! The normal value for success is 0.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return int
      */
     public function getStatus(): int
@@ -60,6 +62,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      * This doesn't include things like the HTTP responsetime. Purely the Solr
      * query execution time.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return int
      */
     public function getQueryTime(): int
@@ -71,6 +75,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
     /**
      * Get all term results.
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return array
      */
@@ -85,6 +91,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      * Get term results for a specific field.
      *
      * @param string $field
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return array
      */
@@ -102,6 +110,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     /**
      * IteratorAggregate implementation.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return \ArrayIterator
      */
     public function getIterator(): \ArrayIterator
@@ -113,6 +123,8 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
 
     /**
      * Countable implementation.
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return int
      */

--- a/src/QueryType/Update/Query/Command/AbstractCommand.php
+++ b/src/QueryType/Update/Query/Command/AbstractCommand.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Update\Query\Command;
 
 use Solarium\Core\Configurable;

--- a/src/QueryType/Update/Query/Command/Add.php
+++ b/src/QueryType/Update/Query/Command/Add.php
@@ -1,9 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Update\Query\Command;
 
-use Solarium\Exception\RuntimeException;
 use Solarium\Core\Query\DocumentInterface;
+use Solarium\Exception\RuntimeException;
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 
 /**
@@ -32,7 +39,6 @@ class Add extends AbstractCommand
 
     /**
      * Add a single document.
-     *
      *
      * @param DocumentInterface $document
      *
@@ -97,6 +103,7 @@ class Add extends AbstractCommand
     public function setOverwrite(bool $overwrite): self
     {
         $this->setOption('overwrite', $overwrite);
+
         return $this;
     }
 
@@ -120,6 +127,7 @@ class Add extends AbstractCommand
     public function setCommitWithin(int $commitWithin): self
     {
         $this->setOption('commitwithin', $commitWithin);
+
         return $this;
     }
 

--- a/src/QueryType/Update/Query/Command/Add.php
+++ b/src/QueryType/Update/Query/Command/Add.php
@@ -42,8 +42,6 @@ class Add extends AbstractCommand
      *
      * @param DocumentInterface $document
      *
-     * @throws RuntimeException
-     *
      * @return self Provides fluent interface
      */
     public function addDocument(DocumentInterface $document): self

--- a/src/QueryType/Update/Query/Command/Commit.php
+++ b/src/QueryType/Update/Query/Command/Commit.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Update\Query\Command;
 
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;
@@ -41,6 +48,7 @@ class Commit extends AbstractCommand
     public function setSoftCommit(bool $softCommit): self
     {
         $this->setOption('softcommit', $softCommit);
+
         return $this;
     }
 
@@ -64,6 +72,7 @@ class Commit extends AbstractCommand
     public function setWaitSearcher(bool $waitSearcher): self
     {
         $this->setOption('waitsearcher', $waitSearcher);
+
         return $this;
     }
 
@@ -87,6 +96,7 @@ class Commit extends AbstractCommand
     public function setExpungeDeletes(bool $expungeDeletes): self
     {
         $this->setOption('expungedeletes', $expungeDeletes);
+
         return $this;
     }
 }

--- a/src/QueryType/Update/Query/Command/Delete.php
+++ b/src/QueryType/Update/Query/Command/Delete.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Update\Query\Command;
 
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;
@@ -118,7 +125,7 @@ class Delete extends AbstractCommand
     {
         $id = $this->getOption('id');
         if (null !== $id) {
-            if (is_array($id)) {
+            if (\is_array($id)) {
                 $this->addIds($id);
             } else {
                 $this->addId($id);
@@ -127,7 +134,7 @@ class Delete extends AbstractCommand
 
         $queries = $this->getOption('query');
         if (null !== $queries) {
-            if (is_array($queries)) {
+            if (\is_array($queries)) {
                 $this->addQueries($queries);
             } else {
                 $this->addQuery($queries);

--- a/src/QueryType/Update/Query/Command/Delete.php
+++ b/src/QueryType/Update/Query/Command/Delete.php
@@ -121,7 +121,7 @@ class Delete extends AbstractCommand
     /**
      * Build ids/queries based on options.
      */
-    protected function init()
+    protected function init(): void
     {
         $id = $this->getOption('id');
         if (null !== $id) {

--- a/src/QueryType/Update/Query/Command/Optimize.php
+++ b/src/QueryType/Update/Query/Command/Optimize.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Update\Query\Command;
 
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;
@@ -41,6 +48,7 @@ class Optimize extends AbstractCommand
     public function setSoftCommit(bool $softCommit): self
     {
         $this->setOption('softcommit', $softCommit);
+
         return $this;
     }
 
@@ -64,6 +72,7 @@ class Optimize extends AbstractCommand
     public function setWaitSearcher(bool $waitSearcher): self
     {
         $this->setOption('waitsearcher', $waitSearcher);
+
         return $this;
     }
 
@@ -87,6 +96,7 @@ class Optimize extends AbstractCommand
     public function setMaxSegments(int $maxSegments): self
     {
         $this->setOption('maxsegments', $maxSegments);
+
         return $this;
     }
 }

--- a/src/QueryType/Update/Query/Command/RawXml.php
+++ b/src/QueryType/Update/Query/Command/RawXml.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Update\Query\Command;
 
 use Solarium\Exception\RuntimeException;
@@ -106,7 +113,7 @@ class RawXml extends AbstractCommand
     {
         $command = $this->getOption('command');
         if (null !== $command) {
-            if (is_array($command)) {
+            if (\is_array($command)) {
                 $this->addCommands($command);
             } else {
                 $this->addCommand($command);

--- a/src/QueryType/Update/Query/Command/RawXml.php
+++ b/src/QueryType/Update/Query/Command/RawXml.php
@@ -82,12 +82,12 @@ class RawXml extends AbstractCommand
         }
 
         // discard UTF-8 Byte Order Mark
-        if (pack('CCC', 0xEF, 0xBB, 0xBF) === substr($command, 0, 3)) {
+        if (0 === strpos($command, pack('CCC', 0xEF, 0xBB, 0xBF))) {
             $command = substr($command, 3);
         }
 
         // discard XML declaration
-        if ('<?xml' === substr($command, 0, 5)) {
+        if (0 === strpos($command, '<?xml')) {
             $command = substr($command, strpos($command, '?>') + 2);
         }
 
@@ -109,7 +109,7 @@ class RawXml extends AbstractCommand
     /**
      * Build XML command strings based on options.
      */
-    protected function init()
+    protected function init(): void
     {
         $command = $this->getOption('command');
         if (null !== $command) {

--- a/src/QueryType/Update/Query/Command/Rollback.php
+++ b/src/QueryType/Update/Query/Command/Rollback.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Update\Query\Command;
 
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;

--- a/src/QueryType/Update/Query/Document.php
+++ b/src/QueryType/Update/Query/Document.php
@@ -424,7 +424,7 @@ class Document extends AbstractDocument
      */
     public function getFieldModifier(string $key): ?string
     {
-        return isset($this->modifiers[$key]) ? $this->modifiers[$key] : null;
+        return $this->modifiers[$key] ?? null;
     }
 
     /**

--- a/src/QueryType/Update/Query/Document.php
+++ b/src/QueryType/Update/Query/Document.php
@@ -1,11 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Update\Query;
 
-use Solarium\Core\Query\Helper;
 use Solarium\Core\Query\AbstractDocument;
-use Solarium\Exception\RuntimeException;
 use Solarium\Core\Query\DocumentInterface;
+use Solarium\Core\Query\Helper;
+use Solarium\Exception\RuntimeException;
 
 /**
  * Read/Write Solr document.
@@ -213,11 +220,11 @@ class Document extends AbstractDocument
             $this->setField($key, $value, $boost, $modifier);
         } else {
             // convert single value to array if needed
-            if (!is_array($this->fields[$key])) {
+            if (!\is_array($this->fields[$key])) {
                 $this->fields[$key] = [$this->fields[$key]];
             }
 
-            if ($this->filterControlCharacters && is_string($value)) {
+            if ($this->filterControlCharacters && \is_string($value)) {
                 $value = $this->getHelper()->filterControlCharacters($value);
             }
 
@@ -252,7 +259,7 @@ class Document extends AbstractDocument
         if (null === $value && null === $modifier) {
             $this->removeField($key);
         } else {
-            if ($this->filterControlCharacters && is_string($value)) {
+            if ($this->filterControlCharacters && \is_string($value)) {
                 $value = $this->getHelper()->filterControlCharacters($value);
             }
 
@@ -400,7 +407,7 @@ class Document extends AbstractDocument
      */
     public function setFieldModifier(string $key, string $modifier = null): self
     {
-        if (!in_array($modifier, [self::MODIFIER_ADD, self::MODIFIER_ADD_DISTINCT, self::MODIFIER_REMOVE, self::MODIFIER_REMOVEREGEX, self::MODIFIER_INC, self::MODIFIER_SET], true)) {
+        if (!\in_array($modifier, [self::MODIFIER_ADD, self::MODIFIER_ADD_DISTINCT, self::MODIFIER_REMOVE, self::MODIFIER_REMOVEREGEX, self::MODIFIER_INC, self::MODIFIER_SET], true)) {
             throw new RuntimeException('Attempt to set an atomic update modifier that is not supported');
         }
         $this->modifiers[$key] = $modifier;
@@ -413,7 +420,7 @@ class Document extends AbstractDocument
      *
      * @param string $key
      *
-     * @return null|string
+     * @return string|null
      */
     public function getFieldModifier(string $key): ?string
     {
@@ -431,7 +438,7 @@ class Document extends AbstractDocument
      */
     public function getFields(): array
     {
-        if ((null === $this->key || !isset($this->fields[$this->key])) && count($this->modifiers) > 0) {
+        if ((null === $this->key || !isset($this->fields[$this->key])) && \count($this->modifiers) > 0) {
             throw new RuntimeException('A document that uses modifiers (atomic updates) must have a key defined before it is used');
         }
 

--- a/src/QueryType/Update/Query/Query.php
+++ b/src/QueryType/Update/Query/Query.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Update\Query;
 
 use Solarium\Core\Client\Client;
@@ -140,7 +147,7 @@ class Query extends BaseQuery
         $type = strtolower($type);
 
         if (!isset($this->commandTypes[$type])) {
-            throw new InvalidArgumentException('Update commandtype unknown: '.$type);
+            throw new InvalidArgumentException(sprintf('Update commandtype unknown: %s', $type));
         }
 
         $class = $this->commandTypes[$type];
@@ -527,7 +534,7 @@ class Query extends BaseQuery
             foreach ($this->options['command'] as $key => $value) {
                 $type = $value['type'];
 
-                if (self::COMMAND_ADD == $type) {
+                if (self::COMMAND_ADD === $type) {
                     throw new RuntimeException('Adding documents is not supported in configuration, use the API for this');
                 }
 

--- a/src/QueryType/Update/Query/Query.php
+++ b/src/QueryType/Update/Query/Query.php
@@ -526,7 +526,7 @@ class Query extends BaseQuery
      *
      * @throws RuntimeException
      */
-    protected function init()
+    protected function init(): void
     {
         parent::init();
 

--- a/src/QueryType/Update/RequestBuilder.php
+++ b/src/QueryType/Update/RequestBuilder.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Update;
 
 use Solarium\Core\Client\Request;
@@ -256,13 +263,13 @@ class RequestBuilder extends BaseRequestBuilder
 
         // Remove the values if 'null' or empty list is specified as the new value
         // @see https://lucene.apache.org/solr/guide/updating-parts-of-documents.html#atomic-updates
-        if (Document::MODIFIER_SET === $modifier && is_array($value) && empty($value)) {
+        if (Document::MODIFIER_SET === $modifier && \is_array($value) && empty($value)) {
             $value = null;
         }
 
-        if (is_array($value)) {
+        if (\is_array($value)) {
             foreach ($value as $multival) {
-                if (is_array($multival)) {
+                if (\is_array($multival)) {
                     $xml .= '<doc>';
                     foreach ($multival as $k => $v) {
                         $xml .= $this->buildFieldsXml($k, $boost, $v, $modifier);

--- a/src/QueryType/Update/ResponseParser.php
+++ b/src/QueryType/Update/ResponseParser.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Update;
 
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;

--- a/src/QueryType/Update/Result.php
+++ b/src/QueryType/Update/Result.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\QueryType\Update;
 
 use Solarium\Core\Query\Result\QueryType as BaseResult;

--- a/src/QueryType/Update/Result.php
+++ b/src/QueryType/Update/Result.php
@@ -44,6 +44,8 @@ class Result extends BaseResult
      *
      * This is not the HTTP status code! The normal value for success is 0.
      *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
      * @return int
      */
     public function getStatus(): int
@@ -58,6 +60,8 @@ class Result extends BaseResult
      *
      * This doesn't include things like the HTTP responsetime. Purely the Solr
      * query execution time.
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
      *
      * @return int
      */

--- a/src/Support/DataFixtures/Executor.php
+++ b/src/Support/DataFixtures/Executor.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Support\DataFixtures;
 
 use Solarium\Core\Client\ClientInterface;

--- a/src/Support/DataFixtures/Executor.php
+++ b/src/Support/DataFixtures/Executor.php
@@ -34,7 +34,7 @@ class Executor
     /**
      * @param FixtureInterface[] $fixtures
      */
-    public function execute(array $fixtures)
+    public function execute(array $fixtures): void
     {
         foreach ($fixtures as $fixture) {
             $fixture->load($this->client);

--- a/src/Support/DataFixtures/FixtureInterface.php
+++ b/src/Support/DataFixtures/FixtureInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Support\DataFixtures;
 
 use Solarium\Core\Client\ClientInterface;

--- a/src/Support/DataFixtures/FixtureLoader.php
+++ b/src/Support/DataFixtures/FixtureLoader.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Support\DataFixtures;
 
 use ReflectionException;
@@ -42,9 +49,9 @@ class FixtureLoader
      * @param string $dir
      * @param bool   $append
      *
-     * @return self
-     *
      * @throws ReflectionException
+     *
+     * @return self
      */
     public function loadFixturesFromDir(string $dir, bool $append = true)
     {

--- a/src/Support/DataFixtures/FixtureLoader.php
+++ b/src/Support/DataFixtures/FixtureLoader.php
@@ -53,7 +53,7 @@ class FixtureLoader
      *
      * @return self
      */
-    public function loadFixturesFromDir(string $dir, bool $append = true)
+    public function loadFixturesFromDir(string $dir, bool $append = true): self
     {
         if (!$append) {
             $this->purger->purge();

--- a/src/Support/DataFixtures/Loader.php
+++ b/src/Support/DataFixtures/Loader.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Support\DataFixtures;
 
 use ReflectionException;
@@ -53,10 +60,10 @@ class Loader
     /**
      * @param string $dir
      *
-     * @return self
-     *
      * @throws InvalidArgumentException
      * @throws ReflectionException
+     *
+     * @return self
      */
     public function loadFromDirectory(string $dir): self
     {
@@ -73,7 +80,7 @@ class Loader
 
         /** @var $file \DirectoryIterator */
         foreach ($iterator as $file) {
-            if ($file->getBasename($this->fileExtension) == $file->getBasename()) {
+            if ($file->getBasename($this->fileExtension) === $file->getBasename()) {
                 continue;
             }
             $sourceFile = realpath($file->getPathname());
@@ -87,7 +94,7 @@ class Loader
             $reflClass = new \ReflectionClass($className);
             $sourceFile = $reflClass->getFileName();
 
-            if (in_array($sourceFile, $includedFiles, true)) {
+            if (\in_array($sourceFile, $includedFiles, true)) {
                 $fixture = new $className();
 
                 $this->addFixture($fixture);

--- a/src/Support/DataFixtures/Purger.php
+++ b/src/Support/DataFixtures/Purger.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Support\DataFixtures;
 
 use Solarium\Core\Client\ClientInterface;
@@ -39,6 +46,6 @@ class Purger
 
         $result = $this->client->update($update);
 
-        return 0 == $result->getStatus();
+        return 0 === $result->getStatus();
     }
 }

--- a/src/Support/Utility.php
+++ b/src/Support/Utility.php
@@ -29,12 +29,12 @@ class Utility
 
         if (false !== $xml) {
             // discard UTF-8 Byte Order Mark
-            if (pack('CCC', 0xEF, 0xBB, 0xBF) === substr($xml, 0, 3)) {
+            if (0 === strpos($xml, pack('CCC', 0xEF, 0xBB, 0xBF))) {
                 $xml = substr($xml, 3);
             }
 
             // detect XML declaration
-            if ('<?xml' === substr($xml, 0, 5)) {
+            if (0 === strpos($xml, '<?xml')) {
                 $declaration = substr($xml, 0, strpos($xml, '?>') + 2);
 
                 // detect encoding attribute

--- a/src/Support/Utility.php
+++ b/src/Support/Utility.php
@@ -1,7 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
 namespace Solarium\Support;
 
+/**
+ * Utility.
+ */
 class Utility
 {
     /**


### PR DESCRIPTION
fixes #747 

```
vendor/bin/phpcs
vendor/bin/php-cs-fixer fix
```
can now be run without resulting in warnings / errors / modifications

### remarks:
- i've changed all events interfaces to not instantiable classes so there's no need for users of those to do any refactoring. nevertheless, do you want me to make an entry in the changelog for that?
- i'm a bit puzzled by style ci; though they offer a symfony preset, it clearly does not apply all rules described at [symfony's coding standard page](https://symfony.com/doc/current/contributing/code/standards.html) so how to go forward from here: do we move away from ctyle ci or do we add an additional style check step; any suggestions?