### PR TITLE
Doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
-All notable changes to the solarium library will be documented in this file.
+All notable changes to the Solarium library will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
 ## [unreleased]
@@ -78,7 +78,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - \Solarium\Support\Utility::getXmlEncoding()
 
 ### Fixed
-- MoreLikeThis result parsing fails on Solr Cloud
+- MoreLikeThis result parsing fails on SolrCloud
 - MinimumScoreFilter plugin might fail on Solr 7 in cloud mode
 
 
@@ -168,7 +168,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [5.1.3]
 ### Fixed
-- Solarium\Component\ResponseParser\Debug fails on Solr Cloud 6.x during extracting timing phases
+- Solarium\Component\ResponseParser\Debug fails on SolrCloud 6.x during extracting timing phases
 
 
 ## [5.1.2]
@@ -415,7 +415,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [4.0.0-rc.1]
 ### Added
-- Basic support for Solr Cloud streaming expressions
+- Basic support for SolrCloud streaming expressions
 
 
 ## [4.0.0-beta.1]
@@ -430,7 +430,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - More integration tests
 
 ### Removed
-- Outdated symfony versions on test environment
+- Outdated Symfony versions on test environment
 
 ### Fixed
 - Don't escape the '*' in range queries

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Please see the [docs](http://solarium.readthedocs.io/en/stable/) for a more deta
 
 Solarium 6.x only supports PHP 7.2 and up.
 
-It's highly recommended to have Curl enabled in your PHP environment. However if you don't have Curl available you can
-switch from using Curl (the default) to a pure PHP based HTTP client adapter which works for the essential stuff but
+It's highly recommended to have cURL enabled in your PHP environment. However if you don't have cURL available you can
+switch from using cURL (the default) to a pure PHP based HTTP client adapter which works for the essential stuff but
 doesn't support things like parallel query execution.
 
 Alternatively you can inject any PSR-18 compatible HTTP Client using the `Psr18Adapter`.
@@ -34,7 +34,7 @@ Setting "timeout" as "option" in the HTTP Client Adapter is deprecated since Sol
 could handle it. The adapters which can handle it now implement the `TimeoutAwareInterface` and you need to set the
 timeout using the `setTimeout()` function after creating the adapter instance.
 
-In order to fix some issues with complex queries using local parameters Solarium 6 destinguishs between query parameters
+In order to fix some issues with complex queries using local parameters Solarium 6 distinguishes between query parameters
 and local parameters to be embedded in a query. Solarium 5.2 already informed you about the deprecation of some
 parameter names which are in fact local parameters. Solarium doen't convert them magically anymore.
 Local parameter names now have to be prefixed with `local_` if set as option of a constructor.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What is Solarium?
 
-Solarium is a PHP Solr client library that accurately model Solr concepts. Where many other Solr libraries only handle
+Solarium is a PHP Solr client library that accurately models Solr concepts. Where many other Solr libraries only handle
 the communication with Solr, Solarium also relieves you of handling all the complex Solr query parameters using a
 well documented API.
 
@@ -34,7 +34,7 @@ Setting "timeout" as "option" in the HTTP Client Adapter is deprecated since Sol
 could handle it. The adapters which can handle it now implement the `TimeoutAwareInterface` and you need to set the
 timeout using the `setTimeout()` function after creating the adapter instance.
 
-In order to fix some issues with complex queries using local parameters solarium 6 destinguishs between query parameters
+In order to fix some issues with complex queries using local parameters Solarium 6 destinguishs between query parameters
 and local parameters to be embedded in a query. Solarium 5.2 already informed you about the deprecation of some
 parameter names which are in fact local parameters. Solarium doen't convert them magically anymore.
 Local parameter names now have to be prefixed with `local_` if set as option of a constructor.

--- a/docs/customizing-solarium.md
+++ b/docs/customizing-solarium.md
@@ -9,7 +9,7 @@ Solarium was designed to be highly customizable, in the following ways:
 What method of customization to use depends on your case:
 
 -   if you want to use only some parts of Solarium, but not modify it, go with method 1
--   if you want to customize solarium by altering/adding behaviour use the plugin structure. This has many advantages over extending:
+-   if you want to customize Solarium by altering/adding behaviour use the plugin structure. This has many advantages over extending:
     -   Plugins are easily reusable
     -   You can combine multiple plugins
     -   By leaving your Solarium library stock you can add plugins developed by others without issues
@@ -56,7 +56,7 @@ $response = $client->executeRequest($request);
 // and finally you can convert the response into a result
 $result = $client->createResult($query, $response);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$result->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -45,7 +45,7 @@ $query = $client->createQuery($client::QUERY_SELECT);
 // this executes the query and returns the result
 $resultset = $client->execute($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator
@@ -167,7 +167,7 @@ $query->createFilterQuery('newprice')->setQuery('price:374');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo '<hr/>NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -128,4 +128,4 @@ This exception indicates that a problem occurred in the communication with the S
 
 #### `StreamException`
 
-This exception indicates that a problem occurred with a streaming expression. You should catch this (or a more generic exception) for every streaming exception request that is executed.
+This exception indicates that a problem occurred with a streaming expression. You should catch this (or a more generic exception) for every streaming expression request that is executed.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@ Installation
 
 For installing Solarium a minimal PHP version 7.2 is required.
 
-There is no Solr version requirement. But it's highly recommended that you use at least 7.7. All older version are EOL.
+There is no Solr version requirement. But it's highly recommended that you use at least 7.7. All older versions are EOL.
 
 ### Getting Solarium
 
@@ -51,7 +51,7 @@ To check your installation you can do a Solarium version check with the followin
 require_once(__DIR__.'/init.php');
 htmlHeader();
 
-// check solarium version available
+// check Solarium version available
 echo 'Solarium library version: ' . Solarium\Client::VERSION . ' - ';
 
 // create a client instance
@@ -115,7 +115,7 @@ If you know of any other integrations please let it know!
 Basic usage
 ===========
 
-All the code display below can be found in the /examples dir of the project, where you can also easily execute the code. For more info see [Example code](V3:Example_code "wikilink").
+All the code displayed below can be found in the /examples dir of the project, where you can also easily execute the code. For more info see [Example code](V3:Example_code "wikilink").
 
 All the examples use the init.php file. This file registers the Solarium autoloader, sets up a client adapter and event dispatcher, and also loads the `$config` array for use in the client constructor.
 
@@ -140,7 +140,7 @@ $config = array(
             'port' => 8983,
             'path' => '/',
             'core' => 'techproducts',
-            // For Solr Cloud you need to provide a collection instead of core:
+            // For SolrCloud you need to provide a collection instead of core:
             // 'collection' => 'techproducts',
         )
     )
@@ -166,7 +166,7 @@ $query = $client->createQuery($client::QUERY_SELECT);
 // this executes the query and returns the result
 $resultset = $client->execute($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator
@@ -218,7 +218,7 @@ $facetSet->createFacetField('stock')->setField('inStock');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts
@@ -273,7 +273,7 @@ htmlFooter();
 
 ```
 
-Or by id 
+Or by id: 
 
 ```php
 <?php
@@ -354,7 +354,7 @@ Example code
 ============
 
 With Solarium a set of examples is available to demonstrate the usage and to test your Solr environment. But since the
-examples are not included in the distribution you need a git checkout of solarium and install the dependencies:
+examples are not included in the distribution you need a git checkout of Solarium and install the dependencies:
 ```
 git clone https://github.com/solariumphp/solarium.git
 cd solarium

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -145,16 +145,16 @@ $customizer->createCustomization('id')
 // create a basic query to execute
 $query = $client->createSelect();
 
-// execute query (you should be able to see the extra params in the solr log file)
+// execute query (you should be able to see the extra params in the Solr log file)
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound() . '<br/>';
 
 // execute the same query again (this time the 'id' param should no longer show up in the logs)
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 htmlFooter();
@@ -212,7 +212,7 @@ for ($i = 1; $i <= 8; $i++) {
     echo 'Server: ' . $loadbalancer->getLastEndpoint() .'<hr/>';
 }
 
-// force a server for a query (normally solr 3 is extremely unlikely based on its weight)
+// force a server for a query (normally 'local3' is extremely unlikely based on its weight)
 $loadbalancer->setForcedEndpointForNextQuery('local3');
 
 $resultset = $client->select($query);
@@ -275,7 +275,7 @@ $query->setFilterMode($query::FILTER_MODE_MARK);
 // this executes the query and returns the result
 $resultset = $client->execute($query);
 
-// display the total number of documents found by solr and the maximum score
+// display the total number of documents found by Solr and the maximum score
 echo 'NumFound: '.$resultset->getNumFound();
 echo '<br/>MaxScore: '.$resultset->getMaxScore();
 
@@ -377,7 +377,7 @@ htmlFooter();
 
 // Note: for this example on a default Solr index (with a tiny index) running on localhost the performance gain is
 // minimal to none, sometimes even slightly slower!
-// In a realworld scenario with network latency, a bigger dataset, more complex queries or multiple solr instances the
+// In a realworld scenario with network latency, a bigger dataset, more complex queries or multiple Solr instances the
 // performance gain is much more.
 
 ```
@@ -422,7 +422,7 @@ $query->createFilterQuery('fq')->setQuery($fq);
 // without the plugin this query would fail as it is bigger than the default servlet container header buffer
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator
@@ -481,7 +481,7 @@ $prefetch = $client->getPlugin('prefetchiterator');
 $prefetch->setPrefetch(2); //fetch 2 rows per query (for real world use this can be way higher)
 $prefetch->setQuery($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: ' . count($prefetch);
 
 // show document IDs using the resultset iterator

--- a/docs/queries/morelikethis-query.md
+++ b/docs/queries/morelikethis-query.md
@@ -41,7 +41,7 @@ Use the `moreLikeThis` method of the client to execute the query object. See the
 Result of a MLT query
 ---------------------
 
-The result of a mlt query shares the features of the select query result. On top of that the following is added:
+The result of a MLT query shares the features of the select query result. On top of that the following is added:
 
 ### Interestingterms
 
@@ -76,7 +76,7 @@ $query->createFilterQuery('stock')->setQuery('inStock:true');
 $query->setInterestingTerms('details');
 $query->setMatchInclude(true);
 
-// enable mlt component
+// enable MLT component
 $mlt = $query->getMoreLikeThis();
 $mlt->setCount(10);
 
@@ -94,7 +94,7 @@ foreach ($resultset->getMatch() as $field => $value) {
 }
 echo '</table><hr/>';
 
-// display the total number of MLT documents found by solr
+// display the total number of MLT documents found by Solr
 echo 'Number of MLT matches found: '.$resultset->getNumFound().'<br/><br/>';
 echo '<b>Listing of matched docs:</b>';
 

--- a/docs/queries/ping-query.md
+++ b/docs/queries/ping-query.md
@@ -35,7 +35,7 @@ Example
 require_once(__DIR__.'/init.php');
 htmlHeader();
 
-// check solarium version available
+// check Solarium version available
 echo 'Solarium library version: ' . Solarium\Client::VERSION . ' - ';
 
 // create a client instance

--- a/docs/queries/query-helper/escaping.md
+++ b/docs/queries/query-helper/escaping.md
@@ -25,7 +25,7 @@ $query->setQuery('features:' . $helper->escapePhrase($input));
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/query-helper/placeholders.md
+++ b/docs/queries/query-helper/placeholders.md
@@ -57,7 +57,7 @@ echo $query->getQuery() . '<br/>';
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/query-helper/query-helper.md
+++ b/docs/queries/query-helper/query-helper.md
@@ -54,7 +54,7 @@ $query->createFilterQuery('region')->setQuery($helper->geofilt('store', 45.15, -
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/realtimeget-query.md
+++ b/docs/queries/realtimeget-query.md
@@ -47,7 +47,7 @@ $doc1 = $update->createDocument();
 $doc1->id = $id;
 $doc1->name = 'realtime-get-test-'.date('Y-m-d H:i:s');
 
-// set a very long commitWithin time and add it to solr
+// set a very long commitWithin time and add it to Solr
 $update->addDocument($doc1, null, 1000000);
 $client->update($update);
 

--- a/docs/queries/select-query/building-a-select-query/adding-filterqueries.md
+++ b/docs/queries/select-query/building-a-select-query/adding-filterqueries.md
@@ -33,7 +33,7 @@ $query->createFilterQuery('maxprice')->setQuery('price:[1 TO 300]');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/select-query/building-a-select-query/building-a-select-query.md
+++ b/docs/queries/select-query/building-a-select-query/building-a-select-query.md
@@ -56,7 +56,7 @@ $query->addSort('price', $query::SORT_ASC);
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display the max score
@@ -126,7 +126,7 @@ $query = $client->createSelect($select);
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/docs/queries/select-query/building-a-select-query/components/dismax-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/dismax-component.md
@@ -48,7 +48,7 @@ $query->setQuery('memory -printer');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/select-query/building-a-select-query/components/distributed-search-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/distributed-search-component.md
@@ -35,7 +35,7 @@ $distributedSearch->addShard('shard2', 'localhost:7574/solr');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/select-query/building-a-select-query/components/edismax-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/edismax-component.md
@@ -46,7 +46,7 @@ $query->setQuery('memory -printer');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
@@ -45,7 +45,7 @@ $facetSet->createFacetField('stock')->setField('inStock');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-multiquery.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-multiquery.md
@@ -34,7 +34,7 @@ $facet->createQuery('nostock_pricecat2', 'inStock:false AND price:[300 TO *]');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-pivot.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-pivot.md
@@ -42,7 +42,7 @@ $facet->addFields('popularity,cat');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet results

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-query.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-query.md
@@ -36,7 +36,7 @@ $facetSet->createFacetQuery('stock')->setQuery('inStock: true');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet query count

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-range.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-range.md
@@ -48,7 +48,7 @@ $facet->setEnd(1000);
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts
@@ -100,7 +100,7 @@ $facet->setPivot(['inStock']);
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display pivot facet counts

--- a/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
@@ -65,7 +65,7 @@ $hl->setSimplePostfix('</b>');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 $highlighting = $resultset->getHighlighting();
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator
@@ -125,7 +125,7 @@ $hl->getField('features')->setSimplePrefix('<i>')->setSimplePostfix('</i>');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 $highlighting = $resultset->getHighlighting();
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
@@ -43,7 +43,7 @@ $query->setQuery('apache')
 $resultset = $client->select($query);
 $mlt = $resultset->getMoreLikeThis();
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator
@@ -63,7 +63,7 @@ foreach ($resultset as $document) {
 
     echo '</table><br/><b>MLT results:</b><br/>';
 
-    // mlt results can be fetched by document id (the field defined as uniquekey in this schema)
+    // MLT results can be fetched by document id (the field defined as uniquekey in this schema)
     $mltResult = $mlt->getResult($document->id);
     if ($mltResult) {
         echo 'Max score: '.$mltResult->getMaximumScore().'<br/>';

--- a/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
@@ -46,7 +46,7 @@ $elevate->setExcludeIds(array('SP2514N', '6H500F0'));
 
 // this executes the query and returns the result
 $resultset = $client->select($query);
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/select-query/building-a-select-query/components/query-rerankquery-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-rerankquery-component.md
@@ -41,7 +41,7 @@ $rerank->setWeight(3);
 
 // this executes the query and returns the result
 $resultset = $client->select($query);
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/select-query/executing-a-select-query.md
+++ b/docs/queries/select-query/executing-a-select-query.md
@@ -17,7 +17,7 @@ $query = $client->createQuery($client::QUERY_SELECT);
 // this executes the query and returns the result
 $resultset = $client->execute($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/select-query/re-use-of-queries.md
+++ b/docs/queries/select-query/re-use-of-queries.md
@@ -60,7 +60,7 @@ class LowerPriceQuery extends PriceQuery
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/select-query/result-of-a-select-query/component-results/facetset-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/facetset-result.md
@@ -32,7 +32,7 @@ $facetSet->createFacetField('stock')->setField('inStock');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts
@@ -84,7 +84,7 @@ $facetSet->createFacetQuery('stock')->setQuery('inStock: true');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet query count
@@ -137,7 +137,7 @@ $facet->createQuery('nostock_pricecat2', 'inStock:false AND price:[300 TO *]');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts
@@ -193,7 +193,7 @@ $facet->setEnd(1000);
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/docs/queries/select-query/result-of-a-select-query/component-results/highlighting-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/highlighting-result.md
@@ -27,7 +27,7 @@ $hl->setSimplePostfix('</b>');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 $highlighting = $resultset->getHighlighting();
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
@@ -28,7 +28,7 @@ $query->setQuery('apache')
 $resultset = $client->select($query);
 $mlt = $resultset->getMoreLikeThis();
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator
@@ -48,7 +48,7 @@ foreach ($resultset as $document) {
 
     echo '</table><br/><b>MLT results:</b><br/>';
 
-    // mlt results can be fetched by document id (the field defined as uniquekey in this schema)
+    // MLT results can be fetched by document id (the field defined as uniquekey in this schema)
     $mltResult = $mlt->getResult($document->id);
     if ($mltResult) {
         echo 'Max score: '.$mltResult->getMaximumScore().'<br/>';

--- a/docs/queries/select-query/result-of-a-select-query/result-of-a-select-query.md
+++ b/docs/queries/select-query/result-of-a-select-query/result-of-a-select-query.md
@@ -51,7 +51,7 @@ $query = $client->createQuery($client::QUERY_SELECT);
 // this executes the query and returns the result
 $resultset = $client->execute($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/docs/queries/server-query/core-admin-query.md
+++ b/docs/queries/server-query/core-admin-query.md
@@ -1,11 +1,11 @@
-Core admin queries can be used to administrate cores on your solr server (https://lucene.apache.org/solr/guide/coreadmin-api.html)
+CoreAdmin queries can be used to [administrate cores on your Solr server](https://lucene.apache.org/solr/guide/coreadmin-api.html).
 
-The core admin api on the Apache Solr server has several "actions" available and every action can have a set of arguments.
+The CoreAdmin API on the Apache Solr server has several "actions" available and every action can have a set of arguments.
 
-Building an core admin query
-----------------------------
+Building a CoreAdmin query
+--------------------------
 
-The following example shows how your can build a core admin query that executes the status action:
+The following example shows how your can build a CoreAdmin query that executes the status action:
 
 ```php
 <?php
@@ -16,10 +16,10 @@ htmlHeader();
 // create a client instance
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
-// create a core admin query
+// create a CoreAdmin query
 $coreAdminQuery = $client->createCoreAdmin();
 
-// use the core admin query to build a Status action
+// use the CoreAdmin query to build a Status action
 $statusAction = $coreAdminQuery->createStatus();
 $statusAction->setCore('techproducts');
 $coreAdminQuery->setAction($statusAction);
@@ -27,7 +27,7 @@ $coreAdminQuery->setAction($statusAction);
 $response = $client->coreAdmin($coreAdminQuery);
 $statusResult = $response->getStatusResult();
 
-echo '<b>Core admin status action execution:</b><br/>';
+echo '<b>CoreAdmin status action execution:</b><br/>';
 echo 'Uptime of the core ( ' .$statusResult->getCoreName(). ' ): ' . $statusResult->getUptime();
 
 htmlFooter();
@@ -105,9 +105,9 @@ Use to rename a core.
 RequestRecovery
 ===============
 
-Use to recover a core. 
+Use to recover a core.
 
-**Note**: Only relevant for solrcloud where cores are shards and a cover can be recovered from the leader (a copy of that core on another node)
+**Note**: Only relevant for SolrCloud where cores are shards and a cover can be recovered from the leader (a copy of that core on another node).
 
 **Available action methods**:
 
@@ -131,7 +131,7 @@ RequestStatus can be used later to retrieve the state for that asynchronous acti
 Split
 =====
 
-Use to split a core. 
+Use to split a core.
 
 See also: https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-split
 
@@ -150,7 +150,7 @@ See also: https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-spli
 Status
 ======
 
-Use to get the status of one or all cores:
+Use to get the status of one or all cores.
 
 **Note**: When no name is passed the status for all cores will be retrieved.
 

--- a/docs/queries/update-query/building-an-update-query/commit-command.md
+++ b/docs/queries/update-query/building-an-update-query/commit-command.md
@@ -11,7 +11,7 @@ Options
 |----------------|---------|---------------|-------------------------------------------------------------------------------------------------------------|
 | softcommit     | boolean | null          | Enable or disable softCommit                                                                                |
 | waitsearcher   | boolean | null          | Block until a new searcher is opened and registered as the main query searcher, making the changes visible. |
-| expungedeletes | boolean | null          | Merge segments with deletes away (available since solr 1.4)                                                 |
+| expungedeletes | boolean | null          | Merge segments with deletes away (available since Solr 1.4)                                                 |
 ||
 
 For all options:

--- a/docs/solarium-concepts.md
+++ b/docs/solarium-concepts.md
@@ -49,7 +49,7 @@ $facet = $facetSet->createFacetField('stock')->setField('inStock');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts
@@ -116,7 +116,7 @@ $query = $client->createSelect($select);
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts
@@ -194,7 +194,7 @@ $query = new ProductPriceLimitedQuery;
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/examples/1.1-check-solarium-and-ping.php
+++ b/examples/1.1-check-solarium-and-ping.php
@@ -3,7 +3,7 @@
 require_once(__DIR__.'/init.php');
 htmlHeader();
 
-// check solarium version available
+// check Solarium version available
 echo 'Solarium library version: ' . Solarium\Client::VERSION . ' - ';
 
 // create a client instance

--- a/examples/1.2-basic-select.php
+++ b/examples/1.2-basic-select.php
@@ -21,7 +21,7 @@ $query->setStart(($currentPage - 1) * $resultsPerPage);
 // this executes the query and returns the result
 $resultset = $client->execute($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/1.3-basic-update.php
+++ b/examples/1.3-basic-update.php
@@ -4,7 +4,7 @@ require_once(__DIR__.'/init.php');
 htmlHeader();
 
 if ($_POST) {
-    // if data is posted add it to solr
+    // if data is posted add it to Solr
 
     // create a client instance
     $client = new Solarium\Client($adapter, $eventDispatcher, $config);

--- a/examples/2.1.1-query-params.php
+++ b/examples/2.1.1-query-params.php
@@ -25,7 +25,7 @@ $query->addSort('price', $query::SORT_ASC);
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display the max score

--- a/examples/2.1.2-custom-result-document.php
+++ b/examples/2.1.2-custom-result-document.php
@@ -26,7 +26,7 @@ $query->setDocumentClass('MyDoc');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/2.1.3-filterquery.php
+++ b/examples/2.1.3-filterquery.php
@@ -15,7 +15,7 @@ $query->createFilterQuery('maxprice')->setQuery('price:[1 TO 300]');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/2.1.5.1.1-facet-field.php
+++ b/examples/2.1.5.1.1-facet-field.php
@@ -18,7 +18,7 @@ $facetSet->createFacetField('stock')->setField('inStock');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/examples/2.1.5.1.1.1-facet-field-filters.php
+++ b/examples/2.1.5.1.1.1-facet-field-filters.php
@@ -38,7 +38,7 @@ $facetSet->createFacetField('electronicsExclude')->setField('cat')->setExcludeTe
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/examples/2.1.5.1.1.2-facet-field-excludes.php
+++ b/examples/2.1.5.1.1.2-facet-field-excludes.php
@@ -27,7 +27,7 @@ $facetSet->createFacetField('unfiltered')->setField('cat')->getLocalParameters()
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/examples/2.1.5.1.2-facet-query.php
+++ b/examples/2.1.5.1.2-facet-query.php
@@ -18,7 +18,7 @@ $facetSet->createFacetQuery('stock')->setQuery('inStock: true');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet query count

--- a/examples/2.1.5.1.3-facet-multiquery.php
+++ b/examples/2.1.5.1.3-facet-multiquery.php
@@ -22,7 +22,7 @@ $facet->createQuery('nostock_pricecat2', 'inStock:false AND price:[300 TO *]');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/examples/2.1.5.1.4-facet-range.php
+++ b/examples/2.1.5.1.4-facet-range.php
@@ -22,7 +22,7 @@ $facet->setEnd(1000);
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/examples/2.1.5.1.5-facet-pivot.php
+++ b/examples/2.1.5.1.5-facet-pivot.php
@@ -23,7 +23,7 @@ $facet->addFields('popularity,cat');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet results

--- a/examples/2.1.5.1.6-facet-interval.php
+++ b/examples/2.1.5.1.6-facet-interval.php
@@ -20,7 +20,7 @@ $facet->setSet(array('1-9' => '[1,10)', '10-49' => '[10,50)', '49>' => '[50,*)')
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/examples/2.1.5.1.7-facet-json-terms.php
+++ b/examples/2.1.5.1.7-facet-json-terms.php
@@ -21,7 +21,7 @@ $facetSet->addFacet($categoriesTerms);
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/examples/2.1.5.1.8-facet-json-query.php
+++ b/examples/2.1.5.1.8-facet-json-query.php
@@ -21,7 +21,7 @@ $facetSet->addFacet($inStockFacet);
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // JsonQuery returns a FacetSet, not Buckets like a JsonTerms facet

--- a/examples/2.1.5.1.9-facet-json-range.php
+++ b/examples/2.1.5.1.9-facet-json-range.php
@@ -27,7 +27,7 @@ $facetSet->addFacet($priceranges);
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/examples/2.1.5.12-queryelevation.php
+++ b/examples/2.1.5.12-queryelevation.php
@@ -28,7 +28,7 @@ $elevate->setExcludeIds(array('SP2514N', '6H500F0'));
 
 // this executes the query and returns the result
 $resultset = $client->select($query);
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/2.1.5.2-morelikethis.php
+++ b/examples/2.1.5.2-morelikethis.php
@@ -20,7 +20,7 @@ $query->setQuery('apache')
 $resultset = $client->select($query);
 $mlt = $resultset->getMoreLikeThis();
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator
@@ -40,7 +40,7 @@ foreach ($resultset as $document) {
 
     echo '</table><br/><b>MLT results:</b><br/>';
 
-    // mlt results can be fetched by document id (the field defined as uniquekey in this schema)
+    // MLT results can be fetched by document id (the field defined as uniquekey in this schema)
     $mltResult = $mlt->getResult($document->id);
     if ($mltResult) {
         echo 'Max score: '.$mltResult->getMaximumScore().'<br/>';

--- a/examples/2.1.5.3-highlighting.php
+++ b/examples/2.1.5.3-highlighting.php
@@ -19,7 +19,7 @@ $hl->setSimplePostfix('</b>');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 $highlighting = $resultset->getHighlighting();
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/2.1.5.3.1-per-field-highlighting.php
+++ b/examples/2.1.5.3.1-per-field-highlighting.php
@@ -21,7 +21,7 @@ $hl->getField('features')->setSimplePrefix('<i>')->setSimplePostfix('</i>');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 $highlighting = $resultset->getHighlighting();
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/2.1.5.4-dismax.php
+++ b/examples/2.1.5.4-dismax.php
@@ -19,7 +19,7 @@ $query->setQuery('memory -printer');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/2.1.5.5-edismax.php
+++ b/examples/2.1.5.5-edismax.php
@@ -18,7 +18,7 @@ $query->setQuery('memory -printer');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/2.1.5.8-distributed-search.php
+++ b/examples/2.1.5.8-distributed-search.php
@@ -20,7 +20,7 @@ $distributedSearch->addShard('shard2', 'localhost:7574/solr');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/2.1.5.9-spellcheck.php
+++ b/examples/2.1.5.9-spellcheck.php
@@ -8,7 +8,7 @@ $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect()
-    // Unfortunately the /select handler of the techproducts examlpe doesn't contain a spellchecker anymore.
+    // Unfortunately the /select handler of the techproducts example doesn't contain a spellchecker anymore.
     // Therefore we have to use the /browse handler and turn of velocity by forcing json as response writer.
     ->setHandler('browse')
     ->setResponseWriter(\Solarium\Core\Query\AbstractQuery::WT_JSON)

--- a/examples/2.1.6-helper-functions.php
+++ b/examples/2.1.6-helper-functions.php
@@ -19,7 +19,7 @@ $query->createFilterQuery('region')->setQuery($helper->geofilt('store',45.15, -9
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/2.1.7-query-reuse.php
+++ b/examples/2.1.7-query-reuse.php
@@ -55,7 +55,7 @@ class LowerPriceQuery extends PriceQuery
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/2.2.1.1-atomic-updates.php
+++ b/examples/2.2.1.1-atomic-updates.php
@@ -50,7 +50,7 @@ $query->createFilterQuery('newprice')->setQuery('price:374');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo '<hr/>NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/2.3.1-mlt-query.php
+++ b/examples/2.3.1-mlt-query.php
@@ -10,7 +10,7 @@ $client = new Client($adapter, $eventDispatcher, $config);
 
 // get a morelikethis query instance
 $query = $client->createSelect()
-    // Unfortunately the /mlt handler of the techproducts examlpe doesn't exist anymore.
+    // Unfortunately the /mlt handler of the techproducts example doesn't exist anymore.
     // Therefore we have to use the /browse handler and turn of velocity by forcing json as response writer.
     ->setHandler('browse')
     ->setResponseWriter(\Solarium\Core\Query\AbstractQuery::WT_JSON);
@@ -51,7 +51,7 @@ echo '<hr/>';
 
 $mlt = $resultset->getMoreLikeThis();
 
-// display the total number of MLT documents found by solr
+// display the total number of MLT documents found by Solr
 echo 'Number of MLT matches found: '.$resultset->getNumFound().'<br/><br/>';
 echo '<b>Listing of matched docs:</b>';
 

--- a/examples/2.3.2-mlt-stream.php
+++ b/examples/2.3.2-mlt-stream.php
@@ -34,7 +34,7 @@ foreach ($resultset->getMatch() as $field => $value) {
 }
 echo '</table><hr/>';
 
-// display the total number of MLT documents found by solr
+// display the total number of MLT documents found by Solr
 echo 'Number of MLT matches found: '.$resultset->getNumFound().'<br/><br/>';
 echo '<b>Listing of matched docs:</b>';
 

--- a/examples/2.8-realtime-get-query.php
+++ b/examples/2.8-realtime-get-query.php
@@ -15,7 +15,7 @@ $doc1 = $update->createDocument();
 $doc1->id = $id;
 $doc1->name = 'realtime-get-test-'.date('Y-m-d H:i:s');
 
-// set a very long commitWithin time and add it to solr
+// set a very long commitWithin time and add it to Solr
 $update->addDocument($doc1, null, 1000000);
 $client->update($update);
 

--- a/examples/2.9-server-core-admin-status.php
+++ b/examples/2.9-server-core-admin-status.php
@@ -6,17 +6,17 @@ htmlHeader();
 // create a client instance
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
-// create a core admin query
+// create a CoreAdmin query
 $coreAdminQuery = $client->createCoreAdmin();
 
-// use the core admin query to build a Status action
+// use the CoreAdmin query to build a Status action
 $statusAction = $coreAdminQuery->createStatus();
 $coreAdminQuery->setAction($statusAction);
 
 $response = $client->coreAdmin($coreAdminQuery);
 $statusResults = $response->getStatusResults();
 
-echo '<b>Core admin status action execution:</b><br/>';
+echo '<b>CoreAdmin status action execution:</b><br/>';
 foreach($statusResults as $statusResult) {
     echo 'Uptime of the core ( ' .$statusResult->getCoreName(). ' ): ' . $statusResult->getUptime();
 }

--- a/examples/4.1-api-usage.php
+++ b/examples/4.1-api-usage.php
@@ -26,7 +26,7 @@ $facet = $facetSet->createFacetField('stock')->setField('inStock');
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/examples/4.2-configuration-usage.php
+++ b/examples/4.2-configuration-usage.php
@@ -37,7 +37,7 @@ $query = $client->createSelect($select);
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/examples/4.3-extending-usage.php
+++ b/examples/4.3-extending-usage.php
@@ -48,7 +48,7 @@ $query = new ProductPriceLimitedQuery;
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // display facet counts

--- a/examples/5.1-partial-usage.php
+++ b/examples/5.1-partial-usage.php
@@ -28,7 +28,7 @@ $response = $client->executeRequest($request);
 // and finally you can convert the response into a result
 $result = $client->createResult($query, $response);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$result->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/5.2-extending.php
+++ b/examples/5.2-extending.php
@@ -38,7 +38,7 @@ echo 'Query class: ' . get_class($query) . '<br/>';
 // execute query
 $result = $client->execute($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$result->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/6.1.1-psr18-adapter.php
+++ b/examples/6.1.1-psr18-adapter.php
@@ -17,7 +17,7 @@ $query = $client->createSelect();
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/6.1.2-curl-adapter.php
+++ b/examples/6.1.2-curl-adapter.php
@@ -15,7 +15,7 @@ $query = $client->createSelect();
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/6.1.3-http-adapter.php
+++ b/examples/6.1.3-http-adapter.php
@@ -15,7 +15,7 @@ $query = $client->createSelect();
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/6.2-escaping.php
+++ b/examples/6.2-escaping.php
@@ -20,7 +20,7 @@ $query->setQuery('features:' . $helper->escapePhrase($input));
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/6.3-placeholder-syntax.php
+++ b/examples/6.3-placeholder-syntax.php
@@ -22,7 +22,7 @@ echo $query->getQuery() . '<br/>';
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/7.1-plugin-loadbalancer.php
+++ b/examples/7.1-plugin-loadbalancer.php
@@ -32,7 +32,7 @@ for ($i = 1; $i <= 8; $i++) {
     echo 'Server: ' . $loadbalancer->getLastEndpoint() .'<hr/>';
 }
 
-// force a server for a query (normally solr 3 is extremely unlikely based on its weight)
+// force a server for a query (normally 'local3' is extremely unlikely based on its weight)
 $loadbalancer->setForcedEndpointForNextQuery('local3');
 
 $resultset = $client->select($query);

--- a/examples/7.2-plugin-postbigrequest.php
+++ b/examples/7.2-plugin-postbigrequest.php
@@ -22,7 +22,7 @@ $query->createFilterQuery('fq')->setQuery($fq);
 // without the plugin this query would fail as it is bigger than the default servlet container header buffer
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 // show documents using the resultset iterator

--- a/examples/7.3-plugin-customizerequest.php
+++ b/examples/7.3-plugin-customizerequest.php
@@ -34,16 +34,16 @@ $customizer->createCustomization('id')
 // create a basic query to execute
 $query = $client->createSelect();
 
-// execute query (you should be able to see the extra params in the solr log file)
+// execute query (you should be able to see the extra params in the Solr log file)
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound() . '<br/>';
 
 // execute the same query again (this time the 'id' param should no longer show up in the logs)
 $resultset = $client->select($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: '.$resultset->getNumFound();
 
 htmlFooter();

--- a/examples/7.4-plugin-parallelexecution.php
+++ b/examples/7.4-plugin-parallelexecution.php
@@ -49,5 +49,5 @@ htmlFooter();
 
 // Note: for this example on a default Solr index (with a tiny index) running on localhost the performance gain is
 // minimal to none, sometimes even slightly slower!
-// In a realworld scenario with network latency, a bigger dataset, more complex queries or multiple solr instances the
+// In a realworld scenario with network latency, a bigger dataset, more complex queries or multiple Solr instances the
 // performance gain is much more.

--- a/examples/7.6-plugin-prefetchiterator.php
+++ b/examples/7.6-plugin-prefetchiterator.php
@@ -20,7 +20,7 @@ $prefetch = $client->getPlugin('prefetchiterator');
 $prefetch->setPrefetch(2); //fetch 2 rows per query (for real world use this can be way higher)
 $prefetch->setQuery($query);
 
-// display the total number of documents found by solr
+// display the total number of documents found by Solr
 echo 'NumFound: ' . count($prefetch);
 
 // show document IDs using the resultset iterator

--- a/examples/7.7-plugin-minimumscorefilter.php
+++ b/examples/7.7-plugin-minimumscorefilter.php
@@ -17,7 +17,7 @@ $query->setFilterMode($query::FILTER_MODE_MARK);
 // this executes the query and returns the result
 $resultset = $client->execute($query);
 
-// display the total number of documents found by solr and the maximum score
+// display the total number of documents found by Solr and the maximum score
 echo 'NumFound: '.$resultset->getNumFound();
 echo '<br/>MaxScore: '.$resultset->getMaxScore();
 

--- a/src/Builder/AbstractExpressionVisitor.php
+++ b/src/Builder/AbstractExpressionVisitor.php
@@ -23,7 +23,7 @@ use Solarium\Exception\RuntimeException;
 abstract class AbstractExpressionVisitor
 {
     /**
-     * Converts a comparison expression into solr query language.
+     * Converts a comparison expression into Solr query language.
      *
      * @param \Solarium\Builder\ExpressionInterface $expression
      *
@@ -32,7 +32,7 @@ abstract class AbstractExpressionVisitor
     abstract public function walkExpression(ExpressionInterface $expression);
 
     /**
-     * Converts a value expression into solr query part.
+     * Converts a value expression into Solr query part.
      *
      * @param \Solarium\Builder\Value $value
      *

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -256,7 +256,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
         if (\count($stats) > 0) {
             $key = ['stats' => implode('', $stats)];
 
-            // when specifying stats, solr sets the field as key
+            // when specifying stats, Solr sets the field as key
             $facet->setKey(implode(',', $facet->getFields()));
         } else {
             $key = ['key' => $facet->getKey()];

--- a/src/Component/RequestBuilder/RequestParamsTrait.php
+++ b/src/Component/RequestBuilder/RequestParamsTrait.php
@@ -87,7 +87,7 @@ trait RequestParamsTrait
                 }
                 $this->params[$key][] = $value;
             } else {
-                // not all solr handlers support 0/1 as boolean values...
+                // not all Solr handlers support 0/1 as boolean values...
                 if (true === $value) {
                     $value = 'true';
                 } elseif (false === $value) {

--- a/src/Component/ResponseParser/Grouping.php
+++ b/src/Component/ResponseParser/Grouping.php
@@ -111,9 +111,9 @@ class Grouping implements ComponentParserInterface
      * Helper method to extract a ValueGroup object from the given value group result array.
      *
      * @param string        $valueResultClass the grouping resultvaluegroupclass option
-     * @param string        $documentClass    the name of the solr document class to use
-     * @param array         $valueGroupResult the group result from the solr response
-     * @param AbstractQuery $query            the current solr query
+     * @param string        $documentClass    the name of the Solr document class to use
+     * @param array         $valueGroupResult the group result from the Solr response
+     * @param AbstractQuery $query            the current Solr query
      *
      * @return object
      */

--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -40,7 +40,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
     }
 
     /**
-     * Get the response for a curl handle.
+     * Get the response for a cURL handle.
      *
      * @param resource $handle
      * @param string   $httpResponse
@@ -66,7 +66,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
     }
 
     /**
-     * Create curl handle for a request.
+     * Create cURL handle for a request.
      *
      * @param Request  $request
      * @param Endpoint $endpoint

--- a/src/Core/Client/Request.php
+++ b/src/Core/Client/Request.php
@@ -348,7 +348,7 @@ class Request extends Configurable implements RequestParamsInterface
     }
 
     /**
-     * Execute a request outside of the core context in the global solr context.
+     * Execute a request outside of the core context in the global Solr context.
      *
      * @param bool $isServerRequest
      *

--- a/src/Core/Query/AbstractQuery.php
+++ b/src/Core/Query/AbstractQuery.php
@@ -177,7 +177,7 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
     /**
      * Removes a param that was previously added by addParam.
      *
-     * Note: This can not be used to remove known default parameters of the solarium api.
+     * Note: This can not be used to remove known default parameters of the Solarium API.
      *
      * @param string $name
      *

--- a/src/Plugin/ParallelExecution/ParallelExecution.php
+++ b/src/Plugin/ParallelExecution/ParallelExecution.php
@@ -21,8 +21,8 @@ use Solarium\Plugin\ParallelExecution\Event\ExecuteStart as ExecuteStartEvent;
 /**
  * ParallelExecution plugin.
  *
- * You can use this plugin to run multiple queries parallel. This functionality depends on the curl adapter so you
- * do need to have curl available in your PHP environment.
+ * You can use this plugin to run multiple queries parallel. This functionality depends on the cURL adapter so you
+ * do need to have cURL available in your PHP environment.
  *
  * While query execution is parallel, the results only become available as soon as all requests have finished. So the
  * time of the slowest query will be the effective execution time for all queries.
@@ -166,7 +166,7 @@ class ParallelExecution extends AbstractPlugin
      */
 
     /**
-     * Set curl adapter (the only type that supports parallelexecution).
+     * Set cURL adapter (the only type that supports ParallelExecution).
      */
     protected function initPluginType()
     {

--- a/src/QueryType/MoreLikeThis/RequestBuilder.php
+++ b/src/QueryType/MoreLikeThis/RequestBuilder.php
@@ -30,7 +30,7 @@ class RequestBuilder extends SelectRequestBuilder
     {
         $request = parent::build($query);
 
-        // add mlt params to request
+        // add MLT params to request
         $request->addParam('mlt.interestingTerms', $query->getInterestingTerms());
         $request->addParam('mlt.match.include', $query->getMatchInclude());
         $request->addParam('mlt.match.offset', $query->getMatchOffset());

--- a/src/QueryType/MoreLikeThis/Result.php
+++ b/src/QueryType/MoreLikeThis/Result.php
@@ -16,15 +16,15 @@ use Solarium\QueryType\Select\Result\Result as SelectResult;
 /**
  * MoreLikeThis query result.
  *
- * This is the standard resulttype for a moreLikeThis query. Example usage:
+ * This is the standard resulttype for a MoreLikeThis query. Example usage:
  * <code>
- * // total solr mlt results
+ * // total Solr MLT results
  * $result->getNumFound();
  *
  * // results fetched
  * count($result);
  *
- * // iterate over fetched mlt docs
+ * // iterate over fetched MLT docs
  * foreach ($result as $doc) {
  *    ....
  * }

--- a/src/QueryType/Select/Result/Result.php
+++ b/src/QueryType/Select/Result/Result.php
@@ -27,7 +27,7 @@ use Solarium\Core\Query\Result\QueryType as BaseResult;
  *
  * This is the standard resulttype for a select query. Example usage:
  * <code>
- * // total solr results
+ * // total Solr results
  * $result->getNumFound();
  *
  * // results fetched

--- a/src/QueryType/Server/AbstractServerQuery.php
+++ b/src/QueryType/Server/AbstractServerQuery.php
@@ -19,7 +19,7 @@ use Solarium\QueryType\Server\Query\Action\ActionInterface;
 abstract class AbstractServerQuery extends AbstractQuery implements ActionInterface
 {
     /**
-     * Action that should be performed on the core admin api.
+     * Action that should be performed on the CoreAdmin API.
      *
      * @var ActionInterface
      */

--- a/src/QueryType/Server/CoreAdmin/Query/Query.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Query.php
@@ -30,7 +30,7 @@ use Solarium\QueryType\Server\Query\RequestBuilder;
 /**
  * CoreAdmin query.
  *
- * Can be used to perform an action on the core admin endpoint
+ * Can be used to perform an action on the admin/cores endpoint
  */
 class Query extends AbstractServerQuery
 {

--- a/src/QueryType/Server/CoreAdmin/ResponseParser.php
+++ b/src/QueryType/Server/CoreAdmin/ResponseParser.php
@@ -18,7 +18,7 @@ use Solarium\QueryType\Server\CoreAdmin\Result\Result;
 use Solarium\QueryType\Server\CoreAdmin\Result\StatusResult;
 
 /**
- * Parse Core Admin response data.
+ * Parse CoreAdmin response data.
  */
 class ResponseParser extends ResponseParserAbstract implements ResponseParserInterface
 {

--- a/src/QueryType/Update/Query/Query.php
+++ b/src/QueryType/Update/Query/Query.php
@@ -30,7 +30,7 @@ use Solarium\QueryType\Update\Result;
 /**
  * Update query.
  *
- * Can be used to send multiple update commands to solr, e.g. add, delete,
+ * Can be used to send multiple update commands to Solr, e.g. add, delete,
  * rollback, commit, optimize.
  * Multiple commands of any type can be combined into a single update query.
  */

--- a/tests/Core/Client/Adapter/CurlTest.php
+++ b/tests/Core/Client/Adapter/CurlTest.php
@@ -20,7 +20,7 @@ class CurlTest extends TestCase
     public function setUp(): void
     {
         if (!function_exists('curl_init')) {
-            $this->markTestSkipped('Curl not available, skipping Curl adapter tests');
+            $this->markTestSkipped('cURL not available, skipping cURL adapter tests.');
         }
 
         $this->adapter = new Curl();

--- a/tests/Integration/SolrCloud/CurlTest.php
+++ b/tests/Integration/SolrCloud/CurlTest.php
@@ -15,7 +15,7 @@ class CurlTest extends AbstractCloudTest
     public function setUp(): void
     {
         parent::setUp();
-        // The default timeout of solarium of 5s seems to be too aggressive on travis and causes random test failures.
+        // The default timeout of Solarium of 5s seems to be too aggressive on Travis and causes random test failures.
         // Set it to the PHP default of 13s.
         $adapter = new Curl();
         $adapter->setTimeout(CURLOPT_TIMEOUT);

--- a/tests/Integration/SolrServer/CurlTest.php
+++ b/tests/Integration/SolrServer/CurlTest.php
@@ -15,7 +15,7 @@ class CurlTest extends AbstractServerTest
     public function setUp(): void
     {
         parent::setUp();
-        // The default timeout of solarium of 5s seems to be too aggressive on travis and causes random test failures.
+        // The default timeout of Solarium of 5s seems to be too aggressive on Travis and causes random test failures.
         // Set it to the PHP default of 13s.
         $adapter = new Curl();
         $adapter->setTimeout(CURLOPT_TIMEOUT);


### PR DESCRIPTION
I spotted a typo in the docs and got a bit carried away.

- Fixed a handful of random typos.
- Consistent capitalisation of Solarium.
- Consistent capitalisation of Solr, SolrCloud, CoreAdmin … as per the ref guide.
- Consistent capitalisation of cURL as per the PHP manual.
- `https:` for a few links that were still `http:` and redirect anyway.