### PR TITLE
Possible to set non-default context on an endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [6.3.0]
+### Added
+- Possibility to set the context on an endpoint for SolrCloud instances with a non-default `hostContext` or Solr instances behind a reverse proxy, defaults to `solr` if omitted
+
+
 ## [6.2.0]
 ### Added
 - Component\FacetSet::setOffset()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [6.3.0]
+## [6.2.1]
 ### Added
 - Possibility to set the context on an endpoint for SolrCloud instances with a non-default `hostContext` or Solr instances behind a reverse proxy, defaults to `solr` if omitted
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See https://solr.apache.org/guide/local-parameters-in-queries.html for an introd
 
 ### Pitfall when upgrading from 3.x or 4.x
 
-In the past, the V1 API endpoint **_solr_** was not added automatically, so most users set it as path on the endpoint.
+In the past, the V1 API endpoint `solr` was not added automatically, so most users set it as path on the endpoint.
 This bug was discovered with the addition of V2 API support. In almost every setup, the path has to be set to `/`
 instead of `/solr` with this release!
 
@@ -94,6 +94,21 @@ has to be changed to something like
 'path' => '/',
 'collection' => 'xxxx',
 ```
+
+This led to a problem if the endpoint _isn't_ the default `solr`. Since 6.3, a different context can be configured.
+
+An old settings like
+```
+'path' => '/index/xxxx/'
+```
+can be changed to something like
+```
+'path' => '/',
+'context' => 'index',
+'collection' => 'xxxx',
+```
+
+This works for SolrCloud instances with a non-default `hostContext` and Solr instances behind a reverse proxy.
 
 ## Run the examples
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ has to be changed to something like
 'collection' => 'xxxx',
 ```
 
-This led to a problem if the endpoint _isn't_ the default `solr`. Since 6.3, a different context can be configured.
+This led to a problem if the endpoint _isn't_ the default `solr`. Since 6.2.1, a different context can be configured.
 
 An old settings like
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,7 +93,7 @@ has to be changed to something like
 'collection' => 'xxxx',
 ```
 
-This led to a problem if the endpoint _isn't_ the default `solr`. Since 6.3, a different context can be configured.
+This led to a problem if the endpoint _isn't_ the default `solr`. Since 6.2.1, a different context can be configured.
 
 An old settings like
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,7 +77,7 @@ htmlFooter();
 
 ### Pitfall when upgrading from earlier versions to 5.x
 
-In the past, the V1 API endpoint **_solr_** was not added automatically, so most users set it as path on the endpoint.
+In the past, the V1 API endpoint `solr` was not added automatically, so most users set it as path on the endpoint.
 This bug was discovered with the addition of V2 API support. In almost every setup, the path has to be set to `/`
 instead of `/solr` with this release!
 
@@ -93,6 +93,20 @@ has to be changed to something like
 'collection' => 'xxxx',
 ```
 
+This led to a problem if the endpoint _isn't_ the default `solr`. Since 6.3, a different context can be configured.
+
+An old settings like
+```
+'path' => '/index/xxxx/'
+```
+can be changed to something like
+```
+'path' => '/',
+'context' => 'index',
+'collection' => 'xxxx',
+```
+
+This works for SolrCloud instances with a non-default `hostContext` and Solr instances behind a reverse proxy.
 
 ### Available integrations
 
@@ -142,6 +156,8 @@ $config = array(
             'core' => 'techproducts',
             // For SolrCloud you need to provide a collection instead of core:
             // 'collection' => 'techproducts',
+            // Set the `hostContext` for the Solr web application if it's not the default 'solr':
+            // 'context' => 'solr',
         )
     )
 );

--- a/examples/config.php
+++ b/examples/config.php
@@ -7,6 +7,7 @@ $config = array(
             'host' => '127.0.0.1',
             'port' => 8983,
             'path' => '/',
+            // 'context' => 'solr', # only necessary to set if not the default 'solr'
             'core' => 'techproducts',
         )
     )

--- a/src/Core/Client/Endpoint.php
+++ b/src/Core/Client/Endpoint.php
@@ -30,6 +30,7 @@ class Endpoint extends Configurable
         'host' => '127.0.0.1',
         'port' => 8983,
         'path' => '/',
+        'context' => 'solr',
         'collection' => null,
         'core' => null,
         'leader' => false,
@@ -45,7 +46,7 @@ class Endpoint extends Configurable
      */
     public function __toString()
     {
-        $output = __CLASS__.'::__toString'."\n".'host: '.$this->getHost()."\n".'port: '.$this->getPort()."\n".'path: '.$this->getPath()."\n".'collection: '.$this->getCollection()."\n".'core: '.$this->getCore()."\n".'authentication: '.print_r($this->getAuthentication(), true);
+        $output = __CLASS__.'::__toString'."\n".'host: '.$this->getHost()."\n".'port: '.$this->getPort()."\n".'path: '.$this->getPath()."\n".'context: '.$this->getContext()."\n".'collection: '.$this->getCollection()."\n".'core: '.$this->getCore()."\n".'authentication: '.print_r($this->getAuthentication(), true);
 
         return $output;
     }
@@ -133,11 +134,7 @@ class Endpoint extends Configurable
      */
     public function setPath(string $path): self
     {
-        if ('/' === substr($path, -1)) {
-            $path = substr($path, 0, -1);
-        }
-
-        $this->setOption('path', $path);
+        $this->setOption('path', rtrim($path, '/'));
 
         return $this;
     }
@@ -150,6 +147,32 @@ class Endpoint extends Configurable
     public function getPath(): ?string
     {
         return $this->getOption('path');
+    }
+
+    /**
+     * Set context option.
+     *
+     * If the context has a leading or trailing slash it will be removed.
+     *
+     * @param string $context
+     *
+     * @return self Provides fluent interface
+     */
+    public function setContext(string $context): self
+    {
+        $this->setOption('context', trim($context, '/'));
+
+        return $this;
+    }
+
+    /**
+     * Get context option.
+     *
+     * @return string|null
+     */
+    public function getContext(): ?string
+    {
+        return $this->getOption('context');
     }
 
     /**
@@ -236,10 +259,11 @@ class Endpoint extends Configurable
     public function getCollectionBaseUri(): string
     {
         $uri = $this->getServerUri();
+        $context = $this->getContext();
         $collection = $this->getCollection();
 
         if ($collection) {
-            $uri .= 'solr/'.$collection.'/';
+            $uri .= $context.'/'.$collection.'/';
         } else {
             throw new UnexpectedValueException('No collection set.');
         }
@@ -259,11 +283,12 @@ class Endpoint extends Configurable
     public function getCoreBaseUri(): string
     {
         $uri = $this->getServerUri();
+        $context = $this->getContext();
         $core = $this->getCore();
 
         if ($core) {
             // V1 API
-            $uri .= 'solr/'.$core.'/';
+            $uri .= $context.'/'.$core.'/';
         } else {
             throw new UnexpectedValueException('No core set.');
         }
@@ -300,7 +325,7 @@ class Endpoint extends Configurable
      */
     public function getV1BaseUri(): string
     {
-        return $this->getServerUri().'solr/';
+        return $this->getServerUri().$this->getContext().'/';
     }
 
     /**
@@ -384,8 +409,10 @@ class Endpoint extends Configurable
      * Initialization hook.
      *
      * In this case the path needs to be cleaned of trailing slashes.
+     * The context needs to be cleaned of leading and trailing slashes.
      *
      * @see setPath()
+     * @see setContext()
      */
     protected function init()
     {
@@ -393,6 +420,9 @@ class Endpoint extends Configurable
             switch ($name) {
                 case 'path':
                     $this->setPath($value);
+                    break;
+                case 'context':
+                    $this->setContext($value);
                     break;
             }
         }


### PR DESCRIPTION
Closes #853.

I've assumed in README/getting-started that this will be released in Solarium 6.3. Looks 'cleaner' than 6.2.1 if it has to live permanently in the documentation.

---

FYI, writing unit tests like this doesn't work as was apparently expected.

https://github.com/solariumphp/solarium/blob/f63861d9246e8f06487ec2dfaea3cef0d4babccc/tests/Core/Client/EndpointTest.php#L93-L101

The unit test ends when the exception is encountered and the second assertion is never tested. One solution would be to have the test for the exception as the last one in the method. For clarity, I put the exception tests in their own methods.