### PR TITLE
allow php 8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [7.2, 7.3, 7.4]
+                php: [7.2, 7.3, 7.4, 8.0]
                 solr: [7, 8]
                 mode: [cloud, server]
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -63,7 +63,6 @@ jobs:
 
             - name: Install dependencies
               run: |
-                composer require phpstan/phpstan:0.12.25
                 composer update
 
             - name: Run tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -67,7 +67,7 @@ jobs:
 
             - name: Run tests
               run: |
-                vendor/bin/phpstan analyze src/ tests/ --level=1
+                vendor/bin/phpstan analyze src/ tests/ --level=1 --memory-limit=1G
                 vendor/bin/phpunit -c phpunit.xml --exclude-group skip_for_solr_${{ matrix.mode }} -v --coverage-clover build/logs/clover.xml
 
             - name: Execute examples

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "psr/event-dispatcher": "^1.0",
         "psr/http-client": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^8.5 || ^9.4",
         "roave/security-advisories": "dev-master",
         "symfony/event-dispatcher": "^4.3 || ^5.0"
     },

--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -73,7 +73,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
      *
      * @throws InvalidArgumentException
      *
-     * @return resource
+     * @return resource|\CurlHandle
      */
     public function createHandle($request, $endpoint)
     {

--- a/src/Core/Query/AbstractDocument.php
+++ b/src/Core/Query/AbstractDocument.php
@@ -24,10 +24,8 @@ abstract class AbstractDocument implements DocumentInterface, \IteratorAggregate
     /**
      * @param mixed $name
      * @param mixed $value
-     *
-     * @return \Solarium\Core\Query\DocumentInterface
      */
-    abstract public function __set($name, $value): DocumentInterface;
+    abstract public function __set($name, $value): void;
 
     /**
      * Get field value by name.

--- a/src/Plugin/MinimumScoreFilter/Document.php
+++ b/src/Plugin/MinimumScoreFilter/Document.php
@@ -93,10 +93,8 @@ class Document implements DocumentInterface, \IteratorAggregate, \Countable, \Ar
      * @param string $value
      *
      * @throws RuntimeException
-     *
-     * @return self
      */
-    public function __set($name, $value): self
+    public function __set($name, $value): void
     {
         throw new RuntimeException('A readonly document cannot be altered');
     }

--- a/src/QueryType/Select/Result/Document.php
+++ b/src/QueryType/Select/Result/Document.php
@@ -10,7 +10,6 @@
 namespace Solarium\QueryType\Select\Result;
 
 use Solarium\Core\Query\AbstractDocument;
-use Solarium\Core\Query\DocumentInterface;
 use Solarium\Exception\RuntimeException;
 
 /**

--- a/src/QueryType/Select/Result/Document.php
+++ b/src/QueryType/Select/Result/Document.php
@@ -48,10 +48,8 @@ class Document extends AbstractDocument
      * @param string $value
      *
      * @throws RuntimeException
-     *
-     * @return DocumentInterface
      */
-    public function __set($name, $value): DocumentInterface
+    public function __set($name, $value): void
     {
         throw new RuntimeException('A readonly document cannot be altered');
     }

--- a/src/QueryType/Update/Query/Document.php
+++ b/src/QueryType/Update/Query/Document.php
@@ -175,14 +175,10 @@ class Document extends AbstractDocument
      *
      * @param string $name
      * @param mixed  $value
-     *
-     * @return self
      */
-    public function __set($name, $value): DocumentInterface
+    public function __set($name, $value): void
     {
         $this->setField($name, $value);
-
-        return $this;
     }
 
     /**

--- a/src/QueryType/Update/Query/Document.php
+++ b/src/QueryType/Update/Query/Document.php
@@ -10,7 +10,6 @@
 namespace Solarium\QueryType\Update\Query;
 
 use Solarium\Core\Query\AbstractDocument;
-use Solarium\Core\Query\DocumentInterface;
 use Solarium\Core\Query\Helper;
 use Solarium\Exception\RuntimeException;
 
@@ -187,14 +186,10 @@ class Document extends AbstractDocument
      * Magic method for removing fields by un-setting object properties
      *
      * @param string $name
-     *
-     * @return self
      */
-    public function __unset($name): self
+    public function __unset($name): void
     {
         $this->removeField($name);
-
-        return $this;
     }
 
     /**

--- a/tests/Core/Client/Adapter/CurlTest.php
+++ b/tests/Core/Client/Adapter/CurlTest.php
@@ -78,7 +78,11 @@ class CurlTest extends TestCase
         $curlAdapter = new Curl();
         $handler = $curlAdapter->createHandle($request, $endpoint);
 
-        $this->assertIsResource($handler);
+        if (class_exists(\CurlHandle::class)) {
+            $this->assertInstanceOf(\CurlHandle::class, $handler);
+        } else {
+            $this->assertIsResource($handler);
+        }
         curl_close($handler);
     }
 }


### PR DESCRIPTION
This makes solarium PHP 8 compatible and allows to use it with PHP 8.

**Note:** there are some code changes that might be considered BC breaks. So maybe we should discuss this.

TODOs:
- [x] run CI tests with php 8 / nightly
- [x] we should first merge https://github.com/solariumphp/solarium/pull/881