### PR TITLE
Integration test for #184 and #252

### DIFF
--- a/tests/Component/ResponseParser/SpellcheckTest.php
+++ b/tests/Component/ResponseParser/SpellcheckTest.php
@@ -44,6 +44,16 @@ class SpellcheckTest extends TestCase
         $collations = $result->getCollations();
         $this->assertEquals('dell ultrasharp', $collations[0]->getQuery());
         $this->assertEquals('dell ultrasharp new', $collations[1]->getQuery());
+        $this->assertEquals(
+            [
+                'delll' => 'dell',
+                'ultrashar' => [
+                    'ultrasharp',
+                    'ultrasharp',
+                ],
+            ],
+            $collations[0]->getCorrections()
+        );
     }
 
     public function providerParseExtended()
@@ -106,6 +116,8 @@ class SpellcheckTest extends TestCase
                                     1 => 'dell',
                                     2 => 'ultrashar',
                                     3 => 'ultrasharp',
+                                    4 => 'ultrashar',
+                                    5 => 'ultrasharp',
                                 ],
                             ],
                             'collation',
@@ -120,6 +132,8 @@ class SpellcheckTest extends TestCase
                                     1 => 'dell',
                                     2 => 'ultrashar',
                                     3 => 'ultrasharp',
+                                    4 => 'ultrashar',
+                                    5 => 'ultrasharp',
                                 ],
                             ],
                         ],
@@ -170,8 +184,7 @@ class SpellcheckTest extends TestCase
                                 ],
                             ],
                         ],
-                        'correctlySpelled',
-                        false,
+                        'correctlySpelled' => false,
                         'collations' => [
                             'collation',
                             [
@@ -182,6 +195,8 @@ class SpellcheckTest extends TestCase
                                     1 => 'dell',
                                     2 => 'ultrashar',
                                     3 => 'ultrasharp',
+                                    4 => 'ultrashar',
+                                    5 => 'ultrasharp',
                                 ],
                             ],
                             'collation',
@@ -193,6 +208,8 @@ class SpellcheckTest extends TestCase
                                     1 => 'dell',
                                     2 => 'ultrashar',
                                     3 => 'ultrasharp',
+                                    4 => 'ultrashar',
+                                    5 => 'ultrasharp',
                                 ],
                             ],
                         ],
@@ -288,8 +305,7 @@ class SpellcheckTest extends TestCase
                                 ],
                             ],
                         ],
-                        'correctlySpelled',
-                        false,
+                        'correctlySpelled' => false,
                         'collations' => [
                             'collation',
                             'dell ultrasharp',
@@ -391,8 +407,7 @@ class SpellcheckTest extends TestCase
                                 ],
                             ],
                         ],
-                        'correctlySpelled',
-                        false,
+                        'correctlySpelled' => false,
                         'collations' => [
                             'collation',
                             'dell ultrasharp',

--- a/tests/Component/Result/Spellcheck/SuggestionTest.php
+++ b/tests/Component/Result/Spellcheck/SuggestionTest.php
@@ -24,6 +24,8 @@ class SuggestionTest extends TestCase
 
     protected $frequency;
 
+    protected $originalTerm;
+
     public function setUp(): void
     {
         $this->numFound = 1;
@@ -40,13 +42,15 @@ class SuggestionTest extends TestCase
                 'freq' => 1,
             ],
         ];
+        $this->originalTerm = 'wrongword';
 
         $this->result = new Suggestion(
             $this->numFound,
             $this->startOffset,
             $this->endOffset,
             $this->originalFrequency,
-            $this->words
+            $this->words,
+            $this->originalTerm,
         );
     }
 
@@ -83,5 +87,10 @@ class SuggestionTest extends TestCase
     public function testGetWords()
     {
         $this->assertEquals($this->words, $this->result->getWords());
+    }
+
+    public function testGetOriginalTerm()
+    {
+        $this->assertEquals($this->originalTerm, $this->result->getOriginalTerm());
     }
 }

--- a/tests/QueryType/Select/Result/AbstractResultTest.php
+++ b/tests/QueryType/Select/Result/AbstractResultTest.php
@@ -30,13 +30,15 @@ abstract class AbstractResultTest extends TestCase
 
     protected $grouping;
 
+    protected $spellcheck;
+
+    protected $suggester;
+
     protected $stats;
 
     protected $debug;
 
     protected $analytics;
-
-    protected $spellcheck;
 
     public function setUp(): void
     {
@@ -54,6 +56,7 @@ abstract class AbstractResultTest extends TestCase
         $this->highlighting = null;
         $this->grouping = null;
         $this->spellcheck = null;
+        $this->suggester = null;
         $this->stats = null;
         $this->debug = null;
         $this->analytics = null;
@@ -64,6 +67,7 @@ abstract class AbstractResultTest extends TestCase
             ComponentAwareQueryInterface::COMPONENT_HIGHLIGHTING => $this->highlighting,
             ComponentAwareQueryInterface::COMPONENT_GROUPING => $this->grouping,
             ComponentAwareQueryInterface::COMPONENT_SPELLCHECK => $this->spellcheck,
+            ComponentAwareQueryInterface::COMPONENT_SUGGESTER => $this->suggester,
             ComponentAwareQueryInterface::COMPONENT_STATS => $this->stats,
             ComponentAwareQueryInterface::COMPONENT_DEBUG => $this->debug,
             ComponentAwareQueryInterface::COMPONENT_ANALYTICS => $this->analytics,
@@ -146,6 +150,14 @@ abstract class AbstractResultTest extends TestCase
         $this->assertSame(
             $this->components[ComponentAwareQueryInterface::COMPONENT_SPELLCHECK],
             $this->result->getSpellcheck()
+        );
+    }
+
+    public function testGetSuggester()
+    {
+        $this->assertSame(
+            $this->components[ComponentAwareQueryInterface::COMPONENT_SUGGESTER],
+            $this->result->getSuggester()
         );
     }
 


### PR DESCRIPTION
Closes #184 by proving it's no longer relevant on current Solr versions.

Also closes #252 which was essentially the same bug. The code throwing the notice has been moved from the Suggester to the Spellcheck reponse parser since this issue was reported.
> Notice: Undefined index: numFound in [...]/vendor/solarium/solarium/library/Solarium/QueryType/Suggester/ResponseParser.php line 78