### PR TITLE
MoreLikeThis overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 ### Added
+- MoreLikeThis::setMaximumDocumentFrequency()
+- MoreLikeThis::setMaximumDocumentFrequencyPercentage()
+- getInterestingTerms() of MoreLikeThis Component results
 
 ### Fixed
 
 ### Changed
 
 ### Removed
+
+### Deprecated
+- Support for `mlt.match.include` and `mlt.match.offset` in MoreLikeThis Component (they only work in MLT queries)
 
 
 ## [6.1.1]

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -95,12 +95,13 @@ Overview of Solarium exceptions
 
 ### Logic exceptions
 
-Logic exceptions represent errors in the program logic. You should fix them in your code.
+Logic exceptions represent errors in the program logic. You should prevent them from happening with proper input validation in your code.
 
-Solarium can throw one type of logic exception. It extends its SPL counterpart to implement `Solarium\Exception\ExceptionInterface` and `Solarium\Exception\LogicExceptionInterface`.
+Solarium can throw two types of logic exceptions. Both extend their SPL counterpart to implement `Solarium\Exception\ExceptionInterface` and `Solarium\Exception\LogicExceptionInterface`.
 
 | Exception                                     | Extends                    |
 | --------------------------------------------- | -------------------------- |
+| `Solarium\Exception\DomainException`          | `DomainException`          |
 | `Solarium\Exception\InvalidArgumentException` | `InvalidArgumentException` |
 
 

--- a/docs/queries/morelikethis-query.md
+++ b/docs/queries/morelikethis-query.md
@@ -1,6 +1,6 @@
 A MoreLikeThis (MLT) query is designed to generate information about "similar" documents using the MoreLikeThis functionality provided by Lucene. It supports faceting, paging, and filtering using CommonQueryParameters.
 
-This query uses the [Solr MoreLikeThis Handler](https://lucene.apache.org/solr/guide/morelikethis.html) that specifically returns MLT results. Alternatively you can use the [MLT component](V2:MoreLikeThis_component "wikilink") for the select query.
+This query uses the [Solr MoreLikeThis Handler](https://lucene.apache.org/solr/guide/morelikethis.html) that specifically returns MLT results. Alternatively you can use the [MLT component](select-query/building-a-select-query/components/morelikethis-component.md) for the select query.
 
 Building a MLT query
 --------------------
@@ -48,8 +48,14 @@ The result of a MLT query shares the features of the select query result. On top
 
 ### Interestingterms
 
-This will show what "interesting" terms are used for the MoreLikeThis query.
-Only available if interestingterms wasn't set to `none` in the query.
+This will show what "interesting" terms (the top TF/IDF terms) are used for the MoreLikeThis query.
+
+The format of the interesting terms depends on the value set for interestingterms in the query.
+
+* `list`: The terms are returned as an array of strings.
+* `details`: Each term is an array key associated with the boost value used by Solr.
+    Unless you set boost to `true`, this will be `1.0` for every term.
+* `none`: The terms aren't available with the resultset and an exception is thrown if you try and fetch them anyway.
 
 ### Match
 
@@ -135,7 +141,7 @@ Matching against supplied text
 Instead of querying the index for a document to match against, you can also find
 similar documents based on supplied text.
 
-In this case, there is no document to include with matchinclude set to `true`.
+In this case, there is no document to include when matchinclude is set to `true`.
 
 ### Example
 

--- a/docs/queries/morelikethis-query.md
+++ b/docs/queries/morelikethis-query.md
@@ -61,6 +61,42 @@ The format of the interesting terms depends on the value set for interestingterm
 
 The document used for matching MLT results. Only available if matchinclude was set to `true` in the query.
 
+Setting up the MLT handler
+--------------------------
+
+The examples below assume an MLT handler is set up at `/mlt`. Solr's example configsets don't include one by default.
+
+### In `solrconfig.xml`
+
+```xml
+<requestHandler name="/mlt" class="solr.MoreLikeThisHandler" />
+```
+
+### Through the Config API
+
+```php
+<?php
+
+require_once(__DIR__.'/init.php');
+
+
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+$query = $client->createApi([
+    'version' => Solarium\Core\Client\Request::API_V1,
+    'handler' => 'techproducts/config',
+    'method' => Solarium\Core\Client\Request::METHOD_POST,
+    'rawdata' => json_encode([
+        'add-requesthandler' => [
+            'name' => '/mlt',
+            'class' => 'solr.MoreLikeThisHandler',
+        ],
+    ]),
+]);
+
+$client->execute($query);
+```
+
 Example
 -------
 
@@ -145,13 +181,13 @@ In this case, there is no document to include when matchinclude is set to `true`
 
 ### Example
 
+This example assumes the `/mlt` handler is already set up ([see above](#setting-up-the-mlt-handler)).
+
 ```php
 <?php
 
 require_once(__DIR__.'/init.php');
 htmlHeader();
-
-echo "<h2>Note: The techproducts example doesn't include a /mlt handler anymore!</h2>";
 
 // create a client instance
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);

--- a/docs/queries/morelikethis-query.md
+++ b/docs/queries/morelikethis-query.md
@@ -9,28 +9,31 @@ See the example code below.
 
 **Available options:**
 
-| Name                     | Type    | Default value                 | Description                                                                                                                                                         |
-|--------------------------|---------|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| handler                  | string  | select                        | Name of the Solr request handler to use, without leading or trailing slashes                                                                                        |
-| resultclass              | string  | Solarium\_Result\_Select      | Classname for result. If you set a custom classname make sure the class is readily available (or through autoloading)                                               |
-| documentclass            | string  | Solarium\_Document\_ReadWrite | Classname for documents in the resultset. If you set a custom classname make sure the class is readily available (or through autoloading)                           |
-| query                    | string  | \*:\*                         | Query to execute                                                                                                                                                    |
-| start                    | int     | 0                             | Start position (offset) in the complete Solr query resultset, to paginate big resultsets.                                                                           |
-| rows                     | integer | 10                            | Number of rows to fetch, starting from the 'start' (offset) position. It's a limit, you might get less.                                                             |
-| fields                   | string  | -   ,score                    | Comma separated list of fields to fetch from Solr. There are two special values: '\*' meaning 'all fields' and 'score' to also fetch the Solr document score value. |
-| sort                     | array   | empty array                   | Array with sort field as key and sort order as values. Multiple entries possible, they are used in the order of the array. Example: array('price' =&gt; 'asc')      |
-| stream                   | boolean | false                         | Set to true to post query content instead of using the URL param                                                                                                    |
-| interestingTerms         | string  | none                          | Must be one of: none, list, details                                                                                                                                 |
-| matchinclude             | boolean | false                         |                                                                                                                                                                     |
-| mltfields                | string  | none                          | The fields to use for similarity. NOTE: if possible, these should have a stored TermVector                                                                          |
-| minimumtermfrequency     | int     | none                          |                                                                                                                                                                     |
-| minimumdocumentfrequency | int     | none                          |                                                                                                                                                                     |
-| minimumwordlength        | int     | none                          |                                                                                                                                                                     |
-| maximumwordlength        | int     | none                          |                                                                                                                                                                     |
-| maximumqueryterms        | int     | none                          |                                                                                                                                                                     |
-| maximumnumberoftokens    | int     | none                          |                                                                                                                                                                     |
-| boost                    | boolean | none                          | If true the query will be boosted by the interesting term relevance                                                                                                 |
-| queryfields              | string  | none                          | Query fields and their boosts using the same format as that used in DisMaxQParserPlugin. These fields must also be specified in fields.                             |
+| Name                               | Type    | Default value                 | Description                                                                                                                                                                      |
+|------------------------------------|---------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| handler                            | string  | select                        | Name of the Solr request handler to use, without leading or trailing slashes                                                                                                     |
+| resultclass                        | string  | Solarium\_Result\_Select      | Classname for result. If you set a custom classname make sure the class is readily available (or through autoloading)                                                            |
+| documentclass                      | string  | Solarium\_Document\_ReadWrite | Classname for documents in the resultset. If you set a custom classname make sure the class is readily available (or through autoloading)                                        |
+| query                              | string  | \*:\*                         | Query to execute                                                                                                                                                                 |
+| start                              | int     | 0                             | Start position (offset) in the complete Solr query resultset, to paginate big resultsets.                                                                                        |
+| rows                               | int     | 10                            | Number of rows to fetch, starting from the 'start' (offset) position. It's a limit, you might get less.                                                                          |
+| fields                             | string  | \*,score                      | Comma separated list of fields to fetch from Solr. There are two special values: '\*' meaning 'all fields' and 'score' to also fetch the Solr document score value.              |
+| sort                               | array   | empty array                   | Array with sort field as key and sort order as values. Multiple entries possible, they are used in the order of the array. Example: array('price' =&gt; 'asc')                   |
+| stream                             | boolean | false                         | Set to true to post query content instead of using the URL param                                                                                                                 |
+| matchinclude                       | boolean | false                         | Specifies whether or not the response should include the matched document. If set to false, the response will look like a normal select response.                                |
+| matchoffset                        | int     | 0                             | Specifies an offset into the main query search results to locate the document on which the MoreLikeThis query should operate.                                                    |
+| interestingTerms                   | string  | none                          | Controls how the handler presents the "interesting" terms. Must be one of: none, list, details.                                                                                  |
+| mltfields                          | string  | null                          | The fields to use for similarity. NOTE: if possible, these should have a stored TermVector. Separate multiple fields with commas.                                                |
+| minimumtermfrequency               | int     | null                          | Minimum Term Frequency - the frequency below which terms will be ignored in the source doc.                                                                                      |
+| mimimumdocumentfrequency           | int     | null                          | Minimum Document Frequency - the frequency at which words will be ignored which do not occur in at least this many docs.                                                         |
+| maximumdocumentfrequency           | int     | null                          | Maximum Document Frequency - the frequency at which words will be ignored which occur in more than this many docs.                                                               |
+| maximumdocumentfrequencypercentage | int     | null                          | Maximum Document Frequency Percentage - a relative ratio at which words will be ignored which occur in more than this percentage of the docs in the index.                       |
+| minimumwordlength                  | int     | null                          | Minimum word length below which words will be ignored.                                                                                                                           |
+| maximumwordlength                  | int     | null                          | Maximum word length above which words will be ignored.                                                                                                                           |
+| maximumqueryterms                  | int     | null                          | Maximum number of query terms that will be included in any generated query.                                                                                                      |
+| maximumnumberoftokens              | int     | null                          | Maximum number of tokens to parse in each example doc field that is not stored with TermVector support.                                                                          |
+| boost                              | boolean | null                          | If true the query will be boosted by the interesting term relevance.                                                                                                             |
+| queryfields                        | string  | null                          | Query fields and their boosts using the same format as that used in DisMaxQParserPlugin. These fields must also be specified in mltfields. Separate multiple fields with commas. |
 ||
 
 Executing a MLT query
@@ -46,10 +49,11 @@ The result of a MLT query shares the features of the select query result. On top
 ### Interestingterms
 
 This will show what "interesting" terms are used for the MoreLikeThis query.
+Only available if interestingterms wasn't set to `none` in the query.
 
 ### Match
 
-Get matched documents. Only available if matchinclude was set to true in the query.
+The document used for matching MLT results. Only available if matchinclude was set to `true` in the query.
 
 Example
 -------
@@ -58,30 +62,26 @@ Example
 <?php
 
 require_once(__DIR__.'/init.php');
-use Solarium\Client;
-
 htmlHeader();
 
 // create a client instance
-$client = new Client($adapter, $eventDispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a morelikethis query instance
-$query = $client->createMoreLikeThis();
+$query = $client->createMoreLikethis();
 
-$query->setQuery('id:SP2514N');
-$query->setMltFields('manu,cat');
-$query->setMinimumDocumentFrequency(1);
-$query->setMinimumTermFrequency(1);
-$query->createFilterQuery('stock')->setQuery('inStock:true');
-$query->setInterestingTerms('details');
-$query->setMatchInclude(true);
-
-// enable MLT component
-$mlt = $query->getMoreLikeThis();
-$mlt->setCount(10);
+// query a document you want similar documents for
+$query->setQuery('id:SP2514N')
+    ->setMltFields('manu,cat')
+    ->setMinimumDocumentFrequency(1)
+    ->setMinimumTermFrequency(1)
+    ->setInterestingTerms('details')
+    ->setBoost(true)
+    ->setMatchInclude(true)
+    ->createFilterQuery('stock')->setQuery('inStock:true');
 
 // this executes the query and returns the result
-$resultset = $client->select($query);
+$resultset = $client->moreLikeThis($query);
 
 echo 'Document used for matching:<br/><table>';
 foreach ($resultset->getMatch() as $field => $value) {
@@ -96,6 +96,92 @@ echo '</table><hr/>';
 
 // display the total number of MLT documents found by Solr
 echo 'Number of MLT matches found: '.$resultset->getNumFound().'<br/><br/>';
+
+// display the "interesting" terms for the query
+echo 'Interesting terms with the boost value used:';
+echo '<ul>';
+foreach ($resultset->getInterestingTerms() as $term => $boost) {
+    echo '<li>'.$term.' (boost='.$boost.')</li>';
+}
+echo '</ul>';
+
+echo '<b>Listing of matched docs:</b>';
+
+// show MLT documents using the resultset iterator
+foreach ($resultset as $document) {
+
+    echo '<hr/><table>';
+
+    // the documents are also iterable, to get all fields
+    foreach ($document as $field => $value) {
+        // this converts multivalue fields to a comma-separated string
+        if (is_array($value)) {
+            $value = implode(', ', $value);
+        }
+
+        echo '<tr><th>' . $field . '</th><td>' . $value . '</td></tr>';
+    }
+
+    echo '</table>';
+}
+
+htmlFooter();
+
+```
+
+Matching against supplied text
+------------------------------
+
+Instead of querying the index for a document to match against, you can also find
+similar documents based on supplied text.
+
+In this case, there is no document to include with matchinclude set to `true`.
+
+### Example
+
+```php
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+echo "<h2>Note: The techproducts example doesn't include a /mlt handler anymore!</h2>";
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// get a morelikethis query instance
+$query = $client->createMoreLikeThis();
+
+// supply text you want similar documents for
+$text = <<<EOT
+Samsung SpinPoint P120 SP2514N - hard drive - 250 GB - ATA-133
+7200RPM, 8MB cache, IDE Ultra ATA-133, NoiseGuard, SilentSeek technology, Fluid Dynamic Bearing (FDB) motor
+EOT;
+
+$query->setQuery($text);
+$query->setQueryStream(true);
+$query->setMltFields('name,features');
+$query->setMinimumDocumentFrequency(1);
+$query->setMinimumTermFrequency(1);
+$query->createFilterQuery('stock')->setQuery('inStock:true');
+$query->setInterestingTerms('details');
+$query->setBoost(true);
+
+// this executes the query and returns the result
+$resultset = $client->moreLikeThis($query);
+
+// display the total number of MLT documents found by Solr
+echo 'Number of MLT matches found: '.$resultset->getNumFound().'<br/><br/>';
+
+// display the "interesting" terms for the query
+echo 'Interesting terms with the boost value used:';
+echo '<ul>';
+foreach ($resultset->getInterestingTerms() as $term => $boost) {
+    echo '<li>'.$term.' (boost='.$boost.')</li>';
+}
+echo '</ul>';
+
 echo '<b>Listing of matched docs:</b>';
 
 // show MLT documents using the resultset iterator

--- a/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
@@ -76,7 +76,7 @@ foreach ($resultset as $document) {
         foreach ($mltResult as $mltDoc) {
             echo 'MLT result doc: '. $mltDoc->name . ' (id='. $mltDoc->id . ')<br/>';
         }
-        echo 'MLT interesting terms: '.implode(', ', $mltResult->getInterestingTerms()).'<br/>';
+        echo 'MLT interesting terms: '.implode(', ', $mlt->getInterestingTerm($document->id)).'<br/>';
     } else {
         echo 'No MLT results';
     }

--- a/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
@@ -76,7 +76,7 @@ foreach ($resultset as $document) {
         foreach ($mltResult as $mltDoc) {
             echo 'MLT result doc: '. $mltDoc->name . ' (id='. $mltDoc->id . ')<br/>';
         }
-        // available since Solr 8
+        // available since Solr 8.2 if the query wasn't distributed
         if (null !== $interestingTerms = $mlt->getInterestingTerm($document->id)) {
             echo 'MLT interesting terms: '.implode(', ', $interestingTerms).'<br/>';
         }

--- a/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
@@ -1,20 +1,23 @@
-The morelikethis component can be used if you want to retrieve similar documents for your query results. This component uses morelikethis in the standardrequesthandler, not the standalone morelikethis handler. For more info see <https://lucene.apache.org/solr/guide/morelikethis.html>.
+The MoreLikeThis component can be used if you want to retrieve similar documents for your query results. This component uses MoreLikeThis in the StandardRequestHandler, not the standalone MoreLikeThisHandler. For more info see <https://lucene.apache.org/solr/guide/morelikethis.html>.
 
 Options
 -------
 
-| Name                     | Type    | Default value | Description                                                                                                                                                                  |
-|--------------------------|---------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| fields                   | string  | null          | The fields to use for similarity. NOTE: if possible, these should have a stored TermVector. Separate multiple fields with commas.                                            |
-| minimumtermfrequency     | int     | null          | Minimum Term Frequency - the frequency below which terms will be ignored in the source doc.                                                                                  |
-| mimimumdocumentfrequency | int     | null          | Minimum Document Frequency - the frequency at which words will be ignored which do not occur in at least this many docs.                                                     |
-| minimumwordlength        | int     | null          | Minimum word length below which words will be ignored.                                                                                                                       |
-| maximumwordlength        | int     | null          | Maximum word length above which words will be ignored.                                                                                                                       |
-| maximumqueryterms        | int     | null          | Maximum number of query terms that will be included in any generated query.                                                                                                  |
-| maximumnumberoftokens    | int     | null          | Maximum number of tokens to parse in each example doc field that is not stored with TermVector support.                                                                      |
-| boost                    | boolean | null          | If true the query will be boosted by the interesting term relevance.                                                                                                         |
-| queryfields              | string  | null          | Query fields and their boosts using the same format as that used in DisMaxQParserPlugin. These fields must also be specified in fields.Separate multiple fields with commas. |
-| count                    | int     | null          | The number of similar documents to return for each result                                                                                                                    |
+| Name                               | Type    | Default value | Description                                                                                                                                                                   |
+|------------------------------------|---------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| fields                             | string  | null          | The fields to use for similarity. NOTE: if possible, these should have a stored TermVector. Separate multiple fields with commas.                                             |
+| minimumtermfrequency               | int     | null          | Minimum Term Frequency - the frequency below which terms will be ignored in the source doc.                                                                                   |
+| mimimumdocumentfrequency           | int     | null          | Minimum Document Frequency - the frequency at which words will be ignored which do not occur in at least this many docs.                                                      |
+| maximumdocumentfrequency           | int     | null          | Maximum Document Frequency - the frequency at which words will be ignored which occur in more than this many docs.                                                            |
+| maximumdocumentfrequencypercentage | int     | null          | Maximum Document Frequency Percentage - a relative ratio at which words will be ignored which occur in more than this percentage of the docs in the index.                    |
+| minimumwordlength                  | int     | null          | Minimum word length below which words will be ignored.                                                                                                                        |
+| maximumwordlength                  | int     | null          | Maximum word length above which words will be ignored.                                                                                                                        |
+| maximumqueryterms                  | int     | null          | Maximum number of query terms that will be included in any generated query.                                                                                                   |
+| maximumnumberoftokens              | int     | null          | Maximum number of tokens to parse in each example doc field that is not stored with TermVector support.                                                                       |
+| boost                              | boolean | null          | If true the query will be boosted by the interesting term relevance.                                                                                                          |
+| queryfields                        | string  | null          | Query fields and their boosts using the same format as that used in DisMaxQParserPlugin. These fields must also be specified in fields. Separate multiple fields with commas. |
+| count                              | int     | null          | The number of similar documents to return for each result.                                                                                                                    |
+| interestingTerms                   | string  | null          | Controls how the component presents the "interesting" terms. Must be one of: none, list, details.                                                                             |
 ||
 
 Example
@@ -37,7 +40,8 @@ $query->setQuery('apache')
       ->getMoreLikeThis()
       ->setFields('manu,cat')
       ->setMinimumDocumentFrequency(1)
-      ->setMinimumTermFrequency(1);
+      ->setMinimumTermFrequency(1)
+      ->setInterestingTerms('list');
 
 // this executes the query and returns the result
 $resultset = $client->select($query);
@@ -72,6 +76,7 @@ foreach ($resultset as $document) {
         foreach ($mltResult as $mltDoc) {
             echo 'MLT result doc: '. $mltDoc->name . ' (id='. $mltDoc->id . ')<br/>';
         }
+        echo 'MLT interesting terms: '.implode(', ', $mltResult->getInterestingTerms()).'<br/>';
     } else {
         echo 'No MLT results';
     }

--- a/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
@@ -76,7 +76,10 @@ foreach ($resultset as $document) {
         foreach ($mltResult as $mltDoc) {
             echo 'MLT result doc: '. $mltDoc->name . ' (id='. $mltDoc->id . ')<br/>';
         }
-        echo 'MLT interesting terms: '.implode(', ', $mlt->getInterestingTerm($document->id)).'<br/>';
+        // available since Solr 8
+        if (null !== $interestingTerms = $mlt->getInterestingTerm($document->id)) {
+            echo 'MLT interesting terms: '.implode(', ', $interestingTerms).'<br/>';
+        }
     } else {
         echo 'No MLT results';
     }

--- a/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
@@ -1,6 +1,21 @@
-Results of the MoreLikeThis component are included with the query resultset, but not directly coupled to the resulting documents. Just like in the Solr response data it is a separate dataset. However the MoreLikeThis resultset has a method to easily access MLT results for a specific document by id (the id depends on your schema).
+Results of the MoreLikeThis component are included with the query resultset, but not directly coupled to the resulting documents.
+Just like in the Solr response data it is a separate dataset. However the MoreLikeThis resultset has a method to easily access
+MLT results for a specific document by its id (the `uniqueKey` defined in your schema).
 
-In the example code below you can see it in use. For each document the MLT result is fetched. This result is an instance of Solarium\\QueryType\\Select\\Result\\MoreLikeThis\\MoreLikeThis and contains all similar documents for a result. So, as also described in the Solr MLT wiki page, in this case the name MoreLikeThese might be better.
+If interestingterms is set to `list` or `detail`, the "interesting" terms (the top TF/IDF terms) for the query are included with
+the resultset as another separate dataset. These too can be easily accessed by a document id.
+
+In the example code below you can see it in use. For each document the MLT result and interesting terms are fetched.
+
+This result is an instance of `Solarium\Component\Result\MoreLikeThis\Result` and contains all similar documents for a result.
+So, as also described in the Solr MLT wiki page, in this case the name MoreLikeThese might be better.
+
+The format of the interesting terms depends on the value set for interestingterms in the MLT component.
+
+* `list`: The terms are returned as an array of strings.
+* `details`: Each term is an array key associated with the boost value used by Solr.
+    Unless you set boost to `true`, this will be `1.0` for every term.
+* `none`: The terms aren't available with the resultset and an exception is thrown if you try and fetch them anyway.
 
 Example
 -------
@@ -22,7 +37,8 @@ $query->setQuery('apache')
       ->getMoreLikeThis()
       ->setFields('manu,cat')
       ->setMinimumDocumentFrequency(1)
-      ->setMinimumTermFrequency(1);
+      ->setMinimumTermFrequency(1)
+      ->setInterestingTerms('list');
 
 // this executes the query and returns the result
 $resultset = $client->select($query);
@@ -57,6 +73,7 @@ foreach ($resultset as $document) {
         foreach ($mltResult as $mltDoc) {
             echo 'MLT result doc: '. $mltDoc->name . ' (id='. $mltDoc->id . ')<br/>';
         }
+        echo 'MLT interesting terms: '.implode(', ', $mlt->getInterestingTerm($document->id)).'<br/>';
     } else {
         echo 'No MLT results';
     }

--- a/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
@@ -2,8 +2,8 @@ Results of the MoreLikeThis component are included with the query resultset, but
 Just like in the Solr response data it is a separate dataset. However the MoreLikeThis resultset has a method to easily access
 MLT results for a specific document by its id (the `uniqueKey` defined in your schema).
 
-If interestingterms is set to `list` or `detail`, the "interesting" terms (the top TF/IDF terms) for the query are included with
-the resultset as another separate dataset. These too can be easily accessed by a document id.
+Starting with Solr 8, you can also include the "interesting" terms (the top TF/IDF terms) for the query as another separate
+dataset if you set interestingterms to `list` or `details`. These too can be easily accessed by document id.
 
 In the example code below you can see it in use. For each document the MLT result and interesting terms are fetched.
 
@@ -73,7 +73,10 @@ foreach ($resultset as $document) {
         foreach ($mltResult as $mltDoc) {
             echo 'MLT result doc: '. $mltDoc->name . ' (id='. $mltDoc->id . ')<br/>';
         }
-        echo 'MLT interesting terms: '.implode(', ', $mlt->getInterestingTerm($document->id)).'<br/>';
+        // available since Solr 8
+        if (null !== $interestingTerms = $mlt->getInterestingTerm($document->id)) {
+            echo 'MLT interesting terms: '.implode(', ', $interestingTerms).'<br/>';
+        }
     } else {
         echo 'No MLT results';
     }

--- a/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
+++ b/docs/queries/select-query/result-of-a-select-query/component-results/morelikethis-result.md
@@ -2,7 +2,7 @@ Results of the MoreLikeThis component are included with the query resultset, but
 Just like in the Solr response data it is a separate dataset. However the MoreLikeThis resultset has a method to easily access
 MLT results for a specific document by its id (the `uniqueKey` defined in your schema).
 
-Starting with Solr 8, you can also include the "interesting" terms (the top TF/IDF terms) for the query as another separate
+Starting with Solr 8.2, you can also include the "interesting" terms (the top TF/IDF terms) for the query as another separate
 dataset if you set interestingterms to `list` or `details`. These too can be easily accessed by document id.
 
 In the example code below you can see it in use. For each document the MLT result and interesting terms are fetched.
@@ -16,6 +16,8 @@ The format of the interesting terms depends on the value set for interestingterm
 * `details`: Each term is an array key associated with the boost value used by Solr.
     Unless you set boost to `true`, this will be `1.0` for every term.
 * `none`: The terms aren't available with the resultset and an exception is thrown if you try and fetch them anyway.
+
+In order to get interesting terms with the MLT component, the query must be sent to a single shard and limited to that shard only.
 
 Example
 -------
@@ -73,7 +75,7 @@ foreach ($resultset as $document) {
         foreach ($mltResult as $mltDoc) {
             echo 'MLT result doc: '. $mltDoc->name . ' (id='. $mltDoc->id . ')<br/>';
         }
-        // available since Solr 8
+        // available since Solr 8.2 if the query wasn't distributed
         if (null !== $interestingTerms = $mlt->getInterestingTerm($document->id)) {
             echo 'MLT interesting terms: '.implode(', ', $interestingTerms).'<br/>';
         }

--- a/examples/2.1.5.2-morelikethis.php
+++ b/examples/2.1.5.2-morelikethis.php
@@ -14,7 +14,8 @@ $query->setQuery('apache')
       ->getMoreLikeThis()
       ->setFields('manu,cat')
       ->setMinimumDocumentFrequency(1)
-      ->setMinimumTermFrequency(1);
+      ->setMinimumTermFrequency(1)
+      ->setInterestingTerms('list');
 
 // this executes the query and returns the result
 $resultset = $client->select($query);
@@ -49,6 +50,7 @@ foreach ($resultset as $document) {
         foreach ($mltResult as $mltDoc) {
             echo 'MLT result doc: '. $mltDoc->name . ' (id='. $mltDoc->id . ')<br/>';
         }
+        echo 'MLT interesting terms: '.implode(', ', $mltResult->getInterestingTerms()).'<br/>';
     } else {
         echo 'No MLT results';
     }

--- a/examples/2.1.5.2-morelikethis.php
+++ b/examples/2.1.5.2-morelikethis.php
@@ -50,7 +50,7 @@ foreach ($resultset as $document) {
         foreach ($mltResult as $mltDoc) {
             echo 'MLT result doc: '. $mltDoc->name . ' (id='. $mltDoc->id . ')<br/>';
         }
-        // available since Solr 8
+        // available since Solr 8.2 if the query wasn't distributed
         if (null !== $interestingTerms = $mlt->getInterestingTerm($document->id)) {
             echo 'MLT interesting terms: '.implode(', ', $interestingTerms).'<br/>';
         }

--- a/examples/2.1.5.2-morelikethis.php
+++ b/examples/2.1.5.2-morelikethis.php
@@ -50,7 +50,10 @@ foreach ($resultset as $document) {
         foreach ($mltResult as $mltDoc) {
             echo 'MLT result doc: '. $mltDoc->name . ' (id='. $mltDoc->id . ')<br/>';
         }
-        echo 'MLT interesting terms: '.implode(', ', $mlt->getInterestingTerm($document->id)).'<br/>';
+        // available since Solr 8
+        if (null !== $interestingTerms = $mlt->getInterestingTerm($document->id)) {
+            echo 'MLT interesting terms: '.implode(', ', $interestingTerms).'<br/>';
+        }
     } else {
         echo 'No MLT results';
     }

--- a/examples/2.1.5.2-morelikethis.php
+++ b/examples/2.1.5.2-morelikethis.php
@@ -50,7 +50,7 @@ foreach ($resultset as $document) {
         foreach ($mltResult as $mltDoc) {
             echo 'MLT result doc: '. $mltDoc->name . ' (id='. $mltDoc->id . ')<br/>';
         }
-        echo 'MLT interesting terms: '.implode(', ', $mltResult->getInterestingTerms()).'<br/>';
+        echo 'MLT interesting terms: '.implode(', ', $mlt->getInterestingTerm($document->id)).'<br/>';
     } else {
         echo 'No MLT results';
     }

--- a/examples/2.3.1-mlt-query.php
+++ b/examples/2.3.1-mlt-query.php
@@ -1,38 +1,58 @@
 <?php
 
 require_once(__DIR__.'/init.php');
-use Solarium\Client;
-
 htmlHeader();
 
+echo "<h2>Note: You need to define your own /mlt handler in solrconfig.xml to run this example!</h2>";
+echo "<pre>&lt;requestHandler name=&quot;/mlt&quot; class=&quot;solr.MoreLikeThisHandler&quot;&gt;&lt;/requestHandler&gt;</pre>";
+
 // create a client instance
-$client = new Client($adapter, $eventDispatcher, $config);
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a morelikethis query instance
-$query = $client->createSelect()
-    // Unfortunately the /mlt handler of the techproducts example doesn't exist anymore.
-    // Therefore we have to use the /browse handler and turn of velocity by forcing json as response writer.
-    ->setHandler('browse')
-    ->setResponseWriter(\Solarium\Core\Query\AbstractQuery::WT_JSON);
+$query = $client->createMoreLikethis();
 
-$query->getMoreLikeThis()
-    ->setFields('manu,cat')
+// query a document you want similar documents for
+$query->setQuery('id:SP2514N')
+    ->setMltFields('manu,cat')
     ->setMinimumDocumentFrequency(1)
     ->setMinimumTermFrequency(1)
     ->setInterestingTerms('details')
-    ->setMatchInclude(true);
-
-$query->setQuery('id:SP2514N')
+    ->setBoost(true)
+    ->setMatchInclude(true)
     ->createFilterQuery('stock')->setQuery('inStock:true');
 
 // this executes the query and returns the result
-$resultset = $client->select($query);
+$resultset = $client->moreLikeThis($query);
 
-echo 'Documents used for matching:<br/>';
-// show documents using the resultset iterator
+echo 'Document used for matching:<br/><table>';
+foreach ($resultset->getMatch() as $field => $value) {
+    // this converts multivalue fields to a comma-separated string
+    if (is_array($value)) {
+        $value = implode(', ', $value);
+    }
+
+    echo '<tr><th>' . $field . '</th><td>' . $value . '</td></tr>';
+}
+echo '</table><hr/>';
+
+// display the total number of MLT documents found by Solr
+echo 'Number of MLT matches found: '.$resultset->getNumFound().'<br/><br/>';
+
+// display the "interesting" terms for the query
+echo 'Interesting terms with the boost value used:';
+echo '<ul>';
+foreach ($resultset->getInterestingTerms() as $term => $boost) {
+    echo '<li>'.$term.' (boost='.$boost.')</li>';
+}
+echo '</ul>';
+
+echo '<b>Listing of matched docs:</b>';
+
+// show MLT documents using the resultset iterator
 foreach ($resultset as $document) {
 
-    echo '<table>';
+    echo '<hr/><table>';
 
     // the documents are also iterable, to get all fields
     foreach ($document as $field => $value) {
@@ -45,33 +65,6 @@ foreach ($resultset as $document) {
     }
 
     echo '</table>';
-}
-
-echo '<hr/>';
-
-$mlt = $resultset->getMoreLikeThis();
-
-// display the total number of MLT documents found by Solr
-echo 'Number of MLT matches found: '.$resultset->getNumFound().'<br/><br/>';
-echo '<b>Listing of matched docs:</b>';
-
-// show MLT documents using the resultset iterator
-foreach ($mlt as $results) {
-    foreach ($results as $document) {
-        echo '<hr/><table>';
-
-        // the documents are also iterable, to get all fields
-        foreach ($document as $field => $value) {
-            // this converts multivalue fields to a comma-separated string
-            if (is_array($value)) {
-                $value = implode(', ', $value);
-            }
-
-            echo '<tr><th>' . $field . '</th><td>' . $value . '</td></tr>';
-        }
-
-        echo '</table>';
-    }
 }
 
 htmlFooter();

--- a/examples/2.3.1-mlt-query.php
+++ b/examples/2.3.1-mlt-query.php
@@ -4,7 +4,7 @@ require_once(__DIR__.'/init.php');
 htmlHeader();
 
 echo "<h2>Note: You need to define your own /mlt handler in solrconfig.xml to run this example!</h2>";
-echo "<pre>&lt;requestHandler name=&quot;/mlt&quot; class=&quot;solr.MoreLikeThisHandler&quot;&gt;&lt;/requestHandler&gt;</pre>";
+echo "<pre>&lt;requestHandler name=&quot;/mlt&quot; class=&quot;solr.MoreLikeThisHandler&quot; /&gt;</pre>";
 
 // create a client instance
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);

--- a/examples/2.3.2-mlt-stream.php
+++ b/examples/2.3.2-mlt-stream.php
@@ -3,7 +3,8 @@
 require_once(__DIR__.'/init.php');
 htmlHeader();
 
-echo "<h2>Note: The techproducts example doesn't include a /mlt handler anymore!</h2>";
+echo "<h2>Note: You need to define your own /mlt handler in solrconfig.xml to run this example!</h2>";
+echo "<pre>&lt;requestHandler name=&quot;/mlt&quot; class=&quot;solr.MoreLikeThisHandler&quot;&gt;&lt;/requestHandler&gt;</pre>";
 
 // create a client instance
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);
@@ -11,31 +12,35 @@ $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 // get a morelikethis query instance
 $query = $client->createMoreLikeThis();
 
-$query->setQuery('electronics memory');
+// supply text you want similar documents for
+$text = <<<EOT
+Samsung SpinPoint P120 SP2514N - hard drive - 250 GB - ATA-133
+7200RPM, 8MB cache, IDE Ultra ATA-133, NoiseGuard, SilentSeek technology, Fluid Dynamic Bearing (FDB) motor
+EOT;
+
+$query->setQuery($text);
 $query->setQueryStream(true);
-$query->setMltFields('manu,cat');
+$query->setMltFields('name,features');
 $query->setMinimumDocumentFrequency(1);
 $query->setMinimumTermFrequency(1);
 $query->createFilterQuery('stock')->setQuery('inStock:true');
 $query->setInterestingTerms('details');
-$query->setMatchInclude(true);
+$query->setBoost(true);
 
 // this executes the query and returns the result
-$resultset = $client->select($query);
-
-echo 'Document used for matching:<br/><table>';
-foreach ($resultset->getMatch() as $field => $value) {
-    // this converts multivalue fields to a comma-separated string
-    if (is_array($value)) {
-        $value = implode(', ', $value);
-    }
-
-    echo '<tr><th>' . $field . '</th><td>' . $value . '</td></tr>';
-}
-echo '</table><hr/>';
+$resultset = $client->moreLikeThis($query);
 
 // display the total number of MLT documents found by Solr
 echo 'Number of MLT matches found: '.$resultset->getNumFound().'<br/><br/>';
+
+// display the "interesting" terms for the query
+echo 'Interesting terms with the boost value used:';
+echo '<ul>';
+foreach ($resultset->getInterestingTerms() as $term => $boost) {
+    echo '<li>'.$term.' (boost='.$boost.')</li>';
+}
+echo '</ul>';
+
 echo '<b>Listing of matched docs:</b>';
 
 // show MLT documents using the resultset iterator

--- a/examples/2.3.2-mlt-stream.php
+++ b/examples/2.3.2-mlt-stream.php
@@ -4,7 +4,7 @@ require_once(__DIR__.'/init.php');
 htmlHeader();
 
 echo "<h2>Note: You need to define your own /mlt handler in solrconfig.xml to run this example!</h2>";
-echo "<pre>&lt;requestHandler name=&quot;/mlt&quot; class=&quot;solr.MoreLikeThisHandler&quot;&gt;&lt;/requestHandler&gt;</pre>";
+echo "<pre>&lt;requestHandler name=&quot;/mlt&quot; class=&quot;solr.MoreLikeThisHandler&quot; /&gt;</pre>";
 
 // create a client instance
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);

--- a/examples/execute_all.php
+++ b/examples/execute_all.php
@@ -88,7 +88,7 @@ try {
     foreach (scandir(__DIR__) as $example) {
         if (preg_match('/^\d.*\.php/', $example)) {
             print "\n".$example.' ';
-            if (!in_array($example, ['2.1.5.8-distributed-search.php', '2.3.2-mlt-stream.php'])) {
+            if (!in_array($example, ['2.1.5.8-distributed-search.php', '2.3.1-mlt-query.php', '2.3.2-mlt-stream.php'])) {
                 if ('solrcloud' !== $solr_mode || !in_array($example, ['2.1.5.7-grouping-by-query.php', '2.2.5-rollback.php', '7.1-plugin-loadbalancer.php'])) {
                     ob_start();
                     require($example);

--- a/src/Component/ComponentTraits/MoreLikeThisTrait.php
+++ b/src/Component/ComponentTraits/MoreLikeThisTrait.php
@@ -1,0 +1,351 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Component\ComponentTraits;
+
+use Solarium\Exception\DomainException;
+
+/**
+ * MoreLikeThis Query Trait.
+ */
+trait MoreLikeThisTrait
+{
+    /**
+     * Set minimumtermfrequency option.
+     *
+     * Minimum Term Frequency - the frequency below which terms will be ignored
+     * in the source doc.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $minimum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMinimumTermFrequency(int $minimum): self
+    {
+        $this->setOption('minimumtermfrequency', $minimum);
+
+        return $this;
+    }
+
+    /**
+     * Get minimumtermfrequency option.
+     *
+     * @return int|null
+     */
+    public function getMinimumTermFrequency(): ?int
+    {
+        return $this->getOption('minimumtermfrequency');
+    }
+
+    /**
+     * Set minimumdocumentfrequency option.
+     *
+     * Minimum Document Frequency - the frequency at which words will be
+     * ignored which do not occur in at least this many docs.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $minimum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMinimumDocumentFrequency(int $minimum): self
+    {
+        $this->setOption('minimumdocumentfrequency', $minimum);
+
+        return $this;
+    }
+
+    /**
+     * Get minimumdocumentfrequency option.
+     *
+     * @return int|null
+     */
+    public function getMinimumDocumentFrequency(): ?int
+    {
+        return $this->getOption('minimumdocumentfrequency');
+    }
+
+    /**
+     * Set maximumdocumentfrequency option.
+     *
+     * Maximum Document Frequency - the frequency at which words will be
+     * ignored which occur in more than this many docs.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $maximum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMaximumDocumentFrequency(int $maximum): self
+    {
+        $this->setOption('maximumdocumentfrequency', $maximum);
+
+        return $this;
+    }
+
+    /**
+     * Get maximumdocumentfrequency option.
+     *
+     * @return int|null
+     */
+    public function getMaximumDocumentFrequency(): ?int
+    {
+        return $this->getOption('maximumdocumentfrequency');
+    }
+
+    /**
+     * Set maximumdocumentfrequencypercentage option.
+     *
+     * Maximum Document Frequency Percentage - a relative ratio at which words will be
+     * ignored which occur in more than this percentage of the docs in the index.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $maximumpercentage A percentage between 0 and 100
+     *
+     * @throws \Solarium\Exception\DomainException
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMaximumDocumentFrequencyPercentage(int $maximumpercentage): self
+    {
+        if (0 > $maximumpercentage || 100 < $maximumpercentage) {
+            throw new DomainException(sprintf('Maximum percentage %d is not between 0 and 100.', $maximumpercentage));
+        }
+
+        $this->setOption('maximumdocumentfrequencypercentage', $maximumpercentage);
+
+        return $this;
+    }
+
+    /**
+     * Get maximumdocumentfrequencypercentage option.
+     *
+     * @return int|null
+     */
+    public function getMaximumDocumentFrequencyPercentage(): ?int
+    {
+        return $this->getOption('maximumdocumentfrequencypercentage');
+    }
+
+    /**
+     * Set minimumwordlength option.
+     *
+     * Minimum word length below which words will be ignored.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $minimum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMinimumWordLength(int $minimum): self
+    {
+        $this->setOption('minimumwordlength', $minimum);
+
+        return $this;
+    }
+
+    /**
+     * Get minimumwordlength option.
+     *
+     * @return int|null
+     */
+    public function getMinimumWordLength(): ?int
+    {
+        return $this->getOption('minimumwordlength');
+    }
+
+    /**
+     * Set maximumwordlength option.
+     *
+     * Maximum word length above which words will be ignored.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $maximum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMaximumWordLength(int $maximum): self
+    {
+        $this->setOption('maximumwordlength', $maximum);
+
+        return $this;
+    }
+
+    /**
+     * Get maximumwordlength option.
+     *
+     * @return int|null
+     */
+    public function getMaximumWordLength(): ?int
+    {
+        return $this->getOption('maximumwordlength');
+    }
+
+    /**
+     * Set maximumqueryterms option.
+     *
+     * Maximum number of query terms that will be included in any generated
+     * query.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $maximum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMaximumQueryTerms(int $maximum): self
+    {
+        $this->setOption('maximumqueryterms', $maximum);
+
+        return $this;
+    }
+
+    /**
+     * Get maximumqueryterms option.
+     *
+     * @return int|null
+     */
+    public function getMaximumQueryTerms(): ?int
+    {
+        return $this->getOption('maximumqueryterms');
+    }
+
+    /**
+     * Set maximumnumberoftokens option.
+     *
+     * Maximum number of tokens to parse in each example doc field that is not
+     * stored with TermVector support.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $maximum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMaximumNumberOfTokens(int $maximum): self
+    {
+        $this->setOption('maximumnumberoftokens', $maximum);
+
+        return $this;
+    }
+
+    /**
+     * Get maximumnumberoftokens option.
+     *
+     * @return int|null
+     */
+    public function getMaximumNumberOfTokens(): ?int
+    {
+        return $this->getOption('maximumnumberoftokens');
+    }
+
+    /**
+     * Set boost option.
+     *
+     * If true the query will be boosted by the interesting term relevance.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param bool $boost
+     *
+     * @return self Provides fluent interface
+     */
+    public function setBoost(bool $boost): self
+    {
+        $this->setOption('boost', $boost);
+
+        return $this;
+    }
+
+    /**
+     * Get boost option.
+     *
+     * @return bool|null
+     */
+    public function getBoost(): ?bool
+    {
+        return $this->getOption('boost');
+    }
+
+    /**
+     * Set queryfields option.
+     *
+     * Query fields and their boosts using the same format as that used in
+     * DisMaxQParserPlugin. These fields must also be specified in fields.
+     *
+     * Separate multiple fields with commas if you use string input.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param string|array $queryFields
+     *
+     * @return self Provides fluent interface
+     */
+    public function setQueryFields($queryFields): self
+    {
+        if (\is_string($queryFields)) {
+            $queryFields = explode(',', $queryFields);
+            $queryFields = array_map('trim', $queryFields);
+        }
+
+        $this->setOption('queryfields', $queryFields);
+
+        return $this;
+    }
+
+    /**
+     * Get queryfields option.
+     *
+     * @return array
+     */
+    public function getQueryFields(): array
+    {
+        $queryfields = $this->getOption('queryfields');
+        if (null === $queryfields) {
+            $queryfields = [];
+        }
+
+        return $queryfields;
+    }
+
+    /**
+     * Set the interestingTerms parameter. Must be one of: none, list, details.
+     *
+     * Controls how the component presents the "interesting" terms.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
+     *
+     * @param string $setting
+     *
+     * @return self Provides fluent interface
+     */
+    public function setInterestingTerms(string $setting): self
+    {
+        $this->setOption('interestingTerms', $setting);
+
+        return $this;
+    }
+
+    /**
+     * Get the interestingTerms parameter.
+     *
+     * @return string|null
+     */
+    public function getInterestingTerms(): ?string
+    {
+        return $this->getOption('interestingTerms');
+    }
+}

--- a/src/Component/ComponentTraits/MoreLikeThisTrait.php
+++ b/src/Component/ComponentTraits/MoreLikeThisTrait.php
@@ -9,6 +9,7 @@
 
 namespace Solarium\Component\ComponentTraits;
 
+use Solarium\Component\MoreLikeThisInterface;
 use Solarium\Exception\DomainException;
 
 /**
@@ -26,9 +27,9 @@ trait MoreLikeThisTrait
      *
      * @param int $minimum
      *
-     * @return self Provides fluent interface
+     * @return MoreLikeThisInterface Provides fluent interface
      */
-    public function setMinimumTermFrequency(int $minimum): self
+    public function setMinimumTermFrequency(int $minimum): MoreLikeThisInterface
     {
         $this->setOption('minimumtermfrequency', $minimum);
 
@@ -55,9 +56,9 @@ trait MoreLikeThisTrait
      *
      * @param int $minimum
      *
-     * @return self Provides fluent interface
+     * @return MoreLikeThisInterface Provides fluent interface
      */
-    public function setMinimumDocumentFrequency(int $minimum): self
+    public function setMinimumDocumentFrequency(int $minimum): MoreLikeThisInterface
     {
         $this->setOption('minimumdocumentfrequency', $minimum);
 
@@ -84,9 +85,9 @@ trait MoreLikeThisTrait
      *
      * @param int $maximum
      *
-     * @return self Provides fluent interface
+     * @return MoreLikeThisInterface Provides fluent interface
      */
-    public function setMaximumDocumentFrequency(int $maximum): self
+    public function setMaximumDocumentFrequency(int $maximum): MoreLikeThisInterface
     {
         $this->setOption('maximumdocumentfrequency', $maximum);
 
@@ -115,9 +116,9 @@ trait MoreLikeThisTrait
      *
      * @throws \Solarium\Exception\DomainException
      *
-     * @return self Provides fluent interface
+     * @return MoreLikeThisInterface Provides fluent interface
      */
-    public function setMaximumDocumentFrequencyPercentage(int $maximumpercentage): self
+    public function setMaximumDocumentFrequencyPercentage(int $maximumpercentage): MoreLikeThisInterface
     {
         if (0 > $maximumpercentage || 100 < $maximumpercentage) {
             throw new DomainException(sprintf('Maximum percentage %d is not between 0 and 100.', $maximumpercentage));
@@ -147,9 +148,9 @@ trait MoreLikeThisTrait
      *
      * @param int $minimum
      *
-     * @return self Provides fluent interface
+     * @return MoreLikeThisInterface Provides fluent interface
      */
-    public function setMinimumWordLength(int $minimum): self
+    public function setMinimumWordLength(int $minimum): MoreLikeThisInterface
     {
         $this->setOption('minimumwordlength', $minimum);
 
@@ -175,9 +176,9 @@ trait MoreLikeThisTrait
      *
      * @param int $maximum
      *
-     * @return self Provides fluent interface
+     * @return MoreLikeThisInterface Provides fluent interface
      */
-    public function setMaximumWordLength(int $maximum): self
+    public function setMaximumWordLength(int $maximum): MoreLikeThisInterface
     {
         $this->setOption('maximumwordlength', $maximum);
 
@@ -204,9 +205,9 @@ trait MoreLikeThisTrait
      *
      * @param int $maximum
      *
-     * @return self Provides fluent interface
+     * @return MoreLikeThisInterface Provides fluent interface
      */
-    public function setMaximumQueryTerms(int $maximum): self
+    public function setMaximumQueryTerms(int $maximum): MoreLikeThisInterface
     {
         $this->setOption('maximumqueryterms', $maximum);
 
@@ -233,9 +234,9 @@ trait MoreLikeThisTrait
      *
      * @param int $maximum
      *
-     * @return self Provides fluent interface
+     * @return MoreLikeThisInterface Provides fluent interface
      */
-    public function setMaximumNumberOfTokens(int $maximum): self
+    public function setMaximumNumberOfTokens(int $maximum): MoreLikeThisInterface
     {
         $this->setOption('maximumnumberoftokens', $maximum);
 
@@ -261,9 +262,9 @@ trait MoreLikeThisTrait
      *
      * @param bool $boost
      *
-     * @return self Provides fluent interface
+     * @return MoreLikeThisInterface Provides fluent interface
      */
-    public function setBoost(bool $boost): self
+    public function setBoost(bool $boost): MoreLikeThisInterface
     {
         $this->setOption('boost', $boost);
 
@@ -292,9 +293,9 @@ trait MoreLikeThisTrait
      *
      * @param string|array $queryFields
      *
-     * @return self Provides fluent interface
+     * @return MoreLikeThisInterface Provides fluent interface
      */
-    public function setQueryFields($queryFields): self
+    public function setQueryFields($queryFields): MoreLikeThisInterface
     {
         if (\is_string($queryFields)) {
             $queryFields = explode(',', $queryFields);
@@ -330,9 +331,9 @@ trait MoreLikeThisTrait
      *
      * @param string $setting
      *
-     * @return self Provides fluent interface
+     * @return MoreLikeThisInterface Provides fluent interface
      */
-    public function setInterestingTerms(string $setting): self
+    public function setInterestingTerms(string $setting): MoreLikeThisInterface
     {
         $this->setOption('interestingTerms', $setting);
 

--- a/src/Component/MoreLikeThis.php
+++ b/src/Component/MoreLikeThis.php
@@ -9,6 +9,7 @@
 
 namespace Solarium\Component;
 
+use Solarium\Component\ComponentTraits\MoreLikeThisTrait;
 use Solarium\Component\RequestBuilder\ComponentRequestBuilderInterface;
 use Solarium\Component\RequestBuilder\MoreLikeThis as RequestBuilder;
 use Solarium\Component\ResponseParser\ComponentParserInterface;
@@ -21,6 +22,8 @@ use Solarium\Component\ResponseParser\MoreLikeThis as ResponseParser;
  */
 class MoreLikeThis extends AbstractComponent
 {
+    use MoreLikeThisTrait;
+
     /**
      * Get component type.
      *
@@ -55,7 +58,7 @@ class MoreLikeThis extends AbstractComponent
      * Set fields option.
      *
      * The fields to use for similarity. NOTE: if possible, these should have a
-     * stored TermVector
+     * stored TermVector.
      *
      * When using string input you can separate multiple fields with commas.
      *
@@ -93,329 +96,9 @@ class MoreLikeThis extends AbstractComponent
     }
 
     /**
-     * Set the interestingTerms parameter. Must be one of: none, list, details.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
-     *
-     * @param string $term
-     *
-     * @return self Provides fluent interface
-     */
-    public function setInterestingTerms(string $term): self
-    {
-        $this->setOption('interestingTerms', $term);
-
-        return $this;
-    }
-
-    /**
-     * Get the interestingTerm parameter.
-     *
-     * @return string|null
-     */
-    public function getInterestingTerms(): ?string
-    {
-        return $this->getOption('interestingTerms');
-    }
-
-    /**
-     * Set the match.include parameter, which is either 'true' or 'false'.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
-     *
-     * @param bool $include
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMatchInclude(bool $include): self
-    {
-        $this->setOption('matchinclude', $include);
-
-        return $this;
-    }
-
-    /**
-     * Get the match.include parameter.
-     *
-     * @return bool|null
-     */
-    public function getMatchInclude(): ?bool
-    {
-        return $this->getOption('matchinclude');
-    }
-
-    /**
-     * Set the mlt.match.offset parameter, which determines the which result from the query should be used for MLT
-     * For paging of MLT use setStart / setRows.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
-     *
-     * @param int $offset
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMatchOffset(int $offset): self
-    {
-        $this->setOption('matchoffset', $offset);
-
-        return $this;
-    }
-
-    /**
-     * Get the mlt.match.offset parameter.
-     *
-     * @return int|null
-     */
-    public function getMatchOffset(): ?int
-    {
-        return $this->getOption('matchoffset');
-    }
-
-    /**
-     * Set minimumtermfrequency option.
-     *
-     * Minimum Term Frequency - the frequency below which terms will be ignored
-     * in the source doc.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param int $minimum
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMinimumTermFrequency(int $minimum): self
-    {
-        $this->setOption('minimumtermfrequency', $minimum);
-
-        return $this;
-    }
-
-    /**
-     * Get minimumtermfrequency option.
-     *
-     * @return int|null
-     */
-    public function getMinimumTermFrequency(): ?int
-    {
-        return $this->getOption('minimumtermfrequency');
-    }
-
-    /**
-     * Set minimumdocumentfrequency option.
-     *
-     * Minimum Document Frequency - the frequency at which words will be
-     * ignored which do not occur in at least this many docs.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param int $minimum
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMinimumDocumentFrequency(int $minimum): self
-    {
-        $this->setOption('minimumdocumentfrequency', $minimum);
-
-        return $this;
-    }
-
-    /**
-     * Get minimumdocumentfrequency option.
-     *
-     * @return int|null
-     */
-    public function getMinimumDocumentFrequency(): ?int
-    {
-        return $this->getOption('minimumdocumentfrequency');
-    }
-
-    /**
-     * Set minimumwordlength option.
-     *
-     * Minimum word length below which words will be ignored.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param int $minimum
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMinimumWordLength(int $minimum): self
-    {
-        $this->setOption('minimumwordlength', $minimum);
-
-        return $this;
-    }
-
-    /**
-     * Get minimumwordlength option.
-     *
-     * @return int|null
-     */
-    public function getMinimumWordLength(): ?int
-    {
-        return $this->getOption('minimumwordlength');
-    }
-
-    /**
-     * Set maximumwordlength option.
-     *
-     * Maximum word length above which words will be ignored.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param int $maximum
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMaximumWordLength(int $maximum): self
-    {
-        $this->setOption('maximumwordlength', $maximum);
-
-        return $this;
-    }
-
-    /**
-     * Get maximumwordlength option.
-     *
-     * @return int|null
-     */
-    public function getMaximumWordLength(): ?int
-    {
-        return $this->getOption('maximumwordlength');
-    }
-
-    /**
-     * Set maximumqueryterms option.
-     *
-     * Maximum number of query terms that will be included in any generated
-     * query.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param int $maximum
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMaximumQueryTerms(int $maximum): self
-    {
-        $this->setOption('maximumqueryterms', $maximum);
-
-        return $this;
-    }
-
-    /**
-     * Get maximumqueryterms option.
-     *
-     * @return int|null
-     */
-    public function getMaximumQueryTerms(): ?int
-    {
-        return $this->getOption('maximumqueryterms');
-    }
-
-    /**
-     * Set maximumnumberoftokens option.
-     *
-     * Maximum number of tokens to parse in each example doc field that is not
-     * stored with TermVector support.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param int $maximum
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMaximumNumberOfTokens(int $maximum): self
-    {
-        $this->setOption('maximumnumberoftokens', $maximum);
-
-        return $this;
-    }
-
-    /**
-     * Get maximumnumberoftokens option.
-     *
-     * @return int|null
-     */
-    public function getMaximumNumberOfTokens(): ?int
-    {
-        return $this->getOption('maximumnumberoftokens');
-    }
-
-    /**
-     * Set boost option.
-     *
-     * If true the query will be boosted by the interesting term relevance.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param bool $boost
-     *
-     * @return self Provides fluent interface
-     */
-    public function setBoost(bool $boost): self
-    {
-        $this->setOption('boost', $boost);
-
-        return $this;
-    }
-
-    /**
-     * Get boost option.
-     *
-     * @return bool|null
-     */
-    public function getBoost(): ?bool
-    {
-        return $this->getOption('boost');
-    }
-
-    /**
-     * Set queryfields option.
-     *
-     * Query fields and their boosts using the same format as that used in
-     * DisMaxQParserPlugin. These fields must also be specified in fields.
-     *
-     * When using string input you can separate multiple fields with commas.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param string|array $queryFields
-     *
-     * @return self Provides fluent interface
-     */
-    public function setQueryFields($queryFields): self
-    {
-        if (\is_string($queryFields)) {
-            $queryFields = explode(',', $queryFields);
-            $queryFields = array_map('trim', $queryFields);
-        }
-
-        $this->setOption('queryfields', $queryFields);
-
-        return $this;
-    }
-
-    /**
-     * Get queryfields option.
-     *
-     * @return array
-     */
-    public function getQueryFields(): array
-    {
-        $queryfields = $this->getOption('queryfields');
-        if (null === $queryfields) {
-            $queryfields = [];
-        }
-
-        return $queryfields;
-    }
-
-    /**
      * Set count option.
      *
-     * The number of similar documents to return for each result
+     * The number of similar documents to return for each result.
      *
      * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethiscomponent
      *
@@ -438,6 +121,74 @@ class MoreLikeThis extends AbstractComponent
     public function getCount(): ?int
     {
         return $this->getOption('count');
+    }
+
+    /**
+     * Set the match.include parameter, which is either 'true' or 'false'.
+     *
+     * This doesn't actually do anything for the MoreLikeThisComponent as
+     * this parameter is only for the MoreLikeThisHandler.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
+     *
+     * @param bool $include
+     *
+     * @return self Provides fluent interface
+     *
+     * @deprecated Will be removed in Solarium 8. This parameter is only accessible through the MoreLikeThisHandler.
+     */
+    public function setMatchInclude(bool $include): self
+    {
+        return $this;
+    }
+
+    /**
+     * Get the match.include parameter.
+     *
+     * This always returns null for the MoreLikeThisComponent as
+     * this parameter is only for the MoreLikeThisHandler.
+     *
+     * @return bool|null
+     *
+     * @deprecated Will be removed in Solarium 8. This parameter is only accessible through the MoreLikeThisHandler.
+     */
+    public function getMatchInclude(): ?bool
+    {
+        return null;
+    }
+
+    /**
+     * Set the mlt.match.offset parameter.
+     *
+     * This doesn't actually do anything for the MoreLikeThisComponent as
+     * this parameter is only for the MoreLikeThisHandler.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
+     *
+     * @param int $offset
+     *
+     * @return self Provides fluent interface
+     *
+     * @deprecated Will be removed in Solarium 8. This parameter is only accessible through the MoreLikeThisHandler.
+     */
+    public function setMatchOffset(int $offset): self
+    {
+        return $this;
+    }
+
+    /**
+     * Get the mlt.match.offset parameter.
+     *
+     * This always returns null for the MoreLikeThisComponent as
+     * this parameter is only for the MoreLikeThisHandler.
+     *
+     * @return int|null
+     *
+     * @deprecated Will be removed in Solarium 8. This parameter is only accessible through the MoreLikeThisHandler.
+     */
+    public function getMatchOffset(): ?int
+    {
+        return null;
     }
 
     /**

--- a/src/Component/MoreLikeThis.php
+++ b/src/Component/MoreLikeThis.php
@@ -20,7 +20,7 @@ use Solarium\Component\ResponseParser\MoreLikeThis as ResponseParser;
  *
  * @see https://lucene.apache.org/solr/guide/morelikethis.html
  */
-class MoreLikeThis extends AbstractComponent
+class MoreLikeThis extends AbstractComponent implements MoreLikeThisInterface
 {
     use MoreLikeThisTrait;
 

--- a/src/Component/MoreLikeThisInterface.php
+++ b/src/Component/MoreLikeThisInterface.php
@@ -1,0 +1,247 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Component;
+
+use Solarium\Core\ConfigurableInterface;
+
+/**
+ * MoreLikeThis Interface.
+ */
+interface MoreLikeThisInterface extends ConfigurableInterface
+{
+    /**
+     * Set minimumtermfrequency option.
+     *
+     * Minimum Term Frequency - the frequency below which terms will be ignored
+     * in the source doc.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $minimum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMinimumTermFrequency(int $minimum): self;
+
+    /**
+     * Get minimumtermfrequency option.
+     *
+     * @return int|null
+     */
+    public function getMinimumTermFrequency(): ?int;
+
+    /**
+     * Set minimumdocumentfrequency option.
+     *
+     * Minimum Document Frequency - the frequency at which words will be
+     * ignored which do not occur in at least this many docs.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $minimum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMinimumDocumentFrequency(int $minimum): self;
+
+    /**
+     * Get minimumdocumentfrequency option.
+     *
+     * @return int|null
+     */
+    public function getMinimumDocumentFrequency(): ?int;
+
+    /**
+     * Set maximumdocumentfrequency option.
+     *
+     * Maximum Document Frequency - the frequency at which words will be
+     * ignored which occur in more than this many docs.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $maximum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMaximumDocumentFrequency(int $maximum): self;
+
+    /**
+     * Get maximumdocumentfrequency option.
+     *
+     * @return int|null
+     */
+    public function getMaximumDocumentFrequency(): ?int;
+
+    /**
+     * Set maximumdocumentfrequencypercentage option.
+     *
+     * Maximum Document Frequency Percentage - a relative ratio at which words will be
+     * ignored which occur in more than this percentage of the docs in the index.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $maximumpercentage A percentage between 0 and 100
+     *
+     * @throws \Solarium\Exception\DomainException
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMaximumDocumentFrequencyPercentage(int $maximumpercentage): self;
+
+    /**
+     * Get maximumdocumentfrequencypercentage option.
+     *
+     * @return int|null
+     */
+    public function getMaximumDocumentFrequencyPercentage(): ?int;
+
+    /**
+     * Set minimumwordlength option.
+     *
+     * Minimum word length below which words will be ignored.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $minimum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMinimumWordLength(int $minimum): self;
+
+    /**
+     * Get minimumwordlength option.
+     *
+     * @return int|null
+     */
+    public function getMinimumWordLength(): ?int;
+
+    /**
+     * Set maximumwordlength option.
+     *
+     * Maximum word length above which words will be ignored.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $maximum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMaximumWordLength(int $maximum): self;
+
+    /**
+     * Get maximumwordlength option.
+     *
+     * @return int|null
+     */
+    public function getMaximumWordLength(): ?int;
+
+    /**
+     * Set maximumqueryterms option.
+     *
+     * Maximum number of query terms that will be included in any generated
+     * query.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $maximum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMaximumQueryTerms(int $maximum): self;
+
+    /**
+     * Get maximumqueryterms option.
+     *
+     * @return int|null
+     */
+    public function getMaximumQueryTerms(): ?int;
+
+    /**
+     * Set maximumnumberoftokens option.
+     *
+     * Maximum number of tokens to parse in each example doc field that is not
+     * stored with TermVector support.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param int $maximum
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMaximumNumberOfTokens(int $maximum): self;
+
+    /**
+     * Get maximumnumberoftokens option.
+     *
+     * @return int|null
+     */
+    public function getMaximumNumberOfTokens(): ?int;
+
+    /**
+     * Set boost option.
+     *
+     * If true the query will be boosted by the interesting term relevance.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param bool $boost
+     *
+     * @return self Provides fluent interface
+     */
+    public function setBoost(bool $boost): self;
+
+    /**
+     * Get boost option.
+     *
+     * @return bool|null
+     */
+    public function getBoost(): ?bool;
+
+    /**
+     * Set queryfields option.
+     *
+     * Query fields and their boosts using the same format as that used in
+     * DisMaxQParserPlugin. These fields must also be specified in fields.
+     *
+     * Separate multiple fields with commas if you use string input.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     *
+     * @param string|array $queryFields
+     *
+     * @return self Provides fluent interface
+     */
+    public function setQueryFields($queryFields): self;
+
+    /**
+     * Get queryfields option.
+     *
+     * @return array
+     */
+    public function getQueryFields(): array;
+
+    /**
+     * Set the interestingTerms parameter. Must be one of: none, list, details.
+     *
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
+     *
+     * @param string $term
+     *
+     * @return self Provides fluent interface
+     */
+    public function setInterestingTerms(string $term): self;
+
+    /**
+     * Get the interestingTerms parameter.
+     *
+     * @return string|null
+     */
+    public function getInterestingTerms(): ?string;
+}

--- a/src/Component/RequestBuilder/MoreLikeThis.php
+++ b/src/Component/RequestBuilder/MoreLikeThis.php
@@ -31,12 +31,11 @@ class MoreLikeThis implements ComponentRequestBuilderInterface
         // enable morelikethis
         $request->addParam('mlt', 'true');
 
-        $request->addParam('mlt.interestingTerms', $component->getInterestingTerms());
-        $request->addParam('mlt.match.include', $component->getMatchInclude());
-        $request->addParam('mlt.match.offset', $component->getMatchOffset());
         $request->addParam('mlt.fl', \count($component->getFields()) ? implode(',', $component->getFields()) : null);
         $request->addParam('mlt.mintf', $component->getMinimumTermFrequency());
         $request->addParam('mlt.mindf', $component->getMinimumDocumentFrequency());
+        $request->addParam('mlt.maxdf', $component->getMaximumDocumentFrequency());
+        $request->addParam('mlt.maxdfpct', $component->getMaximumDocumentFrequencyPercentage());
         $request->addParam('mlt.minwl', $component->getMinimumWordLength());
         $request->addParam('mlt.maxwl', $component->getMaximumWordLength());
         $request->addParam('mlt.maxqt', $component->getMaximumQueryTerms());
@@ -47,6 +46,7 @@ class MoreLikeThis implements ComponentRequestBuilderInterface
             \count($component->getQueryFields()) ? $component->getQueryFields() : null
         );
         $request->addParam('mlt.count', $component->getCount());
+        $request->addParam('mlt.interestingTerms', $component->getInterestingTerms());
 
         return $request;
     }

--- a/src/Component/ResponseParser/MoreLikeThis.php
+++ b/src/Component/ResponseParser/MoreLikeThis.php
@@ -59,10 +59,16 @@ class MoreLikeThis extends AbstractResponseParser implements ComponentParserInte
                     $docs[] = new $documentClass($fields);
                 }
 
+                $interestingTerms = null;
+                if (isset($data['interestingTerms'][$key])) {
+                    $interestingTerms = $data['interestingTerms'][$key];
+                }
+
                 $results[$key] = new Result(
                     $result['numFound'],
                     isset($result['maxScore']) ? $result['maxScore'] : null,
-                    $docs
+                    $docs,
+                    $interestingTerms
                 );
             }
         }

--- a/src/Component/ResponseParser/MoreLikeThis.php
+++ b/src/Component/ResponseParser/MoreLikeThis.php
@@ -70,8 +70,7 @@ class MoreLikeThis extends AbstractResponseParser implements ComponentParserInte
 
             if ('none' === $moreLikeThis->getInterestingTerms()) {
                 $interestingTerms = null;
-            }
-            elseif (isset($data['interestingTerms'])) {
+            } elseif (isset($data['interestingTerms'])) {
                 // We don't need to convertToKeyValueArray. Solr's MoreLikeThisComponent uses a SimpleOrderedMap
                 // for representing interesting terms. A SimpleOrdereMap is always returned using the "map" format.
                 $interestingTerms = $data['interestingTerms'];

--- a/src/Component/Result/MoreLikeThis/MoreLikeThis.php
+++ b/src/Component/Result/MoreLikeThis/MoreLikeThis.php
@@ -35,7 +35,7 @@ class MoreLikeThis implements \IteratorAggregate, \Countable
     /**
      * Constructor.
      *
-     * @param array $results
+     * @param array      $results
      * @param array|null $interestingTerms
      */
     public function __construct(array $results, ?array $interestingTerms)

--- a/src/Component/Result/MoreLikeThis/MoreLikeThis.php
+++ b/src/Component/Result/MoreLikeThis/MoreLikeThis.php
@@ -9,6 +9,8 @@
 
 namespace Solarium\Component\Result\MoreLikeThis;
 
+use Solarium\Exception\UnexpectedValueException;
+
 /**
  * Select component morelikethis result.
  */
@@ -22,13 +24,24 @@ class MoreLikeThis implements \IteratorAggregate, \Countable
     protected $results;
 
     /**
+     * Interesting terms.
+     *
+     * Only available if mlt.interestingTerms wasn't 'none'.
+     *
+     * @var array|null
+     */
+    protected $interestingTerms;
+
+    /**
      * Constructor.
      *
      * @param array $results
+     * @param array|null $interestingTerms
      */
-    public function __construct(array $results)
+    public function __construct(array $results, ?array $interestingTerms)
     {
         $this->results = $results;
+        $this->interestingTerms = $interestingTerms;
     }
 
     /**
@@ -51,6 +64,59 @@ class MoreLikeThis implements \IteratorAggregate, \Countable
     public function getResults(): array
     {
         return $this->results;
+    }
+
+    /**
+     * Get a list of interesting terms by document key.
+     *
+     * This will show what "interesting" terms are used for the MoreLikeThis
+     * query. These are the top TF/IDF terms.
+     *
+     * If mlt.interestingTerms was 'list', a flat list is returned.
+     *
+     * If mlt.interestingTerms was 'details',
+     * this shows you the term and boost used for each term. Unless
+     * mlt.boost was true all terms will have boost=1.0.
+     *
+     * If mlt.interestingTerms was 'none', the terms aren't available
+     * and an exception is thrown.
+     *
+     * @param mixed $key
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return array|null
+     */
+    public function getInterestingTerm($key): ?array
+    {
+        if (null === $this->interestingTerms) {
+            throw new UnexpectedValueException('interestingterms is none');
+        }
+
+        return $this->interestingTerms[$key] ?? null;
+    }
+
+    /**
+     * Get interesting terms for all documents.
+     *
+     * If mlt.interestingTerms was 'none', the terms aren't available
+     * and an exception is thrown.
+     *
+     * @see getInterestingTerm() for a description of how the terms will be returned for each document key
+     *
+     * @return array
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return array[]
+     */
+    public function getInterestingTerms(): array
+    {
+        if (null === $this->interestingTerms) {
+            throw new UnexpectedValueException('interestingterms is none');
+        }
+
+        return $this->interestingTerms;
     }
 
     /**

--- a/src/Component/Result/MoreLikeThis/Result.php
+++ b/src/Component/Result/MoreLikeThis/Result.php
@@ -40,21 +40,32 @@ class Result implements \IteratorAggregate, \Countable
     protected $maximumScore;
 
     /**
+     * MLT interesting terms.
+     *
+     * Only available if mlt.interestingTerms wasn't 'none'.
+     *
+     * @var array|null
+     */
+    protected $interestingTerms;
+
+    /**
      * Constructor.
      *
-     * @param int   $numFound
-     * @param float $maxScore
-     * @param array $documents
+     * @param int    $numFound
+     * @param float  $maxScore
+     * @param array  $documents
+     * @param ?array $interestingTerms
      */
-    public function __construct(int $numFound, float $maxScore = null, array $documents = [])
+    public function __construct(int $numFound, float $maxScore = null, array $documents = [], ?array $interestingTerms = null)
     {
         $this->numFound = $numFound;
         $this->maximumScore = $maxScore;
         $this->documents = $documents;
+        $this->interestingTerms = $interestingTerms;
     }
 
     /**
-     * get Solr numFound.
+     * Get Solr numFound.
      *
      * Returns the number of MLT documents found by Solr (this is NOT the
      * number of documents fetched from Solr!)
@@ -84,6 +95,28 @@ class Result implements \IteratorAggregate, \Countable
     public function getDocuments(): array
     {
         return $this->documents;
+    }
+
+    /**
+     * Get MLT interesting terms.
+     *
+     * This will show what "interesting" terms are used for the MoreLikeThis
+     * query. These are the top tf/idf terms.
+     *
+     * If mlt.interestingTerms was 'list', a flat list is returned.
+     *
+     * If mlt.interestingTerms was 'details',
+     * this shows you the term and boost used for each term. Unless
+     * mlt.boost was true all terms will have boost=1.0.
+     *
+     * If mlt.interestingTerms was 'none', the terms aren't available
+     * and null is returned.
+     *
+     * @return array
+     */
+    public function getInterestingTerms(): ?array
+    {
+        return $this->interestingTerms;
     }
 
     /**

--- a/src/Component/Result/MoreLikeThis/Result.php
+++ b/src/Component/Result/MoreLikeThis/Result.php
@@ -40,28 +40,17 @@ class Result implements \IteratorAggregate, \Countable
     protected $maximumScore;
 
     /**
-     * MLT interesting terms.
-     *
-     * Only available if mlt.interestingTerms wasn't 'none'.
-     *
-     * @var array|null
-     */
-    protected $interestingTerms;
-
-    /**
      * Constructor.
      *
-     * @param int    $numFound
-     * @param float  $maxScore
-     * @param array  $documents
-     * @param ?array $interestingTerms
+     * @param int   $numFound
+     * @param float $maxScore
+     * @param array $documents
      */
-    public function __construct(int $numFound, float $maxScore = null, array $documents = [], ?array $interestingTerms = null)
+    public function __construct(int $numFound, float $maxScore = null, array $documents = [])
     {
         $this->numFound = $numFound;
         $this->maximumScore = $maxScore;
         $this->documents = $documents;
-        $this->interestingTerms = $interestingTerms;
     }
 
     /**
@@ -95,28 +84,6 @@ class Result implements \IteratorAggregate, \Countable
     public function getDocuments(): array
     {
         return $this->documents;
-    }
-
-    /**
-     * Get MLT interesting terms.
-     *
-     * This will show what "interesting" terms are used for the MoreLikeThis
-     * query. These are the top tf/idf terms.
-     *
-     * If mlt.interestingTerms was 'list', a flat list is returned.
-     *
-     * If mlt.interestingTerms was 'details',
-     * this shows you the term and boost used for each term. Unless
-     * mlt.boost was true all terms will have boost=1.0.
-     *
-     * If mlt.interestingTerms was 'none', the terms aren't available
-     * and null is returned.
-     *
-     * @return array
-     */
-    public function getInterestingTerms(): ?array
-    {
-        return $this->interestingTerms;
     }
 
     /**

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Exception;
+
+/**
+ * Domain exception for Solarium classes.
+ */
+class DomainException extends \DomainException implements LogicExceptionInterface
+{
+}

--- a/src/QueryType/MoreLikeThis/Query.php
+++ b/src/QueryType/MoreLikeThis/Query.php
@@ -9,6 +9,8 @@
 
 namespace Solarium\QueryType\MoreLikeThis;
 
+use Solarium\Component\ComponentTraits\MoreLikeThisTrait;
+use Solarium\Component\MoreLikeThisInterface;
 use Solarium\Core\Client\Client;
 use Solarium\Core\Query\RequestBuilderInterface;
 use Solarium\Core\Query\ResponseParserInterface;
@@ -24,8 +26,10 @@ use Solarium\QueryType\Select\Result\Document;
  *
  * @see https://lucene.apache.org/solr/guide/other-parsers.html#more-like-this-query-parser
  */
-class Query extends SelectQuery
+class Query extends SelectQuery implements MoreLikeThisInterface
 {
+    use MoreLikeThisTrait;
+
     /**
      * Default options.
      *
@@ -39,9 +43,9 @@ class Query extends SelectQuery
         'start' => 0,
         'rows' => 10,
         'fields' => '*,score',
-        'interestingTerms' => 'none',
         'matchinclude' => false,
         'matchoffset' => 0,
+        'interestingTerms' => 'none',
         'stream' => false,
         'omitheader' => true,
     ];
@@ -105,89 +109,10 @@ class Query extends SelectQuery
     }
 
     /**
-     * Set the interestingTerms parameter. Must be one of: none, list, details.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
-     *
-     * @param string $term
-     *
-     * @return self Provides fluent interface
-     */
-    public function setInterestingTerms(string $term): self
-    {
-        $this->setOption('interestingTerms', $term);
-
-        return $this;
-    }
-
-    /**
-     * Get the interestingTerm parameter.
-     *
-     * @return string|null
-     */
-    public function getInterestingTerms(): ?string
-    {
-        return $this->getOption('interestingTerms');
-    }
-
-    /**
-     * Set the match.include parameter, which is either 'true' or 'false'.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
-     *
-     * @param bool $include
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMatchInclude(bool $include): self
-    {
-        $this->setOption('matchinclude', $include);
-
-        return $this;
-    }
-
-    /**
-     * Get the match.include parameter.
-     *
-     * @return bool|null
-     */
-    public function getMatchInclude(): ?bool
-    {
-        return $this->getOption('matchinclude');
-    }
-
-    /**
-     * Set the mlt.match.offset parameter, which determines the which result from the query should be used for MLT
-     * For paging of MLT use setStart / setRows.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
-     *
-     * @param int $offset
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMatchOffset(int $offset): self
-    {
-        $this->setOption('matchoffset', $offset);
-
-        return $this;
-    }
-
-    /**
-     * Get the mlt.match.offset parameter.
-     *
-     * @return int|null
-     */
-    public function getMatchOffset(): ?int
-    {
-        return $this->getOption('matchoffset');
-    }
-
-    /**
      * Set MLT fields option.
      *
      * The fields to use for similarity. NOTE: if possible, these should have a
-     * stored TermVector
+     * stored TermVector.
      *
      * Separate multiple fields with commas if you use string input.
      *
@@ -225,243 +150,55 @@ class Query extends SelectQuery
     }
 
     /**
-     * Set minimumtermfrequency option.
+     * Set the match.include parameter, which is either 'true' or 'false'.
      *
-     * Minimum Term Frequency - the frequency below which terms will be ignored
-     * in the source doc.
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param int $minimum
+     * @param bool $include
      *
      * @return self Provides fluent interface
      */
-    public function setMinimumTermFrequency(int $minimum): self
+    public function setMatchInclude(bool $include): self
     {
-        $this->setOption('minimumtermfrequency', $minimum);
+        $this->setOption('matchinclude', $include);
 
         return $this;
     }
 
     /**
-     * Get minimumtermfrequency option.
-     *
-     * @return int|null
-     */
-    public function getMinimumTermFrequency(): ?int
-    {
-        return $this->getOption('minimumtermfrequency');
-    }
-
-    /**
-     * Set minimumdocumentfrequency option.
-     *
-     * Minimum Document Frequency - the frequency at which words will be
-     * ignored which do not occur in at least this many docs.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param int $minimum
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMinimumDocumentFrequency(int $minimum): self
-    {
-        $this->setOption('minimumdocumentfrequency', $minimum);
-
-        return $this;
-    }
-
-    /**
-     * Get minimumdocumentfrequency option.
-     *
-     * @return int|null
-     */
-    public function getMinimumDocumentFrequency(): ?int
-    {
-        return $this->getOption('minimumdocumentfrequency');
-    }
-
-    /**
-     * Set minimumwordlength option.
-     *
-     * Minimum word length below which words will be ignored.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param int $minimum
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMinimumWordLength(int $minimum): self
-    {
-        $this->setOption('minimumwordlength', $minimum);
-
-        return $this;
-    }
-
-    /**
-     * Get minimumwordlength option.
-     *
-     * @return int|null
-     */
-    public function getMinimumWordLength(): ?int
-    {
-        return $this->getOption('minimumwordlength');
-    }
-
-    /**
-     * Set maximumwordlength option.
-     *
-     * Maximum word length above which words will be ignored.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param int $maximum
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMaximumWordLength(int $maximum): self
-    {
-        $this->setOption('maximumwordlength', $maximum);
-
-        return $this;
-    }
-
-    /**
-     * Get maximumwordlength option.
-     *
-     * @return int|null
-     */
-    public function getMaximumWordLength(): ?int
-    {
-        return $this->getOption('maximumwordlength');
-    }
-
-    /**
-     * Set maximumqueryterms option.
-     *
-     * Maximum number of query terms that will be included in any generated
-     * query.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param int $maximum
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMaximumQueryTerms(int $maximum): self
-    {
-        $this->setOption('maximumqueryterms', $maximum);
-
-        return $this;
-    }
-
-    /**
-     * Get maximumqueryterms option.
-     *
-     * @return int|null
-     */
-    public function getMaximumQueryTerms(): ?int
-    {
-        return $this->getOption('maximumqueryterms');
-    }
-
-    /**
-     * Set maximumnumberoftokens option.
-     *
-     * Maximum number of tokens to parse in each example doc field that is not
-     * stored with TermVector support.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param int $maximum
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMaximumNumberOfTokens(int $maximum): self
-    {
-        $this->setOption('maximumnumberoftokens', $maximum);
-
-        return $this;
-    }
-
-    /**
-     * Get maximumnumberoftokens option.
-     *
-     * @return int|null
-     */
-    public function getMaximumNumberOfTokens(): ?int
-    {
-        return $this->getOption('maximumnumberoftokens');
-    }
-
-    /**
-     * Set boost option.
-     *
-     * If true the query will be boosted by the interesting term relevance.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param bool $boost
-     *
-     * @return self Provides fluent interface
-     */
-    public function setBoost(bool $boost): self
-    {
-        $this->setOption('boost', $boost);
-
-        return $this;
-    }
-
-    /**
-     * Get boost option.
+     * Get the match.include parameter.
      *
      * @return bool|null
      */
-    public function getBoost(): ?bool
+    public function getMatchInclude(): ?bool
     {
-        return $this->getOption('boost');
+        return $this->getOption('matchinclude');
     }
 
     /**
-     * Set queryfields option.
+     * Set the mlt.match.offset parameter, which determines on which result from the query MLT should operate.
+     * For paging of MLT use setStart / setRows.
      *
-     * Query fields and their boosts using the same format as that used in
-     * DisMaxQParserPlugin. These fields must also be specified in fields.
+     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
      *
-     * Separate multiple fields with commas if you use string input.
-     *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
-     *
-     * @param string|array $queryFields
+     * @param int $offset
      *
      * @return self Provides fluent interface
      */
-    public function setQueryFields($queryFields): self
+    public function setMatchOffset(int $offset): self
     {
-        if (\is_string($queryFields)) {
-            $queryFields = explode(',', $queryFields);
-            $queryFields = array_map('trim', $queryFields);
-        }
-
-        $this->setOption('queryfields', $queryFields);
+        $this->setOption('matchoffset', $offset);
 
         return $this;
     }
 
     /**
-     * Get queryfields option.
+     * Get the mlt.match.offset parameter.
      *
-     * @return array
+     * @return int|null
      */
-    public function getQueryFields(): array
+    public function getMatchOffset(): ?int
     {
-        $value = $this->getOption('queryfields');
-        if (null === $value) {
-            $value = [];
-        }
-
-        return $value;
+        return $this->getOption('matchoffset');
     }
 }

--- a/src/QueryType/MoreLikeThis/RequestBuilder.php
+++ b/src/QueryType/MoreLikeThis/RequestBuilder.php
@@ -31,18 +31,20 @@ class RequestBuilder extends SelectRequestBuilder
         $request = parent::build($query);
 
         // add MLT params to request
-        $request->addParam('mlt.interestingTerms', $query->getInterestingTerms());
-        $request->addParam('mlt.match.include', $query->getMatchInclude());
-        $request->addParam('mlt.match.offset', $query->getMatchOffset());
         $request->addParam('mlt.fl', implode(',', $query->getMltFields()));
         $request->addParam('mlt.mintf', $query->getMinimumTermFrequency());
         $request->addParam('mlt.mindf', $query->getMinimumDocumentFrequency());
+        $request->addParam('mlt.maxdf', $query->getMaximumDocumentFrequency());
+        $request->addParam('mlt.maxdfpct', $query->getMaximumDocumentFrequencyPercentage());
         $request->addParam('mlt.minwl', $query->getMinimumWordLength());
         $request->addParam('mlt.maxwl', $query->getMaximumWordLength());
         $request->addParam('mlt.maxqt', $query->getMaximumQueryTerms());
         $request->addParam('mlt.maxntp', $query->getMaximumNumberOfTokens());
         $request->addParam('mlt.boost', $query->getBoost());
         $request->addParam('mlt.qf', $query->getQueryFields());
+        $request->addParam('mlt.match.include', $query->getMatchInclude());
+        $request->addParam('mlt.match.offset', $query->getMatchOffset());
+        $request->addParam('mlt.interestingTerms', $query->getInterestingTerms());
 
         // convert query to stream if necessary
         if (true === $query->getQueryStream()) {

--- a/src/QueryType/MoreLikeThis/Result.php
+++ b/src/QueryType/MoreLikeThis/Result.php
@@ -45,10 +45,17 @@ class Result extends SelectResult
     /**
      * Get MLT interesting terms.
      *
-     * this will show what "interesting" terms are used for the MoreLikeThis
-     * query. These are the top tf/idf terms. NOTE: if you select 'details',
+     * This will show what "interesting" terms are used for the MoreLikeThis
+     * query. These are the top tf/idf terms.
+     *
+     * If mlt.interestingTerms was 'list', a flat list is returned.
+     *
+     * If mlt.interestingTerms was 'details',
      * this shows you the term and boost used for each term. Unless
-     * mlt.boost=true all terms will have boost=1.0
+     * mlt.boost was true all terms will have boost=1.0.
+     *
+     * If mlt.interestingTerms was 'none', the terms aren't available
+     * and an exception is thrown.
      *
      * @throws UnexpectedValueException
      *

--- a/src/QueryType/MoreLikeThis/Result.php
+++ b/src/QueryType/MoreLikeThis/Result.php
@@ -46,7 +46,7 @@ class Result extends SelectResult
      * Get MLT interesting terms.
      *
      * This will show what "interesting" terms are used for the MoreLikeThis
-     * query. These are the top tf/idf terms.
+     * query. These are the top TF/IDF terms.
      *
      * If mlt.interestingTerms was 'list', a flat list is returned.
      *

--- a/tests/Component/MoreLikeThisTest.php
+++ b/tests/Component/MoreLikeThisTest.php
@@ -5,6 +5,7 @@ namespace Solarium\Tests\Component;
 use PHPUnit\Framework\TestCase;
 use Solarium\Component\ComponentAwareQueryInterface;
 use Solarium\Component\MoreLikeThis;
+use Solarium\Exception\DomainException;
 
 class MoreLikeThisTest extends TestCase
 {
@@ -22,39 +23,39 @@ class MoreLikeThisTest extends TestCase
     {
         $options = [
             'fields' => 'fieldA,fieldB',
-            'interestingTerms' => 'none',
-            'matchinclude' => true,
-            'matchoffset' => 5,
             'minimumtermfrequency' => 10,
             'minimumdocumentfrequency' => 2,
+            'maximumdocumentfrequency' => 20,
+            'maximumdocumentfrequencypercentage' => 75,
             'minimumwordlength' => 3,
             'maximumwordlength' => 10,
             'maximumqueryterms' => 4,
             'maximumnumberoftokens' => 20,
-            'boost' => 1.5,
+            'boost' => true,
             'queryfields' => 'fieldC,fieldD',
             'count' => 5,
+            'interestingTerms' => 'none',
         ];
 
         $this->mlt->setOptions($options);
 
-        $this->assertEquals(explode(',', $options['fields']), $this->mlt->getFields());
-        $this->assertEquals($options['interestingTerms'], $this->mlt->getInterestingTerms());
-        $this->assertEquals($options['matchinclude'], $this->mlt->getMatchInclude());
-        $this->assertEquals($options['matchoffset'], $this->mlt->getMatchOffset());
-        $this->assertEquals($options['minimumtermfrequency'], $this->mlt->getMinimumTermFrequency());
-        $this->assertEquals($options['minimumdocumentfrequency'], $this->mlt->getMinimumDocumentFrequency());
-        $this->assertEquals($options['minimumwordlength'], $this->mlt->getMinimumWordLength());
-        $this->assertEquals($options['maximumwordlength'], $this->mlt->getMaximumWordLength());
-        $this->assertEquals($options['maximumqueryterms'], $this->mlt->getMaximumQueryTerms());
-        $this->assertEquals($options['boost'], $this->mlt->getBoost());
-        $this->assertEquals(explode(',', $options['queryfields']), $this->mlt->getQueryFields());
-        $this->assertEquals($options['count'], $this->mlt->getCount());
+        $this->assertSame(explode(',', $options['fields']), $this->mlt->getFields());
+        $this->assertSame($options['minimumtermfrequency'], $this->mlt->getMinimumTermFrequency());
+        $this->assertSame($options['minimumdocumentfrequency'], $this->mlt->getMinimumDocumentFrequency());
+        $this->assertSame($options['maximumdocumentfrequency'], $this->mlt->getMaximumDocumentFrequency());
+        $this->assertSame($options['maximumdocumentfrequencypercentage'], $this->mlt->getMaximumDocumentFrequencyPercentage());
+        $this->assertSame($options['minimumwordlength'], $this->mlt->getMinimumWordLength());
+        $this->assertSame($options['maximumwordlength'], $this->mlt->getMaximumWordLength());
+        $this->assertSame($options['maximumqueryterms'], $this->mlt->getMaximumQueryTerms());
+        $this->assertTrue($this->mlt->getBoost());
+        $this->assertSame(explode(',', $options['queryfields']), $this->mlt->getQueryFields());
+        $this->assertSame($options['count'], $this->mlt->getCount());
+        $this->assertSame($options['interestingTerms'], $this->mlt->getInterestingTerms());
     }
 
     public function testGetType()
     {
-        $this->assertEquals(ComponentAwareQueryInterface::COMPONENT_MORELIKETHIS, $this->mlt->getType());
+        $this->assertSame(ComponentAwareQueryInterface::COMPONENT_MORELIKETHIS, $this->mlt->getType());
     }
 
     public function testGetResponseParser()
@@ -73,12 +74,22 @@ class MoreLikeThisTest extends TestCase
         );
     }
 
+    public function testGetFieldsAlwaysReturnsArray()
+    {
+        $this->mlt->setFields(null);
+
+        $this->assertSame(
+            [],
+            $this->mlt->getFields()
+        );
+    }
+    
     public function testSetAndGetFields()
     {
         $value = 'name,description';
         $this->mlt->setFields($value);
 
-        $this->assertEquals(
+        $this->assertSame(
             ['name', 'description'],
             $this->mlt->getFields()
         );
@@ -89,42 +100,9 @@ class MoreLikeThisTest extends TestCase
         $value = ['name', 'description'];
         $this->mlt->setFields($value);
 
-        $this->assertEquals(
+        $this->assertSame(
             $value,
             $this->mlt->getFields()
-        );
-    }
-
-    public function testSetAndGetInterestingTerms()
-    {
-        $value = 'details';
-        $this->mlt->setInterestingTerms($value);
-
-        $this->assertEquals(
-            $value,
-            $this->mlt->getInterestingTerms()
-        );
-    }
-
-    public function testSetAndMatchInclude()
-    {
-        $value = false;
-        $this->mlt->setMatchInclude($value);
-
-        $this->assertEquals(
-            $value,
-            $this->mlt->getMatchInclude()
-        );
-    }
-
-    public function testSetAndGetMatchOffset()
-    {
-        $value = 17;
-        $this->mlt->setMatchOffset($value);
-
-        $this->assertEquals(
-            $value,
-            $this->mlt->getMatchOffset()
         );
     }
 
@@ -133,7 +111,7 @@ class MoreLikeThisTest extends TestCase
         $value = 2;
         $this->mlt->setMinimumTermFrequency($value);
 
-        $this->assertEquals(
+        $this->assertSame(
             $value,
             $this->mlt->getMinimumTermFrequency()
         );
@@ -144,10 +122,43 @@ class MoreLikeThisTest extends TestCase
         $value = 4;
         $this->mlt->setMinimumDocumentFrequency($value);
 
-        $this->assertEquals(
+        $this->assertSame(
             $value,
             $this->mlt->getMinimumDocumentFrequency()
         );
+    }
+
+    public function testMaximumDocumentFrequency()
+    {
+        $value = 4;
+        $this->mlt->setMaximumDocumentFrequency($value);
+
+        $this->assertSame(
+            $value,
+            $this->mlt->getMaximumDocumentFrequency()
+        );
+    }
+
+    public function testMaximumDocumentFrequencyPercentage()
+    {
+        $value = 75;
+        $this->mlt->setMaximumDocumentFrequencyPercentage($value);
+
+        $this->assertSame(
+            $value,
+            $this->mlt->getMaximumDocumentFrequencyPercentage()
+        );
+    }
+
+    /**
+     * @testWith [-5]
+     *           [120]
+     */
+    public function testMaximumDocumentFrequencyPercentageDomainException(int $value)
+    {
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage(sprintf('Maximum percentage %d is not between 0 and 100.', $value));
+        $this->mlt->setMaximumDocumentFrequencyPercentage($value);
     }
 
     public function testSetAndGetMinimumWordLength()
@@ -155,7 +166,7 @@ class MoreLikeThisTest extends TestCase
         $value = 3;
         $this->mlt->setMinimumWordLength($value);
 
-        $this->assertEquals(
+        $this->assertSame(
             $value,
             $this->mlt->getMinimumWordLength()
         );
@@ -166,7 +177,7 @@ class MoreLikeThisTest extends TestCase
         $value = 15;
         $this->mlt->setMaximumWordLength($value);
 
-        $this->assertEquals(
+        $this->assertSame(
             $value,
             $this->mlt->getMaximumWordLength()
         );
@@ -177,7 +188,7 @@ class MoreLikeThisTest extends TestCase
         $value = 5;
         $this->mlt->setMaximumQueryTerms($value);
 
-        $this->assertEquals(
+        $this->assertSame(
             $value,
             $this->mlt->getMaximumQueryTerms()
         );
@@ -188,7 +199,7 @@ class MoreLikeThisTest extends TestCase
         $value = 5;
         $this->mlt->setMaximumNumberOfTokens($value);
 
-        $this->assertEquals(
+        $this->assertSame(
             $value,
             $this->mlt->getMaximumNumberOfTokens()
         );
@@ -196,12 +207,20 @@ class MoreLikeThisTest extends TestCase
 
     public function testSetAndGetBoost()
     {
-        $value = true;
-        $this->mlt->setBoost($value);
+        $this->mlt->setBoost(true);
 
-        $this->assertEquals(
-            $value,
+        $this->assertTrue(
             $this->mlt->getBoost()
+        );
+    }
+
+    public function testGetQueryFieldsAlwaysReturnsArray()
+    {
+        $this->mlt->setQueryFields(null);
+
+        $this->assertSame(
+            [],
+            $this->mlt->getQueryFields()
         );
     }
 
@@ -210,7 +229,7 @@ class MoreLikeThisTest extends TestCase
         $value = 'content,name';
         $this->mlt->setQueryFields($value);
 
-        $this->assertEquals(
+        $this->assertSame(
             ['content', 'name'],
             $this->mlt->getQueryFields()
         );
@@ -221,7 +240,7 @@ class MoreLikeThisTest extends TestCase
         $value = ['content', 'name'];
         $this->mlt->setQueryFields($value);
 
-        $this->assertEquals(
+        $this->assertSame(
             $value,
             $this->mlt->getQueryFields()
         );
@@ -232,9 +251,42 @@ class MoreLikeThisTest extends TestCase
         $value = 8;
         $this->mlt->setCount($value);
 
-        $this->assertEquals(
+        $this->assertSame(
             $value,
             $this->mlt->getCount()
+        );
+    }
+
+    /**
+     * @deprecated Will be removed in Solarium 8. This parameter is only accessible through the MoreLikeThisHandler.
+     */
+    public function testSetAndGetMatchInclude()
+    {
+        $this->mlt->setMatchInclude(true);
+
+        // always returns null for MLT Component as this parameter is only for MLT Handler
+        $this->assertNull($this->mlt->getMatchInclude());
+    }
+
+    /**
+     * @deprecated Will be removed in Solarium 8. This parameter is only accessible through the MoreLikeThisHandler.
+     */
+    public function testSetAndGetMatchOffset()
+    {
+        $this->mlt->setMatchOffset(20);
+
+        // always returns null for MLT Component as this parameter is only for MLT Handler
+        $this->assertNull($this->mlt->getMatchOffset());
+    }
+
+    public function testSetAndGetInterestingTerms()
+    {
+        $value = 'details';
+        $this->mlt->setInterestingTerms($value);
+
+        $this->assertSame(
+            $value,
+            $this->mlt->getInterestingTerms()
         );
     }
 }

--- a/tests/Component/MoreLikeThisTest.php
+++ b/tests/Component/MoreLikeThisTest.php
@@ -83,7 +83,7 @@ class MoreLikeThisTest extends TestCase
             $this->mlt->getFields()
         );
     }
-    
+
     public function testSetAndGetFields()
     {
         $value = 'name,description';

--- a/tests/Component/RequestBuilder/MoreLikeThisTest.php
+++ b/tests/Component/RequestBuilder/MoreLikeThisTest.php
@@ -18,6 +18,8 @@ class MoreLikeThisTest extends TestCase
         $component->setFields('description,name');
         $component->setMinimumTermFrequency(1);
         $component->setMinimumDocumentFrequency(3);
+        $component->setMaximumDocumentFrequency(6);
+        $component->setMaximumDocumentFrequencyPercentage(75);
         $component->setMinimumWordLength(2);
         $component->setMaximumWordLength(15);
         $component->setMaximumQueryTerms(4);
@@ -25,6 +27,7 @@ class MoreLikeThisTest extends TestCase
         $component->setBoost(true);
         $component->setQueryFields('description');
         $component->setCount(6);
+        $component->setInterestingTerms('test');
 
         $request = $builder->buildComponent($component, $request);
 
@@ -34,6 +37,8 @@ class MoreLikeThisTest extends TestCase
                 'mlt.fl' => 'description,name',
                 'mlt.mintf' => 1,
                 'mlt.mindf' => 3,
+                'mlt.maxdf' => 6,
+                'mlt.maxdfpct' => 75,
                 'mlt.minwl' => 2,
                 'mlt.maxwl' => 15,
                 'mlt.maxqt' => 4,
@@ -41,6 +46,7 @@ class MoreLikeThisTest extends TestCase
                 'mlt.boost' => 'true',
                 'mlt.qf' => ['description'],
                 'mlt.count' => 6,
+                'mlt.interestingTerms' => 'test',
             ],
             $request->getParams()
         );
@@ -54,12 +60,15 @@ class MoreLikeThisTest extends TestCase
         $component = new Component();
         $component->setMinimumTermFrequency(1);
         $component->setMinimumDocumentFrequency(3);
+        $component->setMaximumDocumentFrequency(6);
+        $component->setMaximumDocumentFrequencyPercentage(75);
         $component->setMinimumWordLength(2);
         $component->setMaximumWordLength(15);
         $component->setMaximumQueryTerms(4);
         $component->setMaximumNumberOfTokens(5);
         $component->setBoost(true);
         $component->setCount(6);
+        $component->setInterestingTerms('test');
 
         $request = $builder->buildComponent($component, $request);
 
@@ -68,12 +77,15 @@ class MoreLikeThisTest extends TestCase
                 'mlt' => 'true',
                 'mlt.mintf' => 1,
                 'mlt.mindf' => 3,
+                'mlt.maxdf' => 6,
+                'mlt.maxdfpct' => 75,
                 'mlt.minwl' => 2,
                 'mlt.maxwl' => 15,
                 'mlt.maxqt' => 4,
                 'mlt.maxntp' => 5,
                 'mlt.boost' => 'true',
                 'mlt.count' => 6,
+                'mlt.interestingTerms' => 'test',
             ],
             $request->getParams()
         );

--- a/tests/Component/ResponseParser/MoreLikeThisTest.php
+++ b/tests/Component/ResponseParser/MoreLikeThisTest.php
@@ -36,7 +36,7 @@ class MoreLikeThisTest extends TestCase
 
         $docs = [new Document(['field1' => 'value1'])];
         $expected = [
-            'id1' => new Result(12, 1.75, $docs),
+            'id1' => new Result(12, 1.75, $docs, null),
         ];
 
         $result = $this->parser->parse($this->query, null, $data);
@@ -66,7 +66,69 @@ class MoreLikeThisTest extends TestCase
 
         $docs = [new Document(['field1' => 'value1'])];
         $expected = [
-            'id1' => new Result(12, null, $docs),
+            'id1' => new Result(12, null, $docs, null),
+        ];
+
+        $result = $this->parser->parse($this->query, null, $data);
+
+        $this->assertEquals($expected, $result->getResults());
+    }
+
+    public function testParseInterestingTermsList()
+    {
+        $data = [
+            'interestingTerms' => [
+                'id1' => [
+                    'field2:term1',
+                    'field2:term2',
+                ],
+            ],
+            'moreLikeThis' => [
+                'id1' => [
+                    'numFound' => 12,
+                    'maxScore' => 1.75,
+                    'docs' => [
+                        ['field1' => 'value1'],
+                    ],
+                ],
+            ],
+        ];
+
+        $docs = [new Document(['field1' => 'value1'])];
+        $interestingTerms = ['field2:term1', 'field2:term2'];
+        $expected = [
+            'id1' => new Result(12, 1.75, $docs, $interestingTerms),
+        ];
+
+        $result = $this->parser->parse($this->query, null, $data);
+
+        $this->assertEquals($expected, $result->getResults());
+    }
+
+    public function testParseInterestingTermsDetails()
+    {
+        $data = [
+            'interestingTerms' => [
+                'id1' => [
+                    'field2:term1' => 1.0,
+                    'field2:term2' => 1.84,
+                ],
+            ],
+            'moreLikeThis' => [
+                'id1' => [
+                    'numFound' => 12,
+                    'maxScore' => 1.75,
+                    'docs' => [
+                        ['field1' => 'value1'],
+                    ],
+                ],
+            ],
+        ];
+
+        $docs = [new Document(['field1' => 'value1'])];
+        $interestingTerms = ['field2:term1' => 1.0, 'field2:term2' => 1.84];
+        $expected = [
+            'id1' => new Result(12, 1.75, $docs, $interestingTerms),
         ];
 
         $result = $this->parser->parse($this->query, null, $data);

--- a/tests/Component/Result/MoreLikeThis/MoreLikeThisTest.php
+++ b/tests/Component/Result/MoreLikeThis/MoreLikeThisTest.php
@@ -5,6 +5,7 @@ namespace Solarium\Tests\Component\Result\MoreLikeThis;
 use PHPUnit\Framework\TestCase;
 use Solarium\Component\Result\MoreLikeThis\MoreLikeThis;
 use Solarium\Component\Result\MoreLikeThis\Result;
+use Solarium\Exception\UnexpectedValueException;
 use Solarium\QueryType\Select\Result\Document;
 
 class MoreLikeThisTest extends TestCase
@@ -16,6 +17,8 @@ class MoreLikeThisTest extends TestCase
 
     protected $results;
 
+    protected $interestingTerms;
+
     public function setUp(): void
     {
         $docs = [
@@ -24,11 +27,16 @@ class MoreLikeThisTest extends TestCase
         ];
 
         $this->results = [
-            'key1' => new Result(2, 5.13, $docs, null),
-            'key2' => new Result(2, 2.3, $docs, null),
+            'key1' => new Result(2, 5.13, $docs),
+            'key2' => new Result(2, 2.3, $docs),
         ];
 
-        $this->mlt = new MoreLikeThis($this->results);
+        $this->interestingTerms = [
+            'key1' => ['cat:term1' => 1.0, 'cat:term2' => 1.84],
+            'key2' => ['cat:term1' => 1.0, 'cat:term3' => 1.23],
+        ];
+
+        $this->mlt = new MoreLikeThis($this->results, $this->interestingTerms);
     }
 
     public function testGetResults()
@@ -49,6 +57,44 @@ class MoreLikeThisTest extends TestCase
         $this->assertNull(
             $this->mlt->getResult('invalid')
         );
+    }
+
+    public function testGetInterestingTerms()
+    {
+        $this->assertEquals($this->interestingTerms, $this->mlt->getInterestingTerms());
+    }
+
+    public function testGetInterestingTermsNone()
+    {
+        $mlt = new MoreLikeThis($this->results, null);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('interestingterms is none');
+        $mlt->getInterestingTerms();
+    }
+
+    public function testGetInterestingTerm()
+    {
+        $this->assertEquals(
+            $this->interestingTerms['key1'],
+            $this->mlt->getInterestingTerm('key1')
+        );
+    }
+
+    public function testGetInvalidInterestingTerm()
+    {
+        $this->assertNull(
+            $this->mlt->getInterestingTerm('invalid')
+        );
+    }
+
+    public function testGetInterestingTermNone()
+    {
+        $mlt = new MoreLikeThis($this->results, null);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('interestingterms is none');
+        $mlt->getInterestingTerm('key1');
     }
 
     public function testIterator()

--- a/tests/Component/Result/MoreLikeThis/MoreLikeThisTest.php
+++ b/tests/Component/Result/MoreLikeThis/MoreLikeThisTest.php
@@ -24,8 +24,8 @@ class MoreLikeThisTest extends TestCase
         ];
 
         $this->results = [
-            'key1' => new Result(2, 5.13, $docs),
-            'key2' => new Result(2, 2.3, $docs),
+            'key1' => new Result(2, 5.13, $docs, null),
+            'key2' => new Result(2, 2.3, $docs, null),
         ];
 
         $this->mlt = new MoreLikeThis($this->results);

--- a/tests/Component/Result/MoreLikeThis/ResultTest.php
+++ b/tests/Component/Result/MoreLikeThis/ResultTest.php
@@ -18,6 +18,11 @@ class ResultTest extends TestCase
      */
     private $docs;
 
+    /**
+     * @var array
+     */
+    private $interestingTerms;
+
     public function setUp(): void
     {
         $this->docs = [
@@ -25,7 +30,12 @@ class ResultTest extends TestCase
             new Document(['id' => 2, 'name' => 'test2']),
         ];
 
-        $this->mltResult = new Result(2, 5.13, $this->docs);
+        $this->interestingTerms = [
+            'cat:term1' => 1.0,
+            'cat:term2' => 1.84,
+        ];
+
+        $this->mltResult = new Result(2, 5.13, $this->docs, $this->interestingTerms);
     }
 
     public function testGetNumFound()
@@ -41,6 +51,11 @@ class ResultTest extends TestCase
     public function testGetDocuments()
     {
         $this->assertEquals($this->docs, $this->mltResult->getDocuments());
+    }
+
+    public function testInterestingTerms()
+    {
+        $this->assertEquals($this->interestingTerms, $this->mltResult->getInterestingTerms());
     }
 
     public function testIterator()

--- a/tests/Component/Result/MoreLikeThis/ResultTest.php
+++ b/tests/Component/Result/MoreLikeThis/ResultTest.php
@@ -18,11 +18,6 @@ class ResultTest extends TestCase
      */
     private $docs;
 
-    /**
-     * @var array
-     */
-    private $interestingTerms;
-
     public function setUp(): void
     {
         $this->docs = [
@@ -30,12 +25,7 @@ class ResultTest extends TestCase
             new Document(['id' => 2, 'name' => 'test2']),
         ];
 
-        $this->interestingTerms = [
-            'cat:term1' => 1.0,
-            'cat:term2' => 1.84,
-        ];
-
-        $this->mltResult = new Result(2, 5.13, $this->docs, $this->interestingTerms);
+        $this->mltResult = new Result(2, 5.13, $this->docs);
     }
 
     public function testGetNumFound()
@@ -51,11 +41,6 @@ class ResultTest extends TestCase
     public function testGetDocuments()
     {
         $this->assertEquals($this->docs, $this->mltResult->getDocuments());
-    }
-
-    public function testInterestingTerms()
-    {
-        $this->assertEquals($this->interestingTerms, $this->mltResult->getInterestingTerms());
     }
 
     public function testIterator()

--- a/tests/Exception/DomainExceptionTest.php
+++ b/tests/Exception/DomainExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Solarium\Tests\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Exception\DomainException;
+
+class DomainExceptionTest extends TestCase
+{
+    public function testException()
+    {
+        $this->expectException('Solarium\Exception\DomainException');
+        throw new DomainException();
+    }
+
+    public function testSPLException()
+    {
+        $this->expectException('\DomainException');
+        throw new DomainException();
+    }
+
+    public function testSPLParentException()
+    {
+        $this->expectException('\LogicException');
+        throw new DomainException();
+    }
+
+    public function testLogicMarkerInterface()
+    {
+        $this->expectException('Solarium\Exception\LogicExceptionInterface');
+        throw new DomainException();
+    }
+
+    public function testMarkerInterface()
+    {
+        $this->expectException('Solarium\Exception\ExceptionInterface');
+        throw new DomainException();
+    }
+}

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -15,6 +15,7 @@ use Solarium\Core\Client\ClientInterface;
 use Solarium\Core\Client\Request;
 use Solarium\Exception\HttpException;
 use Solarium\Exception\RuntimeException;
+use Solarium\Exception\UnexpectedValueException;
 use Solarium\Plugin\BufferedAdd\Event\AddDocument as BufferedAddAddDocumentEvent;
 use Solarium\Plugin\BufferedAdd\Event\Events as BufferedAddEvents;
 use Solarium\Plugin\BufferedAdd\Event\PostCommit as BufferedAddPostCommitEvent;
@@ -591,6 +592,163 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertSame(32, $queryGroup->getMatches());
         $this->assertSame(0, $queryGroup->getNumFound());
         $this->assertNull($queryGroup->getMaximumScore());
+    }
+
+    public function testMoreLikeThisComponent()
+    {
+        $select = self::$client->createSelect();
+        $select->setQuery('apache');
+        $select->setSorts(['id' => SelectQuery::SORT_ASC]);
+
+        $moreLikeThis = $select->getMoreLikeThis();
+        $moreLikeThis->setFields('manu,cat');
+        $moreLikeThis->setMinimumDocumentFrequency(1);
+        $moreLikeThis->setMinimumTermFrequency(1);
+        $moreLikeThis->setInterestingTerms('none');
+
+        $result = self::$client->select($select);
+        $this->assertSame(2, $result->getNumFound());
+
+        $iterator = $result->getIterator();
+        $mlt = $result->getMoreLikeThis();
+
+        $document = $iterator->current();
+        $this->assertSame('SOLR1000', $document->id);
+        $mltResult = $mlt->getResult($document->id);
+        $this->assertSame(6.2118435, $mltResult->getMaximumScore());
+        $this->assertSame(1, $mltResult->getNumFound());
+        $mltDoc = $mltResult->getIterator()->current();
+        $this->assertSame('UTF8TEST', $mltDoc->id);
+
+        $iterator->next();
+        $document = $iterator->current();
+        $this->assertSame('UTF8TEST', $document->id);
+        $mltResult = $mlt->getResult($document->id);
+        $this->assertSame(6.2118435, $mltResult->getMaximumScore());
+        $this->assertSame(1, $mltResult->getNumFound());
+        $mltDoc = $mltResult->getIterator()->current();
+        $this->assertSame('SOLR1000', $mltDoc->id);
+
+        // with 'none', interesting terms aren't available in the MLT result
+        $this->assertNull($mltResult->getInterestingTerms());
+
+        $moreLikeThis->setInterestingTerms('list');
+        $result = self::$client->select($select);
+        $document = $result->getIterator()->current();
+        $mltResult = $result->getMoreLikeThis()->getResult($document->id);
+
+        // with 'list', interesting terms are a numeric array of strings
+        $interestingTerms = $mltResult->getInterestingTerms();
+        $this->assertSame(0, key($interestingTerms));
+        $this->assertSame('cat:search', current($interestingTerms));
+
+        $moreLikeThis->setInterestingTerms('details');
+        $result = self::$client->select($select);
+        $document = $result->getIterator()->current();
+        $mltResult = $result->getMoreLikeThis()->getResult($document->id);
+
+        // with 'details', interesting terms are an associative array of terms and their boost values
+        $interestingTerms = $mltResult->getInterestingTerms();
+        $this->assertSame('cat:search', key($interestingTerms));
+        $this->assertSame(1.0, current($interestingTerms));
+    }
+
+    public function testMoreLikeThisQuery()
+    {
+        $query = self::$client->createMoreLikethis();
+
+        // the document we query to get similar documents for
+        $query->setQuery('id:SP2514N');
+        $query->setMltFields('manu,cat');
+        $query->setMinimumDocumentFrequency(1);
+        $query->setMinimumTermFrequency(1);
+        $query->setInterestingTerms('details');
+        $query->setBoost(true);
+        $query->setMatchInclude(true);
+        $query->createFilterQuery('stock')->setQuery('inStock:true');
+
+        $resultset = self::$client->moreLikeThis($query);
+        $this->assertSame(7, $resultset->getNumFound());
+
+        $iterator = $resultset->getIterator();
+        $document = $iterator->current();
+        $this->assertSame('6H500F0', $document->id);
+
+        $matchDocument = $resultset->getMatch();
+        $this->assertSame('SP2514N', $matchDocument->id);
+
+        // with 'details', interesting terms are an associative array of terms and their boost values
+        $interestingTerms = $resultset->getInterestingTerms();
+        $this->assertSame('cat:electronics', key($interestingTerms));
+        $this->assertSame(1.0, current($interestingTerms));
+
+        $query->setInterestingTerms('list');
+        $resultset = self::$client->moreLikeThis($query);
+
+        // with 'list', interesting terms are a numeric array of strings
+        $interestingTerms = $resultset->getInterestingTerms();
+        $this->assertSame(0, key($interestingTerms));
+        $this->assertSame('electronics', current($interestingTerms));
+
+        $query->setInterestingTerms('none');
+        $resultset = self::$client->moreLikeThis($query);
+
+        // with 'none', interesting terms aren't available for the result set
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('interestingterms is none');
+        $resultset->getInterestingTerms();
+    }
+
+    public function testMoreLikeThisStream()
+    {
+        $query = self::$client->createMoreLikethis();
+
+        // the supplied text we want similar documents for
+        $text = <<<EOT
+            Samsung SpinPoint P120 SP2514N - hard drive - 250 GB - ATA-133
+            7200RPM, 8MB cache, IDE Ultra ATA-133, NoiseGuard, SilentSeek technology, Fluid Dynamic Bearing (FDB) motor
+            EOT;
+
+        $query->setQuery($text);
+        $query->setQueryStream(true);
+        $query->setMltFields('name,features');
+        $query->setMinimumDocumentFrequency(1);
+        $query->setMinimumTermFrequency(1);
+        $query->setInterestingTerms('details');
+        $query->setBoost(true);
+        $query->setMatchInclude(true);
+        $query->createFilterQuery('stock')->setQuery('inStock:true');
+
+        $resultset = self::$client->moreLikeThis($query);
+        $this->assertSame(3, $resultset->getNumFound());
+
+        $iterator = $resultset->getIterator();
+        $document = $iterator->current();
+        $this->assertSame('SP2514N', $document->id);
+
+        // there is no match document to return, even with matchinclude true
+        $this->assertNull($resultset->getMatch());
+
+        // with 'details', interesting terms are an associative array of terms and their boost values
+        $interestingTerms = $resultset->getInterestingTerms();
+        $this->assertSame('features:cache', key($interestingTerms));
+        $this->assertSame(1.0, current($interestingTerms));
+
+        $query->setInterestingTerms('list');
+        $resultset = self::$client->moreLikeThis($query);
+
+        // with 'list', interesting terms are a numeric array of strings
+        $interestingTerms = $resultset->getInterestingTerms();
+        $this->assertSame(0, key($interestingTerms));
+        $this->assertSame('cache', current($interestingTerms));
+
+        $query->setInterestingTerms('none');
+        $resultset = self::$client->moreLikeThis($query);
+
+        // with 'none', interesting terms aren't available for the result set
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('interestingterms is none');
+        $resultset->getInterestingTerms();
     }
 
     public function testQueryElevation()
@@ -2053,7 +2211,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertSame('HTML Test Title', $document['title'][0], 'Written document does not contain extracted title');
         $this->assertMatchesRegularExpression('/^HTML Test Title\s+HTML Test Body$/', trim($document['content'][0]), 'Written document does not contain extracted result');
 
-        // now cleanup the document the have the initial index state
+        // now cleanup the document to have the initial index state
         $update = self::$client->createUpdate();
         $update->addDeleteQuery('cat:extract-test');
         $update->addCommit(true, true);

--- a/tests/Integration/Fixtures/solrconf.patch
+++ b/tests/Integration/Fixtures/solrconf.patch
@@ -1,5 +1,5 @@
 diff --git a/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml b/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
-index 06ac9b3d2e6..059d5ba898c 100644
+index 06ac9b3d2e6..087287d2339 100644
 --- a/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
 +++ b/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
 @@ -86,6 +86,8 @@
@@ -11,14 +11,13 @@ index 06ac9b3d2e6..059d5ba898c 100644
    <!-- an exact 'path' can be used instead of a 'dir' to specify a
         specific jar file.  This will cause a serious error to be logged
         if it can't be loaded.
-@@ -1008,6 +1010,11 @@
+@@ -1008,6 +1010,10 @@
  
       -->
  
 +  <!-- A request handler for MLT queries.
 +    -->
-+  <requestHandler name="/mlt" class="solr.MoreLikeThisHandler">
-+  </requestHandler>
++  <requestHandler name="/mlt" class="solr.MoreLikeThisHandler" />
 +
     <!-- Spell Check
  

--- a/tests/Integration/Fixtures/solrconf.patch
+++ b/tests/Integration/Fixtures/solrconf.patch
@@ -1,5 +1,5 @@
 diff --git a/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml b/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
-index 59f5eb7b448..c9ffe37a4bb 100644
+index 06ac9b3d2e6..059d5ba898c 100644
 --- a/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
 +++ b/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
 @@ -86,6 +86,8 @@
@@ -11,3 +11,15 @@ index 59f5eb7b448..c9ffe37a4bb 100644
    <!-- an exact 'path' can be used instead of a 'dir' to specify a
         specific jar file.  This will cause a serious error to be logged
         if it can't be loaded.
+@@ -1008,6 +1010,11 @@
+ 
+      -->
+ 
++  <!-- A request handler for MLT queries.
++    -->
++  <requestHandler name="/mlt" class="solr.MoreLikeThisHandler">
++  </requestHandler>
++
+    <!-- Spell Check
+ 
+         The spell check component can return a list of alternative spelling

--- a/tests/QueryType/MoreLikeThis/QueryTest.php
+++ b/tests/QueryType/MoreLikeThis/QueryTest.php
@@ -635,6 +635,7 @@ class QueryTest extends TestCase
             $this->query->getMltFields()
         );
     }
+
     public function testSetAndGetMltFields()
     {
         $value = 'name,description';

--- a/tests/QueryType/MoreLikeThis/QueryTest.php
+++ b/tests/QueryType/MoreLikeThis/QueryTest.php
@@ -5,6 +5,7 @@ namespace Solarium\Tests\QueryType\MoreLikeThis;
 use PHPUnit\Framework\TestCase;
 use Solarium\Component\MoreLikeThis;
 use Solarium\Core\Client\Client;
+use Solarium\Exception\DomainException;
 use Solarium\Exception\InvalidArgumentException;
 use Solarium\Exception\OutOfBoundsException;
 use Solarium\QueryType\MoreLikeThis\Query;
@@ -627,23 +628,13 @@ class QueryTest extends TestCase
         );
     }
 
-    public function testSetAndGetMatchInclude()
+    public function testGetMltFieldsAlwaysReturnsArray()
     {
-        $this->query->setMatchInclude(true);
-        $this->assertTrue($this->query->getMatchInclude());
-    }
-
-    public function testSetAndGetMatchOffset()
-    {
-        $value = 20;
-        $this->query->setMatchOffset($value);
-
         $this->assertSame(
-            $value,
-            $this->query->getMatchOffset()
+            [],
+            $this->query->getMltFields()
         );
     }
-
     public function testSetAndGetMltFields()
     {
         $value = 'name,description';
@@ -666,17 +657,6 @@ class QueryTest extends TestCase
         );
     }
 
-    public function testSetAndGetInterestingTerms()
-    {
-        $value = 'test';
-        $this->query->setInterestingTerms($value);
-
-        $this->assertSame(
-            $value,
-            $this->query->getInterestingTerms()
-        );
-    }
-
     public function testSetAndGetQueryStream()
     {
         $this->query->setQueryStream(true);
@@ -694,7 +674,7 @@ class QueryTest extends TestCase
         );
     }
 
-    public function testMinimumDocumentFrequency()
+    public function testSetAndGetMinimumDocumentFrequency()
     {
         $value = 4;
         $this->query->setMinimumDocumentFrequency($value);
@@ -703,6 +683,39 @@ class QueryTest extends TestCase
             $value,
             $this->query->getMinimumDocumentFrequency()
         );
+    }
+
+    public function testSetAndGetMaximumDocumentFrequency()
+    {
+        $value = 4;
+        $this->query->setMaximumDocumentFrequency($value);
+
+        $this->assertSame(
+            $value,
+            $this->query->getMaximumDocumentFrequency()
+        );
+    }
+
+    public function testSetAndGetMaximumDocumentFrequencyPercentage()
+    {
+        $value = 75;
+        $this->query->setMaximumDocumentFrequencyPercentage($value);
+
+        $this->assertSame(
+            $value,
+            $this->query->getMaximumDocumentFrequencyPercentage()
+        );
+    }
+
+    /**
+     * @testWith [-5]
+     *           [120]
+     */
+    public function testSetAndGetMaximumDocumentFrequencyPercentageDomainException(int $value)
+    {
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage(sprintf('Maximum percentage %d is not between 0 and 100.', $value));
+        $this->query->setMaximumDocumentFrequencyPercentage($value);
     }
 
     public function testSetAndGetMinimumWordLength()
@@ -755,6 +768,16 @@ class QueryTest extends TestCase
         $this->assertTrue($this->query->getBoost());
     }
 
+    public function testGetQueryFieldsAlwaysReturnsArray()
+    {
+        $this->query->setQueryFields(null);
+
+        $this->assertSame(
+            [],
+            $this->query->getQueryFields()
+        );
+    }
+
     public function testSetAndGetQueryFields()
     {
         $value = 'content,name';
@@ -774,6 +797,34 @@ class QueryTest extends TestCase
         $this->assertSame(
             $value,
             $this->query->getQueryFields()
+        );
+    }
+
+    public function testSetAndGetMatchInclude()
+    {
+        $this->query->setMatchInclude(true);
+        $this->assertTrue($this->query->getMatchInclude());
+    }
+
+    public function testSetAndGetMatchOffset()
+    {
+        $value = 20;
+        $this->query->setMatchOffset($value);
+
+        $this->assertSame(
+            $value,
+            $this->query->getMatchOffset()
+        );
+    }
+
+    public function testSetAndGetInterestingTerms()
+    {
+        $value = 'test';
+        $this->query->setInterestingTerms($value);
+
+        $this->assertSame(
+            $value,
+            $this->query->getInterestingTerms()
         );
     }
 }

--- a/tests/QueryType/MoreLikeThis/RequestBuilderTest.php
+++ b/tests/QueryType/MoreLikeThis/RequestBuilderTest.php
@@ -27,36 +27,40 @@ class RequestBuilderTest extends TestCase
 
     public function testBuildParams()
     {
-        $this->query->setInterestingTerms('test');
-        $this->query->setMatchInclude(true);
         $this->query->setStart(12);
-        $this->query->setMatchOffset(15);
         $this->query->setMltFields('description,name');
         $this->query->setMinimumTermFrequency(1);
         $this->query->setMinimumDocumentFrequency(3);
+        $this->query->setMaximumDocumentFrequency(6);
+        $this->query->setMaximumDocumentFrequencyPercentage(75);
         $this->query->setMinimumWordLength(2);
         $this->query->setMaximumWordLength(15);
         $this->query->setMaximumQueryTerms(4);
         $this->query->setMaximumNumberOfTokens(5);
         $this->query->setBoost(true);
         $this->query->setQueryFields('description');
+        $this->query->setMatchInclude(true);
+        $this->query->setMatchOffset(15);
+        $this->query->setInterestingTerms('test');
 
         $request = $this->builder->build($this->query);
 
         $this->assertEquals(
             [
-                'mlt.interestingTerms' => 'test',
-                'mlt.match.include' => 'true',
-                'mlt.match.offset' => 15,
                 'mlt.fl' => 'description,name',
                 'mlt.mintf' => 1,
                 'mlt.mindf' => 3,
+                'mlt.maxdf' => 6,
+                'mlt.maxdfpct' => 75,
                 'mlt.minwl' => 2,
                 'mlt.maxwl' => 15,
                 'mlt.maxqt' => 4,
                 'mlt.maxntp' => 5,
                 'mlt.boost' => 'true',
                 'mlt.qf' => ['description'],
+                'mlt.match.include' => 'true',
+                'mlt.match.offset' => 15,
+                'mlt.interestingTerms' => 'test',
                 'q' => '*:*',
                 'fl' => '*,score',
                 'rows' => 10,

--- a/tests/QueryType/MoreLikeThis/ResultTest.php
+++ b/tests/QueryType/MoreLikeThis/ResultTest.php
@@ -28,6 +28,7 @@ class ResultTest extends TestCase
 
         $result = new Result($query, $response);
         $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('interestingterms is none');
         $result->getInterestingTerms();
     }
 


### PR DESCRIPTION
The initial intention was to just add support for the `mlt.maxdf` and `mlt.maxdfpct` parameters. As most parameters are common between the MoreLikeThis Component and QueryType, there was a lot of duplicate code between the two. I decided to move shared code to a trait and only put the few specific parameters in the proper classes.

To facilitate cross-referencing between the code and the [Solr ref guide](https://solr.apache.org/guide/8_8/morelikethis.html), I rearranged the order of the parameters in the source code (setters, request builder …) to match the order in the ref guide.

Support for `mlt.match.include` and `mlt.match.offset` was duplicated in the Component, even though those parameters only work with MLT queries. I've opted to deprecate their setters/getters for now instead of removing them outright because `setMatchInclude()` was used incorrectly in the examples (see below).

~Although the ref guide doesn't list `mlt.interestingTerms` as a common parameter, it is listed for the MLT Component since Solr 8.2 as _Same as defined below for the MLT Handler._~ The ref guide lists `mlt.interestingTerms` (added to the MLT Component in Solr 8.2) as a common parameter since the Solr 8.8.2 release. I've put it in the trait and added support for it in the Component response parser and result + a short explanation in the docs.

The examples for the MLT QueryType were both incorrect, probably due to the fact that techproducts doesn't come with an `/mlt` handler to run them against.

*2.3.1-mlt-query* executed a Select query with an MLT Component instead of an MLT query. It used `setMatchInclude()` on the Component, even though the `mlt.match.include` parameter is only meaningful for MLT queries. I've rewritten it to execute a real MLT query and updated the docs with the working code.

*2.3.2-mlt-stream* tried to display the match document which doesn't exist in that use case. The use case wasn't really clear from the example code either. It looked a lot like a regular query against a default field. I've adapted it to better show that it matches against supplied text instead of a queried document and added a section to the docs about this. (The Solr ref guide uses the same example we had, but it's less confusing with their surrounding prose.)

I've added an `/mlt` handler in `solrconf.patch` and wrote integration tests based on the example scripts for the Component and the QueryType. With this patched config, the examples can also run in the workflow. To allow standalone execution of `examples/execute_all.php`, I also included a check for the handler and an API query to add it if it doesn't exist. The same API query is included in the docs for people who want to run those examples.