### PR TITLE
Additional tests for range queries

### DIFF
--- a/src/Support/Utility.php
+++ b/src/Support/Utility.php
@@ -48,7 +48,7 @@ class Utility
     }
 
     /**
-     * Checker whether a value is valid point value for spatial search.
+     * Check whether a value is a valid point value for spatial search.
      *
      * Example: '45.15,-93.85' (geodetic & non-geodetic PointType)
      *

--- a/tests/Core/Query/HelperTest.php
+++ b/tests/Core/Query/HelperTest.php
@@ -32,6 +32,11 @@ class HelperTest extends TestCase
             $this->helper->rangeQuery('field', 1, 2)
         );
 
+        $this->assertEquals(
+            'field:[1.5 TO 2.5]',
+            $this->helper->rangeQuery('field', 1.5, 2.5)
+        );
+
         $this->assertSame(
             'store:[45,-94 TO 46,-93]',
             $this->helper->rangeQuery('store', '45,-94', '46,-93')
@@ -48,6 +53,11 @@ class HelperTest extends TestCase
         $this->assertEquals(
             'field:[1 TO 2]',
             $this->helper->rangeQuery('field', 1, 2, true)
+        );
+
+        $this->assertEquals(
+            'field:[1.5 TO 2.5]',
+            $this->helper->rangeQuery('field', 1.5, 2.5, true)
         );
 
         $this->assertSame(
@@ -69,6 +79,11 @@ class HelperTest extends TestCase
         );
 
         $this->assertSame(
+            'field:{1.5 TO 2.5}',
+            $this->helper->rangeQuery('field', 1.5, 2.5, false)
+        );
+
+        $this->assertSame(
             'store:{45,-94 TO 46,-93}',
             $this->helper->rangeQuery('store', '45,-94', '46,-93', false)
         );
@@ -84,6 +99,11 @@ class HelperTest extends TestCase
         $this->assertEquals(
             'field:[1 TO 2]',
             $this->helper->rangeQuery('field', 1, 2, [true, true])
+        );
+
+        $this->assertEquals(
+            'field:[1.5 TO 2.5]',
+            $this->helper->rangeQuery('field', 1.5, 2.5, [true, true])
         );
 
         $this->assertSame(
@@ -104,6 +124,11 @@ class HelperTest extends TestCase
             $this->helper->rangeQuery('field', 1, 2, [true, false])
         );
 
+        $this->assertEquals(
+            'field:[1.5 TO 2.5}',
+            $this->helper->rangeQuery('field', 1.5, 2.5, [true, false])
+        );
+
         $this->assertSame(
             'store:[45,-94 TO 46,-93}',
             $this->helper->rangeQuery('store', '45,-94', '46,-93', [true, false])
@@ -122,6 +147,11 @@ class HelperTest extends TestCase
             $this->helper->rangeQuery('field', 1, 2, [false, true])
         );
 
+        $this->assertEquals(
+            'field:{1.5 TO 2.5]',
+            $this->helper->rangeQuery('field', 1.5, 2.5, [false, true])
+        );
+
         $this->assertSame(
             'store:{45,-94 TO 46,-93]',
             $this->helper->rangeQuery('store', '45,-94', '46,-93', [false, true])
@@ -138,6 +168,11 @@ class HelperTest extends TestCase
         $this->assertEquals(
             'field:{1 TO 2}',
             $this->helper->rangeQuery('field', 1, 2, [false, false])
+        );
+
+        $this->assertEquals(
+            'field:{1.5 TO 2.5}',
+            $this->helper->rangeQuery('field', 1.5, 2.5, [false, false])
         );
 
         $this->assertSame(

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -236,9 +236,28 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertSame(14, $result->getNumFound());
         $this->assertCount(10, $result);
 
+        // MA147LL/A was manufactured on 2005-10-12T08:00:00Z, F8V7067-APL-KIT on 2005-08-01T16:30:25Z
+        $select->setFields('id,manufacturedate_dt');
+        $select->addSort('manufacturedate_dt', $select::SORT_DESC);
+        $select->setQuery(
+            $select->getHelper()->rangeQuery('manufacturedate_dt', '2005-01-01T00:00:00Z', '2005-12-31T23:59:59Z')
+        );
+        $result = self::$client->select($select);
+        $this->assertSame(2, $result->getNumFound());
+        $iterator = $result->getIterator();
+        $this->assertSame([
+            'id' => 'MA147LL/A',
+            'manufacturedate_dt' => '2005-10-12T08:00:00Z',
+        ], $iterator->current()->getFields());
+        $iterator->next();
+        $this->assertSame([
+            'id' => 'F8V7067-APL-KIT',
+            'manufacturedate_dt' => '2005-08-01T16:30:25Z',
+        ], $iterator->current()->getFields());
+
         // VS1GB400C3 costs 74.99, SP2514N costs 92.0, 0579B002 costs 179.99
         $select->setFields('id,price');
-        $select->addSort('price', $select::SORT_ASC);
+        $select->clearSorts()->addSort('price', $select::SORT_ASC);
         $select->setQuery(
             $select->getHelper()->rangeQuery('price', 74.99, 179.99, [true, true])
         );


### PR DESCRIPTION
The correct handling of `float`s was a blind spot in the unit tests for `Helper::rangeQuery()`. Codecov doesn't report this as missing coverage because the diverging execution paths for `int`s, `float`s and `string`s are on a single line in our source code.

https://github.com/solariumphp/solarium/blob/a5bb12e15ee5eef7cc6835cd4bc6fb50357e76e1/src/Core/Query/Helper.php#L192

DateTime representations can be unescaped in range queries (`manufacturedate_dt:[2005-01-01T00:00:00Z TO 2005-21-31T23:59:59Z]`). We don't single them out because they also work when phrase escaped (`manufacturedate_dt:["2005-01-01T00:00:00Z" TO "2005-21-31T23:59:59Z"]`). It doesn't hurt to verify that this yields the expected results in an integration test.