### PR TITLE
Integration test for connection reuse

### DIFF
--- a/docs/client-and-adapters.md
+++ b/docs/client-and-adapters.md
@@ -4,7 +4,7 @@ Client and adapters
 Client
 ------
 
-The client (class `Solarium\Client`) is the main interface of Solarium, a sort of gateway. It holds config settings and has method to access all Solarium functionality. It controls the calling of many underlying Solarium classes but has very little built-in functionality itself.
+The client (class `Solarium\Client`) is the main interface of Solarium, a sort of gateway. It holds config settings and has methods to access all Solarium functionality. It controls the calling of many underlying Solarium classes but has very little built-in functionality itself.
 
 This allows for a lightweight class, so that you can have it available at all times at very little cost. The Solarium\\Client class uses lazy loading where possible. By having all functionality implemented in subclasses you can also easily customize behaviour by altering the mapping to these subclasses, while still maintaining the same client API.
 
@@ -49,7 +49,7 @@ Endpoints support authentication. To use this set the authentication on the endp
 cURL adapter
 ============
 
-This is the standard Solarium adapter. It supports the most features (for instance concurrent requests) and doesn't suffer from memory issues (like `HttpAdapter` in some cases). The only downside is that it depends on the PHP cURL extension, however most PHP environment have this extension. If cURL is not available and installing is not an option you should use one of the other adapters.
+This is the standard Solarium adapter. It supports the most features (for instance concurrent requests) and doesn't suffer from memory issues (like `HttpAdapter` in some cases). The only downside is that it depends on the PHP cURL extension, however most PHP environments have this extension. If cURL is not available and installing is not an option you should use one of the other adapters.
 
 ```php
 <?php
@@ -69,7 +69,7 @@ htmlFooter();
 
 ### Proxy support
 
-The cURL adapter support the use of a proxy. Use the adapter option `proxy` to enable this.
+The cURL adapter supports the use of a proxy. Use the adapter option `proxy` to enable this.
 
 
 HTTP adapter
@@ -117,7 +117,7 @@ htmlFooter();
 
 ```
 
-If your application does many Solr requests during a single PHP process, consider leveraging the [Symphony PSR-18 HTTP Client](https://symfony.com/doc/current/http_client.html#psr-18-and-psr-17) to reuses HTTP connections, which can significantly improve performance.
+If your application does many Solr requests during a single PHP process, consider leveraging the [Symphony PSR-18 HTTP Client](https://symfony.com/doc/current/http_client.html#psr-18-and-psr-17) to reuse HTTP connections, which can significantly improve performance.
 
 Below example registers such a PSR-18 Client with a timeout of 120 seconds.
 

--- a/src/QueryType/Server/Api/Query.php
+++ b/src/QueryType/Server/Api/Query.php
@@ -14,7 +14,6 @@ use Solarium\Core\Client\Request;
 use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\RequestBuilderInterface;
 use Solarium\Core\Query\ResponseParserInterface;
-use Solarium\Core\Query\Result\QueryType;
 
 /**
  * V2 API query.
@@ -29,7 +28,7 @@ class Query extends AbstractQuery
     protected $options = [
         'version' => Request::API_V1,
         'method' => Request::METHOD_GET,
-        'resultclass' => QueryType::class,
+        'resultclass' => Result::class,
     ];
 
     /**

--- a/src/QueryType/Server/Api/ResponseParser.php
+++ b/src/QueryType/Server/Api/ResponseParser.php
@@ -29,6 +29,7 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
     public function parse(ResultInterface $result): array
     {
         $data = $result->getData();
+        $data = $this->parseStatus($data, $result);
         $data = $this->addHeaderInfo($data, $data);
 
         return $data;

--- a/src/QueryType/Server/Api/Result.php
+++ b/src/QueryType/Server/Api/Result.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Server\Api;
+
+use Solarium\QueryType\Server\Query\AbstractResult;
+
+/**
+ * API result.
+ */
+class Result extends AbstractResult
+{
+}

--- a/tests/Integration/ConnectionReuseTest.php
+++ b/tests/Integration/ConnectionReuseTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Solarium\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\ClientInterface;
+use Solarium\Core\Client\Request;
+
+/**
+ * Test connection reuse with PSR-18 adapter.
+ *
+ * @group integration
+ */
+class ConnectionReuseTest extends TestCase
+{
+    /**
+     * @var ClientInterface
+     */
+    protected static $client;
+
+    /**
+     * @var array
+     */
+    protected static $config;
+
+    /**
+     * Original org.eclipse.jetty.io.AbstractConnection log level to restore after the testcase.
+     *
+     * @var string
+     */
+    protected static $origLogLevel;
+
+    /**
+     * Original watcher threshold to restore after the testcase.
+     *
+     * @var string
+     */
+    protected static $origThreshold;
+
+    /**
+     * Keep track of the last retrieved logging timestamp.
+     *
+     * @var int
+     */
+    protected static $since = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$config = [
+            'endpoint' => [
+                'localhost' => [
+                    'host' => '127.0.0.1',
+                    'port' => 8983,
+                    'path' => '/',
+                    'username' => 'solr',
+                    'password' => 'SolrRocks',
+                ],
+            ],
+        ];
+
+        self::$client = TestClientFactory::createWithPsr18Adapter();
+
+        // get the current log level to restore afterwards to avoid excessive logging in other testcases
+        $query = self::$client->createApi([
+            'version' => Request::API_V2,
+            'handler' => 'node/logging',
+        ]);
+        $result = self::$client->execute($query);
+        $connectionLogger = array_values(array_filter(
+            $result->getData()['loggers'],
+            function(array $logger): bool {
+                return 'org.eclipse.jetty.io.AbstractConnection' === $logger['name'];
+            }
+        ))[0];
+        self::$origLogLevel = $connectionLogger['level'];
+
+        // set the minimal log level that will provide us with enough information
+        $query = self::$client->createApi([
+            'version' => Request::API_V2,
+            'handler' => 'node/logging',
+        ]);
+        $query->addParam('set', 'org.eclipse.jetty.io.AbstractConnection:DEBUG');
+        $result = self::$client->execute($query);
+        self::assertTrue($result->getWasSuccessful());
+
+        // get the current watcher threshold to restore afterwards
+        $query = self::$client->createApi([
+            'version' => Request::API_V2,
+            'handler' => 'node/logging',
+        ]);
+        $query->addParam('since', self::$since);
+        $result = self::$client->execute($query);
+        self::$origThreshold = $result->getData()['info']['threshold'];
+
+        // set the watcher threshold to match the log level we need
+        // get the initial timestamp to use for retrieving the logging history
+        $query = self::$client->createApi([
+            'version' => Request::API_V2,
+            'handler' => 'node/logging',
+        ]);
+        $query->addParam('since', self::$since);
+        $query->addParam('threshold', 'DEBUG');
+        $result = self::$client->execute($query);
+        self::$since = $result->getData()['info']['last'];
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        // restore the original log level and watcher threshold
+        $query = self::$client->createApi([
+            'version' => Request::API_V2,
+            'handler' => 'node/logging',
+        ]);
+        $query->addParam('set', sprintf('org.eclipse.jetty.io.AbstractConnection:%s', self::$origLogLevel));
+        $query->addParam('threshold', self::$origThreshold);
+        $result = self::$client->execute($query);
+        self::assertTrue($result->getWasSuccessful());
+    }
+
+    /**
+     * @dataProvider createAdapterProvider
+     */
+    public function testConnectionReuse(string $createFunction, int $expectedCount)
+    {
+        // make sure the next logged timestamp is not on the same millisecond as self::$since
+        usleep(1000);
+
+        $client = TestClientFactory::$createFunction();
+
+        // the logging for 5 requests fits within the default logging watcher buffer size
+        for ($i = 0; $i < 5; ++$i) {
+            $query = $client->createApi([
+                'version' => Request::API_V2,
+                'handler' => 'node/system',
+            ]);
+            $client->execute($query);
+        }
+
+        $query = $client->createApi([
+            'version' => Request::API_V2,
+            'handler' => 'node/logging',
+        ]);
+        $query->addParam('since', self::$since);
+        $result = $client->execute($query);
+        $data = $result->getData();
+        self::$since = $data['info']['last'];
+
+        $connections = $this->extractConnections($data['history']['docs']);
+
+        // The count is off-by-1 with an additional connection for one of the tests:
+        // - the request for node/logging without reuse is included in the count without reuse in most tests in a workflow;
+        // - if it isn't picked up the first time around, it shows up instead when we get the log with reuse.
+        // The request for node/logging with reuse doesn't cause another additional connection because of the reuse.
+        $this->assertContains(\count($connections), [$expectedCount, $expectedCount + 1]);
+    }
+
+    public function createAdapterProvider(): array
+    {
+        return [
+            'without reuse' => ['createWithCurlAdapter', 5],
+            'with reuse' => ['createWithPsr18Adapter', 1],
+        ];
+    }
+
+    /**
+     * Extracts connections from the logging history docs.
+     *
+     * Connections are identified by the org.eclipse.jetty.io.AbstractConnection
+     * logger's message with format "onOpen {}".
+     *
+     * @param array $docs
+     *
+     * @return string[]
+     */
+    protected function extractConnections(array $docs): array
+    {
+        $connections = [];
+
+        foreach ($docs as $doc) {
+            if ('org.eclipse.jetty.io.AbstractConnection' === $doc['logger'] && 0 === strpos($doc['message'], 'onOpen ')) {
+                $connections[] = $doc['message'];
+            }
+        }
+
+        return $connections;
+    }
+}

--- a/tests/Integration/ConnectionReuseTest.php
+++ b/tests/Integration/ConnectionReuseTest.php
@@ -68,7 +68,7 @@ class ConnectionReuseTest extends TestCase
         $result = self::$client->execute($query);
         $connectionLogger = array_values(array_filter(
             $result->getData()['loggers'],
-            function(array $logger): bool {
+            function (array $logger): bool {
                 return 'org.eclipse.jetty.io.AbstractConnection' === $logger['name'];
             }
         ))[0];

--- a/tests/QueryType/Server/Api/QueryTest.php
+++ b/tests/QueryType/Server/Api/QueryTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 use Solarium\Core\Client\Client;
 use Solarium\Core\Client\Request;
 use Solarium\QueryType\Server\Api\Query;
+use Solarium\QueryType\Server\Api\RequestBuilder;
+use Solarium\QueryType\Server\Api\ResponseParser;
+use Solarium\QueryType\Server\Api\Result;
 
 class QueryTest extends TestCase
 {
@@ -30,5 +33,20 @@ class QueryTest extends TestCase
 
         $this->query->setVersion(Request::API_V2);
         $this->assertSame(Request::API_V2, $this->query->getVersion());
+    }
+
+    public function testGetRequestBuilder()
+    {
+        $this->assertInstanceOf(RequestBuilder::class, $this->query->getRequestBuilder());
+    }
+
+    public function testGetResponseParser()
+    {
+        $this->assertInstanceOf(ResponseParser::class, $this->query->getResponseParser());
+    }
+
+    public function testGetResultClass()
+    {
+        $this->assertSame(Result::class, $this->query->getResultClass());
     }
 }

--- a/tests/QueryType/Server/Api/ResponseParserTest.php
+++ b/tests/QueryType/Server/Api/ResponseParserTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Server\Api;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Server\Api\Query;
+use Solarium\QueryType\Server\Api\ResponseParser;
+use Solarium\QueryType\Server\Api\Result;
+
+class ResponseParserTest extends TestCase
+{
+    public function testParse()
+    {
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 13,
+            ],
+            'data' => [
+                'foo' => 'bar',
+            ],
+        ];
+
+        $query = new Query();
+
+        $resultStub = $this->createMock(Result::class);
+        $resultStub->expects($this->any())
+             ->method('getData')
+             ->willReturn($data);
+        $resultStub->expects($this->any())
+             ->method('getQuery')
+             ->willReturn($query);
+
+        $parser = new ResponseParser();
+        $result = $parser->parse($resultStub);
+
+        $expected = [
+            'foo' => 'bar',
+        ];
+
+        $this->assertSame($expected, $result['data']);
+    }
+}


### PR DESCRIPTION
Closes #397.

Consults the logs generated by Jetty to verify that connections are reused with a PSR-18 adapter.