### PR TITLE
Bugfix for uninitialised position in PrefetchIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Helper::rangeQuery() now supports left-inclusive only and right-inclusive only queries
 
 ### Fixed
+- PrefetchIterator::key() should return 0 instead of NULL on a fresh PrefetchIterator
+- PrefetchIterator::next() shouldn't skip fetched results after PrefetchIterator::count() on a fresh PrefetchIterator
 
 ### Changed
 - Exception message for invalid/unavailable file in Extract query now contains filename

--- a/src/Plugin/PrefetchIterator.php
+++ b/src/Plugin/PrefetchIterator.php
@@ -58,7 +58,7 @@ class PrefetchIterator extends AbstractPlugin implements \Iterator, \Countable
      *
      * @var int
      */
-    protected $position;
+    protected $position = 0;
 
     /**
      * Cursor mark.
@@ -262,7 +262,7 @@ class PrefetchIterator extends AbstractPlugin implements \Iterator, \Countable
      */
     protected function resetData(): self
     {
-        $this->position = null;
+        $this->position = 0;
         $this->result = null;
         $this->documents = null;
         $this->start = 0;

--- a/src/Plugin/PrefetchIterator.php
+++ b/src/Plugin/PrefetchIterator.php
@@ -173,7 +173,7 @@ class PrefetchIterator extends AbstractPlugin implements \Iterator, \Countable
     {
         $this->position = 0;
 
-        // this condition prevent useless re-fetching of data if a count is done before the iterator is used
+        // this condition prevents erroneously fetching the next set of results if a count is done before the iterator is used
         if ($this->start !== $this->options['prefetch']) {
             $this->start = 0;
 
@@ -222,7 +222,7 @@ class PrefetchIterator extends AbstractPlugin implements \Iterator, \Countable
     {
         $adjustedIndex = $this->position % $this->options['prefetch'];
 
-        // this condition prevent useless re-fetching of data if a count is done before the iterator is used
+        // this condition prevents erroneously fetching the next set of results if a count is done before the iterator is used
         if (0 === $adjustedIndex && (0 !== $this->position || null === $this->result)) {
             $this->fetchNext();
         }

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -21,6 +21,7 @@ use Solarium\Plugin\BufferedAdd\Event\PostCommit as BufferedAddPostCommitEvent;
 use Solarium\Plugin\BufferedAdd\Event\PostFlush as BufferedAddPostFlushEvent;
 use Solarium\Plugin\BufferedAdd\Event\PreCommit as BufferedAddPreCommitEvent;
 use Solarium\Plugin\BufferedAdd\Event\PreFlush as BufferedAddPreFlushEvent;
+use Solarium\Plugin\PrefetchIterator;
 use Solarium\QueryType\ManagedResources\Query\Synonyms\Synonyms;
 use Solarium\QueryType\Select\Query\Query as SelectQuery;
 use Solarium\QueryType\Select\Result\Document;
@@ -1501,15 +1502,20 @@ abstract class AbstractTechproductsTest extends TestCase
     public function testPrefetchIterator()
     {
         $select = self::$client->createSelect();
+        $select->addSort('id', SelectQuery::SORT_ASC);
+        /** @var PrefetchIterator $prefetch */
         $prefetch = self::$client->getPlugin('prefetchiterator');
         $prefetch->setPrefetch(2);
         $prefetch->setQuery($select);
 
-        // count() uses getNumFound() on the result set and wouldn't actually test if all results are iterated
-        for ($i = 0; $prefetch->valid(); ++$i) {
-            $prefetch->next();
-        }
+        // check upfront that all results are found
+        $this->assertCount(32, $prefetch);
 
+        // verify that each result is iterated in order
+        $id = '';
+        for ($i = 0; $prefetch->valid(); $prefetch->next(), ++$i) {
+            $this->assertLessThan(0, strcmp($id, $id = $prefetch->current()->id));
+        }
         $this->assertSame(32, $i);
     }
 
@@ -1518,15 +1524,19 @@ abstract class AbstractTechproductsTest extends TestCase
         $select = self::$client->createSelect();
         $select->setCursormark('*');
         $select->addSort('id', SelectQuery::SORT_ASC);
+        /** @var PrefetchIterator $prefetch */
         $prefetch = self::$client->getPlugin('prefetchiterator');
         $prefetch->setPrefetch(2);
         $prefetch->setQuery($select);
 
-        // count() uses getNumFound() on the result set and wouldn't actually test if all results are iterated
-        for ($i = 0; $prefetch->valid(); ++$i) {
-            $prefetch->next();
-        }
+        // check upfront that all results are found
+        $this->assertCount(32, $prefetch);
 
+        // verify that each result is iterated in order
+        $id = '';
+        for ($i = 0; $prefetch->valid(); $prefetch->next(), ++$i) {
+            $this->assertLessThan(0, strcmp($id, $id = $prefetch->current()->id));
+        }
         $this->assertSame(32, $i);
     }
 
@@ -1534,6 +1544,7 @@ abstract class AbstractTechproductsTest extends TestCase
     {
         $select = self::$client->createSelect();
         $select->addSort('id', SelectQuery::SORT_ASC);
+        /** @var PrefetchIterator $prefetch */
         $prefetch = self::$client->getPlugin('prefetchiterator');
         $prefetch->setPrefetch(2);
         $prefetch->setQuery($select);


### PR DESCRIPTION
`PrefetchIterator` didn't have an initial value for its `$position` and that causes two bugs. You can test it by replacing the `foreach` loop in `examples/7.6-plugin-prefetchiterator.php`.

1) You got an error when calling `key()` on a fresh iterator if you didn't call `rewind()` first.

```php
for (; $prefetch->valid(); $prefetch->next()) {
    echo '<hr/>'.$prefetch->key().': '. $prefetch->current()->id;
}
```
```
Fatal error: Uncaught TypeError: Return value of Solarium\Plugin\PrefetchIterator::key() must be of the type int, null returned in solarium/src/Plugin/PrefetchIterator.php:205 Stack trace: #0 solarium/examples/7.6-plugin-prefetchiterator.php(26): Solarium\Plugin\PrefetchIterator->key() #1 {main} thrown in solarium/src/Plugin/PrefetchIterator.php on line 205
```

2) If you're doing a `count()` first and then loop through it without `rewind()`ing, the first set of fetched documents would be skipped. In our example, `$i` ended up being 30 for the 32 documents in techproducts.

```php
for ($i = 0; $prefetch->valid(); $prefetch->next(), ++$i) {
    echo '<hr/>'.$i.': '. $prefetch->current()->id;
}
```

These problems don't surface when you're using `foreach` to loop over the results because that does a `rewind()` first. But you would run into it with a `while` in a use case like this:
```php
while ($n < $max && $prefetch->valid()) {
    if (doCheck($prefetch->current()) {
        ++$n;
    }
    $prefetch->next();
}
```

Furthermore, since `count()` implements a method from `\Countable`, it shouldn't have any publically visible effects on the methods that are implemented from `\Iterator`. They're separate interfaces.

Both problems disappear when `$position` is initialised to `0`. In fact the [example in the PHP Manual](https://www.php.net/manual/en/class.iterator.php#iterator.examples) does just that.

I've added a manual walkthrough of a full iteration and some rewinds in the unit tests. I've also added tests to ensure an empty result set works as expected.

I do believe I must've run into the same issue when I first added the integration tests. I didn't include an `assertCount()` then and I think it was because it didn't agree with the loop. It's included now and the loop also checks if the documents are actually iterated in the correct order. This is a relevant test for #610.