### PR TITLE
Integration test for labelled children in nested documents 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [unreleased]
 ### Added
+- Indexing labelled nested child documents through pseudo-fields
 - Extract query now supports extractFormat
 
 ### Fixed

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -65,7 +65,8 @@ abstract class AbstractTechproductsTest extends TestCase
             'handler' => 'admin/info/system',
         ]);
         $response = self::$client->execute($query);
-        self::$solrVersion = $response->getData()['lucene']['solr-spec-version'];
+        $solrSpecVersion = $response->getData()['lucene']['solr-spec-version'];
+        self::$solrVersion = (int) strstr($solrSpecVersion, '.', true);
 
         // disable automatic commits for update tests
         $query = self::$client->createApi([
@@ -917,7 +918,7 @@ abstract class AbstractTechproductsTest extends TestCase
         ], $result->getIterator()->current()->getFields());
 
         // add-distinct with multiple values can add duplicates in Solr 7 cloud mode (SOLR-14550)
-        if ('7' === strstr(self::$solrVersion, '.', true) && $this instanceof AbstractCloudTest) {
+        if (7 === self::$solrVersion && $this instanceof AbstractCloudTest) {
             // we still have to emulate a successful atomic update for the remainder of this test to pass
             $doc = $update->createDocument();
             $doc->setKey('id', 'solarium-test');
@@ -1075,6 +1076,289 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertCount(0, $result);
     }
 
+    public function testNestedDocuments()
+    {
+        $data = [
+            'id' => 'solarium-parent',
+            'name' => 'Solarium Nested Document Parent',
+            'cat' => ['solarium-nested-document', 'parent'],
+            'children' => [
+                [
+                    'id' => 'solarium-child-1',
+                    'name' => 'Solarium Nested Document Child 1',
+                    'cat' => ['solarium-nested-document', 'child'],
+                    'price' => 1.0,
+                    'grandchildren' => [
+                        [
+                            'id' => 'solarium-grandchild-1-1',
+                            'name' => 'Solarium Nested Document Grandchild 1.1',
+                            'cat' => ['solarium-nested-document', 'grandchild'],
+                            'price' => 1.1,
+                        ],
+                    ],
+                ],
+                [
+                    'id' => 'solarium-child-2',
+                    'name' => 'Solarium Nested Document Child 2',
+                    'cat' => ['solarium-nested-document', 'child'],
+                    'price' => 2.0,
+                    'grandchildren' => [
+                        [
+                            'id' => 'solarium-grandchild-2-1',
+                            'name' => 'Solarium Nested Document Grandchild 2.1',
+                            'cat' => ['solarium-nested-document', 'grandchild'],
+                            'price' => 2.1,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $update = self::$client->createUpdate();
+        $doc = $update->createDocument($data);
+        $update->addDocument($doc);
+        $update->addCommit(true, true);
+        self::$client->update($update);
+
+        // get all documents (parents and descendants) as a flat list
+        $select = self::$client->createSelect();
+        $select->setQuery('cat:solarium-nested-document');
+        $select->setFields('id,name,price');
+        $result = self::$client->select($select);
+        $this->assertCount(5, $result);
+
+        // without a sort, children are returned before their parents because they're added in that order to the underlying Lucene index
+        $iterator = $result->getIterator();
+        $this->assertSame([
+            'id' => 'solarium-grandchild-1-1',
+            'name' => 'Solarium Nested Document Grandchild 1.1',
+            'price' => 1.1,
+        ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => 'solarium-child-1',
+            'name' => 'Solarium Nested Document Child 1',
+            'price' => 1.0,
+        ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => 'solarium-grandchild-2-1',
+            'name' => 'Solarium Nested Document Grandchild 2.1',
+            'price' => 2.1,
+        ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => 'solarium-child-2',
+            'name' => 'Solarium Nested Document Child 2',
+            'price' => 2.0,
+        ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => 'solarium-parent',
+            'name' => 'Solarium Nested Document Parent',
+        ], $iterator->current()->getFields());
+
+        // in Solr 7, the [child] transformer returns all descendant documents in a flat list, this is covered in testAnonymouslyNestedDocuments()
+        if (8 <= self::$solrVersion) {
+            // get parent document with nested children as pseudo-fields
+            $select->setQuery('id:solarium-parent');
+            // 'id,[child]' is not enough, either * or the explicit names of the pseudo-fields are needed to actually include them
+            $select->setFields('id,children,grandchildren,[child]');
+            $result = self::$client->select($select);
+            $this->assertCount(1, $result);
+            $iterator = $result->getIterator();
+            $this->assertSame([
+                'id' => 'solarium-parent',
+                'children' => [
+                    [
+                        'id' => 'solarium-child-1',
+                        'grandchildren' => [
+                            [
+                                'id' => 'solarium-grandchild-1-1',
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => 'solarium-child-2',
+                        'grandchildren' => [
+                            [
+                                'id' => 'solarium-grandchild-2-1',
+                            ],
+                        ],
+                    ],
+                ],
+            ], $iterator->current()->getFields());
+
+            // only get descendant documents that match a filter
+            $select->setFields('id,price,children,grandchildren,[child childFilter=price:2.1]');
+            $result = self::$client->select($select);
+            $this->assertCount(1, $result);
+            $iterator = $result->getIterator();
+            $this->assertSame([
+                'id' => 'solarium-parent',
+                'children' => [
+                    [
+                        'id' => 'solarium-child-2',
+                        'price' => 2.0,
+                        'grandchildren' => [
+                            [
+                                'id' => 'solarium-grandchild-2-1',
+                                'price' => 2.1,
+                            ],
+                        ],
+                    ],
+                ],
+            ], $iterator->current()->getFields());
+
+            // limit nested path of child documents to be returned
+            $select->setFields('id,children,grandchildren,[child childFilter=/children/*:*]');
+            $result = self::$client->select($select);
+            $this->assertCount(1, $result);
+            $iterator = $result->getIterator();
+            $this->assertSame([
+                'id' => 'solarium-parent',
+                'children' => [
+                    [
+                        'id' => 'solarium-child-1',
+                    ],
+                    [
+                        'id' => 'solarium-child-2',
+                    ],
+                ],
+            ], $iterator->current()->getFields());
+
+            // limit number of child documents to be returned
+            $select->setFields('id,children,grandchildren,[child limit=1]');
+            $result = self::$client->select($select);
+            $this->assertCount(1, $result);
+            $iterator = $result->getIterator();
+            $this->assertSame([
+                'id' => 'solarium-parent',
+                'children' => [
+                    [
+                        'id' => 'solarium-child-1',
+                        'grandchildren' => [
+                            [
+                                'id' => 'solarium-grandchild-1-1',
+                            ],
+                        ],
+                    ],
+                ],
+            ], $iterator->current()->getFields());
+
+            // only return a subset of the top level fl parameter for the child documents
+            $select->setFields('id,name,price,children,grandchildren,[child fl=id,price]');
+            $result = self::$client->select($select);
+            $this->assertCount(1, $result);
+            $iterator = $result->getIterator();
+            $this->assertSame([
+                'id' => 'solarium-parent',
+                'name' => 'Solarium Nested Document Parent',
+                'children' => [
+                    [
+                        'id' => 'solarium-child-1',
+                        'price' => 1.0,
+                        'grandchildren' => [
+                            [
+                                'id' => 'solarium-grandchild-1-1',
+                                'price' => 1.1,
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => 'solarium-child-2',
+                        'price' => 2.0,
+                        'grandchildren' => [
+                            [
+                                'id' => 'solarium-grandchild-2-1',
+                                'price' => 2.1,
+                            ],
+                        ],
+                    ],
+                ],
+            ], $iterator->current()->getFields());
+        }
+
+        // parent query parser
+        $select->setQuery('{!parent which="cat:parent"}id:solarium-child-1');
+        $select->setFields('id');
+        $result = self::$client->select($select);
+        $this->assertCount(1, $result);
+        $iterator = $result->getIterator();
+        $this->assertSame([
+            'id' => 'solarium-parent',
+        ], $iterator->current()->getFields());
+
+        // child query parser
+        $select->setQuery('{!child of="cat:parent"}id:solarium-parent');
+        $select->setFields('id');
+        $result = self::$client->select($select);
+        $this->assertCount(4, $result);
+        $iterator = $result->getIterator();
+        $this->assertSame([
+            'id' => 'solarium-grandchild-1-1',
+        ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => 'solarium-child-1',
+        ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => 'solarium-grandchild-2-1',
+        ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => 'solarium-child-2',
+        ], $iterator->current()->getFields());
+
+        // in Solr 7, atomic updates of child documents aren't possible
+        if (8 <= self::$solrVersion) {
+            // atomic update: removing all child documents
+            $doc = $update->createDocument();
+            $doc->setKey('id', 'solarium-parent');
+            $doc->setField('cat', 'updated');
+            $doc->setFieldModifier('cat', $doc::MODIFIER_ADD);
+            $doc->setField('children', []);
+            $doc->setFieldModifier('children', $doc::MODIFIER_SET);
+            $update->addDocument($doc);
+            $update->addCommit(true, true);
+            self::$client->update($update);
+            $select->setQuery('id:solarium-parent');
+            $select->setFields('id,name,cat,price,children,grandchildren,[child]');
+            $result = self::$client->select($select);
+            $this->assertCount(1, $result);
+            $iterator = $result->getIterator();
+            $this->assertSame([
+                'id' => 'solarium-parent',
+                'name' => 'Solarium Nested Document Parent',
+                'cat' => [
+                    'solarium-nested-document',
+                    'parent',
+                    'updated',
+                ],
+            ], $iterator->current()->getFields());
+
+            // other atomic updates (replacing, adding, removing child documents) can't be executed through XML (SOLR-12677)
+        }
+
+        // cleanup
+        $update = self::$client->createUpdate();
+        // in Solr 7, the whole block of parent-children documents must be deleted together
+        if (7 === self::$solrVersion) {
+            $update->addDeleteQuery('cat:solarium-nested-document');
+        }
+        // in Solr 8, you can simply delete-by-ID using the id of the root document
+        else {
+            $update->addDeleteById('solarium-parent');
+        }
+        $update->addCommit(true, true);
+        self::$client->update($update);
+        $select->setQuery('cat:solarium-nested-document');
+        $select->setFields('id');
+        $result = self::$client->select($select);
+        $this->assertCount(0, $result);
+    }
+
     public function testAnonymouslyNestedDocuments()
     {
         $data = [
@@ -1153,8 +1437,8 @@ abstract class AbstractTechproductsTest extends TestCase
             'id' => 'solarium-child-2',
         ], $iterator->current()->getFields());
 
-        // [child] transformer doesn't work when the schema includes a _nest_path_ in Solr 8
-        if ('7' === strstr(self::$solrVersion, '.', true)) {
+        // [child] transformer doesn't work for anonymous children when the schema includes a _nest_path_ in Solr 8
+        if (7 === self::$solrVersion) {
             // get all child documents nested inside the parent document
             $select->setQuery('id:solarium-parent');
             $select->setFields('id,[child parentFilter=cat:parent fl=id]');
@@ -1214,10 +1498,44 @@ abstract class AbstractTechproductsTest extends TestCase
             ], $iterator->current()->getFields());
         }
 
+        // in Solr 7, atomic updates of child documents aren't possible
+        if (8 <= self::$solrVersion) {
+            // atomic update: removing all child documents
+            $doc = $update->createDocument();
+            $doc->setKey('id', 'solarium-parent');
+            $doc->setField('cat', 'updated');
+            $doc->setFieldModifier('cat', $doc::MODIFIER_ADD);
+            $doc->setField('_childDocuments_', []);
+            $doc->setFieldModifier('_childDocuments_', $doc::MODIFIER_SET);
+            $update->addDocument($doc);
+            $update->addCommit(true, true);
+            self::$client->update($update);
+            // ensure the update was atomic ('name' must be unchanged, 'cat' must be updated)
+            $select->setQuery('id:solarium-parent');
+            $select->setFields('id,name,cat');
+            $result = self::$client->select($select);
+            $this->assertCount(1, $result);
+            $iterator = $result->getIterator();
+            $this->assertSame([
+                'id' => 'solarium-parent',
+                'name' => 'Solarium Nested Document Parent',
+                'cat' => [
+                    'solarium-nested-document',
+                    'parent',
+                    'updated',
+                ],
+            ], $iterator->current()->getFields());
+            // ensure child documents have been replaced (with nothing)
+            $select->setQuery('{!child of="cat:parent"}id:solarium-parent');
+            $select->setFields('id');
+            $result = self::$client->select($select);
+            $this->assertCount(0, $result);
+        }
+
         // cleanup
         $update = self::$client->createUpdate();
         // in Solr 7, the whole block of parent-children documents must be deleted together
-        if ('7' === strstr(self::$solrVersion, '.', true)) {
+        if (7 === self::$solrVersion) {
             $update->addDeleteQuery('cat:solarium-nested-document');
         }
         // in Solr 8, you can simply delete-by-ID using the id of the root document
@@ -1658,7 +1976,7 @@ abstract class AbstractTechproductsTest extends TestCase
 
     public function testV2Api()
     {
-        if (version_compare(self::$solrVersion, '7', '>=')) {
+        if (7 <= self::$solrVersion) {
             $query = self::$client->createApi([
                 'version' => Request::API_V2,
                 'handler' => 'node/system',

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -1567,6 +1567,7 @@ abstract class AbstractTechproductsTest extends TestCase
 
         // in Solr 7, atomic updates of child documents aren't possible
         // in SolrCloud mode, this fails more often with "Async exception during distributed update" than it succeeds
+        // @todo get this sorted for distributed search when #908 is resolved
         if (8 <= self::$solrVersion && $this instanceof AbstractServerTest) {
             // atomic update: removing all child documents
             $doc = $update->createDocument();

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -1499,7 +1499,8 @@ abstract class AbstractTechproductsTest extends TestCase
         }
 
         // in Solr 7, atomic updates of child documents aren't possible
-        if (8 <= self::$solrVersion) {
+        // in SolrCloud mode, this fails more often with "Async exception during distributed update" than it succeeds
+        if (8 <= self::$solrVersion && $this instanceof AbstractServerTest) {
             // atomic update: removing all child documents
             $doc = $update->createDocument();
             $doc->setKey('id', 'solarium-parent');


### PR DESCRIPTION
This closes #870. This also closes #717. This also closes #577.

The integration test adds nested documents and queries them both with a `[child]` tranformer and block join queries. There's quite some differences between Solr 7 and Solr 8 when using `[child]`. Between this test and the one for anonymous children, I believe I have all possibilities covered.

Solr 7 has no support for atomic updates of child documents. Solr 8 does, but they don't work with XML update requests because of [SOLR-12677](https://issues.apache.org/jira/browse/SOLR-12677). In spite of the claim there, I also couldn't get them to work with anonymous children. That might be because I introduced a `_nest_path_` field in our schema to fully support labelled children. You probably shouldn't use the combination of `_nest_path_` and anonymous children in a production environment.

One exception is removing all child documents by setting them to `[]`. There doesn't need to be any nested data in the XML for that atomic update and it does result in the expected behaviour. I've set a watch on SOLR-12677. When it gets fixed, I'll expand the test to cover the full range of atomic operations.