### PR TITLE
Document highlighter method option introduced in #856

### DIFF
--- a/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
@@ -5,6 +5,7 @@ Options
 
 | Name                     | Type    | Default value | Description                                                                        |
 |--------------------------|---------|---------------|------------------------------------------------------------------------------------|
+| method                   | string  | null          | The highlighting implementation to use: 'unified', 'original' or 'fastVector'.     |
 | fields                   | string  | null          | Fields to generate highlighted snippets for. Separate multiple fields with commas. |
 | snippets                 | int     | null          | Maximum number of snippets per field                                               |
 | fragsize                 | int     | null          | The size, in characters, of fragments to consider for highlighting                 |


### PR DESCRIPTION
I've put it as the first option because it's also the first on https://lucene.apache.org/solr/guide/highlighting.html.