### PR TITLE
Remove extension 'intl' from PHP setup for testing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,7 +30,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                 php-version: ${{ matrix.php }}
-                extensions: dom, curl, libxml, mbstring, zip, intl, iconv, json, simplexml
+                extensions: dom, curl, libxml, mbstring, zip, iconv, json, simplexml
                 ini-values: memory_limit=256M,post_max_size=256M
                 coverage: pcov
 


### PR DESCRIPTION
There doesn't seem to be anything in the source or tests that actually requires this PHP extension. I've been using a Docker image that can't install the extension (`nektos/act-environments-ubuntu:18.04`, it seems to resolve the package repo to an IP address it can't reach for `php-intl`) for the last few months and my test results are the same as those on GitHub with the extension.

This is what I get on every local test run:
```
[Run Tests/PHP 7.4, Solr 8 server]   | ==> Setup Extensions
[Run Tests/PHP 7.4, Solr 8 server]   | ✓ dom Enabled
[Run Tests/PHP 7.4, Solr 8 server]   | ✓ curl Enabled
[Run Tests/PHP 7.4, Solr 8 server]   | ✓ libxml Enabled
[Run Tests/PHP 7.4, Solr 8 server]   | ✓ mbstring Enabled
[Run Tests/PHP 7.4, Solr 8 server]   | ✓ zip Enabled
[Run Tests/PHP 7.4, Solr 8 server]   | ✗ intl Could not install intl on PHP 7.4.2
[Run Tests/PHP 7.4, Solr 8 server]   | ✓ iconv Enabled
[Run Tests/PHP 7.4, Solr 8 server]   | ✓ json Enabled
[Run Tests/PHP 7.4, Solr 8 server]   | ✓ simplexml Enabled
```