### PR TITLE
Tika based file extraction with Solr 8.6, fixes #864

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Fixed
+- Tika based file extraction with Solr 8.6
 
 ### Changed
-- require specific symfony/event-dispatcher-contracts package instead of the generic symfony/contracts
+- Require specific symfony/event-dispatcher-contracts package instead of the generic symfony/contracts
 
 ### Removed
 

--- a/src/QueryType/Extract/Result.php
+++ b/src/QueryType/Extract/Result.php
@@ -25,8 +25,8 @@ class Result extends UpdateResult
      * Includes a lazy loading mechanism: JSON body data is decoded on first use and then saved for reuse.
      *
      * @return array
-     * @throws RuntimeException
      *
+     * @throws RuntimeException
      * @throws UnexpectedValueException
      */
     public function getData(): array

--- a/src/QueryType/Extract/Result.php
+++ b/src/QueryType/Extract/Result.php
@@ -9,6 +9,8 @@
 
 namespace Solarium\QueryType\Extract;
 
+use Solarium\Exception\RuntimeException;
+use Solarium\Exception\UnexpectedValueException;
 use Solarium\QueryType\Update\Result as UpdateResult;
 
 /**
@@ -17,4 +19,29 @@ use Solarium\QueryType\Update\Result as UpdateResult;
  */
 class Result extends UpdateResult
 {
+    /**
+     * Get Solr response data.
+     *
+     * Includes a lazy loading mechanism: JSON body data is decoded on first use and then saved for reuse.
+     *
+     * @return array
+     * @throws RuntimeException
+     *
+     * @throws UnexpectedValueException
+     */
+    public function getData(): array
+    {
+        parent::getData();
+
+        // Solr versions before 8.6 used the file name as key within the response. Solr 8.6 uses the general key 'file'.
+        // To be compatible to any version we re-add the specific or the general key.
+        $filename = basename($this->query->getOption('file'));
+        if (!isset($this->data[$filename]) && isset($this->data['file'])) {
+            $this->data[$filename] = $this->data['file'];
+        } elseif (!isset($this->data['file']) && isset($this->data[$filename])) {
+            $this->data['file'] = $this->data[$filename];
+        }
+
+        return $this->data;
+    }
 }

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -1420,6 +1420,7 @@ abstract class AbstractTechproductsTest extends TestCase
 
         $response = self::$client->extract($query);
         $this->assertSame('PDF Test', trim($response->getData()['testpdf.pdf']), 'Can not extract the plain content from the file');
+        $this->assertSame('PDF Test', trim($response->getData()['file']), 'Can not extract the plain content from the file');
     }
 
     public function testV2Api()

--- a/tests/Integration/Fixtures/docker/solr8_cloud/docker-compose.yml
+++ b/tests/Integration/Fixtures/docker/solr8_cloud/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   solr8:
-    image: solr:8.5
+    image: solr:8
     ports:
       - "8983:8983"
     volumes:

--- a/tests/Integration/Fixtures/docker/solr8_server/docker-compose.yml
+++ b/tests/Integration/Fixtures/docker/solr8_server/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   solr8:
-    image: solr:8.5
+    image: solr:8
     ports:
       - "8983:8983"
     volumes:


### PR DESCRIPTION
Solr versions before 8.6 used the file name as key within the response. Solr 8.6 uses the general key 'file'.
To be compatible to any version we re-add the specific or the general key.