### PR TITLE
query parsers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "require-dev": {
         "escapestudios/symfony2-coding-standard": "^3.11",
+        "friendsofphp/php-cs-fixer": "^2.17",
         "guzzlehttp/guzzle": "^7.2",
         "nyholm/psr7": "^1.2",
         "php-http/guzzle7-adapter": "^0.1",

--- a/src/Core/Query/QueryParser/AbstractSpacialParser.php
+++ b/src/Core/Query/QueryParser/AbstractSpacialParser.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Abstractc Spacial Parser.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/spatial-search.html#searching-with-query-parsers
+ */
+class AbstractSpacialParser implements QueryParserInterface
+{
+    protected const TYPE = '';
+
+    /**
+     * @var string|null
+     */
+    private $distance;
+
+    /**
+     * @var string|null
+     */
+    private $pointType;
+
+    /**
+     * @var string
+     */
+    private $spatialField;
+
+    /**
+     * @var string|null
+     */
+    private $score;
+
+    /**
+     * @var string|null
+     */
+    private $filter;
+
+    /**
+     * @param string      $spatialField
+     * @param string|null $distance
+     * @param string|null $pointType
+     * @param string|null $score
+     * @param string|null $filter
+     */
+    public function __construct(string $spatialField, ?string $distance, ?string $pointType, ?string $score, ?string $filter)
+    {
+        $this->distance = $distance;
+        $this->pointType = $pointType;
+        $this->spatialField = $spatialField;
+        $this->score = $score;
+        $this->filter = $filter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'd' => $this->distance,
+                'pt' => $this->pointType,
+                'sfield' => $this->spatialField,
+                'score' => $this->score,
+                'filter' => $this->filter,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', static::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/BboxQueryParser.php
+++ b/src/Core/Query/QueryParser/BboxQueryParser.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Bbox.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/spatial-search.html#bbox
+ */
+final class BboxQueryParser extends AbstractSpacialParser
+{
+    protected const TYPE = 'bbox';
+}

--- a/src/Core/Query/QueryParser/BlockJoinChildQueryParser.php
+++ b/src/Core/Query/QueryParser/BlockJoinChildQueryParser.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Block Join Children.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#block-join-children-query-parser
+ */
+final class BlockJoinChildQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'child';
+
+    /**
+     * @var string
+     */
+    private $of;
+
+    /**
+     * @var string|null
+     */
+    private $filters;
+
+    /**
+     * @var string|null
+     */
+    private $excludeTags;
+
+    /**
+     * @param string      $of
+     * @param string|null $filters
+     * @param string|null $excludeTags
+     */
+    public function __construct(string $of, ?string $filters, ?string $excludeTags)
+    {
+        $this->of = $of;
+        $this->filters = $filters;
+        $this->excludeTags = $excludeTags;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'of' => $this->of,
+                'filters' => $this->filters,
+                'excludeTags' => $this->excludeTags,
+            ],
+            static function ($var) {
+                return null !== $var && (false === \is_array($var) || 0 !== \count($var));
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/BlockJoinParentQueryParser.php
+++ b/src/Core/Query/QueryParser/BlockJoinParentQueryParser.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Block Join Parent.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#block-join-parent-query-parser
+ */
+final class BlockJoinParentQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'parent';
+
+    /**
+     * @var string
+     */
+    private $which;
+
+    /**
+     * @var string|null
+     */
+    private $filters;
+
+    /**
+     * @var string|null
+     */
+    private $excludeTags;
+
+    /**
+     * @var string|null
+     *
+     * options are avg (average), max (maximum), min (minimum), total (sum)
+     */
+    private $score;
+
+    /**
+     * @param string      $which
+     * @param string|null $filters
+     * @param string|null $excludeTags
+     * @param string|null $score
+     */
+    public function __construct(string $which, ?string $filters, ?string $excludeTags, ?string $score)
+    {
+        $this->which = $which;
+        $this->filters = $filters;
+        $this->excludeTags = $excludeTags;
+        $this->score = $score;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'which' => $this->which,
+                'filters' => $this->filters,
+                'excludeTags' => $this->excludeTags,
+                'score' => $this->score,
+            ],
+            static function ($var) {
+                return null !== $var && (false === \is_array($var) || 0 !== \count($var));
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/BooleanQueryParser.php
+++ b/src/Core/Query/QueryParser/BooleanQueryParser.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Boolean.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#boolean-query-parser
+ */
+final class BooleanQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'bool';
+
+    /**
+     * @var string|null
+     */
+    private $must;
+
+    /**
+     * @var string|null
+     */
+    private $mustNot;
+
+    /**
+     * @var string|null
+     */
+    private $should;
+
+    /**
+     * @var string|null
+     */
+    private $filter;
+
+    /**
+     * @var string|null
+     */
+    private $excludeTags;
+
+    /**
+     * @param string|null $must
+     * @param string|null $mustNot
+     * @param string|null $should
+     * @param string|null $filter
+     * @param string|null $excludeTags
+     */
+    public function __construct(?string $must, ?string $mustNot, ?string $should, ?string $filter, ?string $excludeTags)
+    {
+        $this->must = $must;
+        $this->mustNot = $mustNot;
+        $this->should = $should;
+        $this->filter = $filter;
+        $this->excludeTags = $excludeTags;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'must' => $this->must,
+                'must_not' => $this->mustNot,
+                'should' => $this->should,
+                'filter' => $this->filter,
+                'excludeTags' => $this->excludeTags,
+            ],
+            static function ($var) {
+                return null !== $var && (false === \is_array($var) || 0 !== \count($var));
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/BoostQueryParser.php
+++ b/src/Core/Query/QueryParser/BoostQueryParser.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Boost.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#boost-query-parser
+ */
+final class BoostQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'boost';
+
+    /**
+     * @var string
+     */
+    private $boost;
+
+    /**
+     * @param string $boost
+     */
+    public function __construct(string $boost)
+    {
+        $this->boost = $boost;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'b' => $this->boost,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/CollapseQueryParser.php
+++ b/src/Core/Query/QueryParser/CollapseQueryParser.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Collapse.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/collapse-and-expand-results.html
+ */
+final class CollapseQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'collapse';
+
+    /**
+     * @var string|null
+     */
+    private $min;
+
+    /**
+     * @var string|null
+     */
+    private $max;
+
+    /**
+     * @var string|null
+     */
+    private $sort;
+
+    /**
+     * @var string|null
+     *
+     * options are restricted to: ignore, expand and collapse
+     */
+    private $nullPolicy;
+
+    /**
+     * @var string|null
+     */
+    private $hint;
+
+    /**
+     * @var int|null
+     */
+    private $size;
+
+    /**
+     * @param string|null $min
+     * @param string|null $max
+     * @param string|null $sort
+     * @param string|null $nullPolicy
+     * @param string|null $hint
+     * @param int|null    $size
+     */
+    public function __construct(?string $min = null, ?string $max = null, ?string $sort = null, ?string $nullPolicy = null, ?string $hint = null, ?int $size = null)
+    {
+        $this->min = $min;
+        $this->max = $max;
+        $this->sort = $sort;
+        $this->nullPolicy = $nullPolicy;
+        $this->hint = $hint;
+        $this->size = $size;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'min' => $this->min,
+                'max' => $this->max,
+                'sort' => $this->sort,
+                'nullPolicy' => $this->nullPolicy,
+                'hint' => $this->hint,
+                'size' => $this->size,
+            ],
+            static function ($var) {
+                return null !== $var && (false === \is_array($var) || 0 !== \count($var));
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/ComplexPhraseQueryParser.php
+++ b/src/Core/Query/QueryParser/ComplexPhraseQueryParser.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Complex Phrase.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#complex-phrase-query-parser
+ */
+final class ComplexPhraseQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'complexphrase';
+
+    /**
+     * @var bool|null
+     */
+    private $inOrder;
+
+    /**
+     * @var string|null
+     */
+    private $df;
+
+    /**
+     * @param bool|null   $inOrder
+     * @param string|null $df
+     */
+    public function __construct(?bool $inOrder, ?string $df)
+    {
+        $this->inOrder = $inOrder;
+        $this->df = $df;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'inOrder' => $this->inOrder,
+                'df' => $this->df,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/FieldQueryParser.php
+++ b/src/Core/Query/QueryParser/FieldQueryParser.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Field.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#field-query-parser
+ */
+final class FieldQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'field';
+
+    /**
+     * @var string
+     */
+    private $field;
+
+    /**
+     * @param string $field
+     */
+    public function __construct(string $field)
+    {
+        $this->field = $field;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'f' => $this->field,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/FiltersQueryParser.php
+++ b/src/Core/Query/QueryParser/FiltersQueryParser.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Filters.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#filters-query-parser
+ */
+final class FiltersQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'filters';
+
+    /**
+     * @var string
+     */
+    private $param;
+
+    /**
+     * @var string|null
+     */
+    private $excludeTags;
+
+    /**
+     * @param string      $param
+     * @param string|null $excludeTags
+     */
+    public function __construct(string $param, ?string $excludeTags)
+    {
+        $this->param = $param;
+        $this->excludeTags = $excludeTags;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'param' => $this->param,
+                'excludeTags' => $this->excludeTags,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/FunctionRangeQueryParser.php
+++ b/src/Core/Query/QueryParser/FunctionRangeQueryParser.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Function Range.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#function-range-query-parser
+ */
+final class FunctionRangeQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'frange';
+
+    /**
+     * @var int|null
+     */
+    private $lower;
+
+    /**
+     * @var int|null
+     */
+    private $upper;
+
+    /**
+     * @var bool
+     */
+    private $includeLower;
+
+    /**
+     * @var bool
+     */
+    private $includeUpper;
+
+    /**
+     * @param int|null $lower
+     * @param int|null $upper
+     * @param bool     $includeLower
+     * @param bool     $includeUpper
+     */
+    public function __construct(?int $lower, ?int $upper, bool $includeLower = true, bool $includeUpper = true)
+    {
+        $this->lower = $lower;
+        $this->upper = $upper;
+        $this->includeLower = $includeLower;
+        $this->includeUpper = $includeUpper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'lower' => $this->lower,
+                'upper' => $this->upper,
+                'incl' => $this->includeLower,
+                'incu' => $this->includeUpper,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/GeofiltQueryParser.php
+++ b/src/Core/Query/QueryParser/GeofiltQueryParser.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Geofilt.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/8_6/spatial-search.html#geofilt
+ */
+final class GeofiltQueryParser extends AbstractSpacialParser
+{
+    protected const TYPE = 'geofilt';
+}

--- a/src/Core/Query/QueryParser/GraphQueryParser.php
+++ b/src/Core/Query/QueryParser/GraphQueryParser.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Graph.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#graph-query-parser
+ */
+final class GraphQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'graph';
+
+    /**
+     * @var string|null
+     */
+    private $to;
+
+    /**
+     * @var string|null
+     */
+    private $from;
+
+    /**
+     * @var string|null
+     */
+    private $traversalFilter;
+
+    /**
+     * @var int|null
+     */
+    private $maxDepth;
+
+    /**
+     * @var bool|null
+     */
+    private $returnRoot;
+
+    /**
+     * @var bool|null
+     */
+    private $returnOnlyLeaf;
+
+    /**
+     * @var bool|null
+     */
+    private $useAutomations;
+
+    /**
+     * @param string|null $to
+     * @param string|null $from
+     * @param string|null $traversalFilter
+     * @param int|null    $maxDepth
+     * @param bool|null   $returnRoot
+     * @param bool|null   $returnOnlyLeaf
+     * @param bool|null   $useAutomations
+     */
+    public function __construct(?string $to, ?string $from, ?string $traversalFilter, ?int $maxDepth, ?bool $returnRoot, ?bool $returnOnlyLeaf, ?bool $useAutomations)
+    {
+        $this->to = $to;
+        $this->from = $from;
+        $this->traversalFilter = $traversalFilter;
+        $this->maxDepth = $maxDepth;
+        $this->returnRoot = $returnRoot;
+        $this->returnOnlyLeaf = $returnOnlyLeaf;
+        $this->useAutomations = $useAutomations;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'to' => $this->to,
+                'from' => $this->from,
+                'traversalFilter' => $this->traversalFilter,
+                'maxDepth' => $this->maxDepth,
+                'returnRoot' => $this->returnRoot,
+                'returnOnlyLeaf' => $this->returnOnlyLeaf,
+                'useAutn' => $this->useAutomations,
+            ],
+            static function ($var) {
+                return null !== $var && (false === \is_array($var) || 0 !== \count($var));
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/HashRangeQueryParser.php
+++ b/src/Core/Query/QueryParser/HashRangeQueryParser.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Hash Range.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#hash-range-query-parser
+ */
+final class HashRangeQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'hash_range';
+
+    /**
+     * @var string
+     */
+    private $field;
+
+    /**
+     * @var int
+     */
+    private $lower;
+
+    /**
+     * @var int
+     */
+    private $upper;
+
+    /**
+     * @param string $field
+     * @param int    $lower
+     * @param int    $upper
+     */
+    public function __construct(string $field, int $lower, int $upper)
+    {
+        $this->field = $field;
+        $this->lower = $lower;
+        $this->upper = $upper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'f' => $this->field,
+                'l' => $this->lower,
+                'u' => $this->upper,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/JoinQueryParser.php
+++ b/src/Core/Query/QueryParser/JoinQueryParser.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Join.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#join-query-parser
+ */
+final class JoinQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'join';
+
+    /**
+     * @var string
+     */
+    private $from;
+
+    /**
+     * @var string
+     */
+    private $to;
+
+    /**
+     * @var string|null
+     */
+    private $fromIndex;
+
+    /**
+     * @var string|null
+     *
+     * options include avg (average), max (maximum), min (minimum), total (total), or none
+     */
+    private $score;
+
+    /**
+     * @var string|null
+     *
+     * options are restricted to: index, dvWithScore, and topLevelDV
+     */
+    private $method;
+
+    /**
+     * @param string      $from
+     * @param string      $to
+     * @param string|null $fromIndex
+     * @param string|null $score
+     * @param string|null $method
+     */
+    public function __construct(string $from, string $to, ?string $fromIndex, ?string $score, ?string $method)
+    {
+        $this->from = $from;
+        $this->to = $to;
+        $this->fromIndex = $fromIndex;
+        $this->score = $score;
+        $this->method = $method;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'from' => $this->from,
+                'to' => $this->to,
+                'fromIndex' => $this->fromIndex,
+                'score' => $this->score,
+                'method' => $this->method,
+            ],
+            static function ($var) {
+                return null !== $var && (false === \is_array($var) || 0 !== \count($var));
+            }
+        );
+
+        $values = array_map(static function ($value) {
+            if (\is_string($value) && strpos($value, ' ')) {
+                return sprintf('\'%s\'', $value);
+            }
+
+            return $value;
+        }, $values);
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/LearningToRankQueryParser.php
+++ b/src/Core/Query/QueryParser/LearningToRankQueryParser.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Learning To Rank.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#learning-to-rank-query-parser
+ */
+final class LearningToRankQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'ltr';
+
+    /**
+     * @var string
+     */
+    private $model;
+
+    /**
+     * @var int
+     */
+    private $reRankDocs;
+
+    /**
+     * @param string $model
+     * @param int    $reRankDocs
+     */
+    public function __construct(string $model, int $reRankDocs)
+    {
+        $this->model = $model;
+        $this->reRankDocs = $reRankDocs;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'model' => $this->model,
+                'reRankDocs' => $this->reRankDocs,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/LinkQueryParser.php
+++ b/src/Core/Query/QueryParser/LinkQueryParser.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Link.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#join-query-parser
+ */
+final class LinkQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'join';
+
+    /**
+     * @var string
+     */
+    private $from;
+
+    /**
+     * @var string
+     */
+    private $to;
+
+    /**
+     * @var string|null
+     */
+    private $fromIndex;
+
+    /**
+     * @var string|null
+     *
+     * options include avg (average), max (maximum), min (minimum), total (total), or none
+     */
+    private $score;
+
+    /**
+     * @var string|null
+     *
+     * options are restricted to: index, dvWithScore, and topLevelDV
+     */
+    private $method;
+
+    /**
+     * @param string      $from
+     * @param string      $to
+     * @param string|null $fromIndex
+     * @param string|null $score
+     * @param string|null $method
+     */
+    public function __construct(string $from, string $to, ?string $fromIndex, ?string $score, ?string $method)
+    {
+        $this->from = $from;
+        $this->to = $to;
+        $this->fromIndex = $fromIndex;
+        $this->score = $score;
+        $this->method = $method;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'from' => $this->from,
+                'to' => $this->to,
+                'fromIndex' => $this->fromIndex,
+                'score' => $this->score,
+                'method' => $this->method,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/LuceneQueryParser.php
+++ b/src/Core/Query/QueryParser/LuceneQueryParser.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Lucene.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#lucene-query-parser
+ */
+final class LuceneQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'lucene';
+
+    /**
+     * @var string
+     */
+    private $operator;
+
+    /**
+     * @var string
+     */
+    private $defaultField;
+
+    /**
+     * @param string $operator
+     * @param string $defaultField
+     */
+    public function __construct(string $operator, string $defaultField)
+    {
+        $this->operator = $operator;
+        $this->defaultField = $defaultField;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'q.op' => $this->operator,
+                'df' => $this->defaultField,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/MaxScoreQueryParser.php
+++ b/src/Core/Query/QueryParser/MaxScoreQueryParser.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Max Score.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#max-score-query-parser
+ */
+final class MaxScoreQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'maxscore';
+
+    /**
+     * @var float
+     */
+    private $tie;
+
+    /**
+     * @param float $tie
+     */
+    public function __construct(float $tie)
+    {
+        $this->tie = $tie;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'tie' => $this->tie,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/Model/SwitchCase.php
+++ b/src/Core/Query/QueryParser/Model/SwitchCase.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser\Model;
+
+/**
+ * SwitchCase.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+class SwitchCase
+{
+    /**
+     * @var string|null
+     */
+    private $field;
+
+    /**
+     * @var string
+     */
+    private $case;
+
+    /**
+     * @param string|null $field
+     * @param string      $case
+     */
+    public function __construct(?string $field, string $case)
+    {
+        $this->field = $field;
+        $this->case = $case;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        if (null === $this->field) {
+            return sprintf('case = %s', $this->case);
+        }
+
+        return sprintf('case.%s = %s', $this->field, $this->case);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getField(): ?string
+    {
+        return $this->field;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCase(): string
+    {
+        return $this->case;
+    }
+}

--- a/src/Core/Query/QueryParser/MoreLikeThisQueryParser.php
+++ b/src/Core/Query/QueryParser/MoreLikeThisQueryParser.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * More Like This.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#more-like-this-query-parser
+ */
+final class MoreLikeThisQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'mlt';
+
+    /**
+     * @var string
+     */
+    private $fields;
+
+    /**
+     * @var int|null
+     */
+    private $minimumTermFrequency;
+
+    /**
+     * @var int|null
+     */
+    private $minimumDocumentFrequency;
+
+    /**
+     * @var int|null
+     */
+    private $maximumDocumentFrequency;
+
+    /**
+     * @var int|null
+     */
+    private $minimumWordLength;
+
+    /**
+     * @var int|null
+     */
+    private $maximumWordLength;
+
+    /**
+     * @var int|null
+     */
+    private $maximumQueryTerms;
+
+    /**
+     * @var int|null
+     */
+    private $maximumTokens;
+
+    /**
+     * @var bool
+     */
+    private $boost;
+
+    /**
+     * MoreLikeThisQueryParser constructor.
+     *
+     * @param string   $fields
+     * @param int|null $minimumTermFrequency
+     * @param int|null $minimumDocumentFrequency
+     * @param int|null $maximumDocumentFrequency
+     * @param int|null $minimumWordLength
+     * @param int|null $maximumWordLength
+     * @param int|null $maximumQueryTerms
+     * @param int|null $maximumTokens
+     * @param bool     $boost
+     */
+    public function __construct(string $fields, ?int $minimumTermFrequency, ?int $minimumDocumentFrequency, ?int $maximumDocumentFrequency, ?int $minimumWordLength, ?int $maximumWordLength, ?int $maximumQueryTerms, ?int $maximumTokens, bool $boost)
+    {
+        $this->fields = $fields;
+        $this->minimumTermFrequency = $minimumTermFrequency;
+        $this->minimumDocumentFrequency = $minimumDocumentFrequency;
+        $this->maximumDocumentFrequency = $maximumDocumentFrequency;
+        $this->minimumWordLength = $minimumWordLength;
+        $this->maximumWordLength = $maximumWordLength;
+        $this->maximumQueryTerms = $maximumQueryTerms;
+        $this->maximumTokens = $maximumTokens;
+        $this->boost = $boost;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'qf' => $this->fields,
+                'mintf' => $this->minimumTermFrequency,
+                'mindf' => $this->minimumDocumentFrequency,
+                'maxdf' => $this->maximumDocumentFrequency,
+                'minwl' => $this->minimumWordLength,
+                'maxwl' => $this->maximumWordLength,
+                'maxqt' => $this->maximumQueryTerms,
+                'maxntp' => $this->maximumTokens,
+                'boost' => $this->boost,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/NestedQueryParser.php
+++ b/src/Core/Query/QueryParser/NestedQueryParser.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Nested.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#nested-query-parser
+ */
+final class NestedQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'query';
+
+    /**
+     * @var string
+     */
+    private $defType;
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $defType
+     * @param string $value
+     */
+    public function __construct(string $defType, string $value)
+    {
+        $this->defType = $defType;
+        $this->value = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'defType' => $this->defType,
+                'v' => $this->value,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/PayloadCheckQueryParser.php
+++ b/src/Core/Query/QueryParser/PayloadCheckQueryParser.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Payload Check.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#payload-check-parser
+ */
+final class PayloadCheckQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'payload_check';
+
+    /**
+     * @var string
+     */
+    private $field;
+
+    /**
+     * @var string
+     */
+    private $payloads;
+
+    /**
+     * @param string $field
+     * @param string $payloads
+     */
+    public function __construct(string $field, string $payloads)
+    {
+        $this->field = $field;
+        $this->payloads = $payloads;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'f' => $this->field,
+                'payloads' => $this->payloads,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/PayloadScoreQueryParser.php
+++ b/src/Core/Query/QueryParser/PayloadScoreQueryParser.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Payload.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#payload-query-parsers
+ */
+final class PayloadScoreQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'payload_score';
+
+    /**
+     * @var string
+     */
+    private $field;
+
+    /**
+     * @var string
+     */
+    private $function;
+
+    /**
+     * @var string|null
+     */
+    private $operator;
+
+    /**
+     * @var bool|null
+     */
+    private $includeSpanScore;
+
+    /**
+     * @param string      $field
+     * @param string      $function
+     * @param string|null $operator
+     * @param bool|null   $includeSpanScore
+     */
+    public function __construct(string $field, string $function, ?string $operator, ?bool $includeSpanScore)
+    {
+        $this->field = $field;
+        $this->function = $function;
+        $this->operator = $operator;
+        $this->includeSpanScore = $includeSpanScore;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'f' => $this->field,
+                'func' => $this->function,
+                'operator' => $this->operator,
+                'includeSpanScore' => $this->includeSpanScore,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/PrefixQueryParser.php
+++ b/src/Core/Query/QueryParser/PrefixQueryParser.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Prefix.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#prefix-query-parser
+ */
+final class PrefixQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'prefix';
+
+    /**
+     * @var string
+     */
+    private $field;
+
+    /**
+     * @param string $field
+     */
+    public function __construct(string $field)
+    {
+        $this->field = $field;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'f' => $this->field,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/QueryParserInterface.php
+++ b/src/Core/Query/QueryParser/QueryParserInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Query Parser Interface.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ */
+interface QueryParserInterface
+{
+    /**
+     * @return string
+     */
+    public function __toString(): string;
+}

--- a/src/Core/Query/QueryParser/RawQueryParser.php
+++ b/src/Core/Query/QueryParser/RawQueryParser.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Raw.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#raw-query-parser
+ */
+final class RawQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'raw';
+
+    /**
+     * @var string
+     */
+    private $field;
+
+    /**
+     * @param string $field
+     */
+    public function __construct(string $field)
+    {
+        $this->field = $field;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'f' => $this->field,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/ReRankQueryParser.php
+++ b/src/Core/Query/QueryParser/ReRankQueryParser.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * ReRank.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/query-re-ranking.html#rerank-query-parser
+ */
+final class ReRankQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'rerank';
+
+    /**
+     * @var string
+     */
+    private $reRankQuery;
+
+    /**
+     * @var int|null
+     */
+    private $reRankDocs;
+
+    /**
+     * @var int|null
+     */
+    private $reRankWeight;
+
+    /**
+     * @param string   $reRankQuery
+     * @param int|null $reRankDocs
+     * @param int|null $reRankWeight
+     */
+    public function __construct(string $reRankQuery, ?int $reRankDocs, ?int $reRankWeight)
+    {
+        $this->reRankQuery = $reRankQuery;
+        $this->reRankDocs = $reRankDocs;
+        $this->reRankWeight = $reRankWeight;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'reRankQuery' => $this->reRankQuery,
+                'reRankDocs' => $this->reRankDocs,
+                'reRankWeight' => $this->reRankWeight,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/SimpleQueryParser.php
+++ b/src/Core/Query/QueryParser/SimpleQueryParser.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Simple.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#simple-query-parser
+ */
+final class SimpleQueryParser implements QueryParserInterface
+{
+    /**
+     * @var string|null
+     */
+    private $operators;
+
+    /**
+     * @var string|null
+     */
+    private $operator;
+
+    /**
+     * @var string|null
+     */
+    private $fields;
+
+    /**
+     * @var string|null
+     */
+    private $defaultField;
+
+    /**
+     * @param string|null $operators
+     * @param string|null $operator
+     * @param string|null $fields
+     * @param string|null $defaultField
+     */
+    public function __construct(?string $operators, ?string $operator, ?string $fields, ?string $defaultField)
+    {
+        $this->operators = $operators;
+        $this->operator = $operator;
+        $this->fields = $fields;
+        $this->defaultField = $defaultField;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'q.operators' => $this->operators,
+                'q.op' => $this->operator,
+                'qf' => $this->fields,
+                'df' => $this->defaultField,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('%s', http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/SwitchQueryParser.php
+++ b/src/Core/Query/QueryParser/SwitchQueryParser.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+use Solarium\Core\Query\QueryParser\Model\SwitchCase;
+
+/**
+ * Switch.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#switch-query-parser
+ */
+final class SwitchQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'switch';
+
+    /**
+     * @var \Solarium\Core\Query\QueryParser\Model\SwitchCase[]
+     */
+    private $cases;
+
+    /**
+     * @var string|null
+     */
+    private $default;
+
+    /**
+     * @param \Solarium\Core\Query\QueryParser\Model\SwitchCase[] $cases
+     * @param string|null                                         $default
+     */
+    public function __construct(array $cases, ?string $default)
+    {
+        $this->cases = $cases;
+        $this->default = $default;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'cases' => $this->cases,
+                'default' => $this->default,
+            ],
+            static function ($var) {
+                return null !== $var && (false === \is_array($var) || 0 !== \count($var));
+            }
+        );
+
+        $string = sprintf('!%s', self::TYPE);
+
+        if (isset($values['cases'])) {
+            $string .= sprintf(' %s', implode(' ', array_map('strval', $values['cases'])));
+        }
+
+        if (isset($values['default'])) {
+            $string .= sprintf(' default=%s', $values['default']);
+        }
+
+        return $string;
+    }
+
+    /**
+     * @param \Solarium\Core\Query\QueryParser\Model\SwitchCase $case
+     *
+     * @return $this
+     */
+    public function addCase(SwitchCase $case): self
+    {
+        $this->cases[] = $case;
+
+        return $this;
+    }
+}

--- a/src/Core/Query/QueryParser/TermQueryParser.php
+++ b/src/Core/Query/QueryParser/TermQueryParser.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Term.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#term-query-parser
+ */
+final class TermQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'term';
+
+    /**
+     * @var string
+     */
+    private $field;
+
+    /**
+     * @param string $field
+     */
+    public function __construct(string $field)
+    {
+        $this->field = $field;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'f' => $this->field,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/src/Core/Query/QueryParser/TermsQueryParser.php
+++ b/src/Core/Query/QueryParser/TermsQueryParser.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Core\Query\QueryParser;
+
+/**
+ * Terms.
+ *
+ * @author wicliff <wicliff.wolda@gmail.com>
+ *
+ * @see https://lucene.apache.org/solr/guide/other-parsers.html#terms-query-parser
+ */
+final class TermsQueryParser implements QueryParserInterface
+{
+    private const TYPE = 'terms';
+
+    /**
+     * @var string
+     */
+    private $field;
+
+    /**
+     * @var string|null
+     */
+    private $separator;
+
+    /**
+     * @var string|null
+     */
+    private $method;
+
+    /**
+     * @param string      $field
+     * @param string|null $separator
+     * @param string|null $method
+     */
+    public function __construct(string $field, ?string $separator, ?string $method)
+    {
+        $this->field = $field;
+        $this->separator = $separator;
+        $this->method = $method;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        $values = array_filter(
+            [
+                'f' => $this->field,
+                'separator' => $this->separator,
+                'method' => $this->method,
+            ],
+            static function ($var) {
+                return null !== $var;
+            }
+        );
+
+        return sprintf('!%s %s', self::TYPE, http_build_query($values, '', ' '));
+    }
+}

--- a/tests/QueryParserTest.php
+++ b/tests/QueryParserTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarium\Core\Query\QueryParser;
+
+use PHPUnit\Framework\TestCase;
+
+class QueryParserTest extends TestCase
+{
+    public function testCollapse(): void
+    {
+        $collapse = new CollapseQueryParser();
+
+        self::assertIsString((string) $collapse);
+    }
+}


### PR DESCRIPTION
after reading / commenting @ #961 i remembered i once worked on implementing query parsers, but never got around to making a pull request...

from the top of my mind the only thing left to do is find out whether or not these query parsers play nice with local parameters (i.e. whether they are mutually exclusive), create a method `addQueryParser(QueryParserIntervace $parser)` to the abstract query and actually implement it in the `RequestBuilder::build` method to add them to the query (which should be as simple as `(string) $this->methodWhichGetsTheQueryParser()`) and then of course some documentation and tests.

currently i don't have the time to finalise this (and as i don't have a job anymore where solr is used, it would require quite a bit of effort to properly test it) so @mkalkbrenner or @htmax feel free to pick this up and implement it