### PR TITLE
Fix link to ZF2 SolariumModule

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,7 +109,7 @@ Some users of Solarium have been nice enough to create easy ways of integrating 
 -   Wordpress <https://github.com/pantheon-systems/solr-for-wordpress>
 -   SilverStripe <https://github.com/firesphere/silverstripe-solr-search>
 
-If you know of any other integrations please let it know!
+If you know of any other integrations please let us know!
 
 
 Basic usage

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,7 +99,7 @@ has to be changed to something like
 Some users of Solarium have been nice enough to create easy ways of integrating Solarium:
 
 -   A Solarium bundle for Symfony2 <https://github.com/nelmio/NelmioSolariumBundle>
--   Zend Framework 2 module <https://zfmodules.com/Ewgo/SolariumModule>
+-   Zend Framework 2 module <https://github.com/Ewgo/SolariumModule>
 -   Lithium <https://github.com/joseym/li3_solr>
 -   Fuel PHP <https://github.com/bgrimes/fuelphp-solarium>
 -   Yii <https://github.com/estahn/YiiSolarium>


### PR DESCRIPTION
Presently zfmodules.com is a Danish website about leasing vans.