### PR TITLE
[BUG] Change return type of 'getNumberOfGroups()'

### DIFF
--- a/src/Component/Grouping.php
+++ b/src/Component/Grouping.php
@@ -370,9 +370,9 @@ class Grouping extends AbstractComponent
     /**
      * Get numberofgroups option.
      *
-     * @return bool|null
+     * @return int|null
      */
-    public function getNumberOfGroups(): ?bool
+    public function getNumberOfGroups(): ?int
     {
         return $this->getOption('numberofgroups');
     }


### PR DESCRIPTION
Method `getNumberOfGroups()` now returns an integer instead of an boolean.

Resolves: #885