### PR TITLE
Always respect automatic filtering of control characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [unreleased]
+### Added
+- QueryType\Update\Query\Document::setFields() to set all fields on a Document
+
+### Fixed
+- Always respect automatic filtering of control characters in field values in QueryType\Update\Query\Document
+
+
 ## [6.1.5]
 ### Added
 - Component\Result\Stats\Result::getDistinctValues()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Always respect automatic filtering of control characters in field values in QueryType\Update\Query\Document
+- Remove the field modifier along with the value(s) and boost in QueryType\Update\Query\Document::removeField()
 
 
 ## [6.1.5]

--- a/tests/QueryType/Extract/QueryTest.php
+++ b/tests/QueryType/Extract/QueryTest.php
@@ -127,7 +127,7 @@ class QueryTest extends TestCase
     public function testCreateDocument($query)
     {
         $fields = ['key1' => 'value1', 'key2' => 'value2'];
-        $boosts = ['key1' => 1, 'key2' => 2];
+        $boosts = ['key1' => 1.0, 'key2' => 2.0];
         $document = $query->createDocument($fields, $boosts);
 
         $this->assertInstanceOf('Solarium\Tests\QueryType\Extract\MyCustomDoc', $document);

--- a/tests/QueryType/Update/Query/Document/DocumentTest.php
+++ b/tests/QueryType/Update/Query/Document/DocumentTest.php
@@ -191,7 +191,7 @@ class DocumentTest extends TestCase
         $fields = ['id' => 1, 'name' => 'testname', 'categories' => [4, 5]];
         $boosts = ['name' => 2.7];
         $modifiers = ['categories' => Document::MODIFIER_SET];
-        
+
         $this->doc->setKey('id');
         $this->doc->setFields($fields, $boosts, $modifiers);
 

--- a/tests/QueryType/Update/Query/Document/DocumentTest.php
+++ b/tests/QueryType/Update/Query/Document/DocumentTest.php
@@ -26,7 +26,7 @@ class DocumentTest extends TestCase
 
     public function testConstructorWithFieldsAndBoostsAndModifiers()
     {
-        $fields = ['id' => 1, 'name' => 'testname'];
+        $fields = ['id' => 1, 'name' => 'testname', 'categories' => [4, 5]];
         $boosts = ['name' => 2.7];
         $modifiers = ['name' => Document::MODIFIER_SET];
         $doc = new Document($fields, $boosts, $modifiers);
@@ -163,6 +163,54 @@ class DocumentTest extends TestCase
         );
     }
 
+    public function testSetFields()
+    {
+        $this->doc->addField('foo', 'bar');
+        $this->doc->setFieldBoost('name', 2.7);
+        $this->doc->setFieldModifier('categories', Document::MODIFIER_ADD);
+
+        $fields = ['id' => 1, 'name' => 'testname', 'categories' => [4, 5]];
+        $this->doc->setFields($fields);
+
+        $this->assertSame(
+            $fields,
+            $this->doc->getFields()
+        );
+
+        $this->assertNull(
+            $this->doc->getFieldBoost('name')
+        );
+
+        $this->assertNull(
+            $this->doc->getFieldModifier('categories')
+        );
+    }
+
+    public function testSetFieldsWithBoostsAndModifiers()
+    {
+        $fields = ['id' => 1, 'name' => 'testname', 'categories' => [4, 5]];
+        $boosts = ['name' => 2.7];
+        $modifiers = ['categories' => Document::MODIFIER_SET];
+        
+        $this->doc->setKey('id');
+        $this->doc->setFields($fields, $boosts, $modifiers);
+
+        $this->assertSame(
+            $fields,
+            $this->doc->getFields()
+        );
+
+        $this->assertSame(
+            2.7,
+            $this->doc->getFieldBoost('name')
+        );
+
+        $this->assertSame(
+            Document::MODIFIER_SET,
+            $this->doc->getFieldModifier('categories')
+        );
+    }
+
     public function testRemoveField()
     {
         $this->doc->removeField('name');
@@ -207,6 +255,16 @@ class DocumentTest extends TestCase
     public function testRemoveFieldBoostRemoval()
     {
         $this->doc->setFieldBoost('name', 3.2);
+        $this->doc->removeField('name');
+
+        $this->assertNull(
+            $this->doc->getFieldBoost('name')
+        );
+    }
+
+    public function testRemoveFieldModifierRemoval()
+    {
+        $this->doc->setFieldModifier('name', Document::MODIFIER_ADD);
         $this->doc->removeField('name');
 
         $this->assertNull(
@@ -426,11 +484,46 @@ class DocumentTest extends TestCase
         );
     }
 
+    public function testEscapeByDefaultConstructor()
+    {
+        $fields = [
+            'foo' => 'bar'.chr(15),
+            'foos' => ['bar'.chr(15), 'bar'.chr(15).chr(8)],
+        ];
+        $doc = new Document($fields);
+
+        $this->assertSame('bar ', $doc->foo);
+        $this->assertSame(['bar ', 'bar  '], $doc->foos);
+    }
+
+    public function testEscapeByDefaultSetByProperty()
+    {
+        $this->doc->foo = 'bar'.chr(15);
+        $this->doc->foos = ['bar'.chr(15), 'bar'.chr(15).chr(8)];
+
+        $this->assertSame('bar ', $this->doc->foo);
+        $this->assertSame(['bar ', 'bar  '], $this->doc->foos);
+    }
+
     public function testEscapeByDefaultSetField()
     {
         $this->doc->setField('foo', 'bar'.chr(15));
+        $this->doc->setField('foos', ['bar'.chr(15), 'bar'.chr(15).chr(8)]);
 
         $this->assertSame('bar ', $this->doc->foo);
+        $this->assertSame(['bar ', 'bar  '], $this->doc->foos);
+    }
+
+    public function testEscapeByDefaultSetFields()
+    {
+        $fields = [
+            'foo' => 'bar'.chr(15),
+            'foos' => ['bar'.chr(15), 'bar'.chr(15).chr(8)],
+        ];
+        $this->doc->setFields($fields);
+
+        $this->assertSame('bar ', $this->doc->foo);
+        $this->assertSame(['bar ', 'bar  '], $this->doc->foos);
     }
 
     public function testEscapeByDefaultAddField()
@@ -441,12 +534,37 @@ class DocumentTest extends TestCase
         $this->assertSame(['bar ', 'bar  '], $this->doc->foo);
     }
 
+    public function testNoEscapeSetByProperty()
+    {
+        $this->doc->setFilterControlCharacters(false);
+        $this->doc->foo = $value = 'bar'.chr(15);
+        $this->doc->foos = $multivalue = ['bar'.chr(15), 'bar'.chr(15).chr(8)];
+
+        $this->assertSame($value, $this->doc->foo);
+        $this->assertSame($multivalue, $this->doc->foos);
+    }
+
     public function testNoEscapeSetField()
     {
         $this->doc->setFilterControlCharacters(false);
         $this->doc->setField('foo', $value = 'bar'.chr(15));
+        $this->doc->setField('foos', $multivalue = ['bar'.chr(15), 'bar'.chr(15).chr(8)]);
 
         $this->assertSame($value, $this->doc->foo);
+        $this->assertSame($multivalue, $this->doc->foos);
+    }
+
+    public function testNoEscapeSetFields()
+    {
+        $fields = [
+            'foo' => $value = 'bar'.chr(15),
+            'foos' => $multivalue = ['bar'.chr(15), 'bar'.chr(15).chr(8)],
+        ];
+        $this->doc->setFilterControlCharacters(false);
+        $this->doc->setFields($fields);
+
+        $this->assertSame($value, $this->doc->foo);
+        $this->assertSame($multivalue, $this->doc->foos);
     }
 
     public function testNoEscapeAddField()

--- a/tests/QueryType/Update/Query/Document/DocumentTest.php
+++ b/tests/QueryType/Update/Query/Document/DocumentTest.php
@@ -77,6 +77,20 @@ class DocumentTest extends TestCase
             2.3,
             $this->doc->getFieldBoost('myfield')
         );
+
+        $this->doc->addField('myfield', 'myvalue2', 2.7);
+
+        $expectedFields['myfield'] = ['myvalue', 'myvalue2'];
+
+        $this->assertSame(
+            $expectedFields,
+            $this->doc->getFields()
+        );
+
+        $this->assertSame(
+            2.7,
+            $this->doc->getFieldBoost('myfield')
+        );
     }
 
     public function testAddFieldMultivalue()
@@ -105,7 +119,18 @@ class DocumentTest extends TestCase
     {
         $this->doc->clear();
         $this->doc->setKey('id', 1);
-        $this->doc->addField('myfield', 'myvalue', null, Document::MODIFIER_ADD);
+        $this->doc->addField('myfield', 'myvalue', null, Document::MODIFIER_SET);
+
+        $this->assertSame(
+            ['id' => 1, 'myfield' => 'myvalue'],
+            $this->doc->getFields()
+        );
+
+        $this->assertSame(
+            Document::MODIFIER_SET,
+            $this->doc->getFieldModifier('myfield')
+        );
+
         $this->doc->addField('myfield', 'myvalue2', null, Document::MODIFIER_ADD);
 
         $this->assertSame(


### PR DESCRIPTION
Fixes #953.

Made sure control characters are always filtered by default be passing them from the constructor to a new method `setFields()` which ultimately passes them to `setField()` or `addField()` if it's a multivalue field.

Unit tests were expanded to test the filtering when values are set through the constructor, by property or with a method call to ensure the behaviour remains consistent no matter how methods rely upon each other internally.

There is no longer a way to set unfiltered values through the constructor. That could be a BC break for people relying on the old behaviour, but it was never documented to start with.

I had to update an unrelated unit test that passed boosts through the constructor as `int`s. They are now cast to `float` because of the typehint in `setField()` they previously didn't encounter. Solr would do the same casting anyway so this doesn't change what will be indexed.

There was another small inconsistency. When removing a field from a Document, the field's modifier wasn't removed while its boost was. It doesn't matter unless you set a field with the same name again without specifying a modifier. At that point applying the modifier of a removed field to a newly set field seems like a bug to me. (Feel free to disagree with me.)