### PR TITLE
PrefetchIterator documentation

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -5,13 +5,13 @@ Solarium offers a plugin system to allow for easy extension by users. But plugin
 
 
 BufferedAdd plugin
-==================
+------------------
 
 When you need to do a lot of document inserts or updates, for instance a bulk update or initial indexing, it’s most efficient to do this in batches. This makes a lot more difference than you might think, for some benchmarks see [this_blog post](http://www.raspberry.nl/2011/04/08/solr-update-performance/).
 
 This can be done very easily with this plugin, you can simply keep feeding documents, it will automatically create batch update queries for you.
 
-Some notes:
+### Some notes
 
 -   You can set a custom buffer size. The default is 100 documents, a safe value. By increasing this you can get even better performance, but depending on your document size at some level you will run into memory or request limits. A value of 1000 has been successfully used for indexing 200k documents.
 -   You can use the createDocument method with array input, but you can also manually create document instance and use the addDocument(s) method.
@@ -21,31 +21,29 @@ Some notes:
 -   The buffer also has a clear method to reset the buffer contents. However documents that have already been flushed cannot be cleared.
 -   Using the 'setEndpoint' method you can select which endpoint should be used. If you don't set a specific endpoint, the default endpoint of the client instance will be used.
 
-Events
-------
+### Events
 
-### solarium.bufferedAdd.addDocument
+#### solarium.bufferedAdd.addDocument
 
 For each document that is added an 'AddDocument' event is triggered. This even has access to the document being added.
 
-### solarium.bufferedAdd.preFlush
+#### solarium.bufferedAdd.preFlush
 
 Triggered just before a flush. Has access to the document buffer and overwrite and commitWithin settings
 
-### solarium.bufferedAdd.postFlush
+#### solarium.bufferedAdd.postFlush
 
 Triggered just after a flush. Has access to the flush (update query) result
 
-### solarium.bufferedAdd.preCommit
+#### solarium.bufferedAdd.preCommit
 
 Triggered just before a commit. Has access to the document buffer and all commit settings
 
-### solarium.bufferedAdd.postCommit
+#### solarium.bufferedAdd.postCommit
 
 Triggered just after a commit. Has access to the commit (update query) result
 
-Example usage
--------------
+### Example usage
 
 ```php
 <?php
@@ -94,7 +92,7 @@ htmlFooter();
 ```
 
 CustomizeRequest plugin
-=======================
+-----------------------
 
 Solarium has support for the most used features in Solr. But if you need to use a feature not yet supported by Solarium, or even a custom Solr extension, you can use this plugin to manually add params to the request.
 
@@ -105,8 +103,7 @@ This plugin allows you to manually add two settings:
 
 GET params and headers by default are only applied to the next request, but optionally you can make them persistent so they are applied to every request. For GET params you can also set an option to overwrite any existing value(s) with the same name in the original request.
 
-Example usage
--------------
+### Example usage
 
 ```php
 <?php
@@ -162,7 +159,7 @@ htmlFooter();
 ```
 
 LoadBalancer plugin
-===================
+-------------------
 
 This plugin is a code based loadbalancer for when you do need the redundancy and extra performance of multiple Solr servers but have not yet grown to the point where you have dedicated loadbalancers. The main features of this plugin are:
 
@@ -173,15 +170,13 @@ This plugin is a code based loadbalancer for when you do need the redundancy and
 
 All blocked query types (updates by default) are excluded from loadbalancing so they will use the default adapter settings that point to the master. All other queries will be load balanced.
 
-Events
-------
+### Events
 
-### solarium.loadbalancer.endpointFailure
+#### solarium.loadbalancer.endpointFailure
 
 An 'EndpointFailure' event is triggered when a HTTP exception occurs on one of the backends. This event has access to the Endpoint object and the exception that occurred.
 
-Example usage
--------------
+### Example usage
 
 ```php
 <?php
@@ -236,15 +231,14 @@ htmlFooter();
 
 ```
 
-
 MinimumScoreFilter plugin
-=========================
+-------------------------
 
 The MinimumScoreFilter plugin allows you to filter a resultset on a minimum score, calculated using the maxScore and a given ratio. For instance, if you set a ratio of 0.5 and the best scoring document has a score of 1.2, all documents scoring less than 0.6 will be filtered.
 
 There are two modes of filtering, removing or just marking. In the example below the marking mode is used and the examples is pretty much self explanatory. In remove mode documents not meeting the required score are not returned at all.
 
-Some important notes:
+### Some important notes
 
 1.  numFound, facet counts and other Solr data is not adjusted for the filtered documents. Just the document resultset is being filtered, this is done by Solarium AFTER getting standard search results from Solr. If you want to count the number of documents after filtering you would have to do that yourself, by iterating all results after filtering.
 2.  Rows and start (paging and offset) still work, but again this is not adjusted for filtering. So if you sets rows to 10, you might get less because of the filtering.
@@ -252,8 +246,7 @@ Some important notes:
 4.  Result document marking is done using a decorator, so you should still be able to use a custom document class.
 5.  Be aware of the issues related to 'normalizing' scores [more info](http://wiki.apache.org/lucene-java/ScoresAsPercentages). This filter only uses score to calculate the relevancy relative to the best result and doesn't return this calculated score, but be sure to test your results! In cases like an autocomplete or 'best-bet' type of search this filter can be very useful.
 
-Example usage
--------------
+### Example usage
 
 ```php
 <?php
@@ -306,24 +299,24 @@ htmlFooter();
 
 ```
 
-
 ParallelExecution plugin
-========================
+------------------------
 
 This plugin makes it possible to execute multiple Solr queries at the same time, instead of one after the other. For a use case where you need to execute two queries the performance gain can be very big, my tests show close to 50% improvement. This can be very useful if you need to query several Solr instances or get the results for multiple queries.
 
-Some important notes:
+### Some important notes
 
--   This plugin makes use of the cURL client adapter and calls curl\_multi\_exec, so you do need to have cURL available in your PHP environment to be able to use it.
--   Only request execution is parallel, requests preparation and result parsing cannot be done parallel. Luckily these parts cost very little time, far more time is in the requests.
+-   This plugin makes use of the cURL client adapter and calls `curl_multi_exec`, so you do need to have cURL available in your PHP environment to be able to use it.
+-   Only request execution is parallel, request preparation and result parsing cannot be done parallelly. Luckily these parts cost very little time, far more time is in the requests.
 -   The execution time is limited by the slowest request. If you execute 3 queries with timings of 0.2, 0.4 and 1.2 seconds the execution time for all will be (near) 1.2 seconds.
 -   If one of the requests fails the other requests will still be executed and the results parsed. In the result array the entry for the failed query will contain an exception instead of a result object. It’s your own responsibility to check the result type.
--   All query types are supported, and you can even mix query types in the same execute call.
+-   All query types are supported, and you can even mix query types in the same `execute` call.
 -   For testing this plugin you can use a special Solr delay component I’ve created (and used to develop the plugin). For more info see [this blog post](http://www.raspberry.nl/2012/01/04/solr-delay-component/).
--   Add queries using the addQuery method. Supply at least a key and a query instance. Optionally you can supply a client instance as third argument. This can be used to execute queries on different cores or even servers. If omitted the plugin will use its own client instance.
+-   Add queries using the `addQuery` method. Supply at least a key and a query instance. Optionally you can supply a client instance as third argument. This can be used to execute queries on different cores or even servers. If omitted the plugin will use its own client instance.
+-   It's possible to fetch multiple pages of results for the same query parallelly with basic pagination using `setStart` and `setRows`.
+    It's not possible to achieve this with a `cursorMark` because its value for each but the first request depends on the returned `nextCursorMark` of a previous request.
 
-Example usage
--------------
+### Example usage
 
 ```php
 <?php
@@ -382,9 +375,8 @@ htmlFooter();
 
 ```
 
-
 PostBigRequest plugin
-=====================
+---------------------
 
 If you use complex Solr queries with lots of facets and/or filterqueries the total length of your querystring can exceed the default limits of servlet containers. One solution is to alter your servlet container configuration to raise this limit. But if this is not possible or desired this plugin is another way to solve the problem.
 
@@ -394,8 +386,7 @@ For instance in Jetty the default ‘headerBufferSize’ is 4kB. Tomcat has a si
 
 The plugin only uses the length of the querystring to determine the switch to a POST request. Other headers are not included in the length calculation so your limit should be somewhat lower than the limit of the servlet container to allow for room for other headers. This was done to keep the length calculation simple and fast, because the exact headers used can vary for the various client adapters available in Solarium. You can alter the maxquerystringlength by using a config setting or the API. Only GET requests are switched over to POST, if the request already uses the POST method (for instance update queries) it’s not altered.
 
-Example usage
--------------
+### Example usage
 
 ```php
 <?php
@@ -447,16 +438,77 @@ htmlFooter();
 
 ```
 
-
 PrefetchIterator plugin
-=======================
+-----------------------
 
-This plugin can be used for iterating a big resultset. It has an iterator interface and will fetch the results from Solr when needed, in batches of a configurable size (sequential prefetching). You can even iterate all the documents in a Solr index.
+This plugin can be used for iterating a big resultset. It has an `\Iterator` interface and will fetch the results from Solr when needed, in batches of a configurable size (sequential prefetching). You can even iterate all the documents in a Solr index.
 
-It’s very easy to use. You configure a query like you normally would and pass it to the plugin. See the example code below.
+It’s very easy to use. You configure a query like you normally would and pass it to the plugin. See the [example code](#example-usage_6) below.
 
-Example usage
--------------
+### When to use PrefetchIterator
+
+Whether or not you should use PrefetchIterator depends on your use case.
+
+For websites, you probably don't need PrefetchIterator. If you use classic paginated results where users can jump to any specific page, Solr's basic pagination
+is the perfect match. When a user requests page `$p` with `$num` results per page, the translation to Solarium is straightforward.
+
+```php
+$query->setStart(($p - 1) * $num)->setRows($num);
+```
+
+Use cases for PrefetchIterator are more likely to involve background processes and cronjobs. It's very useful when you need to process all results for a query
+(this can be `*:*` for your entire index). It deals with repeating the query every `$num` rows for you without requiring additional logic on your part to keep track of the page.
+
+```php
+$prefetch->setPrefetch($num)->setQuery($query);
+```
+
+### When to use a `cursorMark`
+
+If you want to use a `cursorMark`, the sort for your query MUST include the `uniqueKey` field for your schema. Combining it with a sort on other
+fields is fine, but it can't be omitted.
+
+When you need a very large number of sorted results, basic pagination can be very inefficient. Cursors offer an alternative to scan through results without the performance
+problems of ‘deep paging’. Regardless of index size, there is the benefit that the impact of index modifications between subsequent queries is much smaller with a cursor than
+with basic pagination (see [notes](#some-notes_1) below).
+
+For websites, you can use a `cursorMark` for an infinite scroll to load results sequentially. Instead of telling Solr ‘I want this many results starting at that position’,
+you tell it ‘this is where I got to, give me the next part’ by using the `nextCursorMark` that gets returned with your result. The translation to Solarium is twofold.
+
+```php
+// first request
+$query->setSorts([...])->setRows($num)->setCursormark('*');
+
+// subsequent requests 
+$query->setSorts([...])->setRows($num)->setCursormark($result->getNextCursorMark());
+```
+
+PrefetchIterator makes it set-and-forget by handling that logic for you when repeating the query. Because it can't know whether your sort includes the `uniqueKey` field
+for your schema, you do need to set it to `*` on the query yourself in order to use a cursor instead of basic pagination.
+
+```php
+$query->setSorts([...])->setCursormark('*');
+$prefetch->setPrefetch($num)->setQuery($query);
+```
+
+### Some notes
+
+- Index modifications that affect the order of documents can cause a document to ‘jump pages’ between subsequent requests. The same document could be returned on multiple
+  pages, or be skipped entirely and never show up in your resultset.
+    * With basic pagination, this can be caused by updates to the value of a sort field, as well as by adding or removing documents that match the query.
+    * With a cursor, this can only be caused by updates to the value of a sort field.
+    * If you want to ensure this never happens, use a `cursorMark` and sort _only_ on the `uniqueKey` field.
+- If your sort includes date math relative to `NOW`, it can also mess with the order of results because the value of `NOW` will be recalculated on every request.
+  This can lead to a neverending cursor that keeps returning the same documents. It's best to set a fixed value for `NOW` for your query that will be used on every request.
+  <pre><code class="language-php">$query->setNow($timestamp);</code></pre>
+- Every time a new page of results is fetched, the previously fetched documents are discarded. This allows for iterating very big resultsets with limited memory.
+  You can set the number of rows to fetch per request as low as you like to save on memory. The trade-off is a higher number of requests to Solr.
+  How high you can reasonably set it will largely be determined by the size of the returned documents.
+- When you rewind the iterator (e.g. by looping over it in two consecutive `foreach` loops), all results will have to be refetched from Solr.
+- PrefetchIterator can't be used in combination with [ParallelExecution](#parallelexecution-plugin). The next page of results is only ever fetched after all documents in
+  the previous fetch have been consumed.
+
+### Example usage
 
 ```php
 <?php
@@ -478,7 +530,7 @@ $query->addSort('id', $query::SORT_ASC);
 
 // get a plugin instance and apply settings
 $prefetch = $client->getPlugin('prefetchiterator');
-$prefetch->setPrefetch(2); //fetch 2 rows per query (for real world use this can be way higher)
+$prefetch->setPrefetch(2); // fetch 2 rows per request (for real world use this can be way higher)
 $prefetch->setQuery($query);
 
 // display the total number of documents found by Solr
@@ -492,3 +544,80 @@ foreach ($prefetch as $document) {
 htmlFooter();
 
 ```
+
+### Advanced usage
+
+A more advanced possibility is looping over the iterator with `for` or `while`. This allows for more complex stop conditions,
+e.g. ‘get up to 100 interesting documents and compare them to the same number of top results’ (where ‘interesting’ probably
+can't be determined in a Solr query and you might get less than 100 interesting _or_ total documents).
+
+```php
+$n = 0;
+
+while ($n < 100 && $prefetch->valid()) {
+    if (doCheck($prefetch->key(), $prefetch->current()) {
+        // ...
+
+        ++$n;
+    }
+
+    $prefetch->next();
+}
+
+$prefetch->rewind();
+
+for (; 0 !== $n && $prefetch->valid(); --$n, $prefetch->next()) {
+    doComparison($prefetch->key(), $prefetch->current());
+}
+
+```
+
+The iterator functions MUST be called in the correct order.
+
+- A ‘fresh’ PrefetchIterator is rewound by default. When you want to loop from the start more than once, you have to call
+  `rewind()` before every subsequent loop. Only `foreach` does this automatically (but it's no problem to do it manually anyway).
+- The first call of every iteration MUST be `valid()`. It will tell you if there is a document at the current position.
+    * This is also the point where the next request to Solr is executed if all previously fetched documents have been consumed.
+    * Even though that `for` can never have more iterations than there are documents, the call is still required as all documents
+      have to be refetched after rewinding the iterator.
+    * When part of an expression that also checks other conditions, placing it rightmost takes advantage of lazy evaluation to
+      avoid an unnecessary request to Solr if the other conditions aren't met.
+- The call to `current()` gets the current document from the iterator. Without calling `valid()` first, it CAN fail to return a
+  document even if the full resultset does extend beyond the current position.
+- The call to `key()` returns the current position of the iterator. It can be called before or after `current()`, or omitted.
+- The call to `next()` advances the iterator to the next position. It's good form to make this the last statement of an iteration.
+  You can't get the document at this position without calling `valid()` first in the next iteration.
+
+Another possibility is intentionally _not_ calling `rewind()` before a subsequent loop. This allows for handling documents one
+way up until some threshold condition is met and then switching to a different way, repeated for as many thresholds as required.
+
+```php
+$thresholdMet = false;
+
+while (!$thresholdMet && $prefetch->valid()) {
+    $thresholdMet = doCheck($prefetch->current());
+
+    // do something ...
+
+    $prefetch->next();
+}
+
+$thresholdMet = false;
+
+while (!$thresholdMet && $prefetch->valid()) {
+    $thresholdMet = doCheck($prefetch->current()); // or doAnotherCheck()
+
+    // do something else ...
+
+    $prefetch->next();
+}
+
+// you can stop here if you don't care about the remaining documents
+while ($prefetch->valid()) {
+    // do something with the remaining documents ...
+
+    $prefetch->next();
+}
+
+```
+

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -592,8 +592,9 @@ The iterator functions MUST be called in the correct order.
 Another possibility is intentionally _not_ calling `rewind()` between subsequent loops. This allows for handling documents in
 chunks of an arbitrary size, unrelated to the prefetch size.
 
-This example writes the retrieved documents to a set of CSV files with 65536 rows each, including a header row with the field names.
-(Note: As implemented here, it doesn't handle mutli-valued fields properly.)
+This example writes the retrieved documents to a set of CSV files with 65536 rows each, including a header row with field names.
+(Note: Don't use this code in an actual application as implemented here! The order of the fields isn't guaranteed across
+documents and it doesn't handle mutli-valued fields properly.)
 
 ```php
 $chunk = 1;

--- a/examples/7.6-plugin-prefetchiterator.php
+++ b/examples/7.6-plugin-prefetchiterator.php
@@ -17,7 +17,7 @@ $query->addSort('id', $query::SORT_ASC);
 
 // get a plugin instance and apply settings
 $prefetch = $client->getPlugin('prefetchiterator');
-$prefetch->setPrefetch(2); //fetch 2 rows per query (for real world use this can be way higher)
+$prefetch->setPrefetch(2); // fetch 2 rows per request (for real world use this can be way higher)
 $prefetch->setQuery($query);
 
 // display the total number of documents found by Solr


### PR DESCRIPTION
This closes #610. As suggested by @wickedOne, I've turned my comments on that issue into documentation.

Here's a "printout" for easy reviewing: [Plugins - Solarium PHP Solr client library.pdf](https://github.com/solariumphp/solarium/files/5876631/Plugins.-.Solarium.PHP.Solr.client.library.pdf)

I've rearranged the heading levels of the file to get a nice navigation structure. It does look different when I generate it locally with MkDocs compared to the navigation we get on [Read the Docs](https://solarium.readthedocs.io/en/stable/plugins/).

![afbeelding](https://user-images.githubusercontent.com/12425704/104814647-67da1a80-5810-11eb-899b-c638e86bd10e.png)