### PR TITLE
Tests for setting key to empty string

### DIFF
--- a/tests/Core/Client/ClientTest.php
+++ b/tests/Core/Client/ClientTest.php
@@ -233,6 +233,12 @@ class ClientTest extends TestCase
         $this->client->addEndpoint($endpoint);
     }
 
+    public function testAddEndpointWithEmptyKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->client->createEndpoint('');
+    }
+
     public function testAddEndpointWithDuplicateKey()
     {
         $this->client->createEndpoint('s1');

--- a/tests/Plugin/CustomizeRequest/CustomizeRequestTest.php
+++ b/tests/Plugin/CustomizeRequest/CustomizeRequestTest.php
@@ -143,6 +143,15 @@ class CustomizeRequestTest extends TestCase
         $this->plugin->addCustomization($customization);
     }
 
+    public function testAddCustomizationWithEmptyKey()
+    {
+        $customization = new Customization();
+        $customization->setKey('');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->plugin->addCustomization($customization);
+    }
+
     public function testAddCustomizationWithUsedKey()
     {
         $customization1 = new Customization();

--- a/tests/QueryType/MoreLikeThis/QueryTest.php
+++ b/tests/QueryType/MoreLikeThis/QueryTest.php
@@ -256,6 +256,15 @@ class QueryTest extends TestCase
         $this->query->addFilterQuery($fq);
     }
 
+    public function testAddFilterQueryWithEmptyKey()
+    {
+        $fq = new FilterQuery();
+        $fq->setKey('')->setQuery('category:1');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->query->addFilterQuery($fq);
+    }
+
     public function testAddFilterQueryWithUsedKey()
     {
         $fq1 = new FilterQuery();

--- a/tests/QueryType/Select/Query/AbstractQueryTest.php
+++ b/tests/QueryType/Select/Query/AbstractQueryTest.php
@@ -260,6 +260,15 @@ abstract class AbstractQueryTest extends TestCase
         $this->query->addFilterQuery($fq);
     }
 
+    public function testAddFilterQueryWithEmptyKey()
+    {
+        $fq = new FilterQuery();
+        $fq->setKey('')->setQuery('category:1');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->query->addFilterQuery($fq);
+    }
+
     public function testAddFilterQueryWithUsedKey()
     {
         $fq1 = new FilterQuery();

--- a/tests/QueryType/Select/Query/Component/DisMaxTest.php
+++ b/tests/QueryType/Select/Query/Component/DisMaxTest.php
@@ -190,6 +190,15 @@ class DisMaxTest extends TestCase
         $this->disMax->addBoostQuery($bq);
     }
 
+    public function testAddBoostQueryWithEmptyKey()
+    {
+        $bq = new BoostQuery();
+        $bq->setKey('')->setQuery('category:1');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->disMax->addBoostQuery($bq);
+    }
+
     public function testAddBoostQueryWithUsedKey()
     {
         $bq1 = new BoostQuery();

--- a/tests/QueryType/Select/Query/Component/Facet/MultiQueryTest.php
+++ b/tests/QueryType/Select/Query/Component/Facet/MultiQueryTest.php
@@ -116,12 +116,18 @@ class MultiQueryTest extends TestCase
 
     public function testAddQueryNoKey()
     {
-        $query = 'category:1';
-        $excludes = ['fq1', 'fq2'];
-
         $facetQuery = new Query();
-        $facetQuery->setQuery($query);
-        $facetQuery->getLocalParameters()->addExcludes($excludes);
+        $facetQuery->setQuery('category:1');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->facet->addQuery($facetQuery);
+    }
+
+    public function testAddQueryEmptyKey()
+    {
+        $facetQuery = new Query();
+        $facetQuery->setKey('');
+        $facetQuery->setQuery('category:1');
 
         $this->expectException(InvalidArgumentException::class);
         $this->facet->addQuery($facetQuery);

--- a/tests/QueryType/Select/Query/Component/FacetSetTest.php
+++ b/tests/QueryType/Select/Query/Component/FacetSetTest.php
@@ -225,6 +225,15 @@ class FacetSetTest extends TestCase
         $this->facetSet->addFacet($fq);
     }
 
+    public function testAddFacetWithEmptyKey()
+    {
+        $fq = new FacetQuery();
+        $fq->setKey('')->setQuery('category:1');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->facetSet->addFacet($fq);
+    }
+
     public function testAddFacetWithUsedKey()
     {
         $fq1 = new FacetQuery();

--- a/tests/QueryType/Select/Query/Component/Stats/StatsTest.php
+++ b/tests/QueryType/Select/Query/Component/Stats/StatsTest.php
@@ -133,6 +133,15 @@ class StatsTest extends TestCase
         $this->stats->addField($fld);
     }
 
+    public function testAddFieldWithEmptyKey()
+    {
+        $fld = new Field();
+        $fld->setKey('');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->stats->addField($fld);
+    }
+
     public function testAddFieldWithUsedKey()
     {
         $f1 = new Field();


### PR DESCRIPTION
[64a3639](https://github.com/solariumphp/solarium/commit/64a36391f9795cc4982e88c60dceb977822b9b05) introduced distinct code paths for not setting a key and setting it to an empty string. Existing unit tests only test for `null` (not setting it). Code coverage is happy with this because both paths run through the same line of code for their distinct part.

https://github.com/solariumphp/solarium/blob/64a36391f9795cc4982e88c60dceb977822b9b05/src/Component/FacetSetTrait.php#L45

I've added tests for explicitly setting a key to an empty string. It's a plausible scenario for user code if their keys aren't hardcoded.