### PR TITLE
Unit tests for TimeoutAwareTrait and ConnectionTimeoutAwareTrait

### DIFF
--- a/src/Core/Client/Adapter/TimeoutAwareInterface.php
+++ b/src/Core/Client/Adapter/TimeoutAwareInterface.php
@@ -15,7 +15,7 @@ namespace Solarium\Core\Client\Adapter;
 interface TimeoutAwareInterface
 {
     /**
-     * default timeout that should be respected by adapters implementing this interface.
+     * Default timeout that should be respected by adapters implementing this interface.
      */
     public const DEFAULT_TIMEOUT = 5;
 

--- a/tests/Core/Client/Adapter/ConnectionTimeoutAwareTraitTest.php
+++ b/tests/Core/Client/Adapter/ConnectionTimeoutAwareTraitTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Solarium\Tests\Core\Client\Adapter;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Adapter\ConnectionTimeoutAwareInterface;
+use Solarium\Core\Client\Adapter\ConnectionTimeoutAwareTrait;
+
+class ConnectionTimeoutAwareTraitTest extends TestCase
+{
+    /**
+     * @var DummyConnectionTimeoutAwareAdapter
+     */
+    protected $adapter;
+
+    public function setUp(): void
+    {
+        $this->adapter = new DummyConnectionTimeoutAwareAdapter();
+    }
+
+    public function testDefaultConnectionTimeout(): void
+    {
+        $this->assertNull($this->adapter->getConnectionTimeout());
+    }
+
+    public function testSetAndGetConnectionTimeout(): void
+    {
+        $this->adapter->setConnectionTimeout(10);
+        $this->assertSame(10, $this->adapter->getConnectionTimeout());
+    }
+
+    public function testSetConnectionTimeoutNull(): void
+    {
+        $this->adapter->setConnectionTimeout(null);
+        $this->assertNull($this->adapter->getConnectionTimeout());
+    }
+}
+
+class DummyConnectionTimeoutAwareAdapter implements ConnectionTimeoutAwareInterface
+{
+    use ConnectionTimeoutAwareTrait;
+}

--- a/tests/Core/Client/Adapter/TimeoutAwareTraitTest.php
+++ b/tests/Core/Client/Adapter/TimeoutAwareTraitTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Solarium\Tests\Core\Client\Adapter;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Adapter\TimeoutAwareInterface;
+use Solarium\Core\Client\Adapter\TimeoutAwareTrait;
+
+class TimeoutAwareTraitTest extends TestCase
+{
+    /**
+     * @var DummyTimeoutAwareAdapter
+     */
+    protected $adapter;
+
+    public function setUp(): void
+    {
+        $this->adapter = new DummyTimeoutAwareAdapter();
+    }
+
+    public function testDefaultTimeout(): void
+    {
+        $this->assertSame(TimeoutAwareInterface::DEFAULT_TIMEOUT, $this->adapter->getTimeout());
+    }
+
+    public function testSetAndGetTimeout(): void
+    {
+        $this->adapter->setTimeout(10);
+        $this->assertSame(10, $this->adapter->getTimeout());
+    }
+}
+
+class DummyTimeoutAwareAdapter implements TimeoutAwareInterface
+{
+    use TimeoutAwareTrait;
+}

--- a/tests/Integration/SolrCloud/CurlTest.php
+++ b/tests/Integration/SolrCloud/CurlTest.php
@@ -19,9 +19,9 @@ class CurlTest extends AbstractCloudTest
 
         parent::setUp();
         // The default timeout of Solarium of 5s seems to be too aggressive on Travis and causes random test failures.
-        // Set it to the PHP default of 13s.
         $adapter = new Curl();
-        $adapter->setTimeout(CURLOPT_TIMEOUT);
+        $adapter->setTimeout(15);
+        $adapter->setConnectionTimeout(5);
         self::$client->setAdapter($adapter);
     }
 }

--- a/tests/Integration/SolrServer/CurlTest.php
+++ b/tests/Integration/SolrServer/CurlTest.php
@@ -19,9 +19,9 @@ class CurlTest extends AbstractServerTest
 
         parent::setUp();
         // The default timeout of Solarium of 5s seems to be too aggressive on Travis and causes random test failures.
-        // Set it to the PHP default of 13s.
         $adapter = new Curl();
-        $adapter->setTimeout(CURLOPT_TIMEOUT);
+        $adapter->setTimeout(15);
+        $adapter->setConnectionTimeout(5);
         self::$client->setAdapter($adapter);
     }
 }


### PR DESCRIPTION
As promised in #949.

I've also set an explicit timeout and connection timeout for the integration tests instead of the misguided use of `CURLOPT_TIMEOUT`.