### PR TITLE
Full test coverage for Component\Result\Debug

### DIFF
--- a/src/Component/Result/Debug/Detail.php
+++ b/src/Component/Result/Debug/Detail.php
@@ -36,7 +36,7 @@ class Detail implements \ArrayAccess
     protected $description;
 
     /**
-     * @var array
+     * @var \Solarium\Component\Result\Debug\Detail[]
      */
     protected $subDetails;
 
@@ -109,7 +109,7 @@ class Detail implements \ArrayAccess
 
     public function offsetExists($offset)
     {
-        return in_array($offset, ['match', 'value', 'description']);
+        return \in_array($offset, ['match', 'value', 'description']);
     }
 
     public function offsetGet($offset)
@@ -132,7 +132,7 @@ class Detail implements \ArrayAccess
         $string = '';
         if ($this->match) {
             $string .= sprintf('%f', $this->value).' <= '.$this->description.PHP_EOL;
-            foreach ($this->getSubDetails() as $subDetail) {
+            foreach ($this->getSubDetails() ?? [] as $subDetail) {
                 if ($subDetail->getMatch()) {
                     $string .= '... '.$subDetail;
                 }

--- a/tests/Component/Result/Debug/DetailTest.php
+++ b/tests/Component/Result/Debug/DetailTest.php
@@ -84,4 +84,66 @@ class DetailTest extends TestCase
             $subDetail->getDescription(),
         ]);
     }
+
+    /**
+     * @testWith ["match"]
+     *           ["value"]
+     *           ["description"]
+     */
+    public function testOffsetExists(string $offset)
+    {
+        $this->assertTrue($this->result->offsetExists($offset));
+    }
+
+    public function testOffsetExistsUnknown()
+    {
+        $this->assertFalse($this->result->offsetExists('unknown'));
+    }
+
+    /**
+     * @testWith ["match"]
+     *           ["value"]
+     *           ["description"]
+     */
+    public function testOffsetGet(string $offset)
+    {
+        $this->assertSame($this->{$offset}, $this->result->offsetGet($offset));
+    }
+
+    public function testOffsetGetUnknown()
+    {
+        $this->expectError();
+        $this->result->offsetGet('unknown');
+    }
+
+    public function testOffsetSetImmutable()
+    {
+        $this->result->offsetSet('value', 3.0);
+        $this->assertSame($this->value, $this->result->getValue());
+    }
+
+    public function testOffsetUnsetImmutable()
+    {
+        $this->result->offsetUnset('value');
+        $this->assertSame($this->value, $this->result->getValue());
+    }
+
+    public function testToString()
+    {
+        $expected = '1.500000 <= dummy-desc'.PHP_EOL;
+        $this->assertSame($expected, (string) $this->result);
+    }
+
+    public function testToStringWithSubDetails()
+    {
+        $subDetails = [
+            new Detail(true, 3.14, 'dummy-1'),
+            new Detail(false, 2.72, 'dummy-2'),
+            new Detail(true, 1.41, 'dummy-3'),
+        ];
+        $expected = '1.500000 <= dummy-desc'.PHP_EOL.'... 3.140000 <= dummy-1'.PHP_EOL.'... 1.410000 <= dummy-3'.PHP_EOL;
+
+        $this->result->setSubDetails($subDetails);
+        $this->assertSame($expected, (string) $this->result);
+    }
 }

--- a/tests/Component/Result/Debug/DocumentTest.php
+++ b/tests/Component/Result/Debug/DocumentTest.php
@@ -63,4 +63,11 @@ class DocumentTest extends TestCase
     {
         $this->assertCount(count($this->details), $this->result);
     }
+
+    public function testToString()
+    {
+        $expected = '  dummy1'.PHP_EOL.'  dummy2'.PHP_EOL;
+
+        $this->assertSame($expected, (string) $this->result);
+    }
 }


### PR DESCRIPTION
@mkalkbrenner 
I've completed the test coverage for Debug. There was a small bug in `Detail::__toString()` when no sub-details were set that I had overlooked without the test.