### PR TITLE
Add method option to highlighter

### DIFF
--- a/src/Component/Highlighting/Highlighting.php
+++ b/src/Component/Highlighting/Highlighting.php
@@ -952,7 +952,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     }
 
     /**
-     * Set boundaryscannercountry option.
+     * Set method option.
      *
      * @param string $method
      *
@@ -965,6 +965,11 @@ class Highlighting extends AbstractComponent implements QueryInterface
         return $this;
     }
 
+    /**
+     * Get method option.
+     *
+     * @return string|null
+     */
     public function getMethod(): ?string
     {
         return $this->getOption('method');

--- a/src/Component/Highlighting/Highlighting.php
+++ b/src/Component/Highlighting/Highlighting.php
@@ -952,6 +952,25 @@ class Highlighting extends AbstractComponent implements QueryInterface
     }
 
     /**
+     * Set boundaryscannercountry option.
+     *
+     * @param string $method
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMethod(string $method): self
+    {
+        $this->setOption('method', $method);
+
+        return $this;
+    }
+
+    public function getMethod(): ?string
+    {
+        return $this->getOption('method');
+    }
+
+    /**
      * Initialize options.
      *
      * The field option needs setup work

--- a/src/Component/RequestBuilder/Highlighting.php
+++ b/src/Component/RequestBuilder/Highlighting.php
@@ -66,6 +66,7 @@ class Highlighting implements ComponentRequestBuilderInterface
         $request->addParam('hl.bs.type', $component->getBoundaryScannerType());
         $request->addParam('hl.bs.language', $component->getBoundaryScannerLanguage());
         $request->addParam('hl.bs.country', $component->getBoundaryScannerCountry());
+        $request->addParam('h1.method', $component->getMethod());
 
         // set per-field highlighting params
         foreach ($component->getFields() as $field) {

--- a/tests/Component/RequestBuilder/HighlightingTest.php
+++ b/tests/Component/RequestBuilder/HighlightingTest.php
@@ -59,6 +59,7 @@ class HighlightingTest extends TestCase
         $component->setBoundaryScannerType($component::BOUNDARYSCANNER_TYPE_WORD);
         $component->setBoundaryScannerCountry('be');
         $component->setBoundaryScannerLanguage('en');
+        $component->setMethod('unified');
 
         $request = $builder->buildComponent($component, $request);
 
@@ -105,6 +106,7 @@ class HighlightingTest extends TestCase
                 'hl.bs.type' => 'WORD',
                 'hl.bs.country' => 'be',
                 'hl.bs.language' => 'en',
+                'h1.method' => 'unified',
             ],
             $request->getParams()
         );


### PR DESCRIPTION
Adds the option to specify the highlighter method as per https://github.com/solariumphp/solarium/issues/517

It doesn't include the additional options for the different highlighters. This may require adding additional classes for `UnifiedHighlighter`, `FastVectorHighlighter`, `PostingsHighlighter` etc