### PR TITLE
// single line comments start with space

### DIFF
--- a/src/Component/DisMax.php
+++ b/src/Component/DisMax.php
@@ -317,7 +317,7 @@ class DisMax extends AbstractComponent
             throw new InvalidArgumentException('A boostquery must have a key value');
         }
 
-        //double add calls for the same BQ are ignored, but non-unique keys cause an exception
+        // double add calls for the same BQ are ignored, but non-unique keys cause an exception
         if (\array_key_exists($key, $this->boostQueries) && $this->boostQueries[$key] !== $boostQuery) {
             throw new InvalidArgumentException('A boostquery must have a unique key value within a query');
         }

--- a/src/Component/FacetSetTrait.php
+++ b/src/Component/FacetSetTrait.php
@@ -46,7 +46,7 @@ trait FacetSetTrait
             throw new InvalidArgumentException('A facet must have a key value');
         }
 
-        //double add calls for the same facet are ignored, but non-unique keys cause an exception
+        // double add calls for the same facet are ignored, but non-unique keys cause an exception
         if (\array_key_exists($key, $this->facets) && $this->facets[$key] !== $facet) {
             throw new InvalidArgumentException('A facet must have a unique key value within a query');
         }

--- a/src/Core/Client/Client.php
+++ b/src/Core/Client/Client.php
@@ -355,7 +355,7 @@ class Client extends Configurable implements ClientInterface
             throw new InvalidArgumentException('An endpoint must have a key value');
         }
 
-        //double add calls for the same endpoint are ignored, but non-unique keys cause an exception
+        // double add calls for the same endpoint are ignored, but non-unique keys cause an exception
         if (\array_key_exists($key, $this->endpoints) && $this->endpoints[$key] !== $endpoint) {
             throw new InvalidArgumentException('An endpoint must have a unique key');
         }
@@ -830,7 +830,7 @@ class Client extends Configurable implements ClientInterface
         $event = new PreExecuteRequestEvent($request, $endpoint);
         $this->eventDispatcher->dispatch($event);
         if (null !== $event->getResponse()) {
-            $response = $event->getResponse(); //a plugin result overrules the standard execution result
+            $response = $event->getResponse(); // a plugin result overrules the standard execution result
         } else {
             $response = $this->getAdapter()->execute($request, $endpoint);
         }

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -177,7 +177,7 @@ class Helper
             // Solr seems to require the format PHP erroneously declares as ISO8601.
             /** @noinspection DateTimeConstantsUsageInspection */
             $iso8601 = $input->format(\DateTimeInterface::ISO8601);
-            $iso8601 = strstr($iso8601, '+', true); //strip timezone
+            $iso8601 = strstr($iso8601, '+', true); // strip timezone
             $iso8601 .= 'Z';
 
             return $iso8601;

--- a/src/Plugin/CustomizeRequest/CustomizeRequest.php
+++ b/src/Plugin/CustomizeRequest/CustomizeRequest.php
@@ -87,7 +87,7 @@ class CustomizeRequest extends AbstractPlugin
 
         // check for a unique key
         if (\array_key_exists($key, $this->customizations)) {
-            //double add calls for the same customization are ignored, others cause an exception
+            // double add calls for the same customization are ignored, others cause an exception
             if ($this->customizations[$key] !== $customization) {
                 throw new InvalidArgumentException('A Customization must have a unique key value');
             }

--- a/src/Plugin/PostBigExtractRequest.php
+++ b/src/Plugin/PostBigExtractRequest.php
@@ -107,7 +107,7 @@ class PostBigExtractRequest extends AbstractPlugin
                     }
                 }
 
-                $body .= AdapterHelper::buildUploadBodyFromRequest($request); //must be the last automatically include closing boundary
+                $body .= AdapterHelper::buildUploadBodyFromRequest($request); // must be the last automatically include closing boundary
 
                 $request->setRawData($body);
                 $request->setOption('file', null); // this prevent solarium from call AdapterHelper::buildUploadBodyFromRequest for setting body request

--- a/src/QueryType/Select/Query/Query.php
+++ b/src/QueryType/Select/Query/Query.php
@@ -560,7 +560,7 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface, Query
             throw new InvalidArgumentException('A filterquery must have a key value');
         }
 
-        //double add calls for the same FQ are ignored, but non-unique keys cause an exception
+        // double add calls for the same FQ are ignored, but non-unique keys cause an exception
         if (\array_key_exists($key, $this->filterQueries) && $this->filterQueries[$key] !== $filterQuery) {
             throw new InvalidArgumentException('A filterquery must have a unique key value within a query');
         }

--- a/tests/Component/ResponseParser/GroupingTest.php
+++ b/tests/Component/ResponseParser/GroupingTest.php
@@ -177,7 +177,7 @@ class GroupingTest extends TestCase
 
     public function testParseMissingGroupField()
     {
-        //data does not contain 'fieldA'
+        // data does not contain 'fieldA'
         $data = [
             'grouped' => [
                 'functionF' => [

--- a/tests/Core/Client/ClientTest.php
+++ b/tests/Core/Client/ClientTest.php
@@ -249,10 +249,10 @@ class ClientTest extends TestCase
     public function testAddAndGetEndpoints()
     {
         $options = [
-            //use array key
+            // use array key
             's1' => ['host' => 's1.local'],
 
-            //use key array entry
+            // use key array entry
             ['key' => 's2', 'host' => 's2.local'],
         ];
 

--- a/tests/Core/Client/EndpointTest.php
+++ b/tests/Core/Client/EndpointTest.php
@@ -34,8 +34,8 @@ class EndpointTest extends TestCase
         ];
         $this->endpoint->setOptions($options);
 
-        $options['path'] = '/mysolr'; //expected trimming of trailing slash
-        $options['context'] = 'lunr'; //expected trimming of leading and trailing slash
+        $options['path'] = '/mysolr'; // expected trimming of trailing slash
+        $options['context'] = 'lunr'; // expected trimming of leading and trailing slash
 
         $this->assertSame($options, $this->endpoint->getOptions());
     }

--- a/tests/Core/Query/HelperTest.php
+++ b/tests/Core/Query/HelperTest.php
@@ -516,13 +516,13 @@ class HelperTest extends TestCase
             'Expects invalid strtotime/timestamp input (false) not to be accepted'
         );
 
-        //allow negative dates.
+        // allow negative dates.
         $this->assertNotFalse(
             $this->helper->formatDate(strtotime('2011-10-01')),
             'Expects negative timestamp input to be accepted'
         );
 
-        //@todo find out if we need to any test for php versions / platforms which do not support negative timestamp
+        // @todo find out if we need to any test for php versions / platforms which do not support negative timestamp
 
         $this->assertFalse(
             $this->helper->formatDate(strtotime('2010-31-02')),
@@ -585,7 +585,7 @@ class HelperTest extends TestCase
     public function testFormatDate()
     {
         $timestamp = time();
-        //check if timezone is stripped
+        // check if timezone is stripped
         $expected = strtoupper('Z');
         $actual = substr($this->helper->formatDate($timestamp), 19, 20);
         $this->assertSame($expected, $actual, 'Expects last charachter to be uppercased Z');

--- a/tests/Core/Query/QueryTest.php
+++ b/tests/Core/Query/QueryTest.php
@@ -39,7 +39,7 @@ class QueryTest extends TestCase
         $query = new TestQuery();
         $query->addParam('p1', 'v1');
         $query->addParam('p2', 'v2');
-        $query->addParam('p2', 'v3'); //should overwrite previous value
+        $query->addParam('p2', 'v3'); // should overwrite previous value
 
         $this->assertSame(
             ['p1' => 'v1', 'p2' => 'v3'],

--- a/tests/Plugin/CustomizeRequest/CustomizeRequestTest.php
+++ b/tests/Plugin/CustomizeRequest/CustomizeRequestTest.php
@@ -242,7 +242,7 @@ class CustomizeRequestTest extends TestCase
         $customizations = ['id1' => $customization1, 'id2' => $customization2];
 
         $this->plugin->addCustomizations($customizations);
-        $this->plugin->removeCustomization('id3'); //continue silently
+        $this->plugin->removeCustomization('id3'); // continue silently
         $this->assertSame(
             $customizations,
             $this->plugin->getCustomizations()

--- a/tests/QueryType/MoreLikeThis/QueryTest.php
+++ b/tests/QueryType/MoreLikeThis/QueryTest.php
@@ -180,7 +180,7 @@ class QueryTest extends TestCase
         ];
 
         $this->query->addSorts($sorts);
-        $this->query->removeSort('invalidfield'); //continue silently
+        $this->query->removeSort('invalidfield'); // continue silently
         $this->assertSame(
             $sorts,
             $this->query->getSorts()
@@ -349,7 +349,7 @@ class QueryTest extends TestCase
         $filterQueries = ['fq1' => $fq1, 'fq2' => $fq2];
 
         $this->query->addFilterQueries($filterQueries);
-        $this->query->removeFilterQuery('fq3'); //continue silently
+        $this->query->removeFilterQuery('fq3'); // continue silently
         $this->assertSame(
             $filterQueries,
             $this->query->getFilterQueries()

--- a/tests/QueryType/Select/Query/AbstractQueryTest.php
+++ b/tests/QueryType/Select/Query/AbstractQueryTest.php
@@ -184,7 +184,7 @@ abstract class AbstractQueryTest extends TestCase
         ];
 
         $this->query->addSorts($sorts);
-        $this->query->removeSort('invalidfield'); //continue silently
+        $this->query->removeSort('invalidfield'); // continue silently
         $this->assertSame(
             $sorts,
             $this->query->getSorts()
@@ -353,7 +353,7 @@ abstract class AbstractQueryTest extends TestCase
         $filterQueries = ['fq1' => $fq1, 'fq2' => $fq2];
 
         $this->query->addFilterQueries($filterQueries);
-        $this->query->removeFilterQuery('fq3'); //continue silently
+        $this->query->removeFilterQuery('fq3'); // continue silently
         $this->assertSame(
             $filterQueries,
             $this->query->getFilterQueries()

--- a/tests/QueryType/Select/Query/Component/FacetSetTest.php
+++ b/tests/QueryType/Select/Query/Component/FacetSetTest.php
@@ -330,7 +330,7 @@ class FacetSetTest extends TestCase
         $facets = ['f1' => $fq1, 'f2' => $fq2];
 
         $this->facetSet->addFacets($facets);
-        $this->facetSet->removeFacet('f3'); //continue silently
+        $this->facetSet->removeFacet('f3'); // continue silently
         $this->assertSame(
             $facets,
             $this->facetSet->getFacets()

--- a/tests/QueryType/Select/Query/Component/Stats/StatsTest.php
+++ b/tests/QueryType/Select/Query/Component/Stats/StatsTest.php
@@ -239,7 +239,7 @@ class StatsTest extends TestCase
         $fields = ['f1' => $f1, 'f2' => $f2];
 
         $this->stats->addFields($fields);
-        $this->stats->removeField('f3'); //continue silently
+        $this->stats->removeField('f3'); // continue silently
         $this->assertSame(
             $fields,
             $this->stats->getFields()

--- a/tests/QueryType/Update/Query/Document/DocumentTest.php
+++ b/tests/QueryType/Update/Query/Document/DocumentTest.php
@@ -299,7 +299,7 @@ class DocumentTest extends TestCase
 
     public function testRemoveInvalidField()
     {
-        $this->doc->removeField('invalidname'); //should silently continue...
+        $this->doc->removeField('invalidname'); // should silently continue...
 
         $this->assertSame(
             $this->fields,

--- a/tests/QueryType/Update/Query/QueryTest.php
+++ b/tests/QueryType/Update/Query/QueryTest.php
@@ -195,7 +195,7 @@ class QueryTest extends TestCase
         $commit = new Commit();
         $this->query->add('cm', $commit);
 
-        $this->query->remove('invalidkey'); //should silently ignore
+        $this->query->remove('invalidkey'); // should silently ignore
 
         $this->assertSame(
             ['rb' => $rollback, 'cm' => $commit],


### PR DESCRIPTION
StyleCI kept bugging me with [failed analyses](https://github.styleci.io/analyses/x0VEjA) like this:
```diff
         // check for a unique key
         if (\array_key_exists($key, $this->customizations)) {
-            //double add calls for the same customization are ignored, others cause an exception
+            // double add calls for the same customization are ignored, others cause an exception
             if ($this->customizations[$key] !== $customization) {
                 throw new InvalidArgumentException('A Customization must have a unique key value');
             }
```