### PR TITLE
Integration test for Grouping component

### DIFF
--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -339,7 +339,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $select->addSort('manu_exact', SelectQuery::SORT_ASC);
         $grouping = $select->getGrouping();
         $grouping->setFields('manu_exact');
-        $grouping->setSort('price ASC');
+        $grouping->setSort('price asc');
         $result = self::$client->select($select);
         /** @var GroupingResult $groupingComponentResult */
         $groupingComponentResult = $result->getComponent(ComponentAwareQueryInterface::COMPONENT_GROUPING);
@@ -400,7 +400,7 @@ abstract class AbstractTechproductsTest extends TestCase
             $select->getHelper()->rangeQuery('price', 100, null),
         ]);
         $grouping->setLimit(3);
-        $grouping->setSort('price DESC');
+        $grouping->setSort('price desc');
         $result = self::$client->select($select);
         $groupingComponentResult = $result->getComponent(ComponentAwareQueryInterface::COMPONENT_GROUPING);
 

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -322,6 +322,13 @@ abstract class AbstractTechproductsTest extends TestCase
         }
     }
 
+    /**
+     * The Grouping feature only works if groups are in the same shard. You must use the custom sharding feature to use the Grouping feature.
+     *
+     * @see https://cwiki.apache.org/confluence/display/solr/SolrCloud%20/#SolrCloud-KnownLimitations
+     *
+     * @group skip_for_solr_cloud
+     */
     public function testGroupingComponent()
     {
         self::$client->registerQueryType('grouping', '\Solarium\Tests\Integration\GroupingTestQuery');


### PR DESCRIPTION
This closes #246. The bug had actually been fixed already. The integration test proves that it works.

It's an implementation of the examples from the [ref guide](https://lucene.apache.org/solr/guide/result-grouping.html#grouping-examples). I've chosen an explicit sort order that's easier to verify than the default sort by score.

I had to mark it `@group skip_for_solr_cloud` because the test causes an error in cloud mode.
```
Solarium\Exception\HttpException: Solr HTTP error: OK (500)
{
  "error":{
    "msg":"shard 0 did not set sort field values (FieldDoc.fields is null); you must pass fillFields=true to IndexSearcher.search on each shard",
    "trace":"java.lang.IllegalArgumentException: shard 0 did not set sort field values (FieldDoc.fields is null); you must pass fillFields=true to IndexSearcher.search on each shard\n\tat org.apache.lucene.search.TopDocs$MergeSortQueue.<init>(TopDocs.java:164)\n\tat org.apache.lucene.search.TopDocs.mergeAux(TopDocs.java:266)\n\tat org.apache.lucene.search.TopDocs.merge(TopDocs.java:255)\n\tat org.apache.lucene.search.TopDocs.merge(TopDocs.java:237)\n\tat org.apache.solr.search.grouping.distributed.responseprocessor.TopGroupsShardResponseProcessor.process(TopGroupsShardResponseProcessor.java:181)\n\tat org.apache.solr.handler.component.QueryComponent.handleGroupedResponses(QueryComponent.java:579)\n\tat org.apache.solr.handler.component.QueryComponent.handleResponses(QueryComponent.java:562)\n\tat org.apache.solr.handler.component.SearchHandler.handleRequestBody(SearchHandler.java:426)\n\tat org.apache.solr.handler.RequestHandlerBase.handleRequest(RequestHandlerBase.java:199)\n\tat org.apache.solr.core.SolrCore.execute(SolrCore.java:2551)\n\tat org.apache.solr.servlet.HttpSolrCall.execute(HttpSolrCall.java:733)\n\tat org.apache.solr.servlet.HttpSolrCall.call(HttpSolrCall.java:531)\n\tat org.apache.solr.servlet.SolrDispatchFilter.doFilter(SolrDispatchFilter.java:395)\n\tat org.apache.solr.servlet.SolrDispatchFilter.doFilter(SolrDispatchFilter.java:341)\n\tat org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1602)\n\tat org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:540)\n\tat org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:146)\n\tat org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:548)\n\tat org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)\n\tat org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:257)\n\tat org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1588)\n\tat org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)\n\tat org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1345)\n\tat org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)\n\tat org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:480)\n\tat org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1557)\n\tat org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)\n\tat org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1247)\n\tat org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)\n\tat org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:220)\n\tat org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)\n\tat org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)\n\tat org.eclipse.jetty.rewrite.handler.RewriteHandler.handle(RewriteHandler.java:335)\n\tat org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)\n\tat org.eclipse.jetty.server.Server.handle(Server.java:502)\n\tat org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:364)\n\tat org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)\n\tat org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:305)\n\tat org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)\n\tat org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118)\n\tat org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)\n\tat org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)\n\tat org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)\n\tat org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126)\n\tat org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:366)\n\tat org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:765)\n\tat org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:683)\n\tat java.base/java.lang.Thread.run(Unknown Source)\n",
    "code":500}}
```

I couldn't find anything about that in the ref guide, but the [old wiki](https://cwiki.apache.org/confluence/display/solr/SolrCloud%20/#SolrCloud-KnownLimitations) has this to say:

> The Grouping feature only works if groups are in the same shard. You must use the custom sharding feature to use the Grouping feature.