### PR TITLE
Avoid PHP_EOL in unit tests (for Windows environments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Have a look at `.github/workflows/run-tests.yml` to see how to start a well conf
 If you just want to run the unit tests, just ensure that there's no other Solr server listening on the standard port
 8983 and the integration tests will be skipped.
 
+You can run the tests in a Windows environment. For all of them to pass, you must make sure to
+[checkout with `LF` line endings](https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings).
+
 ## More information
 
 * Docs

--- a/tests/Core/Client/RequestTest.php
+++ b/tests/Core/Client/RequestTest.php
@@ -482,10 +482,11 @@ authentication: Array
 resource: /myHandler?param1=1&param2=test+content
 resource urldecoded: /myHandler?param1=1&param2=test content
 raw data: post data
-EOF;
-        $request .= PHP_EOL.'file upload: '.__FILE__.PHP_EOL;
+file upload: %s
 
-        $this->assertSame($request, (string) $this->request);
+EOF;
+
+        $this->assertSame(sprintf($request, __FILE__), (string) $this->request);
     }
 
     public function testGetAndSetAuthentication()


### PR DESCRIPTION
If you checkout with `LF` line endings on Windows, this one unit test failed because `PHP_EOL` is `CRLF`.

It's hopeless with `CRLF`. I've added a note to the README about checkout with `LF` on Windows.