### PR TITLE
Bugfix for facet queries with local parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Syntax error in request with facet queries that contain local parameters
 
 ### Changed
 

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -187,9 +187,18 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
      */
     public function addFacetQuery($request, $facet): void
     {
+        $localParams = $facet->getLocalParameters()->render();
+        $query = $facet->getQuery();
+
+        // add local params to those already present in the query, e.g. a qparser
+        if (null !== $localParams && null !== $query && 0 === strpos($query, '{!')) {
+            $localParams = strstr($query, '}', true).' '.substr($localParams, 2);
+            $query = substr($query, strpos($query, '}') + 1);
+        }
+
         $request->addParam(
             'facet.query',
-            sprintf('%s%s', $facet->getLocalParameters()->render(), $facet->getQuery())
+            sprintf('%s%s', $localParams, $query)
         );
     }
 

--- a/tests/Component/RequestBuilder/FacetSetTest.php
+++ b/tests/Component/RequestBuilder/FacetSetTest.php
@@ -487,6 +487,26 @@ class FacetSetTest extends TestCase
             urldecode($request->getUri())
         );
     }
+
+    public function testBuildWithQueryFacetWithQparser()
+    {
+        $facet = new FacetQuery(
+            [
+                'local_key' => 'f1',
+                'query' => '{!frange l=100 u=200}price',
+            ]
+        );
+
+        $this->component->addFacet($facet);
+
+        $request = $this->builder->buildComponent($this->component, $this->request);
+
+        $this->assertNull($request->getRawData());
+        $this->assertEquals(
+            '?facet.query={!frange l=100 u=200 key=f1}price&facet=true',
+            urldecode($request->getUri())
+        );
+    }
 }
 
 class UnknownFacet extends FacetField


### PR DESCRIPTION
Closes #229. Closes #936.

I've found a solution for this problem that doesn't break existing code, doesn't sacrifice tagging/excluding as a trade-off and doesn't require any extra effort from the users.