### PR TITLE
Fix return typehint for ClusterState::getCollections()

### DIFF
--- a/src/Core/Client/State/ClusterState.php
+++ b/src/Core/Client/State/ClusterState.php
@@ -121,7 +121,7 @@ class ClusterState
     }
 
     /**
-     * @return ClusterState[]
+     * @return CollectionState[]
      */
     public function getCollections(): array
     {

--- a/src/Core/Client/State/ClusterState.php
+++ b/src/Core/Client/State/ClusterState.php
@@ -121,7 +121,7 @@ class ClusterState
     }
 
     /**
-     * @return null|CollectionState[]
+     * @return CollectionState[]|null
      */
     public function getCollections(): ?array
     {

--- a/src/Core/Client/State/ClusterState.php
+++ b/src/Core/Client/State/ClusterState.php
@@ -121,9 +121,9 @@ class ClusterState
     }
 
     /**
-     * @return CollectionState[]
+     * @return null|CollectionState[]
      */
-    public function getCollections(): array
+    public function getCollections(): ?array
     {
         return $this->collections;
     }


### PR DESCRIPTION

In case there are no collections yet, a `TypeError` is thrown:
```
TypeError: Return value of Solarium\Core\Client\State\ClusterState::getCollections() must be of the type array, null returned
```