### PR TITLE
Fix example code highlighting for Analytics component

### DIFF
--- a/docs/queries/select-query/building-a-select-query/components/analytics-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/analytics-component.md
@@ -59,3 +59,4 @@ $analytics
 // this executes the query and returns the result
 $result = $client->select($query);
 $analytics = $result->getAnalytics();
+```


### PR DESCRIPTION
The example section on https://solarium.readthedocs.io/en/stable/queries/select-query/building-a-select-query/components/analytics-component/ doesn't render correctly because the closing backticks are missing.