### PR TITLE
allow Local Parameters like countDistinct

### DIFF
--- a/src/Component/Result/Stats/Result.php
+++ b/src/Component/Result/Stats/Result.php
@@ -157,7 +157,7 @@ class Result
      *
      * @return string|array|null
      */
-    protected function getValue($name)
+    public function getValue($name)
     {
         return $this->stats[$name] ?? null;
     }


### PR DESCRIPTION
with the actual Result we cant get local parameters like countDistinct, there is no need to keep the function as protected.

$stats = $query->getStats();
$stats->createField($field)->addPivot('tag countDistinct=true');

that parse into

stats.field={!tag=tag countDistinct=true}field

and actually there is no way to get that stats value