### PR TITLE
Managed Resources documentation and examples

### DIFF
--- a/docs/queries/managedresources-query/managed-resources.md
+++ b/docs/queries/managedresources-query/managed-resources.md
@@ -1,0 +1,33 @@
+A Managed Resources query can be used to get metadata about all ManagedResources registered through Solr's RestManager Endpoint.
+For more info see <https://solr.apache.org/guide/managed-resources.html#restmanager-endpoint>.
+
+Example
+-------
+
+```php
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a managed resources query
+$managedResourcesQuery = $client->createManagedResources();
+
+// this executes the query and returns the result
+$result = $client->execute($managedResourcesQuery);
+
+// display resources
+foreach ($result as $resource) {
+    echo '<table>';
+    echo '<tr><th>Resource ID</th><td>' . $resource->getResourceId() . '</td></tr>';
+    echo '<tr><th>Number of Observers</th><td>' . $resource->getNumObservers() . '</td></tr>';
+    echo '<tr><th>Class</th><td>' . $resource->getClass() . '</td></tr>';
+    echo '</table><hr/>';
+}
+
+htmlFooter();
+
+```

--- a/docs/queries/managedresources-query/managed-stopwords.md
+++ b/docs/queries/managedresources-query/managed-stopwords.md
@@ -1,0 +1,221 @@
+A Managed Stopwords query can be used for CRUD operations against Solr's managed resources REST API endpoint.
+For more info see <https://solr.apache.org/guide/managed-resources.html>.
+
+The default operation of a query is reading a stopword list or a single stopword in a list.
+Other operations require an explicit command be set on the query.
+
+Examples
+--------
+
+```php
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+echo '<h1>Commands that operate on a stopword list</h1>';
+
+echo '<h2>Get list</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('english');
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display list properties
+echo '<b>Case sensitive:</b> ' . ($result->isIgnoreCase() ? 'no' : 'yes') . '<br/>';
+echo '<b>Initialized on:</b> ' . $result->getInitializedOn() . '<br/>';
+echo '<b>Updated since init:</b> ' . $result->getUpdatedSinceInit() . '<br/><br/>';
+
+// display stopwords
+echo '<b>Number of stopwords:</b> ' . count($result) . '<br/>';
+echo '<b>Stopwords:</b><br/>';
+echo implode(', ', $result->getItems());
+echo '<br/>';
+
+echo '<h2>Check list existence</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// create an "exists" command and set it on the query
+$existsCommand = $query->createCommand($query::COMMAND_EXISTS);
+$query->setCommand($existsCommand);
+
+foreach (['english', 'dutch'] as $name) {
+    // set the name of the stopword list
+    $query->setName($name);
+
+    // execute the query and return the result
+    $result = $client->execute($query);
+
+    // display the result
+    echo '<b>' . $name . ':</b> ' . ($result->getWasSuccessful() ? 'exists' : 'doesn\'t exist') . '<br/>';
+}
+
+echo '<h2>Create list</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('dutch');
+
+// create a "create" command and set it on the query
+$createCommand = $query->createCommand($query::COMMAND_CREATE);
+$query->setCommand($createCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Stopword list was created.';
+}
+
+echo '<h2>Configure list</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('dutch');
+
+// create initialization arguments and set case sensitivity
+$initArgs = $query->createInitArgs();
+$initArgs->setIgnoreCase(false);
+
+// create a "config" command, set init args on the command and set the command on the query
+$configCommand = $query->createCommand($query::COMMAND_CONFIG);
+$configCommand->setInitArgs($initArgs);
+$query->setCommand($configCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Stopword list configuration updated.';
+}
+
+echo '<h2>Remove list</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('dutch');
+
+// create a "remove" command and set it on the query
+$removeCommand = $query->createCommand($query::COMMAND_REMOVE);
+$query->setCommand($removeCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Stopword list was removed.';
+}
+
+echo '<hr/><h1>Commands that operate on stopwords in a list</h1>';
+
+echo '<h2>Get stopword</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('english');
+
+// set the term, case doesn't matter on this list
+$query->setTerm('StopwordA');
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display stopword, there will be only one
+foreach ($result as $stopword) {
+    echo $stopword;
+}
+
+echo '<h2>Check stopword existence</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('english');
+
+// create an "exists" command
+$existsCommand = $query->createCommand($query::COMMAND_EXISTS);
+
+foreach (['stopwordb', 'stopwordc'] as $term) {
+    // set the term on the command, and set the command on the query
+    $existsCommand->setTerm($term);
+    $query->setCommand($existsCommand);
+
+    // execute the query and return the result
+    $result = $client->execute($query);
+
+    // display the result
+    echo '<b>' . $term . ':</b> ' . ($result->getWasSuccessful() ? 'exists' : 'doesn\'t exist') . '<br/>';
+}
+
+echo '<h2>Add stopwords</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('english');
+
+// create an "add" command, set stopwords on the command, and set the command on the query
+$addCommand = $query->createCommand($query::COMMAND_ADD);
+$addCommand->setStopwords(['foo', 'bar']);
+$query->setCommand($addCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Stopwords were added.';
+}
+
+echo '<h2>Delete stopwords</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('english');
+
+// create a "delete" command
+$deleteCommand = $query->createCommand($query::COMMAND_DELETE);
+
+// unlike adding, deleting has to be done term per term
+foreach (['foo', 'bar'] as $term) {
+    // set the term on the command, and set the command on the query
+    $deleteCommand->setTerm($term);
+    $query->setCommand($deleteCommand);
+
+    // execute the query and return the result
+    $result = $client->execute($query);
+
+    // display the result
+    if ($result->getWasSuccessful()) {
+        echo 'Stopword was deleted.<br/>';
+    }
+}
+
+htmlFooter();
+
+```

--- a/docs/queries/managedresources-query/managed-synonyms.md
+++ b/docs/queries/managedresources-query/managed-synonyms.md
@@ -1,0 +1,281 @@
+A Managed Synonyms query can be used for CRUD operations against Solr's managed resources REST API endpoint.
+For more info see <https://solr.apache.org/guide/managed-resources.html>.
+
+The default operation of a query is reading a synonym list or a single synonym mapping in a list.
+Other operations require an explicit command be set on the query.
+
+Examples
+--------
+
+```php
+<?php
+
+use Solarium\QueryType\ManagedResources\Query\Synonyms\Synonyms;
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+echo '<h1>Commands that operate on a synonym list</h1>';
+
+echo '<h2>Get list</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display list properties
+echo '<b>Case sensitive:</b> ' . ($result->isIgnoreCase() ? 'no' : 'yes') . '<br/>';
+echo '<b>Format:</b> ' . $result->getFormat() . '<br/>';
+echo '<b>Initialized on:</b> ' . $result->getInitializedOn() . '<br/>';
+echo '<b>Updated since init:</b> ' . $result->getUpdatedSinceInit() . '<br/><br/>';
+
+// display synonyms
+echo '<b>Number of synonym mappings:</b> ' . count($result) . '<br/>';
+echo '<b>Synonym mappings:</b><br/>';
+echo '<table>';
+
+foreach ($result as $synonym) {
+    echo '<tr><th>' . $synonym->getTerm() . '</th><td>' . implode(', ', $synonym->getSynonyms()) . '</td></tr>';
+}
+
+echo '</table>';
+
+echo '<h2>Check list existence</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// create an "exists" command and set it on the query
+$existsCommand = $query->createCommand($query::COMMAND_EXISTS);
+$query->setCommand($existsCommand);
+
+foreach (['english', 'dutch'] as $name) {
+    // set the name of the synonym list
+    $query->setName($name);
+
+    // execute the query and return the result
+    $result = $client->execute($query);
+
+    // display the result
+    echo '<b>' . $name . ':</b> ' . ($result->getWasSuccessful() ? 'exists' : 'doesn\'t exist') . '<br/>';
+}
+
+echo '<h2>Create list</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('dutch');
+
+// create a "create" command and set it on the query
+$createCommand = $query->createCommand($query::COMMAND_CREATE);
+$query->setCommand($createCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Synonym list was created.';
+}
+
+echo '<h2>Configure list</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('dutch');
+
+// create initialization arguments and set case sensitivity and format
+$initArgs = $query->createInitArgs();
+$initArgs->setIgnoreCase(false);
+$initArgs->setFormat($initArgs::FORMAT_SOLR);
+
+// create a "config" command, set init args on the command and set the command on the query
+$configCommand = $query->createCommand($query::COMMAND_CONFIG);
+$configCommand->setInitArgs($initArgs);
+$query->setCommand($configCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Synonym list configuration updated.';
+}
+
+echo '<h2>Remove list</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('dutch');
+
+// create a "remove" command and set it on the query
+$removeCommand = $query->createCommand($query::COMMAND_REMOVE);
+$query->setCommand($removeCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Synonym list was removed.';
+}
+
+echo '<hr/><h1>Commands that operate on synonym mappings in a list</h1>';
+
+echo '<h2>Get synonym mapping</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// set the term, case doesn't matter on this list
+$query->setTerm('gb');
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display synonym, there will be only one
+foreach ($result as $synonym) {
+    echo '<b>' . $synonym->getTerm() . '</b>: ' . implode(', ', $synonym->getSynonyms());
+}
+
+echo '<h2>Check synonym mapping existence</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// create an "exists" command
+$existsCommand = $query->createCommand($query::COMMAND_EXISTS);
+
+foreach (['tv', 'radio'] as $term) {
+    // set the term on the command, and set the command on the query
+    $existsCommand->setTerm($term);
+    $query->setCommand($existsCommand);
+
+    // execute the query and return the result
+    $result = $client->execute($query);
+
+    // display the result
+    echo '<b>' . $term . ':</b> ' . ($result->getWasSuccessful() ? 'exists' : 'doesn\'t exist') . '<br/>';
+}
+
+echo '<h2>Add single synonym mapping</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// create a synonym mapping
+$synonyms = new Synonyms();
+$synonyms->setTerm('mad');
+$synonyms->setSynonyms(['angry', 'upset']);
+
+// create an "add" command, set synonym mapping on the command, and set the command on the query
+$addCommand = $query->createCommand($query::COMMAND_ADD);
+$addCommand->setSynonyms($synonyms);
+$query->setCommand($addCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Synonym mapping was added.';
+}
+
+echo '<h2>Delete single synonym mapping</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// create a "delete" command, set the term on the command, and set the command on the query
+$deleteCommand = $query->createCommand($query::COMMAND_DELETE);
+$deleteCommand->setTerm('mad');
+$query->setCommand($deleteCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Synonym mapping was deleted.<br/>';
+}
+
+echo '<h2>Add symmetric synonyms</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// create a synonym mapping but don't set an explicit term, synonyms will be expanded into a mapping for each listed term
+$synonyms = new Synonyms();
+$synonyms->setSynonyms(['funny', 'entertaining', 'whimiscal', 'jocular']);
+
+// create an "add" command, set synonym mapping on the command, and set the command on the query
+$addCommand = $query->createCommand($query::COMMAND_ADD);
+$addCommand->setSynonyms($synonyms);
+$query->setCommand($addCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Synonym mappings were added.';
+}
+
+echo '<h2>Delete expanded synonym mappings</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// create a "delete" command
+$deleteCommand = $query->createCommand($query::COMMAND_DELETE);
+
+// unlike adding, deleting has to be done term per term
+foreach (['funny', 'entertaining', 'whimiscal', 'jocular'] as $term) {
+    // set the term on the command, and set the command on the query
+    $deleteCommand->setTerm($term);
+    $query->setCommand($deleteCommand);
+
+    // execute the query and return the result
+    $result = $client->execute($query);
+
+    // display the result
+    if ($result->getWasSuccessful()) {
+        echo 'Synonym mapping was deleted.<br/>';
+    }
+}
+
+htmlFooter();
+
+```

--- a/examples/2.10.1-managedresources-resources.php
+++ b/examples/2.10.1-managedresources-resources.php
@@ -1,0 +1,24 @@
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a managed resources query
+$managedResourcesQuery = $client->createManagedResources();
+
+// this executes the query and returns the result
+$result = $client->execute($managedResourcesQuery);
+
+// display resources
+foreach ($result as $resource) {
+    echo '<table>';
+    echo '<tr><th>Resource ID</th><td>' . $resource->getResourceId() . '</td></tr>';
+    echo '<tr><th>Number of Observers</th><td>' . $resource->getNumObservers() . '</td></tr>';
+    echo '<tr><th>Class</th><td>' . $resource->getClass() . '</td></tr>';
+    echo '</table><hr/>';
+}
+
+htmlFooter();

--- a/examples/2.10.2-managedresources-stopwords.php
+++ b/examples/2.10.2-managedresources-stopwords.php
@@ -1,0 +1,209 @@
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+echo '<h1>Commands that operate on a stopword list</h1>';
+
+echo '<h2>Get list</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('english');
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display list properties
+echo '<b>Case sensitive:</b> ' . ($result->isIgnoreCase() ? 'no' : 'yes') . '<br/>';
+echo '<b>Initialized on:</b> ' . $result->getInitializedOn() . '<br/>';
+echo '<b>Updated since init:</b> ' . $result->getUpdatedSinceInit() . '<br/><br/>';
+
+// display stopwords
+echo '<b>Number of stopwords:</b> ' . count($result) . '<br/>';
+echo '<b>Stopwords:</b><br/>';
+echo implode(', ', $result->getItems());
+echo '<br/>';
+
+echo '<h2>Check list existence</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// create an "exists" command and set it on the query
+$existsCommand = $query->createCommand($query::COMMAND_EXISTS);
+$query->setCommand($existsCommand);
+
+foreach (['english', 'dutch'] as $name) {
+    // set the name of the stopword list
+    $query->setName($name);
+
+    // execute the query and return the result
+    $result = $client->execute($query);
+
+    // display the result
+    echo '<b>' . $name . ':</b> ' . ($result->getWasSuccessful() ? 'exists' : 'doesn\'t exist') . '<br/>';
+}
+
+echo '<h2>Create list</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('dutch');
+
+// create a "create" command and set it on the query
+$createCommand = $query->createCommand($query::COMMAND_CREATE);
+$query->setCommand($createCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Stopword list was created.';
+}
+
+echo '<h2>Configure list</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('dutch');
+
+// create initialization arguments and set case sensitivity
+$initArgs = $query->createInitArgs();
+$initArgs->setIgnoreCase(false);
+
+// create a "config" command, set init args on the command and set the command on the query
+$configCommand = $query->createCommand($query::COMMAND_CONFIG);
+$configCommand->setInitArgs($initArgs);
+$query->setCommand($configCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Stopword list configuration updated.';
+}
+
+echo '<h2>Remove list</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('dutch');
+
+// create a "remove" command and set it on the query
+$removeCommand = $query->createCommand($query::COMMAND_REMOVE);
+$query->setCommand($removeCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Stopword list was removed.';
+}
+
+echo '<hr/><h1>Commands that operate on stopwords in a list</h1>';
+
+echo '<h2>Get stopword</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('english');
+
+// set the term, case doesn't matter on this list
+$query->setTerm('StopwordA');
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display stopword, there will be only one
+foreach ($result as $stopword) {
+    echo $stopword;
+}
+
+echo '<h2>Check stopword existence</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('english');
+
+// create an "exists" command
+$existsCommand = $query->createCommand($query::COMMAND_EXISTS);
+
+foreach (['stopwordb', 'stopwordc'] as $term) {
+    // set the term on the command, and set the command on the query
+    $existsCommand->setTerm($term);
+    $query->setCommand($existsCommand);
+
+    // execute the query and return the result
+    $result = $client->execute($query);
+
+    // display the result
+    echo '<b>' . $term . ':</b> ' . ($result->getWasSuccessful() ? 'exists' : 'doesn\'t exist') . '<br/>';
+}
+
+echo '<h2>Add stopwords</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('english');
+
+// create an "add" command, set stopwords on the command, and set the command on the query
+$addCommand = $query->createCommand($query::COMMAND_ADD);
+$addCommand->setStopwords(['foo', 'bar']);
+$query->setCommand($addCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Stopwords were added.';
+}
+
+echo '<h2>Delete stopwords</h2>';
+
+// create a managed stopwords query
+$query = $client->createManagedStopwords();
+
+// set the name of the stopword list
+$query->setName('english');
+
+// create a "delete" command
+$deleteCommand = $query->createCommand($query::COMMAND_DELETE);
+
+// unlike adding, deleting has to be done term per term
+foreach (['foo', 'bar'] as $term) {
+    // set the term on the command, and set the command on the query
+    $deleteCommand->setTerm($term);
+    $query->setCommand($deleteCommand);
+
+    // execute the query and return the result
+    $result = $client->execute($query);
+
+    // display the result
+    if ($result->getWasSuccessful()) {
+        echo 'Stopword was deleted.<br/>';
+    }
+}
+
+htmlFooter();

--- a/examples/2.10.3-managedresources-synonyms.php
+++ b/examples/2.10.3-managedresources-synonyms.php
@@ -1,0 +1,269 @@
+<?php
+
+use Solarium\QueryType\ManagedResources\Query\Synonyms\Synonyms;
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+echo '<h1>Commands that operate on a synonym list</h1>';
+
+echo '<h2>Get list</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display list properties
+echo '<b>Case sensitive:</b> ' . ($result->isIgnoreCase() ? 'no' : 'yes') . '<br/>';
+echo '<b>Format:</b> ' . $result->getFormat() . '<br/>';
+echo '<b>Initialized on:</b> ' . $result->getInitializedOn() . '<br/>';
+echo '<b>Updated since init:</b> ' . $result->getUpdatedSinceInit() . '<br/><br/>';
+
+// display synonyms
+echo '<b>Number of synonym mappings:</b> ' . count($result) . '<br/>';
+echo '<b>Synonym mappings:</b><br/>';
+echo '<table>';
+
+foreach ($result as $synonym) {
+    echo '<tr><th>' . $synonym->getTerm() . '</th><td>' . implode(', ', $synonym->getSynonyms()) . '</td></tr>';
+}
+
+echo '</table>';
+
+echo '<h2>Check list existence</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// create an "exists" command and set it on the query
+$existsCommand = $query->createCommand($query::COMMAND_EXISTS);
+$query->setCommand($existsCommand);
+
+foreach (['english', 'dutch'] as $name) {
+    // set the name of the synonym list
+    $query->setName($name);
+
+    // execute the query and return the result
+    $result = $client->execute($query);
+
+    // display the result
+    echo '<b>' . $name . ':</b> ' . ($result->getWasSuccessful() ? 'exists' : 'doesn\'t exist') . '<br/>';
+}
+
+echo '<h2>Create list</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('dutch');
+
+// create a "create" command and set it on the query
+$createCommand = $query->createCommand($query::COMMAND_CREATE);
+$query->setCommand($createCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Synonym list was created.';
+}
+
+echo '<h2>Configure list</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('dutch');
+
+// create initialization arguments and set case sensitivity and format
+$initArgs = $query->createInitArgs();
+$initArgs->setIgnoreCase(false);
+$initArgs->setFormat($initArgs::FORMAT_SOLR);
+
+// create a "config" command, set init args on the command and set the command on the query
+$configCommand = $query->createCommand($query::COMMAND_CONFIG);
+$configCommand->setInitArgs($initArgs);
+$query->setCommand($configCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Synonym list configuration updated.';
+}
+
+echo '<h2>Remove list</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('dutch');
+
+// create a "remove" command and set it on the query
+$removeCommand = $query->createCommand($query::COMMAND_REMOVE);
+$query->setCommand($removeCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Synonym list was removed.';
+}
+
+echo '<hr/><h1>Commands that operate on synonym mappings in a list</h1>';
+
+echo '<h2>Get synonym mapping</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// set the term, case doesn't matter on this list
+$query->setTerm('gb');
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display synonym, there will be only one
+foreach ($result as $synonym) {
+    echo '<b>' . $synonym->getTerm() . '</b>: ' . implode(', ', $synonym->getSynonyms());
+}
+
+echo '<h2>Check synonym mapping existence</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// create an "exists" command
+$existsCommand = $query->createCommand($query::COMMAND_EXISTS);
+
+foreach (['tv', 'radio'] as $term) {
+    // set the term on the command, and set the command on the query
+    $existsCommand->setTerm($term);
+    $query->setCommand($existsCommand);
+
+    // execute the query and return the result
+    $result = $client->execute($query);
+
+    // display the result
+    echo '<b>' . $term . ':</b> ' . ($result->getWasSuccessful() ? 'exists' : 'doesn\'t exist') . '<br/>';
+}
+
+echo '<h2>Add single synonym mapping</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// create a synonym mapping
+$synonyms = new Synonyms();
+$synonyms->setTerm('mad');
+$synonyms->setSynonyms(['angry', 'upset']);
+
+// create an "add" command, set synonym mapping on the command, and set the command on the query
+$addCommand = $query->createCommand($query::COMMAND_ADD);
+$addCommand->setSynonyms($synonyms);
+$query->setCommand($addCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Synonym mapping was added.';
+}
+
+echo '<h2>Delete single synonym mapping</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// create a "delete" command, set the term on the command, and set the command on the query
+$deleteCommand = $query->createCommand($query::COMMAND_DELETE);
+$deleteCommand->setTerm('mad');
+$query->setCommand($deleteCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Synonym mapping was deleted.<br/>';
+}
+
+echo '<h2>Add symmetric synonyms</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// create a synonym mapping but don't set an explicit term, synonyms will be expanded into a mapping for each listed term
+$synonyms = new Synonyms();
+$synonyms->setSynonyms(['funny', 'entertaining', 'whimiscal', 'jocular']);
+
+// create an "add" command, set synonym mapping on the command, and set the command on the query
+$addCommand = $query->createCommand($query::COMMAND_ADD);
+$addCommand->setSynonyms($synonyms);
+$query->setCommand($addCommand);
+
+// execute the query and return the result
+$result = $client->execute($query);
+
+// display the result
+if ($result->getWasSuccessful()) {
+    echo 'Synonym mappings were added.';
+}
+
+echo '<h2>Delete expanded synonym mappings</h2>';
+
+// create a managed synonyms query
+$query = $client->createManagedSynonyms();
+
+// set the name of the synonym list
+$query->setName('english');
+
+// create a "delete" command
+$deleteCommand = $query->createCommand($query::COMMAND_DELETE);
+
+// unlike adding, deleting has to be done term per term
+foreach (['funny', 'entertaining', 'whimiscal', 'jocular'] as $term) {
+    // set the term on the command, and set the command on the query
+    $deleteCommand->setTerm($term);
+    $query->setCommand($deleteCommand);
+
+    // execute the query and return the result
+    $result = $client->execute($query);
+
+    // display the result
+    if ($result->getWasSuccessful()) {
+        echo 'Synonym mapping was deleted.<br/>';
+    }
+}
+
+htmlFooter();

--- a/examples/execute_all.php
+++ b/examples/execute_all.php
@@ -130,6 +130,8 @@ try {
     $skipForCloud = [
         '2.1.5.7-grouping-by-query.php',
         '2.2.5-rollback.php',
+        '2.10.2-managedresources-stopwords.php',
+        '2.10.3-managedresources-synonyms.php',
         '7.1-plugin-loadbalancer.php',
     ];
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -118,12 +118,17 @@
                 </ul>
 
                 <li><a href="2.5-terms-query.php">2.5 Terms query</a></li>
-
                 <li><a href="2.6-suggester-query.php">2.6 Suggester query</a></li>
                 <li><a href="2.7-extract-query.php">2.7 Extract query</a></li>
                 <li><a href="2.8-realtime-get-query.php">2.8 Realtime get query</a></li>
-
                 <li><a href="2.9-server-core-admin-status.php">2.9 Core admin query</a></li>
+
+                <li>2.10. Managed resources queries</li>
+                <ul style="list-style:none;">
+                    <li><a href="2.10.1-managedresources-resources.php">2.10.1 Resources query</a></li>
+                    <li><a href="2.10.2-managedresources-stopwords.php">2.10.2 Stopwords query</a></li>
+                    <li><a href="2.10.3-managedresources-synonyms.php">2.10.3 Synonyms query</a></li>
+                </ul>
             </ul>
 
             <li>4. Usage modes</li>

--- a/src/Core/Client/Client.php
+++ b/src/Core/Client/Client.php
@@ -1298,7 +1298,7 @@ class Client extends Configurable implements ClientInterface
     }
 
     /**
-     * Create a managed resources query instance.
+     * Create a managed stopwords query instance.
      *
      * @param mixed $options
      *
@@ -1310,7 +1310,7 @@ class Client extends Configurable implements ClientInterface
     }
 
     /**
-     * Create a managed resources query instance.
+     * Create a managed synonyms query instance.
      *
      * @param mixed $options
      *

--- a/src/QueryType/ManagedResources/RequestBuilder/Resource.php
+++ b/src/QueryType/ManagedResources/RequestBuilder/Resource.php
@@ -37,7 +37,7 @@ class Resource extends AbstractRequestBuilder
         }
 
         $request = parent::build($query);
-        // reserved characters in a REST resource name need to be encoded twice to make it through the servlet (SOLR-SOLR-6853)
+        // reserved characters in a REST resource name need to be encoded twice to make it through the servlet (SOLR-6853)
         $request->setHandler($query->getHandler().rawurlencode(rawurlencode($query->getName())));
         if (null !== $query->getCommand()) {
             $request->addHeader('Content-Type: application/json; charset=utf-8');
@@ -47,7 +47,7 @@ class Resource extends AbstractRequestBuilder
             $request->setMethod(Request::METHOD_GET);
 
             if (null !== $term = $query->getTerm()) {
-                // reserved characters in a REST resource name need to be encoded twice to make it through the servlet (SOLR-SOLR-6853)
+                // reserved characters in a REST resource name need to be encoded twice to make it through the servlet (SOLR-6853)
                 $request->setHandler($request->getHandler().'/'.rawurlencode(rawurlencode($term)));
             }
         }
@@ -90,12 +90,12 @@ class Resource extends AbstractRequestBuilder
                 if (null === $term = $command->getTerm()) {
                     throw new RuntimeException('Missing term for DELETE command.');
                 }
-                // reserved characters in a REST resource name need to be encoded twice to make it through the servlet (SOLR-SOLR-6853)
+                // reserved characters in a REST resource name need to be encoded twice to make it through the servlet (SOLR-6853)
                 $request->setHandler($request->getHandler().'/'.rawurlencode(rawurlencode($command->getTerm())));
                 break;
             case BaseQuery::COMMAND_EXISTS:
                 if (null !== $term = $command->getTerm()) {
-                    // reserved characters in a REST resource name need to be encoded twice to make it through the servlet (SOLR-SOLR-6853)
+                    // reserved characters in a REST resource name need to be encoded twice to make it through the servlet (SOLR-6853)
                     $request->setHandler($request->getHandler().'/'.rawurlencode(rawurlencode($command->getTerm())));
                 }
                 break;

--- a/tests/Integration/AbstractCloudTest.php
+++ b/tests/Integration/AbstractCloudTest.php
@@ -43,8 +43,8 @@ abstract class AbstractCloudTest extends AbstractTechproductsTest
         $createAction->setName(self::$name)
             ->setCollectionConfigName('techproducts')
             // @todo if we set a lower number of shards compared to the number of nodes we get random test failures for
-            //       the manged resources tests. (Managed resources are deprecated in Solr 8 anyway.) These failures
-            //       only happen with the HttpAdapter and Ps18Adapter. The CurlAdapter has a higher timeout especially
+            //       the managed resources tests. (Managed resources are deprecated in Solr 8 anyway.) These failures
+            //       only happen with the HttpAdapter and Psr18Adapter. The CurlAdapter has a higher timeout especially
             //       for the integration tests which might be the reason.
             ->setNumShards(3);
         $collectionsQuery->setAction($createAction);


### PR DESCRIPTION
Closes #848.

Examples for stopwords and synonyms don't work in SolrCloud with `numShards=2`. I could get them to work by setting it to `3`, but that causes problems for the `MinimumScoreFilter` examples. I opted to exclude them from cloud mode instead.