### PR TITLE
use guzzle 7 client for integration tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     },
     "require-dev": {
         "escapestudios/symfony2-coding-standard": "^3.11",
-        "guzzlehttp/guzzle": "^6.5",
+        "guzzlehttp/guzzle": "^7.2",
         "nyholm/psr7": "^1.2",
-        "php-http/guzzle6-adapter": "^2.0",
+        "php-http/guzzle7-adapter": "^0.1",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",

--- a/examples/6.1.1-psr18-adapter.php
+++ b/examples/6.1.1-psr18-adapter.php
@@ -4,7 +4,7 @@ require_once(__DIR__.'/init.php');
 htmlHeader();
 
 // create a PSR-18 adapter instance
-$httpClient = new Http\Adapter\Guzzle6\Client();
+$httpClient = new Http\Adapter\Guzzle7\Client();
 $factory = new Nyholm\Psr7\Factory\Psr17Factory();
 $adapter = new Solarium\Core\Client\Adapter\Psr18Adapter($httpClient, $factory, $factory);
 

--- a/tests/Integration/TestClientFactory.php
+++ b/tests/Integration/TestClientFactory.php
@@ -2,7 +2,7 @@
 
 namespace Solarium\Tests\Integration;
 
-use Http\Adapter\Guzzle6\Client as GuzzlePsrClient;
+use Http\Adapter\Guzzle7\Client as GuzzlePsrClient;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Solarium\Client;
 use Solarium\Core\Client\Adapter\Curl;


### PR DESCRIPTION
Should make it easier to run tests with PHP 8 since https://github.com/php-http/guzzle7-adapter supports PHP 8 already.