### PR TITLE
Bugfix for mid-set rewind() in PrefetchIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - PrefetchIterator::key() should return 0 instead of NULL on a fresh PrefetchIterator
 - PrefetchIterator::next() shouldn't skip fetched results after PrefetchIterator::count() on a fresh PrefetchIterator
+- PrefetchIterator::rewind() no longer results in duplicate documents when invoked mid-set
 - fixed incorrect median function
 
 ### Changed

--- a/src/Plugin/PrefetchIterator.php
+++ b/src/Plugin/PrefetchIterator.php
@@ -173,9 +173,12 @@ class PrefetchIterator extends AbstractPlugin implements \Iterator, \Countable
     {
         $this->position = 0;
 
-        // this condition prevents erroneously fetching the next set of results if a count is done before the iterator is used
-        if ($this->start !== $this->options['prefetch']) {
+        // this condition prevents needlessly re-fetching if the iterator hasn't moved past its first set of results yet
+        // (this includes when a count is done before the iterator is used)
+        if ($this->start > $this->options['prefetch']) {
             $this->start = 0;
+            $this->result = null;
+            $this->documents = null;
 
             if (null !== $this->cursormark) {
                 $this->cursormark = '*';

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -1567,6 +1567,44 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertSame($without, $with);
     }
 
+    public function testPrefetchIteratorManualRewind()
+    {
+        $select = self::$client->createSelect();
+        $select->addSort('id', SelectQuery::SORT_ASC);
+        /** @var PrefetchIterator $prefetch */
+        $prefetch = self::$client->getPlugin('prefetchiterator');
+        $prefetch->setPrefetch(5);
+        $prefetch->setQuery($select);
+
+        // check if valid (this will fetch the first set of documents)
+        $this->assertTrue($prefetch->valid());
+        // check that we're at position 0
+        $this->assertSame(0, $prefetch->key());
+        // current document is the one with lowest alphabetical id in techproducts
+        $this->assertSame('0579B002', $prefetch->current()->id);
+
+        // move to an arbitrary point past the first set of fetched documents
+        while (12 > $prefetch->key()) {
+            $prefetch->next();
+            // this ensures the next set will be fetched when we've passed the end of a set
+            $this->assertTrue($prefetch->valid());
+        }
+
+        // check that we've reached the expected document at position 12
+        $this->assertSame(12, $prefetch->key());
+        $this->assertSame('NOK', $prefetch->current()->id);
+
+        // this resets the position and clears the last fetched result
+        $prefetch->rewind();
+
+        // check if valid (this will re-fetch the first set of documents)
+        $this->assertTrue($prefetch->valid());
+        // check that we're back at position 0
+        $this->assertSame(0, $prefetch->key());
+        // current document is once again the one with lowest alphabetical id in techproducts
+        $this->assertSame('0579B002', $prefetch->current()->id);
+    }
+
     public function testExtractIntoDocument()
     {
         $extract = self::$client->createExtract();

--- a/tests/Plugin/PrefetchIteratorTest.php
+++ b/tests/Plugin/PrefetchIteratorTest.php
@@ -332,7 +332,6 @@ class PrefetchIteratorTest extends TestCase
         // this should trigger a reset and the foreach will cause a second query execution
         $this->plugin->setQuery($this->query);
 
-
         $results = [];
         foreach ($this->plugin as $doc) {
             $results[] = $doc;


### PR DESCRIPTION
I've discovered another bug in PrefetchIterator while researching #610. This one is in the `rewind()` implementation. It's not introduced by #902, it can be duplicated with a codebase from before this merge.

It happens under a very specific set of conditions: you have to invoke `rewind()` when you've iterated to an arbitrary point in a set that is 1) not the first set fetched, and 2) not the last document in that fetched set; then run through the iterator again. In that case, the already fetched set will be iterated first, then the entire iterator will be ran through. This results in the documents from that set being duplicated, once in the beginning and once in their correct position. The entire number of iterated documents will exceed `numFound` by the size of that set. Note that this also happens if you `break` out of a `foreach` at such a point and then loop over the same iterator with another `foreach`.

To illustrate by inserting this snippet in `examples/7.6-plugin-prefetchiterator.php`:
```php
// get a plugin instance and apply settings
$prefetch = $client->getPlugin('prefetchiterator');
$prefetch->setPrefetch(5); 	
$prefetch->setQuery($query);

// display the total number of documents found by solr
echo 'NumFound: ' . count($prefetch);
$i = 0;
// show document IDs using the resultset iterator
foreach ($prefetch as $document) {
    if (5 === ++$i) {break;}
    //if (8 === ++$i) {break;}
    echo '<hr/>'.$prefetch->key().': '. $document->id;
}
echo '<hr/>';
foreach ($prefetch as $document) {
    echo '<hr/>'.$prefetch->key().': '. $document->id;
}
```

`if (5 === ++$i) {break;}` | `if (8 === ++$i) {break;}`
---------------------------|---------------------------
NumFound: 32           | NumFound: 32
---                    | ---
0: 0579B002            | 0: 0579B002
1: 100-435805          | 1: 100-435805
2: 3007WFP             | 2: 3007WFP
3: 6H500F0             | 3: 6H500F0
                       | 4: 9885A004
                       | 5: EN7800GTX/2DHTV/256M
                       | 6: EUR
---                    | ---
                       | 0: EN7800GTX/2DHTV/256M
                       | 1: EUR
                       | 2: F8V7067-APL-KIT
                       | 3: GB18030TEST
                       | 4: GBP
0: 0579B002            | 5: 0579B002
1: 100-435805          | 6: 100-435805
2: 3007WFP             | 7: 3007WFP
3: 6H500F0             | 8: 6H500F0
4: 9885A004            | 9: 9885A004
5: EN7800GTX/2DHTV/256M| 10: EN7800GTX/2DHTV/256M
6: EUR                 | 11: EUR
7: F8V7067-APL-KIT     | 12: F8V7067-APL-KIT
8: GB18030TEST         | 13: GB18030TEST
9: GBP                 | 14: GBP
10: IW-02              | 15: IW-02
11: MA147LL/A          | 16: MA147LL/A
12: NOK                | 17: NOK
13: SOLR1000           | 18: SOLR1000
14: SP2514N            | 19: SP2514N
15: TWINX2048-3200PRO  | 20: TWINX2048-3200PRO
16: USD                | 21: USD
17: UTF8TEST           | 22: UTF8TEST
18: VA902B             | 23: VA902B
19: VDBDB1A16          | 24: VDBDB1A16
20: VS1GB400C3         | 25: VS1GB400C3
21: adata              | 26: adata
22: apple              | 27: apple
23: asus               | 28: asus
24: ati                | 29: ati
25: belkin             | 30: belkin
26: canon              | 31: canon
27: corsair            | 32: corsair
28: dell               | 33: dell
29: maxtor             | 34: maxtor
30: samsung            | 35: samsung
31: viewsonic          | 36: viewsonic

In fixing this bug, it became obvious that the unit tests for PrefetchIterator didn't really cover any sequential fetching. I've updated it to retrieve partial results from the mock client to better test this behaviour. The tests for reset on `setPrefetch()` and `setQuery()` are rewritten to actually test for the resets specifically. The way there were implemented, it was no longer possible to tell if they triggered `resetData()` because the fixed `rewind()` would have made them pass anyway. (The comment `// the second foreach should trigger a reset` was also wrong because `setPrefetch()`/`setQuery()` trigger the reset.)

I've added an integration to test the fixed behaviour against `techproducts` as well.