### PR TITLE
PHP 8.1 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [7.3, 7.4, 8.0]
+                php: [7.3, 7.4, 8.0, 8.1]
                 solr: [7, 8]
                 mode: [cloud, server]
 
@@ -29,7 +29,7 @@ jobs:
               with:
                 php-version: ${{ matrix.php }}
                 extensions: dom, curl, libxml, mbstring, zip, iconv, json, simplexml
-                ini-values: memory_limit=256M,post_max_size=256M
+                ini-values: memory_limit=256M, post_max_size=256M
                 coverage: pcov
 
             - name: Checkout solarium

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 ### Added
+- PHP 8.1 support
 - QueryType\Update\Query\Document::setFields() to set all fields on a Document
 
 ### Fixed

--- a/src/Component/Result/Debug/Detail.php
+++ b/src/Component/Result/Debug/Detail.php
@@ -116,6 +116,7 @@ class Detail implements \ArrayAccess
         return \in_array($offset, ['match', 'value', 'description']);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->{$offset};

--- a/src/Component/Result/Debug/Detail.php
+++ b/src/Component/Result/Debug/Detail.php
@@ -111,7 +111,7 @@ class Detail implements \ArrayAccess
         return $this->subDetails;
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return \in_array($offset, ['match', 'value', 'description']);
     }
@@ -121,12 +121,12 @@ class Detail implements \ArrayAccess
         return $this->{$offset};
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         // Details are immutable.
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         // Details are immutable.
     }

--- a/src/Core/Query/AbstractDocument.php
+++ b/src/Core/Query/AbstractDocument.php
@@ -120,12 +120,13 @@ abstract class AbstractDocument implements DocumentInterface, \IteratorAggregate
         $this->__set($offset, null);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * ArrayAccess implementation.
      *
      * @param mixed $offset
      *
-     * @return mixed|null
+     * @return mixed
      */
     public function offsetGet($offset)
     {

--- a/src/Core/Query/LocalParameters/LocalParameters.php
+++ b/src/Core/Query/LocalParameters/LocalParameters.php
@@ -894,9 +894,9 @@ class LocalParameters implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
-        return $this->parameters[$offset] = $value;
+        $this->parameters[$offset] = $value;
     }
 
     /**

--- a/src/Core/Query/LocalParameters/LocalParameters.php
+++ b/src/Core/Query/LocalParameters/LocalParameters.php
@@ -883,6 +883,7 @@ class LocalParameters implements \ArrayAccess
         return isset($this->parameters[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * {@inheritdoc}
      */

--- a/src/Plugin/MinimumScoreFilter/Document.php
+++ b/src/Plugin/MinimumScoreFilter/Document.php
@@ -151,12 +151,13 @@ class Document implements DocumentInterface, \IteratorAggregate, \Countable, \Ar
         $this->document->offsetUnset($offset);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * ArrayAccess implementation.
      *
      * @param mixed $offset
      *
-     * @return mixed|null
+     * @return mixed
      */
     public function offsetGet($offset)
     {


### PR DESCRIPTION
Closes #959.

I had to use `#[\ReturnTypeWillChange]` to suppress deprecation notices for `ArrayAccess::offsetGet()` because PHP 7 doesn't support `mixed` as a typehint.

FYI: The current PHPStan rules for Solarium don't check for deprecations.