### PR TITLE
Return body on HTTP error with Adapter\Http

### DIFF
--- a/src/Core/Client/Adapter/Http.php
+++ b/src/Core/Client/Adapter/Http.php
@@ -77,6 +77,7 @@ class Http implements AdapterInterface, TimeoutAwareInterface
                     'timeout' => $this->timeout,
                     'protocol_version' => 1.0,
                     'user_agent' => 'Solarium Http Adapter',
+                    'ignore_errors' => true,
                 ],
             ]
         );

--- a/tests/Core/Client/Adapter/HttpTest.php
+++ b/tests/Core/Client/Adapter/HttpTest.php
@@ -103,6 +103,7 @@ class HttpTest extends TestCase
                     'timeout' => $timeout,
                     'protocol_version' => 1.0,
                     'user_agent' => 'Solarium Http Adapter',
+                    'ignore_errors' => true,
                 ],
             ],
             stream_context_get_options($context)
@@ -133,6 +134,7 @@ class HttpTest extends TestCase
                     'timeout' => $timeout,
                     'protocol_version' => 1.0,
                     'user_agent' => 'Solarium Http Adapter',
+                    'ignore_errors' => true,
                     'header' => $header1."\r\n".$header2,
                 ],
             ],
@@ -162,6 +164,7 @@ class HttpTest extends TestCase
                     'timeout' => $timeout,
                     'protocol_version' => 1.0,
                     'user_agent' => 'Solarium Http Adapter',
+                    'ignore_errors' => true,
                     'content' => $data,
                     'header' => 'Content-Type: text/xml; charset=utf-8',
                 ],
@@ -196,6 +199,7 @@ class HttpTest extends TestCase
                     'timeout' => $timeout,
                     'protocol_version' => 1.0,
                     'user_agent' => 'Solarium Http Adapter',
+                    'ignore_errors' => true,
                 ],
             ],
             $stream_context_get_options
@@ -224,6 +228,7 @@ class HttpTest extends TestCase
                     'timeout' => $timeout,
                     'protocol_version' => 1.0,
                     'user_agent' => 'Solarium Http Adapter',
+                    'ignore_errors' => true,
                     'header' => 'Authorization: Basic c29tZW9uZTpTME0zcDQ1NQ==',
                 ],
             ],
@@ -251,6 +256,7 @@ class HttpTest extends TestCase
                     'timeout' => $timeout,
                     'protocol_version' => 1.0,
                     'user_agent' => 'Solarium Http Adapter',
+                    'ignore_errors' => true,
                 ],
             ],
             stream_context_get_options($context)

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -25,7 +25,6 @@ use Solarium\Plugin\PrefetchIterator;
 use Solarium\QueryType\ManagedResources\Query\Stopwords as StopwordsQuery;
 use Solarium\QueryType\ManagedResources\Query\Synonyms as SynonymsQuery;
 use Solarium\QueryType\ManagedResources\Query\Synonyms\Synonyms;
-use Solarium\QueryType\ManagedResources\RequestBuilder\Resource as ResourceRequestBuilder;
 use Solarium\QueryType\ManagedResources\Result\Resources\Resource as ResourceResultItem;
 use Solarium\QueryType\ManagedResources\Result\Synonyms\Synonyms as SynonymsResultItem;
 use Solarium\QueryType\Select\Query\Query as SelectQuery;
@@ -2825,13 +2824,10 @@ abstract class AbstractTechproductsTest extends TestCase
         $query->setName('english');
         $query->setTerm('foo');
 
-        $requestBuilder = new ResourceRequestBuilder();
-        $request = $requestBuilder->build($query);
-        $response = self::$client->executeRequest($request);
-        $result = self::$client->createResult($query, $response);
+        $result = self::$client->execute($query);
 
         $this->assertFalse($result->getWasSuccessful());
-        $this->assertNotSame('', $response->getBody());
+        $this->assertNotSame('', $result->getResponse()->getBody());
     }
 }
 

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -25,6 +25,7 @@ use Solarium\Plugin\PrefetchIterator;
 use Solarium\QueryType\ManagedResources\Query\Stopwords as StopwordsQuery;
 use Solarium\QueryType\ManagedResources\Query\Synonyms as SynonymsQuery;
 use Solarium\QueryType\ManagedResources\Query\Synonyms\Synonyms;
+use Solarium\QueryType\ManagedResources\RequestBuilder\Resource as ResourceRequestBuilder;
 use Solarium\QueryType\ManagedResources\Result\Resources\Resource as ResourceResultItem;
 use Solarium\QueryType\ManagedResources\Result\Synonyms\Synonyms as SynonymsResultItem;
 use Solarium\QueryType\Select\Query\Query as SelectQuery;
@@ -2815,6 +2816,22 @@ abstract class AbstractTechproductsTest extends TestCase
 
         // both resources must be present in the results
         $this->assertSame(2, $n);
+    }
+
+    public function testGetBodyOnHttpError()
+    {
+        /** @var \Solarium\Core\Query\Status4xxNoExceptionInterface $query */
+        $query = self::$client->createManagedSynonyms();
+        $query->setName('english');
+        $query->setTerm('foo');
+
+        $requestBuilder = new ResourceRequestBuilder();
+        $request = $requestBuilder->build($query);
+        $response = self::$client->executeRequest($request);
+        $result = self::$client->createResult($query, $response);
+
+        $this->assertFalse($result->getWasSuccessful());
+        $this->assertNotSame('', $response->getBody());
     }
 }
 


### PR DESCRIPTION
Solr returns useful error messages in the response body for REST API requests that result in a 4xx status code.

```json
{
  "responseHeader":{
    "status":404,
    "QTime":288},
  "error":{
    "metadata":[
      "error-class","org.apache.solr.common.SolrException",
      "root-error-class","org.apache.solr.common.SolrException"],
    "msg":"foo not found in /schema/analysis/synonyms/english",
    "code":404}}
```

Unlike cURL and PSR18, the HTTP adapter didn't return this body.