### PR TITLE
Bugfix: return type for getMin()/getMax()/getMean() in Stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Always respect automatic filtering of control characters in field values in QueryType\Update\Query\Document
 - Remove the field modifier along with the value(s) and boost in QueryType\Update\Query\Document::removeField()
+- Allow string to be returned for `min`, `max` and `mean` statistics in Component\Result\Stats\ResultTrait
 
 
 ## [6.1.5]

--- a/src/Component/Result/Stats/ResultTrait.php
+++ b/src/Component/Result/Stats/ResultTrait.php
@@ -24,9 +24,9 @@ trait ResultTrait
     /**
      * Get min value.
      *
-     * @return float|null
+     * @return float|string|null
      */
-    public function getMin(): ?float
+    public function getMin()
     {
         return $this->getStatValue('min');
     }
@@ -34,9 +34,9 @@ trait ResultTrait
     /**
      * Get max value.
      *
-     * @return float|null
+     * @return float|string|null
      */
-    public function getMax(): ?float
+    public function getMax()
     {
         return $this->getStatValue('max');
     }
@@ -84,9 +84,9 @@ trait ResultTrait
     /**
      * Get mean value.
      *
-     * @return float|null
+     * @return float|string|null
      */
-    public function getMean(): ?float
+    public function getMean()
     {
         return $this->getStatValue('mean');
     }

--- a/tests/Component/ResponseParser/StatsTest.php
+++ b/tests/Component/ResponseParser/StatsTest.php
@@ -57,6 +57,10 @@ class StatsTest extends TestCase
                             ],
                         ],
                     ],
+                    'fieldD' => [
+                        'min' => '2005-08-01T16:30:25Z',
+                        'mean' => '2006-01-15T12:49:38.727Z',
+                    ],
                 ],
             ],
         ];
@@ -82,6 +86,9 @@ class StatsTest extends TestCase
             '99.9' => 20.9,
         ];
         $this->assertSame($expectedPercentiles, $facets['fieldC']['value1']->getPercentiles());
+
+        $this->assertEquals('2005-08-01T16:30:25Z', $result->getResult('fieldD')->getMin());
+        $this->assertEquals('2006-01-15T12:49:38.727Z', $result->getResult('fieldD')->getMean());
     }
 
     public function testParseNoData()

--- a/tests/QueryType/Select/Result/Stats/FacetValueTest.php
+++ b/tests/QueryType/Select/Result/Stats/FacetValueTest.php
@@ -126,4 +126,38 @@ class FacetValueTest extends TestCase
     {
         $this->assertNull($this->result->getStatValue('unknown'));
     }
+
+    /**
+     * Test stats that return a string value for string fields.
+     */
+    public function testStringStats()
+    {
+        $this->stats = [
+            'min' => 'aaa',
+            'max' => 'zzz',
+        ];
+
+        $this->result = new FacetValue($this->value, $this->stats);
+
+        $this->assertSame($this->stats['min'], $this->result->getMin());
+        $this->assertSame($this->stats['max'], $this->result->getMax());
+    }
+
+    /**
+     * Test stats that return a string value for date fields.
+     */
+    public function testDateStats()
+    {
+        $this->stats = [
+            'min' => '2005-08-01T16:30:25Z',
+            'max' => '2006-02-14T23:55:59Z',
+            'mean' => '2006-01-15T12:49:38.727Z',
+        ];
+
+        $this->result = new FacetValue($this->value, $this->stats);
+
+        $this->assertSame($this->stats['min'], $this->result->getMin());
+        $this->assertSame($this->stats['max'], $this->result->getMax());
+        $this->assertSame($this->stats['mean'], $this->result->getMean());
+    }
 }

--- a/tests/QueryType/Select/Result/Stats/ResultTest.php
+++ b/tests/QueryType/Select/Result/Stats/ResultTest.php
@@ -126,6 +126,40 @@ class ResultTest extends TestCase
     }
 
     /**
+     * Test stats that return a string value for string fields.
+     */
+    public function testStringStats()
+    {
+        $this->stats = [
+            'min' => 'aaa',
+            'max' => 'zzz',
+        ];
+
+        $this->result = new Result($this->field, $this->stats);
+
+        $this->assertSame($this->stats['min'], $this->result->getMin());
+        $this->assertSame($this->stats['max'], $this->result->getMax());
+    }
+
+    /**
+     * Test stats that return a string value for date fields.
+     */
+    public function testDateStats()
+    {
+        $this->stats = [
+            'min' => '2005-08-01T16:30:25Z',
+            'max' => '2006-02-14T23:55:59Z',
+            'mean' => '2006-01-15T12:49:38.727Z',
+        ];
+
+        $this->result = new Result($this->field, $this->stats);
+
+        $this->assertSame($this->stats['min'], $this->result->getMin());
+        $this->assertSame($this->stats['max'], $this->result->getMax());
+        $this->assertSame($this->stats['mean'], $this->result->getMean());
+    }
+
+    /**
      * @deprecated
      */
     public function testGetValue()


### PR DESCRIPTION
Fixes a bug introduced in #943. Closes #957.

The return type for `getMin()`, `getMax()` and `getMean()` was changed to `float|null` based on the [examples in the ref guide](https://solr.apache.org/guide/8_9/the-stats-component.html#stats-component-example) that only contain `double` values in the XML. For `min` and `max`, the actual values can also be `str` or `date` in XML, for `mean` it can be `date`. The correct union type in PHP to cover these possibilities (and the value not being present) is `float|string|null`.

```xml
<lst name="stats">
  <lst name="stats_fields">
    <lst name="termfreq(text,memory)">
      <double name="min">0.0</double>
      <double name="max">3.0</double>
      <long name="count">33</long>
      <long name="missing">0</long>
      <double name="sum">10.0</double>
      <double name="sumOfSquares">22.0</double>
      <double name="mean">0.30303030303030304</double>
      <double name="stddev">0.7699370300894939</double>
    </lst>
    <lst name="price">
      <double name="min">0.0</double>
      <double name="max">2199.0</double>
      <long name="count">16</long>
      <long name="missing">17</long>
      <double name="sum">5251.270030975342</double>
      <double name="sumOfSquares">6038619.175900028</double>
      <double name="mean">328.20437693595886</double>
      <double name="stddev">536.3536996709846</double>
    </lst>
    <lst name="popularity">
      <double name="min">0.0</double>
      <double name="max">10.0</double>
      <long name="count">15</long>
      <long name="missing">18</long>
      <double name="sum">85.0</double>
      <double name="sumOfSquares">603.0</double>
      <double name="mean">5.666666666666667</double>
      <double name="stddev">2.943920288775949</double>
    </lst>
    <lst name="manufacturedate_dt">
      <date name="min">2005-08-01T16:30:25Z</date>
      <date name="max">2006-02-14T23:55:59Z</date>
      <long name="count">11</long>
      <long name="missing">22</long>
      <double name="sum">1.2510623166E13</double>
      <date name="mean">2006-01-15T12:49:38.727Z</date>
      <double name="sumOfSquares">1.4229031714649898E25</double>
      <double name="stddev">5.765776375213974E9</double>
    </lst>
    <lst name="manu_id_s">
      <str name="min">apple</str>
      <str name="max">viewsonic</str>
      <long name="count">18</long>
      <long name="missing">15</long>
    </lst>
  </lst>
</lst>
```