### PR TITLE
(WIP) fix: Facet pivots don't support limits

### DIFF
--- a/src/Component/Facet/Pivot.php
+++ b/src/Component/Facet/Pivot.php
@@ -37,28 +37,6 @@ class Pivot extends AbstractFacet
     }
 
     /**
-     * Set the facet limit.
-     *
-     * @param int $limit
-     *
-     * @return self Provides fluent interface
-     */
-    public function setLimit($limit): self
-    {
-        return $this->setOption('limit', $limit);
-    }
-
-    /**
-     * Get the facet limit.
-     *
-     * @return int
-     */
-    public function getLimit(): ?int
-    {
-        return $this->getOption('limit');
-    }
-
-    /**
      * Set the facet mincount.
      *
      * @param int $minCount

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -267,7 +267,6 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
             sprintf('%s%s', $facet->getLocalParameters()->render(), implode(',', $facet->getFields()))
         );
         $request->addParam('facet.pivot.mincount', $facet->getMinCount(), true);
-        $request->addParam('facet.pivot.limit', $facet->getLimit(), true);
     }
 
     /**


### PR DESCRIPTION

**Update** (2021-04-04): I realized this feature was explicitly added in https://github.com/solariumphp/solarium/pull/732 and pointed out as missing in https://github.com/solariumphp/solarium/issues/713.
Now I wonder if I am missing something, but for me the [Solr documentation](https://solr.apache.org/guide/8_6/faceting.html#additional-pivot-parameters) seemed rather clear and also [google](https://www.google.com/search?q=%22facet.pivot.limit%22) does not really yield anything for `facet.pivot.limit`.

---

> ⚠️  This PR is **work-in-progress**:
> - Did not run/update any tests
> - Not sure if I might be missing something in the Solr specification

I just hunted down a bug in my app where I did **not properly set the facet limits**.

Calling `setLimit` on a `Pivot` results in a `facet.pivot.limit` parameter to be set in the Solr request, which does not seem to be a supported parameter. Instead, the limit must be set on the `FacetSet` itself (which will yield `facet.limit`). See [Solr documentation](https://solr.apache.org/guide/8_6/faceting.html#additional-pivot-parameters) with a reference to this.

Unfortunately, I currently can't spend more time on this topic (investigation/implementation), but wanted to already start a conversation with this PR.
