### PR TITLE
Fix typo: loose → lose

### DIFF
--- a/docs/queries/update-query/update-query.md
+++ b/docs/queries/update-query/update-query.md
@@ -2,6 +2,6 @@ Update queries allow you to add, delete, commit, optimize and rollback commands.
 
 -   Solr has no 'update' command. But if you add a document with a value for the 'unique key' field that already exists in the index that existing document will be overwritten by your new document.
 -   You can only add complete documents. If you want to update only a single field you still need to 'add' the whole document.
--   Always use a database or other persistent storage as the source for building documents to add. Don't be tempted to emulate an update command by selecting a document, altering it and adding it. Almost all schemas will have fields that are indexed and not stored. You will loose the data in those fields.
+-   Always use a database or other persistent storage as the source for building documents to add. Don't be tempted to emulate an update command by selecting a document, altering it and adding it. Almost all schemas will have fields that are indexed and not stored. You will lose the data in those fields.
 -   The best way to use update queries is also related to your Solr config. If you are for instance using the autocommit feature of Solr you probably don't want to use a commit command in your update queries. Make sure you know the configuration details of the Solr core you use.
 

--- a/src/Core/Query/AbstractRequestBuilder.php
+++ b/src/Core/Query/AbstractRequestBuilder.php
@@ -45,7 +45,7 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
 
         $request->addParam('wt', $query->getResponseWriter());
         if ($query::WT_JSON === $query->getResponseWriter()) {
-            // Only flat JSON format is supported. Other JSON formats are easier to handle but might loose information.
+            // Only flat JSON format is supported. Other JSON formats are easier to handle but might lose information.
             $request->addParam('json.nl', 'flat');
         }
 

--- a/src/QueryType/Update/Query/Document.php
+++ b/src/QueryType/Update/Query/Document.php
@@ -23,7 +23,7 @@ use Solarium\Exception\RuntimeException;
  * While it is possible to use this document type for a select, alter it and use
  * it in an update query (effectively the 'edit' that Solr doesn't have) this
  * is not recommended. Most Solr indexes have fields that are indexed and not
- * stored. You will loose that data because it is impossible to retrieve it from
+ * stored. You will lose that data because it is impossible to retrieve it from
  * Solr. Always update from the original data source.
  *
  * Atomic updates are also support, using the field modifiers.


### PR DESCRIPTION
A few loose ends that got lost. 😉