### PR TITLE
Escaping of local parameter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Solarium library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Fixed
+- Local parameter values are now escaped automatically when necessary
+
 
 ## [6.2.2]
 ### Added

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -332,7 +332,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
 
         foreach ($facet->getSet() as $key => $setValue) {
             if (\is_string($key)) {
-                $setValue = $this->renderLocalParams($setValue, ['key' => '"'.$key.'"']);
+                $setValue = $this->renderLocalParams($setValue, ['key' => $key]);
             }
             $request->addParam("f.$field.facet.interval.set", $setValue);
         }

--- a/src/Core/Query/AbstractRequestBuilder.php
+++ b/src/Core/Query/AbstractRequestBuilder.php
@@ -70,6 +70,7 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
     public function renderLocalParams(string $value, array $localParams = []): string
     {
         $params = '';
+        $helper = $this->getHelper();
 
         if (0 === strpos($value, '{!')) {
             $params = substr($value, 2, strpos($value, '}') - 2).' ';
@@ -87,7 +88,7 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
                 $paramValue = $paramValue ? 'true' : 'false';
             }
 
-            $params .= $paramName.'='.$paramValue.' ';
+            $params .= $paramName.'='.$helper->escapeLocalParamValue($paramValue).' ';
         }
 
         if ('' !== $params = trim($params)) {

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -102,6 +102,30 @@ class Helper
     }
 
     /**
+     * Escape a local parameter value.
+     *
+     * This method wraps the value in single quotes if it contains a space,
+     * a single quote, a double quote, or a right curly bracket. It backslash
+     * escapes single quotes and backslashes within that quoted string.
+     *
+     * A value that doesn't require quoting is returned as is.
+     *
+     * @see https://solr.apache.org/guide/local-parameters-in-queries.html#basic-syntax-of-local-parameters
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    public function escapeLocalParamValue(string $value): string
+    {
+        if (preg_match('/[ \'"}]/', $value)) {
+            $value = "'".preg_replace("/('|\\\\)/", '\\\$1', $value)."'";
+        }
+
+        return $value;
+    }
+
+    /**
      * Format a date to the expected formatting used in Solr.
      *
      * This format was derived to be standards compliant (ISO 8601).
@@ -329,7 +353,7 @@ class Helper
                     $value = $value ? 'true' : 'false';
                 }
 
-                $output .= ' '.$key.'='.$value;
+                $output .= ' '.$key.'='.$this->escapeLocalParamValue($value);
             }
         }
         $output .= '}';

--- a/tests/Component/RequestBuilder/FacetSetTest.php
+++ b/tests/Component/RequestBuilder/FacetSetTest.php
@@ -738,7 +738,7 @@ class FacetSetTest extends TestCase
         $this->assertNull($request->getRawData());
 
         $this->assertEquals(
-            '?facet.interval={!key=f1}cat&f.cat.facet.interval.set=int1&f.cat.facet.interval.set={!key="one"}int2&facet=true',
+            '?facet.interval={!key=f1}cat&f.cat.facet.interval.set=int1&f.cat.facet.interval.set={!key=one}int2&facet=true',
             urldecode($request->getUri())
         );
     }

--- a/tests/Core/Query/HelperTest.php
+++ b/tests/Core/Query/HelperTest.php
@@ -473,6 +473,42 @@ class HelperTest extends TestCase
         );
     }
 
+    /**
+     * @dataProvider escapeLocalParamValueProvider
+     */
+    public function testEscapeLocalParamValue(string $value, string $expected)
+    {
+        $this->assertSame(
+            $expected,
+            $this->helper->escapeLocalParamValue($value)
+        );
+    }
+
+    public function escapeLocalParamValueProvider(): array
+    {
+        return [
+            'space' => ['a b', "'a b'"],
+            "'" => ["a'b", "'a\\'b'"],
+            '"' => ['a"b', "'a\"b'"],
+            "\\'" => ["a\\'b", "'a\\\\\\'b'"],
+            '\\"' => ['a\\"b', "'a\\\\\"b'"],
+            '}' => ['ab}', "'ab}'"],
+        ];
+    }
+
+    /**
+     * @testWith ["ab"]
+     *           ["a\\b"]
+     *           ["{!ab"]
+     */
+    public function testEscapeLocalParamValueNoEscape(string $value)
+    {
+        $this->assertSame(
+            $value,
+            $this->helper->escapeLocalParamValue($value)
+        );
+    }
+
     public function testFormatDateInputTimestamp()
     {
         $this->assertFalse(

--- a/tests/Core/Query/RequestBuilderTest.php
+++ b/tests/Core/Query/RequestBuilderTest.php
@@ -157,6 +157,24 @@ class RequestBuilderTest extends TestCase
         );
     }
 
+    public function testRenderLocalParamsWithEscapes()
+    {
+        $myParams = [
+            'as.is' => 'as-is',
+            'space' => 'the final frontier',
+            'single.quote' => "'60s",
+            'double.quote' => '"so-called"',
+            'backslash' => ' \ ',
+            'curly' => '{x}',
+            'list' => ['wax on', 'wax off'],
+        ];
+
+        $this->assertSame(
+            "{!as.is=as-is space='the final frontier' single.quote='\\'60s' double.quote='\"so-called\"' backslash=' \\\\ ' curly='{x}' list='wax on,wax off'}myValue",
+            $this->builder->renderLocalParams('myValue', $myParams)
+        );
+    }
+
     public function testRenderLocalParamsWithoutParams()
     {
         $this->assertSame(


### PR DESCRIPTION
Fixes #974.

Integration test uses facet fields because that's the way we've encountered the bug in production. All components that use local parameters with user supplied values are potentially affected.

This will break BC for users who noticed this bug and worked around it by slapping quotes around an affected value before passing it to Solarium. (That's actually the fix that was implemented internally too in [4c7e202](https://github.com/solariumphp/solarium/commit/4c7e202e372cf2bac238003975e75c4ddfe1ca13) for facet interval keys.)