### PR TITLE
Stats overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Component\Result\Stats\FacetValue::getDistinctValues()
 - Component\Result\Stats\FacetValue::getCountDistinct()
 - Component\Result\Stats\FacetValue::getCardinality()
+- Component\Result\Stats\FacetValue::getStatValue()
 
 ### Fixed
 - Component\Result\Stats\Result::getPercentiles() returns percentiles as an associative array
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Component\Result\Stats\Result::getMean() returns `NAN` instead of `'NaN'` if mean is NaN
 - Component\Result\Stats\FacetValue::getMean() returns `NAN` instead of `'NaN'` if mean is NaN
+- Component\Result\Stats\Result::getValue() is renamed to getStatValue()
 
 ### Removed
 
@@ -41,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parsing nested details in debug response
 
 ### Changed
-- Solarium\Component/Result/Stats/Result::getValue() is now public
+- Solarium\Component\Result\Stats\Result::getValue() is now public
 
 
 ## [6.1.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 - Component\Result\Stats\FacetValue::getFacets()
+- Component\Result\Stats\Result::getValue()
 
 
 ## [6.1.4]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 ### Added
+- Component\Result\Stats\Result::getDistinctValues()
+- Component\Result\Stats\Result::getCountDistinct()
+- Component\Result\Stats\Result::getCardinality()
+- Component\Result\Stats\FacetValue::getPercentiles()
+- Component\Result\Stats\FacetValue::getDistinctValues()
+- Component\Result\Stats\FacetValue::getCountDistinct()
+- Component\Result\Stats\FacetValue::getCardinality()
 
 ### Fixed
+- Component\Result\Stats\Result::getPercentiles() returns percentiles as an associative array
 
 ### Changed
+- Component\Result\Stats\Result::getMean() returns `NAN` instead of `'NaN'` if mean is NaN
+- Component\Result\Stats\FacetValue::getMean() returns `NAN` instead of `'NaN'` if mean is NaN
 
 ### Removed
 
 ### Deprecated
+- Component\Result\Stats\FacetValue::getFacets()
 
 
 ## [6.1.4]

--- a/docs/queries/select-query/building-a-select-query/components/stats-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/stats-component.md
@@ -69,3 +69,41 @@ foreach ($statsResult as $field) {
 htmlFooter();
 
 ```
+
+Local parameters can be used to request a subset of the supported statistics.
+
+```php
+$stats->createField('{!min=true max=true mean=true}popularity');
+```
+
+Some statistics are not computed by default in Solr. You can request them
+via local parameters.
+
+```php
+/* Percentiles */
+$stats->createField('{!percentiles="99,99.9,99.99"}popularity');
+// ...
+$field->getPercentiles();
+
+/* The set of all distinct values */
+$stats->createField('{!distinctValues=true}popularity');
+// ...
+$field->getDistinctValues();
+
+/* The exact number of distinct values */
+$stats->createField('{!countDistinct=true}popularity');
+// ...
+$field->getCountDistinct();
+
+/* A statistical approximation of the number of distinct values */
+$stats->createField('{!cardinality=0.3}popularity');
+// ...
+$field->getCardinality();
+```
+
+This overrides the default set of statistics. Explicitly add any of the default
+statistics you also want computed.
+
+```php
+$stats->createField('{!min=true max=true percentiles="99,99.9,99.99"}popularity');
+```

--- a/examples/2.1.5.10.1-stats-percentiles.php
+++ b/examples/2.1.5.10.1-stats-percentiles.php
@@ -1,0 +1,37 @@
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// get a select query instance
+$query = $client->createSelect();
+$query->setRows(0);
+
+// percentiles aren't computed by default and have to be specified explicitly via local parameters
+// this overrides the default set, explicitly add any other statistics you still want computed
+$stats = $query->getStats();
+$stats->createField('{!min=true max=true percentiles="1,10,90,99"}popularity');
+$stats->createField('{!min=true max=true percentiles="99,99.9,99.99"}price');
+
+// this executes the query and returns the result
+$resultset = $client->select($query);
+$statsResult = $resultset->getStats();
+
+// display the stats results
+foreach ($statsResult as $field) {
+    echo '<h1>' . $field->getName() . '</h1>';
+    echo 'Min: ' . $field->getMin() . '<br/>';
+    echo 'Max: ' . $field->getMax() . '<br/>';
+    echo 'Percentiles: <br/>';
+    echo '<table>';
+    foreach ($field->getPercentiles() as $percentile => $value) {
+        echo '<tr><th>' . $percentile . '</th><td>' . $value . '</td></tr>';
+    }
+    echo '</table>';
+    echo '<hr/>';
+}
+
+htmlFooter();

--- a/examples/2.1.5.10.2-stats-distinct-values.php
+++ b/examples/2.1.5.10.2-stats-distinct-values.php
@@ -1,0 +1,38 @@
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// get a select query instance
+$query = $client->createSelect();
+$query->setRows(0);
+
+// distinct values aren't computed by default and have to be specified explicitly via local parameters
+// this overrides the default set, explicitly add any other statistics you still want computed
+$stats = $query->getStats();
+$stats->createField('{!min=true max=true distinctValues=true countDistinct=true}popularity');
+$stats->createField('{!min=true max=true distinctValues=true countDistinct=true}price');
+
+// this executes the query and returns the result
+$resultset = $client->select($query);
+$statsResult = $resultset->getStats();
+
+// display the stats results
+foreach ($statsResult as $field) {
+    echo '<h1>' . $field->getName() . '</h1>';
+    echo 'Min: ' . $field->getMin() . '<br/>';
+    echo 'Max: ' . $field->getMax() . '<br/>';
+    echo 'Number of distinct values: ' . $field->getCountDistinct() . '<br/>';
+    echo 'Distinct values: <br/>';
+    echo '<ul>';
+    foreach ($field->getDistinctValues() as $value) {
+        echo '<li>' . $value . '</li>';
+    }
+    echo '</ul>';
+    echo '<hr/>';
+}
+
+htmlFooter();

--- a/examples/2.1.5.10.3-stats-cardinality.php
+++ b/examples/2.1.5.10.3-stats-cardinality.php
@@ -1,0 +1,33 @@
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// get a select query instance
+$query = $client->createSelect();
+$query->setRows(0);
+
+// cardinality isn't computed by default and has to be specified explicitly via local parameters
+// this overrides the default set, explicitly add any other statistics you still want computed
+$stats = $query->getStats();
+$stats->createField('{!min=true max=true countDistinct=true cardinality=0.1}popularity');
+$stats->createField('{!min=true max=true countDistinct=true cardinality=0.1}price');
+
+// this executes the query and returns the result
+$resultset = $client->select($query);
+$statsResult = $resultset->getStats();
+
+// display the stats results
+foreach ($statsResult as $field) {
+    echo '<h1>' . $field->getName() . '</h1>';
+    echo 'Min: ' . $field->getMin() . '<br/>';
+    echo 'Max: ' . $field->getMax() . '<br/>';
+    echo 'Exact number of distinct values: ' . $field->getCountDistinct() . '<br/>';
+    echo 'Approximate number of distinct values: ' . $field->getCardinality() . '<br/>';
+    echo '<hr/>';
+}
+
+htmlFooter();

--- a/examples/index.html
+++ b/examples/index.html
@@ -80,6 +80,11 @@
                         <li><a href="2.1.5.8-distributed-search.php">2.1.5.8 Distributed search (sharding)</a></li>
                         <li><a href="2.1.5.9-spellcheck.php">2.1.5.9 Spellcheck</a></li>
                         <li><a href="2.1.5.10-stats.php">2.1.5.10 Stats</a></li>
+                        <ul style="list-style:none;">
+                            <li><a href="2.1.5.10.1-stats-percentiles.php">2.1.5.10.1 Percentiles</a></li>
+                            <li><a href="2.1.5.10.2-stats-distinct-values.php">2.1.5.10.2 Distinct values</a></li>
+                            <li><a href="2.1.5.10.3-stats-cardinality.php">2.1.5.10.3 Cardinality</a></li>
+                        </ul>
                         <li><a href="2.1.5.11-debug.php">2.1.5.11 Debug (DebugQuery)</a></li>
                         <li><a href="2.1.5.12-queryelevation.php">2.1.5.12 Query Elevation</a></li>
                     </ul>

--- a/src/Component/Result/Stats/FacetValue.php
+++ b/src/Component/Result/Stats/FacetValue.php
@@ -50,7 +50,7 @@ class FacetValue
      *
      * @return array|null
      *
-     * @deprecated Will be removed in Solarium 7.
+     * @deprecated Will be removed in Solarium 7
      */
     public function getFacets(): ?array
     {

--- a/src/Component/Result/Stats/FacetValue.php
+++ b/src/Component/Result/Stats/FacetValue.php
@@ -14,19 +14,14 @@ namespace Solarium\Component\Result\Stats;
  */
 class FacetValue
 {
+    use ResultTrait;
+
     /**
      * Facet value.
      *
      * @var string
      */
     protected $value;
-
-    /**
-     * Stats data.
-     *
-     * @var array
-     */
-    protected $stats;
 
     /**
      * Constructor.
@@ -51,92 +46,14 @@ class FacetValue
     }
 
     /**
-     * Get min value.
-     *
-     * @return float|null
-     */
-    public function getMin(): ?float
-    {
-        return $this->stats['min'];
-    }
-
-    /**
-     * Get max value.
-     *
-     * @return float|null
-     */
-    public function getMax(): ?float
-    {
-        return $this->stats['max'];
-    }
-
-    /**
-     * Get sum value.
-     *
-     * @return float
-     */
-    public function getSum(): float
-    {
-        return $this->stats['sum'];
-    }
-
-    /**
-     * Get count value.
-     *
-     * @return int
-     */
-    public function getCount(): int
-    {
-        return (int) $this->stats['count'];
-    }
-
-    /**
-     * Get missing value.
-     *
-     * @return string
-     */
-    public function getMissing(): string
-    {
-        return $this->stats['missing'];
-    }
-
-    /**
-     * Get sumOfSquares value.
-     *
-     * @return float
-     */
-    public function getSumOfSquares(): float
-    {
-        return $this->stats['sumOfSquares'];
-    }
-
-    /**
-     * Get mean value.
-     *
-     * @return string|float
-     */
-    public function getMean()
-    {
-        return $this->stats['mean'];
-    }
-
-    /**
-     * Get stddev value.
-     *
-     * @return float
-     */
-    public function getStddev(): float
-    {
-        return $this->stats['stddev'];
-    }
-
-    /**
      * Get facet stats.
      *
-     * @return array
+     * @return array|null
+     *
+     * @deprecated Will be removed in Solarium 7.
      */
-    public function getFacets(): array
+    public function getFacets(): ?array
     {
-        return $this->stats['facets'];
+        return null;
     }
 }

--- a/src/Component/Result/Stats/Result.php
+++ b/src/Component/Result/Stats/Result.php
@@ -14,19 +14,14 @@ namespace Solarium\Component\Result\Stats;
  */
 class Result
 {
+    use ResultTrait;
+
     /**
      * Field name.
      *
      * @var string
      */
     protected $field;
-
-    /**
-     * Stats data.
-     *
-     * @var array
-     */
-    protected $stats;
 
     /**
      * Constructor.
@@ -51,114 +46,12 @@ class Result
     }
 
     /**
-     * Get min value.
-     *
-     * @return string|null
-     */
-    public function getMin(): ?string
-    {
-        return $this->getValue('min');
-    }
-
-    /**
-     * Get max value.
-     *
-     * @return string|null
-     */
-    public function getMax(): ?string
-    {
-        return $this->getValue('max');
-    }
-
-    /**
-     * Get sum value.
-     *
-     * @return string|null
-     */
-    public function getSum(): ?string
-    {
-        return $this->getValue('sum');
-    }
-
-    /**
-     * Get count value.
-     *
-     * @return int|null
-     */
-    public function getCount(): ?int
-    {
-        return (int) $this->getValue('count');
-    }
-
-    /**
-     * Get missing value.
-     *
-     * @return string|null
-     */
-    public function getMissing(): ?string
-    {
-        return $this->getValue('missing');
-    }
-
-    /**
-     * Get sumOfSquares value.
-     *
-     * @return string|null
-     */
-    public function getSumOfSquares(): ?string
-    {
-        return $this->getValue('sumOfSquares');
-    }
-
-    /**
-     * Get mean value.
-     *
-     * @return string|null
-     */
-    public function getMean(): ?string
-    {
-        return $this->getValue('mean');
-    }
-
-    /**
-     * Get stddev value.
-     *
-     * @return string|null
-     */
-    public function getStddev(): ?string
-    {
-        return $this->getValue('stddev');
-    }
-
-    /**
      * Get facet stats.
      *
      * @return array|null
      */
     public function getFacets(): ?array
     {
-        return $this->getValue('facets');
-    }
-
-    /**
-     * Get percentile stats.
-     *
-     * @return array|null
-     */
-    public function getPercentiles(): ?array
-    {
-        return $this->getValue('percentiles');
-    }
-
-    /**
-     * Get value by name.
-     *
-     * @param mixed $name
-     *
-     * @return string|array|null
-     */
-    public function getValue($name)
-    {
-        return $this->stats[$name] ?? null;
+        return $this->getStatValue('facets');
     }
 }

--- a/src/Component/Result/Stats/Result.php
+++ b/src/Component/Result/Stats/Result.php
@@ -54,4 +54,18 @@ class Result
     {
         return $this->getStatValue('facets');
     }
+
+    /**
+     * Get value by stat name.
+     *
+     * @param string $stat
+     *
+     * @return mixed|null
+     *
+     * @deprecated Use getStatValue() instead
+     */
+    public function getValue(string $stat)
+    {
+        return $this->getStatValue($stat);
+    }
 }

--- a/src/Component/Result/Stats/ResultTrait.php
+++ b/src/Component/Result/Stats/ResultTrait.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Component\Result\Stats;
+
+/**
+ * Select component stats result trait.
+ */
+trait ResultTrait
+{
+    /**
+     * Stats data.
+     *
+     * @var array
+     */
+    protected $stats;
+
+    /**
+     * Get min value.
+     *
+     * @return float|null
+     */
+    public function getMin(): ?float
+    {
+        return $this->getStatValue('min');
+    }
+
+    /**
+     * Get max value.
+     *
+     * @return float|null
+     */
+    public function getMax(): ?float
+    {
+        return $this->getStatValue('max');
+    }
+
+    /**
+     * Get sum value.
+     *
+     * @return float|null
+     */
+    public function getSum(): ?float
+    {
+        return $this->getStatValue('sum');
+    }
+
+    /**
+     * Get count value.
+     *
+     * @return int|null
+     */
+    public function getCount(): ?int
+    {
+        return (int) $this->getStatValue('count');
+    }
+
+    /**
+     * Get missing value.
+     *
+     * @return int|null
+     */
+    public function getMissing(): ?int
+    {
+        return $this->getStatValue('missing');
+    }
+
+    /**
+     * Get sumOfSquares value.
+     *
+     * @return float|null
+     */
+    public function getSumOfSquares(): ?float
+    {
+        return $this->getStatValue('sumOfSquares');
+    }
+
+    /**
+     * Get mean value.
+     *
+     * @return float|null
+     */
+    public function getMean(): ?float
+    {
+        return $this->getStatValue('mean');
+    }
+
+    /**
+     * Get stddev value.
+     *
+     * @return float|null
+     */
+    public function getStddev(): ?float
+    {
+        return $this->getStatValue('stddev');
+    }
+
+    /**
+     * Get percentiles.
+     *
+     * @return array|null
+     */
+    public function getPercentiles(): ?array
+    {
+        return $this->getStatValue('percentiles');
+    }
+
+    /**
+     * Get the set of all distinct values.
+     *
+     * @return array|null
+     */
+    public function getDistinctValues(): ?array
+    {
+        return $this->getStatValue('distinctValues');
+    }
+
+    /**
+     * Get the exact number of distinct values.
+     *
+     * @return int|null
+     */
+    public function getCountDistinct(): ?int
+    {
+        return $this->getStatValue('countDistinct');
+    }
+
+    /**
+     * Get a statistical approximation of the number of distinct values.
+     *
+     * @return int|null
+     */
+    public function getCardinality(): ?int
+    {
+        return $this->getStatValue('cardinality');
+    }
+
+    /**
+     * Get value by stat name.
+     *
+     * @param string $stat
+     *
+     * @return mixed|null
+     */
+    public function getStatValue(string $stat)
+    {
+        return $this->stats[$stat] ?? null;
+    }
+}

--- a/tests/QueryType/Select/Result/Stats/FacetValueTest.php
+++ b/tests/QueryType/Select/Result/Stats/FacetValueTest.php
@@ -24,11 +24,21 @@ class FacetValueTest extends TestCase
             'max' => 3.5,
             'sum' => 3.333,
             'count' => -1,
-            'missing' => 'dummyMissing',
+            'missing' => 0,
             'sumOfSquares' => 17.23,
-            'mean' => 'dummyMean',
+            'mean' => 3.14,
             'stddev' => 1.11,
-            'facets' => ['dummyFacets'],
+            'percentiles' => [
+                '50.0' => 3.14,
+                '90.0' => 42.0,
+            ],
+            'distinctValues' => [
+                'dummy1',
+                'dummy2',
+            ],
+            'countDistinct' => 3,
+            'cardinality' => 2,
+            'dummy' => 'test',
         ];
 
         $this->result = new FacetValue($this->value, $this->stats);
@@ -79,8 +89,41 @@ class FacetValueTest extends TestCase
         $this->assertSame($this->stats['stddev'], $this->result->getStddev());
     }
 
+    public function testGetPercentiles()
+    {
+        $this->assertSame($this->stats['percentiles'], $this->result->getPercentiles());
+    }
+
+    public function testGetDistinctValues()
+    {
+        $this->assertSame($this->stats['distinctValues'], $this->result->getDistinctValues());
+    }
+
+    public function testGetCountDistinct()
+    {
+        $this->assertSame($this->stats['countDistinct'], $this->result->getCountDistinct());
+    }
+
+    public function testGetCardinality()
+    {
+        $this->assertSame($this->stats['cardinality'], $this->result->getCardinality());
+    }
+
+    /**
+     * @deprecated Will be removed in Solarium 7.
+     */
     public function testGetFacets()
     {
-        $this->assertSame($this->stats['facets'], $this->result->getFacets());
+        $this->assertNull($this->result->getFacets());
+    }
+
+    public function testGetStatValue()
+    {
+        $this->assertSame($this->stats['dummy'], $this->result->getStatValue('dummy'));
+    }
+
+    public function testGetStatValueUnknown()
+    {
+        $this->assertNull($this->result->getStatValue('unknown'));
     }
 }

--- a/tests/QueryType/Select/Result/Stats/FacetValueTest.php
+++ b/tests/QueryType/Select/Result/Stats/FacetValueTest.php
@@ -110,7 +110,7 @@ class FacetValueTest extends TestCase
     }
 
     /**
-     * @deprecated Will be removed in Solarium 7.
+     * @deprecated Will be removed in Solarium 7
      */
     public function testGetFacets()
     {

--- a/tests/QueryType/Select/Result/Stats/ResultTest.php
+++ b/tests/QueryType/Select/Result/Stats/ResultTest.php
@@ -20,15 +20,26 @@ class ResultTest extends TestCase
     {
         $this->field = 'myfield';
         $this->stats = [
-            'min' => 'dummyMin',
-            'max' => 'dummyMax',
-            'sum' => 'dummySum',
+            'min' => 0.0,
+            'max' => 1.0,
+            'sum' => 4.2,
             'count' => -1,
-            'missing' => 'dummyMissing',
-            'sumOfSquares' => 'dummySos',
-            'mean' => 'dummyMean',
-            'stddev' => 'dummyStddev',
+            'missing' => 0,
+            'sumOfSquares' => 1.41,
+            'mean' => 3.14,
+            'stddev' => 0.2,
+            'percentiles' => [
+                '50.0' => 3.14,
+                '90.0' => 42.0,
+            ],
+            'distinctValues' => [
+                'dummy1',
+                'dummy2',
+            ],
+            'countDistinct' => 3,
+            'cardinality' => 2,
             'facets' => ['dummyFacets'],
+            'dummy' => 'test',
         ];
 
         $this->result = new Result($this->field, $this->stats);
@@ -79,8 +90,38 @@ class ResultTest extends TestCase
         $this->assertSame($this->stats['stddev'], $this->result->getStddev());
     }
 
+    public function testGetPercentiles()
+    {
+        $this->assertSame($this->stats['percentiles'], $this->result->getPercentiles());
+    }
+
+    public function testGetDistinctValues()
+    {
+        $this->assertSame($this->stats['distinctValues'], $this->result->getDistinctValues());
+    }
+
+    public function testGetCountDistinct()
+    {
+        $this->assertSame($this->stats['countDistinct'], $this->result->getCountDistinct());
+    }
+
+    public function testGetCardinality()
+    {
+        $this->assertSame($this->stats['cardinality'], $this->result->getCardinality());
+    }
+
     public function testGetFacets()
     {
         $this->assertSame($this->stats['facets'], $this->result->getFacets());
+    }
+
+    public function testGetStatValue()
+    {
+        $this->assertSame($this->stats['dummy'], $this->result->getStatValue('dummy'));
+    }
+
+    public function testGetStatValueUnknown()
+    {
+        $this->assertNull($this->result->getStatValue('unknown'));
     }
 }

--- a/tests/QueryType/Select/Result/Stats/ResultTest.php
+++ b/tests/QueryType/Select/Result/Stats/ResultTest.php
@@ -124,4 +124,20 @@ class ResultTest extends TestCase
     {
         $this->assertNull($this->result->getStatValue('unknown'));
     }
+
+    /**
+     * @deprecated
+     */
+    public function testGetValue()
+    {
+        $this->assertSame($this->stats['dummy'], $this->result->getValue('dummy'));
+    }
+
+    /**
+     * @deprecated
+     */
+    public function testGetValueUnknown()
+    {
+        $this->assertNull($this->result->getValue('unknown'));
+    }
 }

--- a/tests/QueryType/Select/Result/Stats/StatsTest.php
+++ b/tests/QueryType/Select/Result/Stats/StatsTest.php
@@ -18,8 +18,8 @@ class StatsTest extends TestCase
     public function setUp(): void
     {
         $this->data = [
-            'key1' => new Result('field1', ['mean' => 'value1']),
-            'key2' => new Result('field2', ['mean' => 'value2']),
+            'key1' => new Result('field1', ['mean' => 2.72]),
+            'key2' => new Result('field2', ['mean' => 3.14]),
         ];
         $this->stats = new Stats($this->data);
     }
@@ -27,7 +27,7 @@ class StatsTest extends TestCase
     public function testGetResult()
     {
         $this->assertSame('field1', $this->stats->getResult('key1')->getName());
-        $this->assertSame('value1', $this->stats->getResult('key1')->getMean());
+        $this->assertSame(2.72, $this->stats->getResult('key1')->getMean());
     }
 
     public function testGetInvalidResult()


### PR DESCRIPTION
Closes #534. Closes #865.

Added support for the recent additions to Solr's [Stats Component](https://solr.apache.org/guide/8_9/the-stats-component.html): `distinctValues`, `countDistinct`, `cardinality`.

Moved common functionality between `Result\Stats\Result` and `Result\Stats\FacetValue` to a trait. This avoids inconsistencies like `percentiles` being support in `Result` but not in `FacetValue`. As a consequence, I had to rename the recently-made-public (PR #922) `getValue()` to `getStatValue()` because `FacetValue` already had a public method `getValue()` that can't be renamed without breaking BC. I hadn't anticipated that PR to be merged and released already, so now I have to break BC on that. I think that's the lesser evil because it's so recent?

I don't think there was a way that `Component\Result\Stats\FacetValue::getFacets()` could have ever returned anything so I deprecated it. I guess it was only there because it was copypasted from `Result`, but correct me if I'm wrong!

Inconsistencies from the JSON representation are normalized in the Response Parser.

New functionality is mentioned summarily in the docs and full examples have been added.