### PR TITLE
Update links: //lucene.apache.org/solr/ → //solr.apache.org/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,4 +23,4 @@ If you are uncertain about any part or need help please feel free to ask for hel
 * Solarium follows the Symfony2 code standards: http://symfony.com/doc/current/contributing/code/standards.html
 * Each PR will be checked for code standards violations. Of course anything other than a 'green' status needs to be fixed before a PR can be merged.
 * Each PR will be checked by the CI environment automatically. Of course anything other than a 'green' status needs to be fixed before a PR can be merged.
-* If you link to the Solr reference guide in a comment or the docs, use a 'versionless' URL (e.g. <https://lucene.apache.org/solr/guide/getting-started.html>). This will always redirect to the latest release.
+* If you link to the Solr reference guide in a comment or the docs, use a 'versionless' URL (e.g. <https://solr.apache.org/guide/getting-started.html>). This will always redirect to the latest release.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Solarium 6:
 $categoriesTerms = new Solarium\Component\Facet\JsonTerms(['local_key' => 'categories', 'field' => 'cat', 'limit'=>4,'numBuckets'=>true]);
 ```
 
-See https://lucene.apache.org/solr/guide/local-parameters-in-queries.html for an introduction about local parameters.
+See https://solr.apache.org/guide/local-parameters-in-queries.html for an introduction about local parameters.
 
 
 ### Pitfall when upgrading from 3.x or 4.x

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -183,7 +183,7 @@ foreach ($resultset as $document) {
 htmlFooter();
 ```
 
-Your schema has to meet certain criteria for this to work. For more info on Solr atomic updates please read the manual: <https://lucene.apache.org/solr/guide/updating-parts-of-documents.html#atomic-updates>
+Your schema has to meet certain criteria for this to work. For more info on Solr atomic updates please read the manual: <https://solr.apache.org/guide/updating-parts-of-documents.html#atomic-updates>.
 
 Versioning
 ----------

--- a/docs/queries/extract-query.md
+++ b/docs/queries/extract-query.md
@@ -1,4 +1,4 @@
-An extract query can be used to index files in Solr. For more info see <https://lucene.apache.org/solr/guide/uploading-data-with-solr-cell-using-apache-tika.html>
+An extract query can be used to index files in Solr. For more info see <https://solr.apache.org/guide/uploading-data-with-solr-cell-using-apache-tika.html>.
 
 Building an extract query
 -------------------------

--- a/docs/queries/morelikethis-query.md
+++ b/docs/queries/morelikethis-query.md
@@ -1,6 +1,6 @@
 A MoreLikeThis (MLT) query is designed to generate information about "similar" documents using the MoreLikeThis functionality provided by Lucene. It supports faceting, paging, and filtering using CommonQueryParameters.
 
-This query uses the [Solr MoreLikeThis Handler](https://lucene.apache.org/solr/guide/morelikethis.html) that specifically returns MLT results. Alternatively you can use the [MLT component](select-query/building-a-select-query/components/morelikethis-component.md) for the select query.
+This query uses the [Solr MoreLikeThis Handler](https://solr.apache.org/guide/morelikethis.html) that specifically returns MLT results. Alternatively you can use the [MLT component](select-query/building-a-select-query/components/morelikethis-component.md) for the select query.
 
 Building a MLT query
 --------------------

--- a/docs/queries/ping-query.md
+++ b/docs/queries/ping-query.md
@@ -2,7 +2,7 @@ A ping query can be used to check the connection to the Solr server and the heal
 
 *It's not advisable to check Solr with a ping before every request, this can have a big performance impact. You are better of using the ping query with intervals, or as a check after a query error to see if the query was faulty or if Solr has problems.*
 
-The search executed by a ping is configured with the Request Parameters API. For more info see <https://lucene.apache.org/solr/guide/ping.html>
+The search executed by a ping is configured with the Request Parameters API. For more info see <https://solr.apache.org/guide/ping.html>.
 
 Creating a ping query
 ---------------------

--- a/docs/queries/query-helper/query-helper.md
+++ b/docs/queries/query-helper/query-helper.md
@@ -20,7 +20,7 @@ See the API docs (linked at the bottom of this page) for more details.
 Dereferenced params
 -------------------
 
-The query helper also supports dereferenced params. See the implementation of the join() and qparser() methods. For more info also see <https://lucene.apache.org/solr/guide/local-parameters-in-queries.html#parameter-dereferencing>:
+The query helper also supports dereferenced params. See the implementation of the `join()` and `qparser()` methods. For more info also see <https://solr.apache.org/guide/local-parameters-in-queries.html#parameter-dereferencing>:
 
 > Parameter dereferencing, or indirection, lets you use the value of another argument rather than specifying it directly. This can be used to simplify queries, decouple user input from query parameters, or decouple front-end GUI parameters from defaults set in `solrconfig.xml`.
 

--- a/docs/queries/realtimeget-query.md
+++ b/docs/queries/realtimeget-query.md
@@ -1,4 +1,4 @@
-A RealtimeGet query is useful when using Solr as a NoSQL store. For more info see <https://lucene.apache.org/solr/guide/realtime-get.html>
+A RealtimeGet query is useful when using Solr as a NoSQL store. For more info see <https://solr.apache.org/guide/realtime-get.html>.
 
 Building a realtime query
 -------------------------

--- a/docs/queries/select-query/building-a-select-query/components/analytics-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/analytics-component.md
@@ -1,4 +1,4 @@
-For a description of the Solr AnalyticsComponent see the [Solr Ref Guide](https://lucene.apache.org/solr/guide/analytics.html).
+For a description of the Solr Analytics Component see the [Solr Ref Guide](https://solr.apache.org/guide/analytics.html).
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/debug-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/debug-component.md
@@ -1,4 +1,4 @@
-For a description of Solr debugging see <https://lucene.apache.org/solr/guide/common-query-parameters.html#debug-parameter>.
+For a description of Solr debugging see <https://solr.apache.org/guide/common-query-parameters.html#debug-parameter>.
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/distributed-search-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/distributed-search-component.md
@@ -1,4 +1,4 @@
-For a description of Solr distributed search (also referred to as 'shards' or 'sharding') see <https://lucene.apache.org/solr/guide/distributed-search-with-index-sharding.html>.
+For a description of Solr distributed search (also referred to as 'shards' or 'sharding') see <https://solr.apache.org/guide/distributed-search-with-index-sharding.html>.
 
 Options
 -------
@@ -27,7 +27,7 @@ $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $query = $client->createSelect();
 
 // add distributed search settings
-// see https://lucene.apache.org/solr/guide/distributed-search-with-index-sharding.html#testing-index-sharding-on-two-local-servers for setting up two Solr instances
+// see https://solr.apache.org/guide/distributed-search-with-index-sharding.html#testing-index-sharding-on-two-local-servers for setting up two Solr instances
 $distributedSearch = $query->getDistributedSearch();
 $distributedSearch->addShard('shard1', 'localhost:8983/solr');
 $distributedSearch->addShard('shard2', 'localhost:7574/solr');

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-field.md
@@ -18,7 +18,7 @@ Only the facet-type specific options are listed. See [Facetset component](V3:Fac
 | offset             | int     | null          | Show facet count starting from this offset.                                                                                                          |
 | mincount           | int     | null          | Minimal term count to be included in facet count results.                                                                                            |
 | missing            | boolean | null          | Also make a count of all document that have no value for the facet field.                                                                            |
-| method             | string  | null          | Use one of the class constants as value. See <https://lucene.apache.org/solr/guide/faceting.html#field-value-faceting-parameters> for details.       |
+| method             | string  | null          | Use one of the class constants as value. See <https://solr.apache.org/guide/faceting.html#field-value-faceting-parameters> for details.              |
 ||
 
 Example

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-pivot.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-pivot.md
@@ -1,4 +1,4 @@
-The facet class supports the Solr pivot facet: <https://lucene.apache.org/solr/guide/faceting.html#pivot-decision-tree-faceting>.
+The facet class supports the Solr pivot facet: <https://solr.apache.org/guide/faceting.html#pivot-decision-tree-faceting>.
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-range.md
+++ b/docs/queries/select-query/building-a-select-query/components/facetset-component/facet-range.md
@@ -1,4 +1,4 @@
-The facet class supports the Solr range facet: <https://lucene.apache.org/solr/guide/faceting.html#range-faceting>.
+The facet class supports the Solr range facet: <https://solr.apache.org/guide/faceting.html#range-faceting>.
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/grouping-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/grouping-component.md
@@ -1,4 +1,4 @@
-For a description of Solr grouping (also referred to as 'result grouping' or 'field collapse') see <https://lucene.apache.org/solr/guide/result-grouping.html>.
+For a description of Solr grouping (also referred to as 'result grouping' or 'field collapse') see <https://solr.apache.org/guide/result-grouping.html>.
 
 It's important to have a good understanding of the available options, as they can have have big effects on the result format.
 

--- a/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
@@ -1,4 +1,4 @@
-The highlighting component can be used to highlight matches in content. For more info see <https://lucene.apache.org/solr/guide/highlighting.html>.
+The highlighting component can be used to highlight matches in content. For more info see <https://solr.apache.org/guide/highlighting.html>.
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/morelikethis-component.md
@@ -1,4 +1,4 @@
-The MoreLikeThis component can be used if you want to retrieve similar documents for your query results. This component uses MoreLikeThis in the StandardRequestHandler, not the standalone MoreLikeThisHandler. For more info see <https://lucene.apache.org/solr/guide/morelikethis.html>.
+The MoreLikeThis component can be used if you want to retrieve similar documents for your query results. This component uses MoreLikeThis in the StandardRequestHandler, not the standalone MoreLikeThisHandler. For more info see <https://solr.apache.org/guide/morelikethis.html>.
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
@@ -1,4 +1,4 @@
-Query Elevation is a Solr component that lets you configure the top results for a given query regardless of the normal Lucene scoring. Elevated query results can be configured in an external XML file or at request time. For more info see <https://lucene.apache.org/solr/guide/the-query-elevation-component.html>.
+Query Elevation is a Solr component that lets you configure the top results for a given query regardless of the normal Lucene scoring. Elevated query results can be configured in an external XML file or at request time. For more info see <https://solr.apache.org/guide/the-query-elevation-component.html>.
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/query-rerankquery-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-rerankquery-component.md
@@ -2,7 +2,7 @@ Query Re-Ranking allows you to run a simple query (A) for matching documents and
 
 Since the more costly ranking from query B is only applied to the top N documents, it will have less impact on performance then just using the complex query B by itself. The trade off is that documents which score very low using the simple query A may not be considered during the re-ranking phase, even if they would score very highly using query B.
 
-For more info see <https://lucene.apache.org/solr/guide/query-re-ranking.html>.
+For more info see <https://solr.apache.org/guide/query-re-ranking.html>.
 
 Options
 -------

--- a/docs/queries/select-query/building-a-select-query/components/spellcheck-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/spellcheck-component.md
@@ -1,4 +1,4 @@
-For a description of Solr spellcheck (also referred to as 'query suggest') see <https://lucene.apache.org/solr/guide/spell-checking.html>.
+For a description of Solr spellcheck (also referred to as 'query suggest') see <https://solr.apache.org/guide/spell-checking.html>.
 
 The `setQuery()` method of this component supports [placeholders](V3:Placeholders "wikilink").
 
@@ -25,7 +25,7 @@ Options
 Collate params
 --------------
 
-Using the API method setCollateParam($param, $value) you can set any collate params you need. For more info see <https://lucene.apache.org/solr/guide/spell-checking.html#spell-check-parameters>.
+Using the API method setCollateParam($param, $value) you can set any collate params you need. For more info see <https://solr.apache.org/guide/spell-checking.html#spell-check-parameters>.
 
 Example
 -------

--- a/docs/queries/select-query/building-a-select-query/components/stats-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/stats-component.md
@@ -1,4 +1,4 @@
-For a description of the Solr StatsComponent see <https://lucene.apache.org/solr/guide/the-stats-component.html>.
+For a description of the Solr StatsComponent see <https://solr.apache.org/guide/the-stats-component.html>.
 
 Options
 -------

--- a/docs/queries/select-query/select-query.md
+++ b/docs/queries/select-query/select-query.md
@@ -1,5 +1,5 @@
 With select queries you can select documents and/or facet counts from your Solr index. Solr select queries have lots of options. See the following pages in the Solr reference guide for an intro:
 
-- [Common Query Parameters](https://lucene.apache.org/solr/guide/common-query-parameters.html)
-- [The Standard Query Parser](https://lucene.apache.org/solr/guide/the-standard-query-parser.html)
-- [Faceting](https://lucene.apache.org/solr/guide/faceting.html)
+- [Common Query Parameters](https://solr.apache.org/guide/common-query-parameters.html)
+- [The Standard Query Parser](https://solr.apache.org/guide/the-standard-query-parser.html)
+- [Faceting](https://solr.apache.org/guide/faceting.html)

--- a/docs/queries/server-query/core-admin-query.md
+++ b/docs/queries/server-query/core-admin-query.md
@@ -1,4 +1,4 @@
-CoreAdmin queries can be used to [administrate cores on your Solr server](https://lucene.apache.org/solr/guide/coreadmin-api.html).
+CoreAdmin queries can be used to [administrate cores on your Solr server](https://solr.apache.org/guide/coreadmin-api.html).
 
 The CoreAdmin API on the Apache Solr server has several "actions" available and every action can have a set of arguments.
 
@@ -133,7 +133,7 @@ Split
 
 Use to split a core.
 
-See also: https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-split
+See also: <https://solr.apache.org/guide/coreadmin-api.html#coreadmin-split>.
 
 **Available action methods**:
 

--- a/docs/queries/suggester-query.md
+++ b/docs/queries/suggester-query.md
@@ -1,4 +1,4 @@
-A suggester query is a fast way to create an autocomplete feature. For more info on the Solr suggester component see: <https://lucene.apache.org/solr/guide/suggester.html>.
+A suggester query is a fast way to create an autocomplete feature. For more info on the Solr SuggestComponent see: <https://solr.apache.org/guide/suggester.html>.
 
 Building a suggester query
 --------------------------
@@ -10,7 +10,7 @@ See the example code below.
 | Name            | Type             | Default value | Description                                                                            |
 |-----------------|------------------|---------------|----------------------------------------------------------------------------------------|
 | query           | string           | null          | Query to spellcheck                                                                    |
-| dictionary      | string or array  | null          | The name(s) of the dictionary or dictionaries to use                                                      |
+| dictionary      | string or array  | null          | The name(s) of the dictionary or dictionaries to use                                   |
 | onlymorepopular | boolean          | null          | Only return suggestions that result in more hits for the query than the existing query |
 | collate         | boolean          | null          |                                                                                        |
 ||

--- a/docs/queries/terms-query.md
+++ b/docs/queries/terms-query.md
@@ -1,4 +1,4 @@
-A terms query provides access to the indexed terms in a field. For details see: <https://lucene.apache.org/solr/guide/the-terms-component.html>.
+A terms query provides access to the indexed terms in a field. For details see: <https://solr.apache.org/guide/the-terms-component.html>.
 
 Building a terms query
 ----------------------

--- a/docs/queries/update-query/building-an-update-query/building-an-update-query.md
+++ b/docs/queries/update-query/building-an-update-query/building-an-update-query.md
@@ -1,4 +1,4 @@
-An update query has options and commands. These commands and options are instructions for the client classes to build and execute a request and return the correct result. In the following sections both the options and commands will be discussed in detail. You can also take a look at <https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#xml-formatted-index-updates> for more information about the underlying Solr update handler XML request format.
+An update query has options and commands. These commands and options are instructions for the client classes to build and execute a request and return the correct result. In the following sections both the options and commands will be discussed in detail. You can also take a look at <https://solr.apache.org/guide/uploading-data-with-index-handlers.html#xml-formatted-index-updates> for more information about the underlying Solr update handler XML request format.
 
 Options
 -------

--- a/docs/queries/update-query/building-an-update-query/optimize-command.md
+++ b/docs/queries/update-query/building-an-update-query/optimize-command.md
@@ -1,6 +1,6 @@
 You can use this command to optimize your Solr index. Optimizing 'defragments' your index. The space taken by deleted document data is reclaimed and can merge the index into fewer segments. This can improve search performance a lot.
 
-See <https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#commit-and-optimize-during-updates> for more info about optimizing.
+See <https://solr.apache.org/guide/uploading-data-with-index-handlers.html#commit-and-optimize-during-updates> for more info about optimizing.
 
 While 'optimizing' sounds like it's always a good thing to do, you should use it with care, as it can have a negative performance impact *during the optimize process*. If possible use try to use it outside peak hours.
 

--- a/examples/2.1.5.1.9-facet-json-range.php
+++ b/examples/2.1.5.1.9-facet-json-range.php
@@ -18,7 +18,7 @@ $facetSet = $query->getFacetSet();
 // create a json range instance and set options
 // Set the 'other' parameter to retrieve counts for before, after, between, or all three.
 // Possible values are : JsonRange::OTHER_BEFORE, JsonRange::OTHER_AFTER, JsonRange::OTHER_BETWEEN, JsonRange::OTHER_ALL
-// See https://lucene.apache.org/solr/guide/json-facet-api.html#range-facet-parameters
+// See https://solr.apache.org/guide/json-facet-api.html#range-facet-parameters
 $priceranges = new JsonRange(['local_key' => 'priceranges', 'field' => 'price', 'start'=>1 ,'end'=>300,'gap'=>100, 'other'=>JsonRange::OTHER_ALL]);
 
 // add json range instance to the facetSet

--- a/examples/2.1.5.8-distributed-search.php
+++ b/examples/2.1.5.8-distributed-search.php
@@ -12,7 +12,7 @@ $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $query = $client->createSelect();
 
 // add distributed search settings
-// see https://lucene.apache.org/solr/guide/distributed-search-with-index-sharding.html#testing-index-sharding-on-two-local-servers for setting up two Solr instances
+// see https://solr.apache.org/guide/distributed-search-with-index-sharding.html#testing-index-sharding-on-two-local-servers for setting up two Solr instances
 $distributedSearch = $query->getDistributedSearch();
 $distributedSearch->addShard('shard1', 'localhost:8983/solr');
 $distributedSearch->addShard('shard2', 'localhost:7574/solr');

--- a/src/Builder/Analytics/MappingFunction.php
+++ b/src/Builder/Analytics/MappingFunction.php
@@ -23,157 +23,157 @@ use Solarium\Builder\FunctionInterface;
 class MappingFunction implements FunctionInterface, ExpressionInterface
 {
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#negation
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#negation
      */
     public const NEGATION = 'neg';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#absolute-value
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#absolute-value
      */
     public const ABSOLUTE_VALUE = 'abs';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#analytics-round
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#analytics-round
      */
     public const ROUND = 'round';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#ceiling
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#ceiling
      */
     public const CEILING = 'ceil';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#analytics-floor
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#analytics-floor
      */
     public const FLOOR = 'floor';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#addition
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#addition
      */
     public const ADDITION = 'add';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#subtraction
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#subtraction
      */
     public const SUBTRACTION = 'sub';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#multiplication
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#multiplication
      */
     public const MULTIPLICATION = 'mult';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#division
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#division
      */
     public const DIVISION = 'div';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#power
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#power
      */
     public const POWER = 'pow';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#logarithm
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#logarithm
      */
     public const LOGARITHM = 'log';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#analytics-and
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#analytics-and
      */
     public const AND = 'and';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#analytics-or
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#analytics-or
      */
     public const OR = 'or';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#exists
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#exists
      */
     public const EXISTS = 'exists';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#equality
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#equality
      */
     public const EQUAL = 'equal';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#greater-than
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#greater-than
      */
     public const GREATER_THAN = 'gt';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#greater-than-or-equals
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#greater-than-or-equals
      */
     public const GREATER_THAN_EQUALS = 'gte';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#less-than
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#less-than
      */
     public const LESS_THAN = 'lt';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#less-than-or-equals
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#less-than-or-equals
      */
     public const LESS_THAN_EQUALS = 'lte';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#analytics-top
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#analytics-top
      */
     public const TOP = 'top';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#bottom
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#bottom
      */
     public const BOTTOM = 'bottom';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#analytics-if
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#analytics-if
      */
     public const IF = 'if';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#replace
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#replace
      */
     public const REPLACE = 'replace';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#fill-missing
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#fill-missing
      */
     public const FILL_MISSING = 'fill_missing';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#remove
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#remove
      */
     public const REMOVE = 'remove';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#filter
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#filter
      */
     public const FILTER = 'filter';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#date-parse
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#date-parse
      */
     public const DATE_PARSE = 'date';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#analytics-date-math
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#analytics-date-math
      */
     public const DATE_MATH = 'date_math';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#explicit-casting
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#explicit-casting
      */
     public const STRING = 'string';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#concatenation
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#concatenation
      */
     public const CONCAT = 'concat';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-mapping-functions.html#separated-concatenation
+     * @see https://solr.apache.org/guide/analytics-mapping-functions.html#separated-concatenation
      */
     public const CONCAT_SEPARATED = 'concat_sep';
 

--- a/src/Builder/Analytics/ReductionFunction.php
+++ b/src/Builder/Analytics/ReductionFunction.php
@@ -24,72 +24,72 @@ use Solarium\Exception\RuntimeException;
 class ReductionFunction implements FunctionInterface, ExpressionInterface
 {
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#count
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#count
      */
     public const COUNT = 'count';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#doc-count
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#doc-count
      */
     public const DOC_COUNT = 'doc_count';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#missing
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#missing
      */
     public const MISSING = 'missing';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#analytics-unique
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#analytics-unique
      */
     public const UNIQUE = 'unique';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#sum
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#sum
      */
     public const SUM = 'sum';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#variance
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#variance
      */
     public const VARIANCE = 'variance';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#standard-deviation
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#standard-deviation
      */
     public const STANDARD_DEVIATION = 'stddev';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#mean
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#mean
      */
     public const MEAN = 'mean';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#weighted-mean
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#weighted-mean
      */
     public const WEIGHTED_MEAN = 'wmean';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#minimum
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#minimum
      */
     public const MINIMUM = 'min';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#maximum
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#maximum
      */
     public const MAXIMUM = 'max';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#median
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#median
      */
     public const MEDIAN = 'median';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#percentile
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#percentile
      */
     public const PERCENTILE = 'percentile';
 
     /**
-     * @see https://lucene.apache.org/solr/guide/analytics-reduction-functions.html#ordinal
+     * @see https://solr.apache.org/guide/analytics-reduction-functions.html#ordinal
      */
     public const ORDINAL = 'ordinal';
 

--- a/src/Component/Analytics/Analytics.php
+++ b/src/Component/Analytics/Analytics.php
@@ -25,7 +25,7 @@ use Solarium\Component\ResponseParser\ComponentParserInterface;
  *
  * @author wicliff <wicliff.wolda@gmail.com>
  *
- * @see https://lucene.apache.org/solr/guide/analytics.html
+ * @see https://solr.apache.org/guide/analytics.html
  */
 class Analytics extends AbstractComponent implements \JsonSerializable
 {

--- a/src/Component/ComponentTraits/MoreLikeThisTrait.php
+++ b/src/Component/ComponentTraits/MoreLikeThisTrait.php
@@ -23,7 +23,7 @@ trait MoreLikeThisTrait
      * Minimum Term Frequency - the frequency below which terms will be ignored
      * in the source doc.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $minimum
      *
@@ -52,7 +52,7 @@ trait MoreLikeThisTrait
      * Minimum Document Frequency - the frequency at which words will be
      * ignored which do not occur in at least this many docs.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $minimum
      *
@@ -81,7 +81,7 @@ trait MoreLikeThisTrait
      * Maximum Document Frequency - the frequency at which words will be
      * ignored which occur in more than this many docs.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $maximum
      *
@@ -110,7 +110,7 @@ trait MoreLikeThisTrait
      * Maximum Document Frequency Percentage - a relative ratio at which words will be
      * ignored which occur in more than this percentage of the docs in the index.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $maximumpercentage A percentage between 0 and 100
      *
@@ -144,7 +144,7 @@ trait MoreLikeThisTrait
      *
      * Minimum word length below which words will be ignored.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $minimum
      *
@@ -172,7 +172,7 @@ trait MoreLikeThisTrait
      *
      * Maximum word length above which words will be ignored.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $maximum
      *
@@ -201,7 +201,7 @@ trait MoreLikeThisTrait
      * Maximum number of query terms that will be included in any generated
      * query.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $maximum
      *
@@ -230,7 +230,7 @@ trait MoreLikeThisTrait
      * Maximum number of tokens to parse in each example doc field that is not
      * stored with TermVector support.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $maximum
      *
@@ -258,7 +258,7 @@ trait MoreLikeThisTrait
      *
      * If true the query will be boosted by the interesting term relevance.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param bool $boost
      *
@@ -289,7 +289,7 @@ trait MoreLikeThisTrait
      *
      * Separate multiple fields with commas if you use string input.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param string|array $queryFields
      *
@@ -327,7 +327,7 @@ trait MoreLikeThisTrait
      *
      * Controls how the component presents the "interesting" terms.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param string $setting
      *

--- a/src/Component/Debug.php
+++ b/src/Component/Debug.php
@@ -17,7 +17,7 @@ use Solarium\Component\ResponseParser\Debug as ResponseParser;
 /**
  * Debug component.
  *
- * @see https://lucene.apache.org/solr/guide/common-query-parameters.html#debug-parameter
+ * @see https://solr.apache.org/guide/common-query-parameters.html#debug-parameter
  */
 class Debug extends AbstractComponent
 {
@@ -64,7 +64,7 @@ class Debug extends AbstractComponent
     /**
      * Set the explainOther query.
      *
-     * @see https://lucene.apache.org/solr/guide/common-query-parameters.html#explainother-parameter
+     * @see https://solr.apache.org/guide/common-query-parameters.html#explainother-parameter
      *
      * @param string $query
      *

--- a/src/Component/DisMax.php
+++ b/src/Component/DisMax.php
@@ -17,7 +17,7 @@ use Solarium\Exception\InvalidArgumentException;
 /**
  * DisMax component.
  *
- * @see https://lucene.apache.org/solr/guide/the-dismax-query-parser.html
+ * @see https://solr.apache.org/guide/the-dismax-query-parser.html
  */
 class DisMax extends AbstractComponent
 {

--- a/src/Component/DistributedSearch.php
+++ b/src/Component/DistributedSearch.php
@@ -15,8 +15,8 @@ use Solarium\Component\RequestBuilder\DistributedSearch as RequestBuilder;
 /**
  * Distributed Search (sharding) component.
  *
- * @see https://lucene.apache.org/solr/guide/distributed-search-with-index-sharding.html
- * @see https://lucene.apache.org/solr/guide/solrcloud.html
+ * @see https://solr.apache.org/guide/distributed-search-with-index-sharding.html
+ * @see https://solr.apache.org/guide/solrcloud.html
  */
 class DistributedSearch extends AbstractComponent
 {
@@ -69,7 +69,7 @@ class DistributedSearch extends AbstractComponent
      *
      * @return self Provides fluent interface
      *
-     * @see https://lucene.apache.org/solr/guide/distributed-search-with-index-sharding.html
+     * @see https://solr.apache.org/guide/distributed-search-with-index-sharding.html
      */
     public function addShard(string $key, string $shard): self
     {
@@ -206,7 +206,7 @@ class DistributedSearch extends AbstractComponent
      *
      * @return self Provides fluent interface
      *
-     * @see https://lucene.apache.org/solr/guide/solrcloud.html
+     * @see https://solr.apache.org/guide/solrcloud.html
      */
     public function addCollection(string $key, string $collection): self
     {
@@ -294,7 +294,7 @@ class DistributedSearch extends AbstractComponent
      *
      * @return self Provides fluent interface
      *
-     * @see https://lucene.apache.org/solr/guide/distributed-requests.html
+     * @see https://solr.apache.org/guide/distributed-requests.html
      */
     public function addReplica(string $key, string $replica): self
     {

--- a/src/Component/EdisMax.php
+++ b/src/Component/EdisMax.php
@@ -15,7 +15,7 @@ use Solarium\Component\RequestBuilder\EdisMax as RequestBuilder;
 /**
  * EdisMax component.
  *
- * @see https://lucene.apache.org/solr/guide/the-extended-dismax-query-parser.html
+ * @see https://solr.apache.org/guide/the-extended-dismax-query-parser.html
  */
 class EdisMax extends DisMax
 {

--- a/src/Component/Facet/AbstractFacet.php
+++ b/src/Component/Facet/AbstractFacet.php
@@ -15,7 +15,7 @@ use Solarium\Core\Query\LocalParameters\LocalParametersTrait;
 /**
  * Facet base class.
  *
- * @see https://lucene.apache.org/solr/guide/faceting.html
+ * @see https://solr.apache.org/guide/faceting.html
  */
 abstract class AbstractFacet extends Configurable implements FacetInterface
 {

--- a/src/Component/Facet/AbstractField.php
+++ b/src/Component/Facet/AbstractField.php
@@ -12,7 +12,7 @@ namespace Solarium\Component\Facet;
 /**
  * Facet query.
  *
- * @see https://lucene.apache.org/solr/guide/faceting.html#field-value-faceting-parameters
+ * @see https://solr.apache.org/guide/faceting.html#field-value-faceting-parameters
  */
 abstract class AbstractField extends AbstractFacet
 {

--- a/src/Component/Facet/AbstractRange.php
+++ b/src/Component/Facet/AbstractRange.php
@@ -14,7 +14,7 @@ use Solarium\Core\Configurable;
 /**
  * Facet range.
  *
- * @see https://lucene.apache.org/solr/guide/faceting.html#range-faceting
+ * @see https://solr.apache.org/guide/faceting.html#range-faceting
  */
 abstract class AbstractRange extends AbstractFacet
 {

--- a/src/Component/Facet/FacetInterface.php
+++ b/src/Component/Facet/FacetInterface.php
@@ -12,7 +12,7 @@ namespace Solarium\Component\Facet;
 /**
  * Facet interface.
  *
- * @see https://lucene.apache.org/solr/guide/faceting.html
+ * @see https://solr.apache.org/guide/faceting.html
  */
 interface FacetInterface
 {

--- a/src/Component/Facet/Field.php
+++ b/src/Component/Facet/Field.php
@@ -14,7 +14,7 @@ use Solarium\Component\FacetSetInterface;
 /**
  * Facet query.
  *
- * @see https://lucene.apache.org/solr/guide/faceting.html#field-value-faceting-parameters
+ * @see https://solr.apache.org/guide/faceting.html#field-value-faceting-parameters
  */
 class Field extends AbstractField
 {

--- a/src/Component/Facet/Interval.php
+++ b/src/Component/Facet/Interval.php
@@ -14,7 +14,7 @@ use Solarium\Component\FacetSetInterface;
 /**
  * Facet interval.
  *
- * @see https://lucene.apache.org/solr/guide/faceting.html#interval-faceting
+ * @see https://solr.apache.org/guide/faceting.html#interval-faceting
  */
 class Interval extends AbstractFacet
 {

--- a/src/Component/Facet/JsonAggregation.php
+++ b/src/Component/Facet/JsonAggregation.php
@@ -14,8 +14,8 @@ use Solarium\Component\FacetSetInterface;
 /**
  * JSON facet aggregation.
  *
- * @see https://lucene.apache.org/solr/guide/json-facet-api.html#stat-facet-example
- * @see https://lucene.apache.org/solr/guide/json-facet-api.html#stat-facet-functions
+ * @see https://solr.apache.org/guide/json-facet-api.html#stat-facet-example
+ * @see https://solr.apache.org/guide/json-facet-api.html#stat-facet-functions
  */
 class JsonAggregation extends AbstractFacet implements JsonFacetInterface
 {

--- a/src/Component/Facet/JsonFacetInterface.php
+++ b/src/Component/Facet/JsonFacetInterface.php
@@ -12,7 +12,7 @@ namespace Solarium\Component\Facet;
 /**
  * JSON facets.
  *
- * @see https://lucene.apache.org/solr/guide/json-facet-api.html
+ * @see https://solr.apache.org/guide/json-facet-api.html
  */
 interface JsonFacetInterface
 {

--- a/src/Component/Facet/JsonFacetTrait.php
+++ b/src/Component/Facet/JsonFacetTrait.php
@@ -17,7 +17,7 @@ use Solarium\Exception\InvalidArgumentException;
 /**
  * JSON facets.
  *
- * @see https://lucene.apache.org/solr/guide/json-facet-api.html
+ * @see https://solr.apache.org/guide/json-facet-api.html
  */
 trait JsonFacetTrait
 {

--- a/src/Component/Facet/JsonQuery.php
+++ b/src/Component/Facet/JsonQuery.php
@@ -17,7 +17,7 @@ use Solarium\Core\Query\Helper;
 /**
  * Facet query.
  *
- * @see https://lucene.apache.org/solr/guide/json-facet-api.html#query-facet
+ * @see https://solr.apache.org/guide/json-facet-api.html#query-facet
  */
 class JsonQuery extends AbstractFacet implements JsonFacetInterface, FacetSetInterface, QueryInterface
 {

--- a/src/Component/Facet/JsonRange.php
+++ b/src/Component/Facet/JsonRange.php
@@ -14,7 +14,7 @@ use Solarium\Component\FacetSetInterface;
 /**
  * Facet range.
  *
- * @see https://lucene.apache.org/solr/guide/json-facet-api.html#range-facet
+ * @see https://solr.apache.org/guide/json-facet-api.html#range-facet
  */
 class JsonRange extends AbstractRange implements JsonFacetInterface, FacetSetInterface
 {

--- a/src/Component/Facet/JsonTerms.php
+++ b/src/Component/Facet/JsonTerms.php
@@ -14,7 +14,7 @@ use Solarium\Component\FacetSetInterface;
 /**
  * Facet query.
  *
- * @see https://lucene.apache.org/solr/guide/json-facet-api.html#terms-facet
+ * @see https://solr.apache.org/guide/json-facet-api.html#terms-facet
  */
 class JsonTerms extends AbstractField implements JsonFacetInterface, FacetSetInterface
 {

--- a/src/Component/Facet/Pivot.php
+++ b/src/Component/Facet/Pivot.php
@@ -15,7 +15,7 @@ use Solarium\Exception\OutOfBoundsException;
 /**
  * Facet pivot.
  *
- * @see https://lucene.apache.org/solr/guide/faceting.html#pivot-decision-tree-faceting
+ * @see https://solr.apache.org/guide/faceting.html#pivot-decision-tree-faceting
  */
 class Pivot extends AbstractFacet
 {

--- a/src/Component/Facet/Query.php
+++ b/src/Component/Facet/Query.php
@@ -17,7 +17,7 @@ use Solarium\Core\Query\Helper;
 /**
  * Facet query.
  *
- * @see https://lucene.apache.org/solr/guide/faceting.html#general-facet-parameters
+ * @see https://solr.apache.org/guide/faceting.html#general-facet-parameters
  */
 class Query extends AbstractFacet implements QueryInterface
 {

--- a/src/Component/Facet/Range.php
+++ b/src/Component/Facet/Range.php
@@ -14,7 +14,7 @@ use Solarium\Component\FacetSetInterface;
 /**
  * Facet range.
  *
- * @see https://lucene.apache.org/solr/guide/faceting.html#range-faceting
+ * @see https://solr.apache.org/guide/faceting.html#range-faceting
  */
 class Range extends AbstractRange
 {

--- a/src/Component/Grouping.php
+++ b/src/Component/Grouping.php
@@ -22,7 +22,7 @@ use Solarium\Component\Result\Grouping\ValueGroup;
  * Also known as Result Grouping or Field Collapsing.
  * See the Solr wiki for more info about this functionality
  *
- * @see https://lucene.apache.org/solr/guide/result-grouping.html
+ * @see https://solr.apache.org/guide/result-grouping.html
  */
 class Grouping extends AbstractComponent
 {

--- a/src/Component/Highlighting/Field.php
+++ b/src/Component/Highlighting/Field.php
@@ -14,7 +14,7 @@ use Solarium\Core\Configurable;
 /**
  * Highlighting per-field settings.
  *
- * @see https://lucene.apache.org/solr/guide/highlighting.html
+ * @see https://solr.apache.org/guide/highlighting.html
  */
 class Field extends Configurable
 {

--- a/src/Component/Highlighting/Highlighting.php
+++ b/src/Component/Highlighting/Highlighting.php
@@ -22,7 +22,7 @@ use Solarium\Exception\InvalidArgumentException;
 /**
  * Highlighting component.
  *
- * @see https://lucene.apache.org/solr/guide/highlighting.html
+ * @see https://solr.apache.org/guide/highlighting.html
  */
 class Highlighting extends AbstractComponent implements QueryInterface
 {

--- a/src/Component/MoreLikeThis.php
+++ b/src/Component/MoreLikeThis.php
@@ -18,7 +18,7 @@ use Solarium\Component\ResponseParser\MoreLikeThis as ResponseParser;
 /**
  * MoreLikeThis component.
  *
- * @see https://lucene.apache.org/solr/guide/morelikethis.html
+ * @see https://solr.apache.org/guide/morelikethis.html
  */
 class MoreLikeThis extends AbstractComponent implements MoreLikeThisInterface
 {
@@ -62,7 +62,7 @@ class MoreLikeThis extends AbstractComponent implements MoreLikeThisInterface
      *
      * When using string input you can separate multiple fields with commas.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param string|array $fields
      *
@@ -100,7 +100,7 @@ class MoreLikeThis extends AbstractComponent implements MoreLikeThisInterface
      *
      * The number of similar documents to return for each result.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethiscomponent
+     * @see https://solr.apache.org/guide/morelikethis.html#search-component-parameters
      *
      * @param int $count
      *
@@ -129,7 +129,7 @@ class MoreLikeThis extends AbstractComponent implements MoreLikeThisInterface
      * This doesn't actually do anything for the MoreLikeThisComponent as
      * this parameter is only for the MoreLikeThisHandler.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
+     * @see https://solr.apache.org/guide/morelikethis.html#request-handler-parameters
      *
      * @param bool $include
      *
@@ -163,7 +163,7 @@ class MoreLikeThis extends AbstractComponent implements MoreLikeThisInterface
      * This doesn't actually do anything for the MoreLikeThisComponent as
      * this parameter is only for the MoreLikeThisHandler.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
+     * @see https://solr.apache.org/guide/morelikethis.html#request-handler-parameters
      *
      * @param int $offset
      *

--- a/src/Component/MoreLikeThisInterface.php
+++ b/src/Component/MoreLikeThisInterface.php
@@ -22,7 +22,7 @@ interface MoreLikeThisInterface extends ConfigurableInterface
      * Minimum Term Frequency - the frequency below which terms will be ignored
      * in the source doc.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $minimum
      *
@@ -43,7 +43,7 @@ interface MoreLikeThisInterface extends ConfigurableInterface
      * Minimum Document Frequency - the frequency at which words will be
      * ignored which do not occur in at least this many docs.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $minimum
      *
@@ -64,7 +64,7 @@ interface MoreLikeThisInterface extends ConfigurableInterface
      * Maximum Document Frequency - the frequency at which words will be
      * ignored which occur in more than this many docs.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $maximum
      *
@@ -85,7 +85,7 @@ interface MoreLikeThisInterface extends ConfigurableInterface
      * Maximum Document Frequency Percentage - a relative ratio at which words will be
      * ignored which occur in more than this percentage of the docs in the index.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $maximumpercentage A percentage between 0 and 100
      *
@@ -107,7 +107,7 @@ interface MoreLikeThisInterface extends ConfigurableInterface
      *
      * Minimum word length below which words will be ignored.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $minimum
      *
@@ -127,7 +127,7 @@ interface MoreLikeThisInterface extends ConfigurableInterface
      *
      * Maximum word length above which words will be ignored.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $maximum
      *
@@ -148,7 +148,7 @@ interface MoreLikeThisInterface extends ConfigurableInterface
      * Maximum number of query terms that will be included in any generated
      * query.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $maximum
      *
@@ -169,7 +169,7 @@ interface MoreLikeThisInterface extends ConfigurableInterface
      * Maximum number of tokens to parse in each example doc field that is not
      * stored with TermVector support.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param int $maximum
      *
@@ -189,7 +189,7 @@ interface MoreLikeThisInterface extends ConfigurableInterface
      *
      * If true the query will be boosted by the interesting term relevance.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param bool $boost
      *
@@ -212,7 +212,7 @@ interface MoreLikeThisInterface extends ConfigurableInterface
      *
      * Separate multiple fields with commas if you use string input.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param string|array $queryFields
      *
@@ -230,7 +230,7 @@ interface MoreLikeThisInterface extends ConfigurableInterface
     /**
      * Set the interestingTerms parameter. Must be one of: none, list, details.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param string $term
      *

--- a/src/Component/QueryElevation.php
+++ b/src/Component/QueryElevation.php
@@ -15,7 +15,7 @@ use Solarium\Component\RequestBuilder\QueryElevation as RequestBuilder;
 /**
  * QueryElevation component.
  *
- * @see https://lucene.apache.org/solr/guide/the-query-elevation-component.html
+ * @see https://solr.apache.org/guide/the-query-elevation-component.html
  */
 class QueryElevation extends AbstractComponent
 {

--- a/src/Component/ReRankQuery.php
+++ b/src/Component/ReRankQuery.php
@@ -15,7 +15,7 @@ use Solarium\Component\RequestBuilder\ReRankQuery as RequestBuilder;
 /**
  * Rerank query.
  *
- * @see https://lucene.apache.org/solr/guide/query-re-ranking.html#rerank-query-parser
+ * @see https://solr.apache.org/guide/query-re-ranking.html#rerank-query-parser
  */
 class ReRankQuery extends AbstractComponent implements QueryInterface
 {

--- a/src/Component/Result/Facet/JsonRange.php
+++ b/src/Component/Result/Facet/JsonRange.php
@@ -16,7 +16,7 @@ namespace Solarium\Component\Result\Facet;
  * value and its count. You can access the values as an array using
  * {@link getValues()} or iterate this object.
  * The additional properties of before, after, and between are only avilable if the initial request has the 'other' param set.
- * See https://lucene.apache.org/solr/guide/json-facet-api.html#range-facet-parameters
+ * See https://solr.apache.org/guide/json-facet-api.html#range-facet-parameters
  */
 class JsonRange extends Buckets
 {

--- a/src/Component/Spatial.php
+++ b/src/Component/Spatial.php
@@ -15,7 +15,7 @@ use Solarium\Component\RequestBuilder\Spatial as RequestBuilder;
 /**
  * Spatial component.
  *
- * @see https://lucene.apache.org/solr/guide/spatial-search.html
+ * @see https://solr.apache.org/guide/spatial-search.html
  */
 class Spatial extends AbstractComponent
 {

--- a/src/Component/Spellcheck.php
+++ b/src/Component/Spellcheck.php
@@ -18,7 +18,7 @@ use Solarium\Component\ResponseParser\Spellcheck as ResponseParser;
 /**
  * Spellcheck component.
  *
- * @see https://lucene.apache.org/solr/guide/spell-checking.html
+ * @see https://solr.apache.org/guide/spell-checking.html
  */
 class Spellcheck extends AbstractComponent implements SpellcheckInterface, QueryInterface
 {

--- a/src/Component/Stats/Stats.php
+++ b/src/Component/Stats/Stats.php
@@ -20,7 +20,7 @@ use Solarium\Exception\InvalidArgumentException;
 /**
  * Stats component.
  *
- * @see https://lucene.apache.org/solr/guide/the-stats-component.html
+ * @see https://solr.apache.org/guide/the-stats-component.html
  */
 class Stats extends AbstractComponent
 {

--- a/src/Component/Suggester.php
+++ b/src/Component/Suggester.php
@@ -18,7 +18,7 @@ use Solarium\Component\ResponseParser\Suggester as ResponseParser;
 /**
  * Spellcheck component.
  *
- * @see https://lucene.apache.org/solr/guide/suggester.html
+ * @see https://solr.apache.org/guide/suggester.html
  */
 class Suggester extends AbstractComponent implements SuggesterInterface, QueryInterface
 {

--- a/src/Core/Query/AbstractRequestBuilder.php
+++ b/src/Core/Query/AbstractRequestBuilder.php
@@ -60,7 +60,7 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
      *
      * LocalParams can be use in various Solr GET params.
      *
-     * @see https://lucene.apache.org/solr/guide/local-parameters-in-queries.html
+     * @see https://solr.apache.org/guide/local-parameters-in-queries.html
      *
      * @param string $value
      * @param array  $localParams in key => value format

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -67,7 +67,7 @@ class Helper
      * If you want to use the input as a phrase please use the {@link escapePhrase()}
      * method, because a phrase requires much less escaping.
      *
-     * @see https://lucene.apache.org/solr/guide/the-standard-query-parser.html#escaping-special-characters
+     * @see https://solr.apache.org/guide/the-standard-query-parser.html#escaping-special-characters
      *
      * @param string $input
      *
@@ -108,7 +108,7 @@ class Helper
      * A date field shall be of the form 1995-12-31T23:59:59Z.
      * The trailing "Z" designates UTC time and is mandatory.
      *
-     * @see https://lucene.apache.org/solr/guide/working-with-dates.html#date-formatting
+     * @see https://solr.apache.org/guide/working-with-dates.html#date-formatting
      *
      * @param int|string|\DateTimeInterface $input Accepted formats: timestamp, date string, DateTime or
      *                                             DateTimeImmutable
@@ -397,7 +397,7 @@ class Helper
     /**
      * Render join localparams syntax.
      *
-     * @see https://lucene.apache.org/solr/guide/other-parsers.html#join-query-parser
+     * @see https://solr.apache.org/guide/other-parsers.html#join-query-parser
      *
      * @param string $from
      * @param string $to
@@ -418,7 +418,7 @@ class Helper
      *
      * This is a Solr 3.2+ feature.
      *
-     * @see https://lucene.apache.org/solr/guide/other-parsers.html#term-query-parser
+     * @see https://solr.apache.org/guide/other-parsers.html#term-query-parser
      *
      * @param string $field
      * @param float  $weight
@@ -435,7 +435,7 @@ class Helper
      *
      * This is a Solr 3.4+ feature.
      *
-     * @see https://lucene.apache.org/solr/guide/common-query-parameters.html#cache-parameter
+     * @see https://solr.apache.org/guide/common-query-parameters.html#cache-parameter
      *
      * @param bool       $useCache
      * @param float|null $cost

--- a/src/Core/Query/LocalParameters/LocalParameters.php
+++ b/src/Core/Query/LocalParameters/LocalParameters.php
@@ -16,7 +16,7 @@ use Solarium\Exception\OutOfBoundsException;
 /**
  * Local Parameters.
  *
- * @see https://lucene.apache.org/solr/guide/local-parameters-in-queries.html
+ * @see https://solr.apache.org/guide/local-parameters-in-queries.html
  *
  * @author wicliff <wicliff.wolda@gmail.com>
  */

--- a/src/QueryType/Extract/Query.php
+++ b/src/QueryType/Extract/Query.php
@@ -23,7 +23,7 @@ use Solarium\QueryType\Update\ResponseParser as UpdateResponseParser;
  * Sends a document extract request to Solr, i.e. upload rich document content
  * such as PDF, Word or HTML, parse the file contents and add it to the index.
  *
- * The Solr server must have the {@link https://lucene.apache.org/solr/guide/uploading-data-with-solr-cell-using-apache-tika.html#configuring-the-extractingrequesthandler-in-solrconfig-xml
+ * The Solr server must have the {@link https://solr.apache.org/guide/uploading-data-with-solr-cell-using-apache-tika.html#configuring-the-extractingrequesthandler-in-solrconfig-xml
  * ExtractingRequestHandler} enabled.
  */
 class Query extends BaseQuery

--- a/src/QueryType/MoreLikeThis/Query.php
+++ b/src/QueryType/MoreLikeThis/Query.php
@@ -24,7 +24,7 @@ use Solarium\QueryType\Select\Result\Document;
  * lots of options and there are many Solarium subclasses for it.
  * See the Solr documentation and the relevant Solarium classes for more info.
  *
- * @see https://lucene.apache.org/solr/guide/other-parsers.html#more-like-this-query-parser
+ * @see https://solr.apache.org/guide/other-parsers.html#more-like-this-query-parser
  */
 class Query extends SelectQuery implements MoreLikeThisInterface
 {
@@ -85,7 +85,7 @@ class Query extends SelectQuery implements MoreLikeThisInterface
      *
      * Set to true to post query content instead of using the URL param
      *
-     * @see https://lucene.apache.org/solr/guide/content-streams.html
+     * @see https://solr.apache.org/guide/content-streams.html
      *
      * @param bool $stream
      *
@@ -116,7 +116,7 @@ class Query extends SelectQuery implements MoreLikeThisInterface
      *
      * Separate multiple fields with commas if you use string input.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#common-parameters-for-morelikethis
+     * @see https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
      *
      * @param string|array $fields
      *
@@ -152,7 +152,7 @@ class Query extends SelectQuery implements MoreLikeThisInterface
     /**
      * Set the match.include parameter, which is either 'true' or 'false'.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
+     * @see https://solr.apache.org/guide/morelikethis.html#request-handler-parameters
      *
      * @param bool $include
      *
@@ -179,7 +179,7 @@ class Query extends SelectQuery implements MoreLikeThisInterface
      * Set the mlt.match.offset parameter, which determines on which result from the query MLT should operate.
      * For paging of MLT use setStart / setRows.
      *
-     * @see https://lucene.apache.org/solr/guide/morelikethis.html#parameters-for-the-morelikethishandler
+     * @see https://solr.apache.org/guide/morelikethis.html#request-handler-parameters
      *
      * @param int $offset
      *

--- a/src/QueryType/RealtimeGet/Query.php
+++ b/src/QueryType/RealtimeGet/Query.php
@@ -21,7 +21,7 @@ use Solarium\QueryType\Select\Result\Document;
  *
  * Realtime Get query for one or multiple document IDs
  *
- * @see https://lucene.apache.org/solr/guide/realtime-get.html
+ * @see https://solr.apache.org/guide/realtime-get.html
  */
 class Query extends BaseQuery
 {

--- a/src/QueryType/Select/Query/FilterQuery.php
+++ b/src/QueryType/Select/Query/FilterQuery.php
@@ -18,7 +18,7 @@ use Solarium\Core\Query\LocalParameters\LocalParametersTrait;
 /**
  * Filterquery.
  *
- * @see https://lucene.apache.org/solr/guide/common-query-parameters.html#fq-filter-query-parameter
+ * @see https://solr.apache.org/guide/common-query-parameters.html#fq-filter-query-parameter
  */
 class FilterQuery extends Configurable implements QueryInterface
 {

--- a/src/QueryType/Server/Collections/Query/Action/ClusterStatus.php
+++ b/src/QueryType/Server/Collections/Query/Action/ClusterStatus.php
@@ -16,7 +16,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 /**
  * Class ClusterStatus.
  *
- * @see https://lucene.apache.org/solr/guide/cluster-node-management.html#clusterstatus
+ * @see https://solr.apache.org/guide/cluster-node-management.html#clusterstatus
  */
 class ClusterStatus extends AbstractAsyncAction
 {

--- a/src/QueryType/Server/Collections/Query/Action/Create.php
+++ b/src/QueryType/Server/Collections/Query/Action/Create.php
@@ -18,7 +18,7 @@ use Solarium\QueryType\Server\Query\Action\NameParameterTrait;
 /**
  * Class Create.
  *
- * @see https://lucene.apache.org/solr/guide/collection-management.html#create
+ * @see https://solr.apache.org/guide/collection-management.html#create
  */
 class Create extends AbstractAsyncAction
 {

--- a/src/QueryType/Server/Collections/Query/Action/Delete.php
+++ b/src/QueryType/Server/Collections/Query/Action/Delete.php
@@ -17,7 +17,7 @@ use Solarium\QueryType\Server\Query\Action\NameParameterTrait;
 /**
  * Class Delete.
  *
- * @see https://lucene.apache.org/solr/guide/collection-management.html#delete
+ * @see https://solr.apache.org/guide/collection-management.html#delete
  */
 class Delete extends AbstractAsyncAction
 {

--- a/src/QueryType/Server/Collections/Query/Action/Reload.php
+++ b/src/QueryType/Server/Collections/Query/Action/Reload.php
@@ -17,7 +17,7 @@ use Solarium\QueryType\Server\Query\Action\NameParameterTrait;
 /**
  * Class Reload for reloading a collection.
  *
- * @see https://lucene.apache.org/solr/guide/collection-management.html#reload
+ * @see https://solr.apache.org/guide/collection-management.html#reload
  */
 class Reload extends AbstractAsyncAction
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Create.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Create.php
@@ -15,7 +15,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 /**
  * Class Create.
  *
- * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-create
+ * @see https://solr.apache.org/guide/coreadmin-api.html#coreadmin-create
  */
 class Create extends AbstractAsyncAction implements CoreActionInterface
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/MergeIndexes.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/MergeIndexes.php
@@ -15,7 +15,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 /**
  * Class MergeIndexes.
  *
- * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-mergeindexes
+ * @see https://solr.apache.org/guide/coreadmin-api.html#coreadmin-mergeindexes
  */
 class MergeIndexes extends AbstractAsyncAction implements CoreActionInterface
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Reload.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Reload.php
@@ -15,7 +15,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAction;
 /**
  * Class Reload.
  *
- * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-reload
+ * @see https://solr.apache.org/guide/coreadmin-api.html#coreadmin-reload
  */
 class Reload extends AbstractAction implements CoreActionInterface
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Rename.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Rename.php
@@ -15,7 +15,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 /**
  * Class Rename.
  *
- * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-rename
+ * @see https://solr.apache.org/guide/coreadmin-api.html#coreadmin-rename
  */
 class Rename extends AbstractAsyncAction implements CoreActionInterface
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/RequestRecovery.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/RequestRecovery.php
@@ -15,7 +15,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAction;
 /**
  * Class RequestRecovery.
  *
- * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-requestrecovery
+ * @see https://solr.apache.org/guide/coreadmin-api.html#coreadmin-requestrecovery
  */
 class RequestRecovery extends AbstractAction implements CoreActionInterface
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/RequestStatus.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/RequestStatus.php
@@ -15,7 +15,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAction;
 /**
  * Class RequestStatus.
  *
- * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-requeststatus
+ * @see https://solr.apache.org/guide/coreadmin-api.html#coreadmin-requeststatus
  */
 class RequestStatus extends AbstractAction
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Split.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Split.php
@@ -15,7 +15,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 /**
  * Class Split.
  *
- * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-split
+ * @see https://solr.apache.org/guide/coreadmin-api.html#coreadmin-split
  */
 class Split extends AbstractAsyncAction implements CoreActionInterface
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Status.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Status.php
@@ -15,7 +15,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAction;
 /**
  * Class Status.
  *
- * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-status
+ * @see https://solr.apache.org/guide/coreadmin-api.html#coreadmin-status
  */
 class Status extends AbstractAction implements CoreActionInterface
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Swap.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Swap.php
@@ -15,7 +15,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 /**
  * Class Swap.
  *
- * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-swap
+ * @see https://solr.apache.org/guide/coreadmin-api.html#coreadmin-swap
  */
 class Swap extends AbstractAsyncAction implements CoreActionInterface
 {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Unload.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Unload.php
@@ -15,7 +15,7 @@ use Solarium\QueryType\Server\Query\Action\AbstractAsyncAction;
 /**
  * Class Unload.
  *
- * @see https://lucene.apache.org/solr/guide/coreadmin-api.html#coreadmin-unload
+ * @see https://solr.apache.org/guide/coreadmin-api.html#coreadmin-unload
  */
 class Unload extends AbstractAsyncAction implements CoreActionInterface
 {

--- a/src/QueryType/Spellcheck/Query.php
+++ b/src/QueryType/Spellcheck/Query.php
@@ -25,7 +25,7 @@ use Solarium\QueryType\Spellcheck\Result\Term;
  *
  * Can be used for an autocomplete feature.
  *
- * @see https://lucene.apache.org/solr/guide/spell-checking.html
+ * @see https://solr.apache.org/guide/spell-checking.html
  */
 class Query extends BaseQuery implements SpellcheckInterface, QueryInterface
 {

--- a/src/QueryType/Suggester/Query.php
+++ b/src/QueryType/Suggester/Query.php
@@ -26,7 +26,7 @@ use Solarium\QueryType\Suggester\Result\Term;
  *
  * Can be used for an autocomplete feature.
  *
- * @see https://lucene.apache.org/solr/guide/suggester.html
+ * @see https://solr.apache.org/guide/suggester.html
  */
 class Query extends BaseQuery implements SuggesterInterface, QueryInterface
 {

--- a/src/QueryType/Update/Query/Command/Add.php
+++ b/src/QueryType/Update/Query/Command/Add.php
@@ -16,7 +16,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query add command.
  *
- * @see https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#adding-documents
+ * @see https://solr.apache.org/guide/uploading-data-with-index-handlers.html#adding-documents
  */
 class Add extends AbstractCommand
 {

--- a/src/QueryType/Update/Query/Command/Commit.php
+++ b/src/QueryType/Update/Query/Command/Commit.php
@@ -14,7 +14,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query commit command.
  *
- * @see https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#commit-and-optimize-during-updates
+ * @see https://solr.apache.org/guide/uploading-data-with-index-handlers.html#commit-and-optimize-during-updates
  */
 class Commit extends AbstractCommand
 {

--- a/src/QueryType/Update/Query/Command/Delete.php
+++ b/src/QueryType/Update/Query/Command/Delete.php
@@ -14,7 +14,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query delete command.
  *
- * @see https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#delete-operations
+ * @see https://solr.apache.org/guide/uploading-data-with-index-handlers.html#delete-operations
  */
 class Delete extends AbstractCommand
 {

--- a/src/QueryType/Update/Query/Command/Optimize.php
+++ b/src/QueryType/Update/Query/Command/Optimize.php
@@ -14,7 +14,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query optimize command.
  *
- * @see https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#commit-and-optimize-during-updates
+ * @see https://solr.apache.org/guide/uploading-data-with-index-handlers.html#commit-and-optimize-during-updates
  */
 class Optimize extends AbstractCommand
 {

--- a/src/QueryType/Update/Query/Command/RawXml.php
+++ b/src/QueryType/Update/Query/Command/RawXml.php
@@ -15,7 +15,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query raw XML command.
  *
- * @see https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#xml-formatted-index-updates
+ * @see https://solr.apache.org/guide/uploading-data-with-index-handlers.html#xml-formatted-index-updates
  */
 class RawXml extends AbstractCommand
 {

--- a/src/QueryType/Update/Query/Command/Rollback.php
+++ b/src/QueryType/Update/Query/Command/Rollback.php
@@ -14,7 +14,7 @@ use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 /**
  * Update query rollback command.
  *
- * @see https://lucene.apache.org/solr/guide/uploading-data-with-index-handlers.html#rollback-operations
+ * @see https://solr.apache.org/guide/uploading-data-with-index-handlers.html#rollback-operations
  */
 class Rollback extends AbstractCommand
 {

--- a/src/QueryType/Update/RequestBuilder.php
+++ b/src/QueryType/Update/RequestBuilder.php
@@ -262,7 +262,7 @@ class RequestBuilder extends BaseRequestBuilder
         $xml = '';
 
         // Remove the values if 'null' or empty list is specified as the new value
-        // @see https://lucene.apache.org/solr/guide/updating-parts-of-documents.html#atomic-updates
+        // @see https://solr.apache.org/guide/updating-parts-of-documents.html#atomic-updates
         if (Document::MODIFIER_SET === $modifier && \is_array($value) && empty($value)) {
             $value = null;
         }

--- a/tests/Builder/Analytics/FunctionBuilderTest.php
+++ b/tests/Builder/Analytics/FunctionBuilderTest.php
@@ -22,7 +22,7 @@ class FunctionBuilderTest extends TestCase
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \Solarium\Exception\RuntimeException
      *
-     * @see https://lucene.apache.org/solr/guide/analytics.html#example-construction
+     * @see https://solr.apache.org/guide/analytics.html#example-construction
      */
     public function testBuilder(): void
     {


### PR DESCRIPTION
Searched/replaced the links and then clicked all 181 of them to ensure they still work. Anchors for the MoreLikeThis page had to be updated.

Rationale for the URL change:

[17 February 2021, Apache Solr becomes an Apache TLP](https://solr.apache.org/news.html#apache-solr-becomes-an-apache-tlp)

> Solr gets a new website at solr.apache.org

MLT anchor were changed in [SOLR-15243: Update MoreLikeThis docs](https://issues.apache.org/jira/browse/SOLR-15243) ([#12](https://github.com/apache/solr/pull/12))