### PR TITLE
Fix PHP 8.1 deprecation

### DIFF
--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -67,7 +67,7 @@ class HttpException extends \RuntimeException implements RuntimeExceptionInterfa
             $message .= "\n".$body;
         }
 
-        parent::__construct($message, $code);
+        parent::__construct($message, $code ?? 0);
     }
 
     /**


### PR DESCRIPTION
Got this in a [failed workflow](https://github.com/thomascorthals/solarium/runs/4906311720?check_suite_focus=true#step:9:7) with a random timeout:

```
Deprecated: Exception::__construct(): Passing null to parameter #2 ($code) of type int is deprecated in /home/runner/work/solarium/solarium/src/Exception/HttpException.php on line 70
```