### PR TITLE
Test escapes for terms and phrases

### DIFF
--- a/tests/Core/Query/HelperTest.php
+++ b/tests/Core/Query/HelperTest.php
@@ -398,10 +398,44 @@ class HelperTest extends TestCase
         $this->assertSame('sum(1,2)', $this->helper->functionCall('sum', [1, 2]));
     }
 
-    public function testEscapeTerm()
+    /**
+     * @dataProvider escapeTermProvider
+     */
+    public function testEscapeTerm(string $term, string $expected)
     {
-        $this->assertSame('a\\+b\/c', $this->helper->escapeTerm('a+b/c'));
-        $this->assertSame('a\ b', $this->helper->escapeTerm('a b'));
+        $this->assertSame(
+            $expected,
+            $this->helper->escapeTerm($term)
+        );
+    }
+
+    /**
+     * @see https://solr.apache.org/guide/the-standard-query-parser.html#escaping-special-characters
+     */
+    public function escapeTermProvider(): array
+    {
+        return [
+            ' ' => ['a b', 'a\\ b'],
+            '+' => ['a+b', 'a\\+b'],
+            '-' => ['a-b', 'a\\-b'],
+            '&&' => ['a&&b', 'a\\&&b'],
+            '||' => ['a||b', 'a\\||b'],
+            '!' => ['a!b', 'a\\!b'],
+            '(' => ['a(b', 'a\\(b'],
+            ')' => ['a)b', 'a\\)b'],
+            '{' => ['a{b', 'a\\{b'],
+            '}' => ['a}b', 'a\\}b'],
+            '[' => ['a[b', 'a\\[b'],
+            ']' => ['a]b', 'a\\]b'],
+            '^' => ['a^b', 'a\\^b'],
+            '"' => ['a"b', 'a\\"b'],
+            '~' => ['a~b', 'a\\~b'],
+            '*' => ['a*b', 'a\\*b'],
+            '?' => ['a?b', 'a\\?b'],
+            ':' => ['a:b', 'a\\:b'],
+            '/' => ['a/b', 'a\\/b'],
+            '\\' => ['a\b', 'a\\\b'],
+        ];
     }
 
     public function testEscapeTermNoEscape()
@@ -412,12 +446,23 @@ class HelperTest extends TestCase
         );
     }
 
-    public function testEscapePhrase()
+    /**
+     * @dataProvider escapePhraseProvider
+     */
+    public function testEscapePhrase(string $phrase, string $expected)
     {
         $this->assertSame(
-            '"a+\\"b"',
-            $this->helper->escapePhrase('a+"b')
+            $expected,
+            $this->helper->escapePhrase($phrase)
         );
+    }
+
+    public function escapePhraseProvider(): array
+    {
+        return [
+            '"' => ['a+"b', '"a+\\"b"'],
+            '\\' => ['a+\b', '"a+\\\b"'],
+        ];
     }
 
     public function testEscapePhraseNoEscape()

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -197,6 +197,56 @@ abstract class AbstractTechproductsTest extends TestCase
             ], $ids);
     }
 
+    /**
+     * @see https://solr.apache.org/guide/the-standard-query-parser.html#escaping-special-characters
+     */
+    public function testEscapes()
+    {
+        $escapeChars = [' ', '+', '-', '&&', '||', '!', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '/', '\\'];
+        $cat = [implode('', $escapeChars)];
+
+        foreach ($escapeChars as $char) {
+            $cat[] = 'a'.$char.'b';
+        }
+
+        $update = self::$client->createUpdate();
+        $doc = $update->createDocument();
+        $doc->setField('id', 'solarium-test-escapes');
+        $doc->setField('name', 'Solarium Test Escapes');
+        $doc->setField('cat', $cat);
+        $update->addDocument($doc);
+        $update->addCommit(true, true);
+        self::$client->update($update);
+
+        $select = self::$client->createSelect();
+        $select->setQuery('id:%T1%', ['solarium-test-escapes']);
+        $result = self::$client->select($select);
+        $this->assertCount(1, $result);
+        $this->assertSame($cat, $result->getIterator()->current()->getFields()['cat']);
+
+        foreach ($escapeChars as $char) {
+            // as term
+            $select->setQuery('cat:%T1%', ['a'.$char.'b']);
+            $result = self::$client->select($select);
+            $this->assertCount(1, $result, $msg = sprintf('Failure with term containing \'%s\'.', $char));
+            $this->assertSame('solarium-test-escapes', $result->getIterator()->current()->getFields()['id'], $msg);
+
+            // as phrase
+            $select->setQuery('cat:%P1%', ['a'.$char.'b']);
+            $result = self::$client->select($select);
+            $this->assertCount(1, $result, $msg = sprintf('Failure with phrase containing \'%s\'.', $char));
+            $this->assertSame('solarium-test-escapes', $result->getIterator()->current()->getFields()['id'], $msg);
+        }
+
+        // cleanup
+        $update->addDeleteQuery('cat:%T1%', [$cat[0]]);
+        $update->addCommit(true, true);
+        self::$client->update($update);
+        $select->setQuery('id:solarium-test-escapes');
+        $result = self::$client->select($select);
+        $this->assertCount(0, $result);
+    }
+
     public function testRangeQueries()
     {
         $select = self::$client->createSelect();


### PR DESCRIPTION
Made the unit tests for `Helper::escapeTerm()` and  `Helper::escapePhrase()` exhaustive for every special character.

Added an integration test that queries techproducts with these characters through placeholders.