### PR TITLE
Remove phpunit 8.5 from require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
-        "phpunit/phpunit": "^8.5 || ^9.4",
+        "phpunit/phpunit": "^9.5",
         "roave/security-advisories": "dev-master",
         "symfony/event-dispatcher": "^4.3 || ^5.0"
     },

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -2051,7 +2051,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $document = $iterator->current();
         $this->assertSame('text/html; charset=UTF-8', $document['content_type'][0], 'Written document does not contain extracted content type');
         $this->assertSame('HTML Test Title', $document['title'][0], 'Written document does not contain extracted title');
-        $this->assertRegExp('/^HTML Test Title\s+HTML Test Body$/', trim($document['content'][0]), 'Written document does not contain extracted result');
+        $this->assertMatchesRegularExpression('/^HTML Test Title\s+HTML Test Body$/', trim($document['content'][0]), 'Written document does not contain extracted result');
 
         // now cleanup the document the have the initial index state
         $update = self::$client->createUpdate();
@@ -2076,8 +2076,8 @@ abstract class AbstractTechproductsTest extends TestCase
         $query->setFile(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'testhtml.html');
 
         $response = self::$client->extract($query);
-        $this->assertRegExp('/^HTML Test Title\s+HTML Test Body$/', trim($response->getData()['testhtml.html']), 'Can not extract the plain content from the HTML file');
-        $this->assertRegExp('/^HTML Test Title\s+HTML Test Body$/', trim($response->getData()['file']), 'Can not extract the plain content from the HTML file');
+        $this->assertMatchesRegularExpression('/^HTML Test Title\s+HTML Test Body$/', trim($response->getData()['testhtml.html']), 'Can not extract the plain content from the HTML file');
+        $this->assertMatchesRegularExpression('/^HTML Test Title\s+HTML Test Body$/', trim($response->getData()['file']), 'Can not extract the plain content from the HTML file');
     }
 
     public function testExtractOnlyXml()


### PR DESCRIPTION
With PHP 7.2 dropped, we no longer need PHPUnit 8.

I've bumped from 9.4 to 9.5, no problems there.

Methods that have been marked as deprecated in 9 have been replaced with the new names that will continue to work in 10.