### PR TITLE
Symfony coding standards for exceptions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,3 +10,4 @@ nav:
   - 'Documents': 'documents.md'
   - 'Customizing': 'customizing-solarium.md'
   - 'Plugins': 'plugins.md'
+  - 'Exceptions': 'exceptions.md'

--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -149,7 +149,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
                 curl_setopt($handler, CURLOPT_POSTFIELDS, $request->getRawData());
             }
         } else {
-            throw new InvalidArgumentException("unsupported method: $method");
+            throw new InvalidArgumentException(sprintf('unsupported method: %s', $method));
         }
 
         return $handler;

--- a/src/Core/Client/Adapter/Psr18Adapter.php
+++ b/src/Core/Client/Adapter/Psr18Adapter.php
@@ -65,7 +65,7 @@ final class Psr18Adapter implements AdapterInterface
         try {
             return $this->createResponse($this->httpClient->sendRequest($this->createPsr7Request($request, $endpoint)));
         } catch (ClientExceptionInterface $clientException) {
-            throw new HttpException("HTTP request failed, {$clientException}");
+            throw new HttpException(sprintf('HTTP request failed, %s', $clientException));
         }
     }
 

--- a/src/Core/Client/Request.php
+++ b/src/Core/Client/Request.php
@@ -191,7 +191,7 @@ class Request extends Configurable implements RequestParamsInterface
     public function setFileUpload($filename): self
     {
         if (!is_file($filename) || !is_readable($filename)) {
-            throw new RuntimeException("Unable to read file '{$filename}' for upload");
+            throw new RuntimeException(sprintf("Unable to read file '%s' for upload", $filename));
         }
 
         $this->setOption('file', $filename);

--- a/tests/Core/Client/Adapter/CurlTest.php
+++ b/tests/Core/Client/Adapter/CurlTest.php
@@ -9,6 +9,7 @@ use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
 use Solarium\Exception\HttpException;
+use Solarium\Exception\InvalidArgumentException;
 
 class CurlTest extends TestCase
 {
@@ -19,7 +20,7 @@ class CurlTest extends TestCase
 
     public function setUp(): void
     {
-        if (!function_exists('curl_init')) {
+        if (!\function_exists('curl_init')) {
             $this->markTestSkipped('cURL not available, skipping cURL adapter tests.');
         }
 
@@ -75,14 +76,27 @@ class CurlTest extends TestCase
         $request->setIsServerRequest(true);
         $endpoint = new Endpoint();
 
-        $curlAdapter = new Curl();
-        $handler = $curlAdapter->createHandle($request, $endpoint);
+        $handler = $this->adapter->createHandle($request, $endpoint);
 
         if (class_exists(\CurlHandle::class)) {
             $this->assertInstanceOf(\CurlHandle::class, $handler);
         } else {
             $this->assertIsResource($handler);
         }
+        curl_close($handler);
+    }
+
+    public function testCreateHandleWithUnknownMethod()
+    {
+        $request = new Request();
+        $request->setMethod('PSOT');
+        $request->setIsServerRequest(true);
+        $endpoint = new Endpoint();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('unsupported method: PSOT');
+        $handler = $this->adapter->createHandle($request, $endpoint);
+
         curl_close($handler);
     }
 }

--- a/tests/Integration/SolrCloud/CurlTest.php
+++ b/tests/Integration/SolrCloud/CurlTest.php
@@ -14,6 +14,10 @@ class CurlTest extends AbstractCloudTest
 {
     public function setUp(): void
     {
+        if (!\function_exists('curl_init')) {
+            $this->markTestSkipped('cURL not available, skipping cURL adapter tests.');
+        }
+
         parent::setUp();
         // The default timeout of Solarium of 5s seems to be too aggressive on Travis and causes random test failures.
         // Set it to the PHP default of 13s.

--- a/tests/Integration/SolrServer/CurlTest.php
+++ b/tests/Integration/SolrServer/CurlTest.php
@@ -14,6 +14,10 @@ class CurlTest extends AbstractServerTest
 {
     public function setUp(): void
     {
+        if (!\function_exists('curl_init')) {
+            $this->markTestSkipped('cURL not available, skipping cURL adapter tests.');
+        }
+
         parent::setUp();
         // The default timeout of Solarium of 5s seems to be too aggressive on Travis and causes random test failures.
         // Set it to the PHP default of 13s.


### PR DESCRIPTION
https://symfony.com/doc/current/contributing/code/standards.html:
> Exception and error message strings must be concatenated using sprintf;

I added a unit test for the exception from the Curl adapter. The one from Psr18Adapter <del>wasn't as trivial and is still uncovered</del> <ins>is also covered</ins>.