### PR TITLE
Auto-detect point values and remove $escape parameter in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Exception message for invalid/unavailable file in Extract query now contains filename
+- Helper::rangeQuery() detects point values without parameter to turn off escaping
 
 ### Removed
 

--- a/docs/queries/query-helper/query-helper.md
+++ b/docs/queries/query-helper/query-helper.md
@@ -7,7 +7,7 @@ Two special types of helper methods are
 Helper methods for general use
 ------------------------------
 
--   rangeQuery($field, $from, $to, $inclusive = true, $escape = true)
+-   rangeQuery($field, $from, $to, $inclusive = true)
 -   qparser($name, $params = array())
 -   functionCall($name, $params = array())
 -   join($from, $to, $dereferenced = false)

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -10,6 +10,7 @@
 namespace Solarium\Core\Query;
 
 use Solarium\Exception\InvalidArgumentException;
+use Solarium\Support\Utility;
 
 /**
  * Query helper.
@@ -167,33 +168,30 @@ class Helper
      * From and to can be any type of data. For instance int, string or point.
      * If they are null, then '*' will be used.
      *
-     * Example: rangeQuery('store', '45,-94', '46,-93', true, false)
+     * Example: rangeQuery('store', '45,-94', '46,-93')
      * Returns: store:[45,-94 TO 46,-93]
      *
-     * Example: rangeQuery('store', '5', '*', false)
-     * Returns: store:{"5" TO *}
+     * Example: rangeQuery('store', 5, null, false)
+     * Returns: store:{5 TO *}
      *
-     * @param string      $field
-     * @param string|null $from
-     * @param string|null $to
-     * @param bool        $inclusive TRUE if the the range should include the boundaries, FALSE otherwise
-     * @param bool        $escape    Whether the values should be escaped as phrase or not. Default is TRUE because
-     *                               escaping is correct for security reasons. But for location searches (point values),
-     *                               escaping would break the functionality
+     * @param string                $field
+     * @param int|float|string|null $from
+     * @param int|float|string|null $to
+     * @param bool                  $inclusive TRUE if the the range should include the boundaries, FALSE otherwise
      *
      * @return string
      */
-    public function rangeQuery(string $field, ?string $from, ?string $to, bool $inclusive = true, bool $escape = true): string
+    public function rangeQuery(string $field, $from, $to, bool $inclusive = true): string
     {
         if (null === $from) {
             $from = '*';
-        } elseif ($escape) {
+        } elseif (!is_int($from) && !is_float($from) && !Utility::isPointValue($from)) {
             $from = $this->escapePhrase($from);
         }
 
         if (null === $to) {
             $to = '*';
-        } elseif ($escape) {
+        } elseif (!is_int($to) && !is_float($to) && !Utility::isPointValue($to)) {
             $to = $this->escapePhrase($to);
         }
 

--- a/src/Support/Utility.php
+++ b/src/Support/Utility.php
@@ -51,7 +51,7 @@ class Utility
      * Checker whether a value is valid point value for spatial search.
      *
      * Example: '45.15,-93.85' (geodetic & non-geodetic PointType)
-     * 
+     *
      * Example: '45.15 -93.85' (non-geodetic RPT)
      *
      * @param string $value
@@ -60,6 +60,6 @@ class Utility
      */
     public static function isPointValue(string $value): bool
     {
-        return (bool)preg_match('/^-?\d+(?:\.\d+)?[, ]-?\d+(?:\.\d+)?$/', $value);
+        return (bool) preg_match('/^-?\d+(?:\.\d+)?[, ]-?\d+(?:\.\d+)?$/', $value);
     }
 }

--- a/src/Support/Utility.php
+++ b/src/Support/Utility.php
@@ -46,4 +46,20 @@ class Utility
 
         return $encoding;
     }
+
+    /**
+     * Checker whether a value is valid point value for spatial search.
+     *
+     * Example: '45.15,-93.85' (geodetic & non-geodetic PointType)
+     * 
+     * Example: '45.15 -93.85' (non-geodetic RPT)
+     *
+     * @param string $value
+     *
+     * @return bool
+     */
+    public static function isPointValue(string $value): bool
+    {
+        return (bool)preg_match('/^-?\d+(?:\.\d+)?[, ]-?\d+(?:\.\d+)?$/', $value);
+    }
 }

--- a/tests/Core/Query/HelperTest.php
+++ b/tests/Core/Query/HelperTest.php
@@ -28,52 +28,62 @@ class HelperTest extends TestCase
     public function testRangeQueryInclusive()
     {
         $this->assertEquals(
-            'field:["1" TO "2"]',
+            'field:[1 TO 2]',
             $this->helper->rangeQuery('field', 1, 2)
         );
 
         $this->assertSame(
             'store:[45,-94 TO 46,-93]',
-            $this->helper->rangeQuery('store', '45,-94', '46,-93', true, false)
+            $this->helper->rangeQuery('store', '45,-94', '46,-93')
+        );
+
+        $this->assertEquals(
+            'field:["A" TO "M"]',
+            $this->helper->rangeQuery('field', 'A', 'M')
         );
     }
 
     public function testRangeQueryExclusive()
     {
         $this->assertSame(
-            'field:{"1" TO "2"}',
+            'field:{1 TO 2}',
             $this->helper->rangeQuery('field', 1, 2, false)
         );
 
         $this->assertSame(
             'store:{45,-94 TO 46,-93}',
-            $this->helper->rangeQuery('store', '45,-94', '46,-93', false, false)
+            $this->helper->rangeQuery('store', '45,-94', '46,-93', false)
+        );
+
+        $this->assertEquals(
+            'field:{"A" TO "M"}',
+            $this->helper->rangeQuery('field', 'A', 'M', false)
         );
     }
 
     public function testRangeQueryInclusiveNullValues()
     {
         $this->assertSame(
-            'field:["1" TO *]',
+            'field:[1 TO *]',
             $this->helper->rangeQuery('field', 1, null)
         );
 
         $this->assertSame(
             'store:[* TO 46,-93]',
-            $this->helper->rangeQuery('store', null, '46,-93', true, false)
+            $this->helper->rangeQuery('store', null, '46,-93')
         );
     }
 
     public function testRangeQueryExclusiveNullValues()
     {
         $this->assertSame(
-            'field:{"1" TO *}',
+            'field:{1 TO *}',
             $this->helper->rangeQuery('field', 1, null, false)
         );
 
         $this->assertSame(
             'store:{* TO 46,-93}',
-            $this->helper->rangeQuery('store', null, '46,-93', false, false)
+            $this->helper->rangeQuery('store', null, '46,-93', false)
         );
     }
 

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -216,14 +216,14 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertCount(10, $result);
 
         $select->setQuery(
-            $select->getHelper()->rangeQuery('store', '-90,-90', '90,90', true, false)
+            $select->getHelper()->rangeQuery('store', '-90,-90', '90,90')
         );
         $result = self::$client->select($select);
         $this->assertSame(2, $result->getNumFound());
         $this->assertCount(2, $result);
 
         $select->setQuery(
-            $select->getHelper()->rangeQuery('store', '-90,-180', '90,180', true, false)
+            $select->getHelper()->rangeQuery('store', '-90,-180', '90,180')
         );
         $result = self::$client->select($select);
         $this->assertSame(14, $result->getNumFound());

--- a/tests/Support/UtilityTest.php
+++ b/tests/Support/UtilityTest.php
@@ -67,15 +67,13 @@ class UtilityTest extends TestCase
     {
         // geodetic, non-geodetic PointType
         $values = ['45,93', '45,-93', '-45,93', '-45,-93', '45.15,93.85', '45.15,-93.85', '-45.15,93.85', '-45.15,-93.85', '-45,93.85', '-45.15,93'];
-        foreach ($values as $value)
-        {
+        foreach ($values as $value) {
             $this->assertTrue(Utility::isPointValue($value));
         }
 
         // non-geodetic RPT
         $values = ['45 93', '45 -93', '-45 93', '-45 -93', '45.15 93.85', '45.15 -93.85', '-45.15 93.85', '-45.15 -93.85', '-45 93.85', '-45.15 93'];
-        foreach ($values as $value)
-        {
+        foreach ($values as $value) {
             $this->assertTrue(Utility::isPointValue($value));
         }
 

--- a/tests/Support/UtilityTest.php
+++ b/tests/Support/UtilityTest.php
@@ -62,4 +62,23 @@ class UtilityTest extends TestCase
             Utility::getXmlEncoding($this->fixtures.DIRECTORY_SEPARATOR.'testxml5-add-iso-8859-1.xml')
         );
     }
+
+    public function testIsPointValue()
+    {
+        // geodetic, non-geodetic PointType
+        $values = ['45,93', '45,-93', '-45,93', '-45,-93', '45.15,93.85', '45.15,-93.85', '-45.15,93.85', '-45.15,-93.85', '-45,93.85', '-45.15,93'];
+        foreach ($values as $value)
+        {
+            $this->assertTrue(Utility::isPointValue($value));
+        }
+
+        // non-geodetic RPT
+        $values = ['45 93', '45 -93', '-45 93', '-45 -93', '45.15 93.85', '45.15 -93.85', '-45.15 93.85', '-45.15 -93.85', '-45 93.85', '-45.15 93'];
+        foreach ($values as $value)
+        {
+            $this->assertTrue(Utility::isPointValue($value));
+        }
+
+        $this->assertFalse(Utility::isPointValue('not a point value'));
+    }
 }


### PR DESCRIPTION
… $helper->rangeQuery()

I've implemented my proposal to close #895.

Removing the `$escape` parameter doesn't break BC because it's just ignored when still passed. Or would it be better to throw a deprecation warning when it's passed?