### PR TITLE
Fix for "maxScore":"NaN" (SOLR-13839)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PrefetchIterator::key() should return 0 instead of NULL on a fresh PrefetchIterator
 - PrefetchIterator::next() shouldn't skip fetched results after PrefetchIterator::count() on a fresh PrefetchIterator
 - PrefetchIterator::rewind() no longer results in duplicate documents when invoked mid-set
-- fixed incorrect median function
+- Fixed incorrect median function
+- Fix for maxScore being returned as "NaN" when group.query doesn't match any docs (SOLR-13839)
 
 ### Changed
 - Exception message for invalid/unavailable file in Extract query now contains filename

--- a/src/Component/ResponseParser/Grouping.php
+++ b/src/Component/ResponseParser/Grouping.php
@@ -89,6 +89,14 @@ class Grouping implements ComponentParserInterface
                 $start = $result['doclist']['start'] ?? null;
                 $maxScore = $result['doclist']['maxScore'] ?? null;
 
+                /*
+                 * https://issues.apache.org/jira/browse/SOLR-13839
+                 * maxScore is returned as "NaN" when group.query doesn't match any docs
+                 */
+                if ('NaN' === $maxScore) {
+                    $maxScore = null;
+                }
+
                 // create document instances
                 $documentClass = $query->getOption('documentclass');
                 $documents = [];

--- a/src/Component/Result/Grouping/QueryGroup.php
+++ b/src/Component/Result/Grouping/QueryGroup.php
@@ -42,7 +42,7 @@ class QueryGroup implements \IteratorAggregate, \Countable
     /**
      * Maximum score in group.
      *
-     * @var float
+     * @var float|null
      */
     protected $maximumScore;
 
@@ -111,9 +111,9 @@ class QueryGroup implements \IteratorAggregate, \Countable
     /**
      * Get maximumScore value.
      *
-     * @return float
+     * @return float|null
      */
-    public function getMaximumScore(): float
+    public function getMaximumScore(): ?float
     {
         return $this->maximumScore;
     }

--- a/src/Component/Result/Grouping/ValueGroup.php
+++ b/src/Component/Result/Grouping/ValueGroup.php
@@ -49,7 +49,7 @@ class ValueGroup implements \IteratorAggregate, \Countable
     /**
      * Maximum score in group.
      *
-     * @var float
+     * @var float|null
      */
     protected $maximumScore;
 

--- a/tests/Component/ResponseParser/GroupingTest.php
+++ b/tests/Component/ResponseParser/GroupingTest.php
@@ -140,7 +140,7 @@ class GroupingTest extends TestCase
 
     /**
      * Test fix for maxScore being returned as "NaN" when group.query doesn't match any docs.
-     * 
+     *
      * @see https://issues.apache.org/jira/browse/SOLR-13839
      */
     public function testQueryGroupParsingFixForSolr13839()

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -519,7 +519,13 @@ abstract class AbstractTechproductsTest extends TestCase
     /**
      * Test fix for maxScore being returned as "NaN" when group.query doesn't match any docs.
      *
+     * Skipped for SolrCloud because maxScore is included in distributed search results even if score is not requested (SOLR-6612).
+     * This makes the test fail on SolrCloud for queries that don't fetch a score and thus aren't affected by SOLR-13839.
+     *
+     * @group skip_for_solr_cloud
+     *
      * @see https://issues.apache.org/jira/browse/SOLR-13839
+     * @see https://issues.apache.org/jira/browse/SOLR-6612
      */
     public function testGroupingComponentFixForSolr13839()
     {

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -422,6 +422,7 @@ abstract class AbstractTechproductsTest extends TestCase
         /** @var ValueGroup $valueGroup */
         $valueGroup = $groupIterator->current();
         $this->assertSame(1, $valueGroup->getNumFound());
+        $this->assertSame(0, $valueGroup->getStart());
         $this->assertSame('A-DATA Technology Inc.', $valueGroup->getValue());
         $docIterator = $valueGroup->getIterator();
         /** @var Document $doc */
@@ -431,6 +432,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $groupIterator->next();
         $valueGroup = $groupIterator->current();
         $this->assertSame(1, $valueGroup->getNumFound());
+        $this->assertSame(0, $valueGroup->getStart());
         $this->assertSame('ASUS Computer Inc.', $valueGroup->getValue());
         $docIterator = $valueGroup->getIterator();
         $doc = $docIterator->current();
@@ -439,6 +441,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $groupIterator->next();
         $valueGroup = $groupIterator->current();
         $this->assertSame(1, $valueGroup->getNumFound());
+        $this->assertSame(0, $valueGroup->getStart());
         $this->assertSame('Apache Software Foundation', $valueGroup->getValue());
         $docIterator = $valueGroup->getIterator();
         $doc = $docIterator->current();
@@ -447,6 +450,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $groupIterator->next();
         $valueGroup = $groupIterator->current();
         $this->assertSame(1, $valueGroup->getNumFound());
+        $this->assertSame(0, $valueGroup->getStart());
         $this->assertSame('Canon Inc.', $valueGroup->getValue());
         $docIterator = $valueGroup->getIterator();
         $doc = $docIterator->current();
@@ -455,6 +459,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $groupIterator->next();
         $valueGroup = $groupIterator->current();
         $this->assertSame(2, $valueGroup->getNumFound());
+        $this->assertSame(0, $valueGroup->getStart());
         $this->assertSame('Corsair Microsystems Inc.', $valueGroup->getValue());
         $docIterator = $valueGroup->getIterator();
         $doc = $docIterator->current();
@@ -476,6 +481,8 @@ abstract class AbstractTechproductsTest extends TestCase
         /** @var QueryGroup $queryGroup */
         $queryGroup = $groupingComponentResult->getGroup('price:[0 TO 99.99]');
         $this->assertSame(5, $queryGroup->getMatches());
+        $this->assertSame(1, $queryGroup->getNumFound());
+        $this->assertSame(0, $queryGroup->getStart());
         $this->assertCount(1, $queryGroup);
         $docIterator = $queryGroup->getIterator();
         $doc = $docIterator->current();
@@ -486,6 +493,8 @@ abstract class AbstractTechproductsTest extends TestCase
 
         $queryGroup = $groupingComponentResult->getGroup('price:[100 TO *]');
         $this->assertSame(5, $queryGroup->getMatches());
+        $this->assertSame(3, $queryGroup->getNumFound());
+        $this->assertSame(0, $queryGroup->getStart());
         $this->assertCount(3, $queryGroup);
         $docIterator = $queryGroup->getIterator();
         $doc = $docIterator->current();
@@ -505,6 +514,58 @@ abstract class AbstractTechproductsTest extends TestCase
             'id' => '0579B002',
             'price' => 179.99,
         ], $doc->getFields());
+    }
+
+    /**
+     * Test fix for maxScore being returned as "NaN" when group.query doesn't match any docs.
+     * 
+     * @see https://issues.apache.org/jira/browse/SOLR-13839
+     */
+    public function testGroupingComponentFixForSolr13839()
+    {
+        self::$client->registerQueryType('grouping', '\Solarium\Tests\Integration\GroupingTestQuery');
+        /** @var GroupingTestQuery $select */
+        $select = self::$client->createQuery('grouping');
+        // without score in the fl parameter, result groups don't have a maxScore
+        $select->setFields('id');
+        $grouping = $select->getGrouping();
+        $grouping->addQueries([
+            'cat:memory',
+            'cat:no-such-cat',
+        ]);
+        $result = self::$client->select($select);
+        $groupingComponentResult = $result->getComponent(ComponentAwareQueryInterface::COMPONENT_GROUPING);
+
+        /** @var QueryGroup $queryGroup */
+        $queryGroup = $groupingComponentResult->getGroup('cat:memory');
+        $this->assertSame(32, $queryGroup->getMatches());
+        $this->assertSame(3, $queryGroup->getNumFound());
+        $this->assertNull($queryGroup->getMaximumScore());
+
+        $queryGroup = $groupingComponentResult->getGroup('cat:no-such-cat');
+        $this->assertSame(32, $queryGroup->getMatches());
+        $this->assertSame(0, $queryGroup->getNumFound());
+        $this->assertNull($queryGroup->getMaximumScore());
+
+        // with score in the fl parameter, result groups have a maxScore
+        $select->setFields('id,score');
+        $grouping = $select->getGrouping();
+        $grouping->addQueries([
+            'cat:memory',
+            'cat:no-such-cat',
+        ]);
+        $result = self::$client->select($select);
+        $groupingComponentResult = $result->getComponent(ComponentAwareQueryInterface::COMPONENT_GROUPING);
+
+        $queryGroup = $groupingComponentResult->getGroup('cat:memory');
+        $this->assertSame(32, $queryGroup->getMatches());
+        $this->assertSame(3, $queryGroup->getNumFound());
+        $this->assertNotNull($queryGroup->getMaximumScore());
+
+        $queryGroup = $groupingComponentResult->getGroup('cat:no-such-cat');
+        $this->assertSame(32, $queryGroup->getMatches());
+        $this->assertSame(0, $queryGroup->getNumFound());
+        $this->assertNull($queryGroup->getMaximumScore());
     }
 
     public function testQueryElevation()

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -518,7 +518,7 @@ abstract class AbstractTechproductsTest extends TestCase
 
     /**
      * Test fix for maxScore being returned as "NaN" when group.query doesn't match any docs.
-     * 
+     *
      * @see https://issues.apache.org/jira/browse/SOLR-13839
      */
     public function testGroupingComponentFixForSolr13839()


### PR DESCRIPTION
Solr returns `"maxScore":"NaN"` when `group.query` doesn't match any docs in standalone/single shard mode with `score` in `fl` ([SOLR-13839](https://issues.apache.org/jira/browse/SOLR-13839)). I've caught this in the response parser to turn it into `null` as the Solarium methods working with this value expect a `float` or `null`. (Actually, I had to fix one of those methods to handle `null` as well.)

I've added unit and integration tests, extended existing tests to cover `maxScore` (and `start` while I was at it), placed comments to reference SOLR-13839 in the source code, and added a note in the `CHANGELOG`. This closes #913.