### PR TITLE
Left-inclusive only and right-inclusive only range queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [unreleased]
 ### Added
 - Extract query now supports extractFormat
+- Helper::rangeQuery() now supports left-inclusive only and right-inclusive only queries
 
 ### Fixed
 

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -174,32 +174,39 @@ class Helper
      * Example: rangeQuery('store', 5, null, false)
      * Returns: store:{5 TO *}
      *
+     * Example: rangeQuery('price', 0, 10, [true, false])
+     * Returns: price:[0 TO 10}
+     *
      * @param string                $field
      * @param int|float|string|null $from
      * @param int|float|string|null $to
-     * @param bool                  $inclusive TRUE if the the range should include the boundaries, FALSE otherwise
+     * @param bool|bool[]           $inclusive TRUE or [TRUE, TRUE] for inclusive, FALSE or [FALSE, FALSE] for exclusive,
+     *                                         [TRUE, FALSE] for left-inclusive only, [FALSE, TRUE] for right-inclusive only
      *
      * @return string
      */
-    public function rangeQuery(string $field, $from, $to, bool $inclusive = true): string
+    public function rangeQuery(string $field, $from, $to, $inclusive = true): string
     {
         if (null === $from) {
             $from = '*';
-        } elseif (!is_int($from) && !is_float($from) && !Utility::isPointValue($from)) {
+        } elseif (!\is_int($from) && !\is_float($from) && !Utility::isPointValue($from)) {
             $from = $this->escapePhrase($from);
         }
 
         if (null === $to) {
             $to = '*';
-        } elseif (!is_int($to) && !is_float($to) && !Utility::isPointValue($to)) {
+        } elseif (!\is_int($to) && !\is_float($to) && !Utility::isPointValue($to)) {
             $to = $this->escapePhrase($to);
         }
 
-        if ($inclusive) {
-            return $field.':['.$from.' TO '.$to.']';
+        if (\is_array($inclusive)) {
+            list($leftInclusive, $rightInclusive) = $inclusive;
+        }
+        else {
+            $leftInclusive = $rightInclusive = $inclusive;
         }
 
-        return $field.':{'.$from.' TO '.$to.'}';
+        return sprintf('%s:%s%s TO %s%s', $field, $leftInclusive ? '[' : '{', $from, $to, $rightInclusive ? ']' : '}');
     }
 
     /**

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -201,8 +201,7 @@ class Helper
 
         if (\is_array($inclusive)) {
             list($leftInclusive, $rightInclusive) = $inclusive;
-        }
-        else {
+        } else {
             $leftInclusive = $rightInclusive = $inclusive;
         }
 

--- a/tests/Core/Query/HelperTest.php
+++ b/tests/Core/Query/HelperTest.php
@@ -25,7 +25,7 @@ class HelperTest extends TestCase
         $this->helper = new Helper($this->query);
     }
 
-    public function testRangeQueryInclusive()
+    public function testRangeQuery()
     {
         $this->assertEquals(
             'field:[1 TO 2]',
@@ -40,6 +40,24 @@ class HelperTest extends TestCase
         $this->assertEquals(
             'field:["A" TO "M"]',
             $this->helper->rangeQuery('field', 'A', 'M')
+        );
+    }
+
+    public function testRangeQueryInclusive()
+    {
+        $this->assertEquals(
+            'field:[1 TO 2]',
+            $this->helper->rangeQuery('field', 1, 2, true)
+        );
+
+        $this->assertSame(
+            'store:[45,-94 TO 46,-93]',
+            $this->helper->rangeQuery('store', '45,-94', '46,-93', true)
+        );
+
+        $this->assertEquals(
+            'field:["A" TO "M"]',
+            $this->helper->rangeQuery('field', 'A', 'M', true)
         );
     }
 
@@ -61,7 +79,79 @@ class HelperTest extends TestCase
         );
     }
 
-    public function testRangeQueryInclusiveNullValues()
+    public function testRangeQueryLeftInclusiveRightInclusive()
+    {
+        $this->assertEquals(
+            'field:[1 TO 2]',
+            $this->helper->rangeQuery('field', 1, 2, [true, true])
+        );
+
+        $this->assertSame(
+            'store:[45,-94 TO 46,-93]',
+            $this->helper->rangeQuery('store', '45,-94', '46,-93', [true, true])
+        );
+
+        $this->assertEquals(
+            'field:["A" TO "M"]',
+            $this->helper->rangeQuery('field', 'A', 'M', [true, true])
+        );
+    }
+
+    public function testRangeQueryLeftInclusiveRightExclusive()
+    {
+        $this->assertEquals(
+            'field:[1 TO 2}',
+            $this->helper->rangeQuery('field', 1, 2, [true, false])
+        );
+
+        $this->assertSame(
+            'store:[45,-94 TO 46,-93}',
+            $this->helper->rangeQuery('store', '45,-94', '46,-93', [true, false])
+        );
+
+        $this->assertEquals(
+            'field:["A" TO "M"}',
+            $this->helper->rangeQuery('field', 'A', 'M', [true, false])
+        );
+    }
+
+    public function testRangeQueryLeftExclusiveRightInclusive()
+    {
+        $this->assertEquals(
+            'field:{1 TO 2]',
+            $this->helper->rangeQuery('field', 1, 2, [false, true])
+        );
+
+        $this->assertSame(
+            'store:{45,-94 TO 46,-93]',
+            $this->helper->rangeQuery('store', '45,-94', '46,-93', [false, true])
+        );
+
+        $this->assertEquals(
+            'field:{"A" TO "M"]',
+            $this->helper->rangeQuery('field', 'A', 'M', [false, true])
+        );
+    }
+
+    public function testRangeQueryLeftExclusiveRightExclusive()
+    {
+        $this->assertEquals(
+            'field:{1 TO 2}',
+            $this->helper->rangeQuery('field', 1, 2, [false, false])
+        );
+
+        $this->assertSame(
+            'store:{45,-94 TO 46,-93}',
+            $this->helper->rangeQuery('store', '45,-94', '46,-93', [false, false])
+        );
+
+        $this->assertEquals(
+            'field:{"A" TO "M"}',
+            $this->helper->rangeQuery('field', 'A', 'M', [false, false])
+        );
+    }
+
+    public function testRangeQueryNullValues()
     {
         $this->assertSame(
             'field:[1 TO *]',
@@ -71,6 +161,19 @@ class HelperTest extends TestCase
         $this->assertSame(
             'store:[* TO 46,-93]',
             $this->helper->rangeQuery('store', null, '46,-93')
+        );
+    }
+
+    public function testRangeQueryInclusiveNullValues()
+    {
+        $this->assertSame(
+            'field:[1 TO *]',
+            $this->helper->rangeQuery('field', 1, null, true)
+        );
+
+        $this->assertSame(
+            'store:[* TO 46,-93]',
+            $this->helper->rangeQuery('store', null, '46,-93', true)
         );
     }
 
@@ -84,6 +187,58 @@ class HelperTest extends TestCase
         $this->assertSame(
             'store:{* TO 46,-93}',
             $this->helper->rangeQuery('store', null, '46,-93', false)
+        );
+    }
+
+    public function testRangeQueryLeftInclusiveRightInclusiveNullValues()
+    {
+        $this->assertSame(
+            'field:[1 TO *]',
+            $this->helper->rangeQuery('field', 1, null, [true, true])
+        );
+
+        $this->assertSame(
+            'store:[* TO 46,-93]',
+            $this->helper->rangeQuery('store', null, '46,-93', [true, true])
+        );
+    }
+
+    public function testRangeQueryLeftInclusiveRightExclusiveNullValues()
+    {
+        $this->assertSame(
+            'field:[1 TO *}',
+            $this->helper->rangeQuery('field', 1, null, [true, false])
+        );
+
+        $this->assertSame(
+            'store:[* TO 46,-93}',
+            $this->helper->rangeQuery('store', null, '46,-93', [true, false])
+        );
+    }
+
+    public function testRangeQueryLeftExclusiveRightInclusiveNullValues()
+    {
+        $this->assertSame(
+            'field:{1 TO *]',
+            $this->helper->rangeQuery('field', 1, null, [false, true])
+        );
+
+        $this->assertSame(
+            'store:{* TO 46,-93]',
+            $this->helper->rangeQuery('store', null, '46,-93', [false, true])
+        );
+    }
+
+    public function testRangeQueryLeftExclusiveRightExclusiveNullValues()
+    {
+        $this->assertSame(
+            'field:{1 TO *}',
+            $this->helper->rangeQuery('field', 1, null, [false, false])
+        );
+
+        $this->assertSame(
+            'store:{* TO 46,-93}',
+            $this->helper->rangeQuery('store', null, '46,-93', [false, false])
         );
     }
 

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -233,6 +233,73 @@ abstract class AbstractTechproductsTest extends TestCase
         $result = self::$client->select($select);
         $this->assertSame(14, $result->getNumFound());
         $this->assertCount(10, $result);
+
+        // VS1GB400C3 costs 74.99, SP2514N costs 92.0, 0579B002 costs 179.99
+        $select->setFields('id,price');
+        $select->addSort('price', $select::SORT_ASC);
+        $select->setQuery(
+            $select->getHelper()->rangeQuery('price', 74.99, 179.99, [true, true])
+        );
+        $result = self::$client->select($select);
+        $this->assertSame(3, $result->getNumFound());
+        $iterator = $result->getIterator();
+        $this->assertSame([
+            'id' => 'VS1GB400C3',
+            'price' => 74.99,
+        ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => 'SP2514N',
+            'price' => 92.0,
+        ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => '0579B002',
+            'price' => 179.99,
+        ], $iterator->current()->getFields());
+
+        $select->setQuery(
+            $select->getHelper()->rangeQuery('price', 74.99, 179.99, [true, false])
+        );
+        $result = self::$client->select($select);
+        $this->assertSame(2, $result->getNumFound());
+        $iterator = $result->getIterator();
+        $this->assertSame([
+            'id' => 'VS1GB400C3',
+            'price' => 74.99,
+        ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => 'SP2514N',
+            'price' => 92.0,
+        ], $iterator->current()->getFields());
+
+        $select->setQuery(
+            $select->getHelper()->rangeQuery('price', 74.99, 179.99, [false, true])
+        );
+        $result = self::$client->select($select);
+        $this->assertSame(2, $result->getNumFound());
+        $iterator = $result->getIterator();
+        $this->assertSame([
+            'id' => 'SP2514N',
+            'price' => 92.0,
+        ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => '0579B002',
+            'price' => 179.99,
+        ], $iterator->current()->getFields());
+
+        $select->setQuery(
+            $select->getHelper()->rangeQuery('price', 74.99, 179.99, [false, false])
+        );
+        $result = self::$client->select($select);
+        $this->assertSame(1, $result->getNumFound());
+        $iterator = $result->getIterator();
+        $this->assertSame([
+            'id' => 'SP2514N',
+            'price' => 92.0,
+        ], $iterator->current()->getFields());
     }
 
     public function testFacetHighlightSpellcheckComponent()

--- a/tests/Support/UtilityTest.php
+++ b/tests/Support/UtilityTest.php
@@ -77,6 +77,9 @@ class UtilityTest extends TestCase
             $this->assertTrue(Utility::isPointValue($value));
         }
 
-        $this->assertFalse(Utility::isPointValue('not a point value'));
+        $values = ['45', '-93', '45.15', '-93.85', '', 'not a point value'];
+        foreach ($values as $value) {
+            $this->assertFalse(Utility::isPointValue($value));
+        }
     }
 }


### PR DESCRIPTION
Solr allows range queries to be left-inclusive or right-inclusive (e.g. `price:{0 TO 10]`, `price:[0 TO 10}`). Adding an additional parameter to `rangeQuery()` wouldn't be backward compatible because there used to be one with a different meaning. Even if that wasn't the case, it couldn't have a straightforward default value in a BC manner.

The best way I could come up with is an array with two booleans for left and right while still allowing a single boolean as shorthand for `[true, true]` or `[false, false]`.