### PR TITLE
Fix support for highlighting methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Solarium\QueryType\Server\Collections\Query\Action\ClusterStatus::getRoute() always returned NULL even if a route was set
+- Solarium\Component\Highlighting\Highlighting::setMethod() didn't set the correct request parameter
 
 ### Removed
 - Solarium\QueryType\Stream\Expression, use Solarium\QueryType\Stream\ExpressionBuilder instead

--- a/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/highlighting-component.md
@@ -7,6 +7,8 @@ Options
 |--------------------------|---------|---------------|------------------------------------------------------------------------------------|
 | method                   | string  | null          | The highlighting implementation to use: 'unified', 'original' or 'fastVector'.     |
 | fields                   | string  | null          | Fields to generate highlighted snippets for. Separate multiple fields with commas. |
+| query                    | string  | null          | Overrides the q parameter for highlighting                                         |
+| queryparser              | string  | null          | The query parser to use if the query option is set                                 |
 | snippets                 | int     | null          | Maximum number of snippets per field                                               |
 | fragsize                 | int     | null          | The size, in characters, of fragments to consider for highlighting                 |
 | mergecontiguous          | boolean | null          | Collapse contiguous fragments into a single fragment                               |
@@ -15,8 +17,9 @@ Options
 | alternatefield           | string  | null          | Alternatefield option                                                              |
 | maxalternatefieldlength  | int     | null          | maxAlternateFieldLength option                                                     |
 | formatter                | string  | null          | formatter option                                                                   |
-| simpleprefix             | string  | null          | Solr option h1.simple.pre                                                          |
-| simplepostfix            | string  | null          | Solr option h1.simple.post                                                         |
+| simpleprefix             | string  | null          | Solr option hl.simple.pre                                                          |
+| simplepostfix            | string  | null          | Solr option hl.simple.post                                                         |
+| encoder                  | string  | null          |                                                                                    |
 | fragmenter               | string  | null          |                                                                                    |
 | fraglistbuilder          | string  | null          |                                                                                    |
 | fragmentsbuilder         | string  | null          |                                                                                    |
@@ -26,7 +29,6 @@ Options
 | regexslop                | float   | null          |                                                                                    |
 | regexpattern             | string  | null          |                                                                                    |
 | regexmaxanalyzedchars    | int     | null          |                                                                                    |
-| query                    | string  | null          | Overrides the q parameter for highlighting                                         |
 | phraselimit              | int     | null          |                                                                                    |
 | multivaluedseparatorchar | string  | null          |                                                                                    |
 | boundaryscannerchars     | string  | null          |                                                                                    |

--- a/src/Component/Highlighting/Field.php
+++ b/src/Component/Highlighting/Field.php
@@ -20,13 +20,17 @@ class Field extends Configurable
 {
     /**
      * Value for fragmenter option gap.
+     *
+     * @deprecated use Highlighting::FRAGMENTER_GAP instead
      */
-    const FRAGMENTER_GAP = 'gap';
+    const FRAGMENTER_GAP = Highlighting::FRAGMENTER_GAP;
 
     /**
      * Value for fragmenter option regex.
+     *
+     * @deprecated use Highlighting::FRAGMENTER_REGEX instead
      */
-    const FRAGMENTER_REGEX = 'regex';
+    const FRAGMENTER_REGEX = Highlighting::FRAGMENTER_REGEX;
 
     /**
      * Get name option.
@@ -50,6 +54,32 @@ class Field extends Configurable
         $this->setOption('name', $name);
 
         return $this;
+    }
+
+    /**
+     * Set highlighter method.
+     *
+     * Use one of the Highlighting::METHOD_* constants as value.
+     *
+     * @param string $method
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMethod(string $method): self
+    {
+        $this->setOption('method', $method);
+
+        return $this;
+    }
+
+    /**
+     * Get highlighter method.
+     *
+     * @return string|null
+     */
+    public function getMethod(): ?string
+    {
+        return $this->getOption('method');
     }
 
     /**
@@ -205,7 +235,7 @@ class Field extends Configurable
     /**
      * Set simple prefix option.
      *
-     * Solr option h1.simple.pre
+     * Solr option hl.simple.pre
      *
      * @param string $prefix
      *
@@ -233,7 +263,7 @@ class Field extends Configurable
     /**
      * Set simple postfix option.
      *
-     * Solr option h1.simple.post
+     * Solr option hl.simple.post
      *
      * @param string $postfix
      *
@@ -261,7 +291,7 @@ class Field extends Configurable
     /**
      * Set fragmenter option.
      *
-     * Use one of the constants as value.
+     * Use one of the Highlighting::FRAGMENTER_* constants as value.
      *
      * @param string $fragmenter
      *

--- a/src/Component/Highlighting/Highlighting.php
+++ b/src/Component/Highlighting/Highlighting.php
@@ -29,6 +29,26 @@ class Highlighting extends AbstractComponent implements QueryInterface
     use QueryTrait;
 
     /**
+     * Unified Highlighter.
+     */
+    const METHOD_UNIFIED = 'unified';
+
+    /**
+     * Original Highlighter.
+     */
+    const METHOD_ORIGINAL = 'original';
+
+    /**
+     * FastVector Highlighter.
+     */
+    const METHOD_FASTVECTOR = 'fastVector';
+
+    /**
+     * HTML/XML encoder.
+     */
+    const ENCODER_HTML = 'html';
+
+    /**
      * Value for fragmenter option gap.
      */
     const FRAGMENTER_GAP = 'gap';
@@ -93,6 +113,32 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function getResponseParser(): ?ComponentParserInterface
     {
         return new ResponseParser();
+    }
+
+    /**
+     * Set highlighter method.
+     *
+     * Use one of the METHOD_* constants as value.
+     *
+     * @param string $method
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMethod(string $method): self
+    {
+        $this->setOption('method', $method);
+
+        return $this;
+    }
+
+    /**
+     * Get highlighter method.
+     *
+     * @return string|null
+     */
+    public function getMethod(): ?string
+    {
+        return $this->getOption('method');
     }
 
     /**
@@ -227,6 +273,30 @@ class Highlighting extends AbstractComponent implements QueryInterface
         $this->addFields($fields);
 
         return $this;
+    }
+
+    /**
+     * Set the query parser to use for the highlight query.
+     *
+     * @param string $parser
+     *
+     * @return self Provides fluent interface
+     */
+    public function setQueryParser(string $parser): self
+    {
+        $this->setOption('queryparser', $parser);
+
+        return $this;
+    }
+
+    /**
+     * Get the query parser to use for the highlight query.
+     *
+     * @return string|null
+     */
+    public function getQueryParser(): ?string
+    {
+        return $this->getOption('queryparser');
     }
 
     /**
@@ -456,7 +526,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     /**
      * Set simple prefix option.
      *
-     * Solr option h1.simple.pre
+     * Solr option hl.simple.pre
      *
      * @param string $prefix
      *
@@ -484,7 +554,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     /**
      * Set simple postfix option.
      *
-     * Solr option h1.simple.post
+     * Solr option hl.simple.post
      *
      * @param string $postfix
      *
@@ -512,7 +582,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     /**
      * Set tag prefix option.
      *
-     * Solr option h1.tag.post
+     * Solr option hl.tag.post
      *
      * @param string $prefix
      *
@@ -540,7 +610,7 @@ class Highlighting extends AbstractComponent implements QueryInterface
     /**
      * Set tag postfix option.
      *
-     * Solr option h1.tag.post
+     * Solr option hl.tag.post
      *
      * @param string $postfix
      *
@@ -566,9 +636,35 @@ class Highlighting extends AbstractComponent implements QueryInterface
     }
 
     /**
+     * Set encoder option.
+     *
+     * Use one of the ENCODER_* constants as value.
+     *
+     * @param string $encoder
+     *
+     * @return self Provides fluent interface
+     */
+    public function setEncoder(string $encoder): self
+    {
+        $this->setOption('encoder', $encoder);
+
+        return $this;
+    }
+
+    /**
+     * Get encoder option.
+     *
+     * @return string|null
+     */
+    public function getEncoder(): ?string
+    {
+        return $this->getOption('encoder');
+    }
+
+    /**
      * Set fragmenter option.
      *
-     * Use one of the constants as value.
+     * Use one of the FRAGMENTER_* constants as value.
      *
      * @param string $fragmenter
      *
@@ -949,30 +1045,6 @@ class Highlighting extends AbstractComponent implements QueryInterface
     public function getBoundaryScannerCountry(): ?string
     {
         return $this->getOption('boundaryscannercountry');
-    }
-
-    /**
-     * Set method option.
-     *
-     * @param string $method
-     *
-     * @return self Provides fluent interface
-     */
-    public function setMethod(string $method): self
-    {
-        $this->setOption('method', $method);
-
-        return $this;
-    }
-
-    /**
-     * Get method option.
-     *
-     * @return string|null
-     */
-    public function getMethod(): ?string
-    {
-        return $this->getOption('method');
     }
 
     /**

--- a/src/Component/RequestBuilder/Highlighting.php
+++ b/src/Component/RequestBuilder/Highlighting.php
@@ -31,11 +31,14 @@ class Highlighting implements ComponentRequestBuilderInterface
     {
         // enable highlighting
         $request->addParam('hl', 'true');
+        $request->addParam('hl.method', $component->getMethod());
 
         // set global highlighting params
-        if (\count($component->getFields()) > 0) {
+        if (0 !== \count($component->getFields())) {
             $request->addParam('hl.fl', implode(',', array_keys($component->getFields())));
         }
+        $request->addParam('hl.q', $component->getQuery());
+        $request->addParam('hl.qparser', $component->getQueryParser());
         $request->addParam('hl.snippets', $component->getSnippets());
         $request->addParam('hl.fragsize', $component->getFragSize());
         $request->addParam('hl.mergeContiguous', $component->getMergeContiguous());
@@ -49,6 +52,7 @@ class Highlighting implements ComponentRequestBuilderInterface
         $request->addParam('hl.simple.post', $component->getSimplePostfix());
         $request->addParam('hl.tag.pre', $component->getTagPrefix());
         $request->addParam('hl.tag.post', $component->getTagPostfix());
+        $request->addParam('hl.encoder', $component->getEncoder());
         $request->addParam('hl.fragmenter', $component->getFragmenter());
         $request->addParam('hl.fragListBuilder', $component->getFragListBuilder());
         $request->addParam('hl.fragmentsBuilder', $component->getFragmentsBuilder());
@@ -58,7 +62,6 @@ class Highlighting implements ComponentRequestBuilderInterface
         $request->addParam('hl.regex.slop', $component->getRegexSlop());
         $request->addParam('hl.regex.pattern', $component->getRegexPattern());
         $request->addParam('hl.regex.maxAnalyzedChars', $component->getRegexMaxAnalyzedChars());
-        $request->addParam('hl.q', $component->getQuery());
         $request->addParam('hl.phraseLimit', $component->getPhraseLimit());
         $request->addParam('hl.multiValuedSeparatorChar', $component->getMultiValuedSeparatorChar());
         $request->addParam('hl.bs.maxScan', $component->getBoundaryScannerMaxScan());
@@ -66,7 +69,6 @@ class Highlighting implements ComponentRequestBuilderInterface
         $request->addParam('hl.bs.type', $component->getBoundaryScannerType());
         $request->addParam('hl.bs.language', $component->getBoundaryScannerLanguage());
         $request->addParam('hl.bs.country', $component->getBoundaryScannerCountry());
-        $request->addParam('h1.method', $component->getMethod());
 
         // set per-field highlighting params
         foreach ($component->getFields() as $field) {
@@ -85,6 +87,7 @@ class Highlighting implements ComponentRequestBuilderInterface
     protected function addFieldParams($field, $request)
     {
         $prefix = 'f.'.$field->getName().'.hl.';
+        $request->addParam($prefix.'method', $field->getMethod());
         $request->addParam($prefix.'snippets', $field->getSnippets());
         $request->addParam($prefix.'fragsize', $field->getFragSize());
         $request->addParam($prefix.'mergeContiguous', $field->getMergeContiguous());

--- a/tests/Component/Highlighting/FieldTest.php
+++ b/tests/Component/Highlighting/FieldTest.php
@@ -21,6 +21,7 @@ class FieldTest extends TestCase
     public function testConfigMode()
     {
         $options = [
+            'method' => 'unified',
             'snippets' => 3,
             'fragsize' => 25,
             'mergecontiguous' => true,
@@ -35,6 +36,7 @@ class FieldTest extends TestCase
 
         $this->fld->setOptions($options);
 
+        $this->assertSame('unified', $this->fld->getMethod());
         $this->assertSame(3, $this->fld->getSnippets());
         $this->assertSame(25, $this->fld->getFragSize());
         $this->assertTrue($this->fld->getMergeContiguous());
@@ -55,6 +57,17 @@ class FieldTest extends TestCase
         $this->assertSame(
             $value,
             $this->fld->getName()
+        );
+    }
+
+    public function testSetAndGetMethod()
+    {
+        $value = 'unified';
+        $this->fld->setMethod($value);
+
+        $this->assertSame(
+            $value,
+            $this->fld->getMethod()
         );
     }
 

--- a/tests/Component/Highlighting/HighlightingTest.php
+++ b/tests/Component/Highlighting/HighlightingTest.php
@@ -23,6 +23,7 @@ class HighlightingTest extends TestCase
     public function testConfigMode()
     {
         $options = [
+            'method' => 'unified',
             'field' => [
                 'fieldA' => [
                     'snippets' => 3,
@@ -30,6 +31,8 @@ class HighlightingTest extends TestCase
                 ],
                 'fieldB',
             ],
+            'query' => 'text:myvalue',
+            'queryparser' => 'myparser',
             'snippets' => 2,
             'fragsize' => 20,
             'mergecontiguous' => true,
@@ -43,6 +46,7 @@ class HighlightingTest extends TestCase
             'simplepostfix' => '</b>',
             'tagprefix' => '<i>',
             'tagpostfix' => '<\i>',
+            'encoder' => 'html',
             'fragmenter' => 'myFragmenter',
             'fraglistbuilder' => 'regex',
             'fragmentsbuilder' => 'myBuilder',
@@ -52,7 +56,6 @@ class HighlightingTest extends TestCase
             'regexslop' => .8,
             'regexpattern' => 'myPattern',
             'regexmaxanalyzedchars' => 500,
-            'query' => 'text:myvalue',
             'phraselimit' => 35,
             'multivaluedseparatorchar' => '|',
             'boundaryscannermaxscan' => 12,
@@ -64,10 +67,13 @@ class HighlightingTest extends TestCase
 
         $this->hlt->setOptions($options);
 
+        $this->assertSame($options['method'], $this->hlt->getMethod());
         $this->assertSame(['fieldA', 'fieldB'], array_keys($this->hlt->getFields()));
         $this->assertSame($options['field']['fieldA']['snippets'], $this->hlt->getField('fieldA')->getSnippets());
         $this->assertSame($options['field']['fieldA']['fragsize'], $this->hlt->getField('fieldA')->getFragSize());
         $this->assertNull($this->hlt->getField('FieldB')->getSnippets());
+        $this->assertSame($options['query'], $this->hlt->getQuery());
+        $this->assertSame($options['queryparser'], $this->hlt->getQueryParser());
         $this->assertSame($options['snippets'], $this->hlt->getSnippets());
         $this->assertSame($options['fragsize'], $this->hlt->getFragSize());
         $this->assertTrue($this->hlt->getMergeContiguous());
@@ -80,6 +86,7 @@ class HighlightingTest extends TestCase
         $this->assertSame($options['simplepostfix'], $this->hlt->getSimplePostfix());
         $this->assertSame($options['tagprefix'], $this->hlt->getTagPrefix());
         $this->assertSame($options['tagpostfix'], $this->hlt->getTagPostfix());
+        $this->assertSame($options['encoder'], $this->hlt->getEncoder());
         $this->assertSame($options['fragmenter'], $this->hlt->getFragmenter());
         $this->assertSame($options['fraglistbuilder'], $this->hlt->getFragListBuilder());
         $this->assertSame($options['fragmentsbuilder'], $this->hlt->getFragmentsBuilder());
@@ -89,7 +96,6 @@ class HighlightingTest extends TestCase
         $this->assertSame($options['regexslop'], $this->hlt->getRegexSlop());
         $this->assertSame($options['regexpattern'], $this->hlt->getRegexPattern());
         $this->assertSame($options['regexmaxanalyzedchars'], $this->hlt->getRegexMaxAnalyzedChars());
-        $this->assertSame($options['query'], $this->hlt->getQuery());
         $this->assertSame($options['phraselimit'], $this->hlt->getPhraseLimit());
         $this->assertSame($options['multivaluedseparatorchar'], $this->hlt->getMultiValuedSeparatorChar());
         $this->assertSame($options['boundaryscannermaxscan'], $this->hlt->getBoundaryScannerMaxScan());
@@ -117,6 +123,17 @@ class HighlightingTest extends TestCase
         $this->assertInstanceOf(
             'Solarium\Component\RequestBuilder\Highlighting',
             $this->hlt->getRequestBuilder()
+        );
+    }
+
+    public function testSetAndGetMethod()
+    {
+        $value = 'unified';
+        $this->hlt->setMethod($value);
+
+        $this->assertSame(
+            $value,
+            $this->hlt->getMethod()
         );
     }
 
@@ -253,6 +270,28 @@ class HighlightingTest extends TestCase
         $this->assertSame(['test3', 'test4'], array_keys($this->hlt->getFields()));
     }
 
+    public function testSetAndGetQuery()
+    {
+        $value = 'text:myvalue';
+        $this->hlt->setQuery($value);
+
+        $this->assertSame(
+            $value,
+            $this->hlt->getQuery()
+        );
+    }
+
+    public function testSetAndGetQueryParser()
+    {
+        $value = 'myparser';
+        $this->hlt->setQueryParser($value);
+
+        $this->assertSame(
+            $value,
+            $this->hlt->getQueryParser()
+        );
+    }
+
     public function testSetAndGetSnippets()
     {
         $value = 2;
@@ -358,6 +397,17 @@ class HighlightingTest extends TestCase
         );
     }
 
+    public function testSetAndGetEncoder()
+    {
+        $value = Highlighting::ENCODER_HTML;
+        $this->hlt->setEncoder($value);
+
+        $this->assertSame(
+            $value,
+            $this->hlt->getEncoder()
+        );
+    }
+
     public function testSetAndGetFragmenter()
     {
         $value = Highlighting::FRAGMENTER_REGEX;
@@ -439,17 +489,6 @@ class HighlightingTest extends TestCase
         $this->assertSame(
             $value,
             $this->hlt->getRegexMaxAnalyzedChars()
-        );
-    }
-
-    public function testSetAndGetQuery()
-    {
-        $value = 'text:myvalue';
-        $this->hlt->setQuery($value);
-
-        $this->assertSame(
-            $value,
-            $this->hlt->getQuery()
         );
     }
 

--- a/tests/Component/RequestBuilder/HighlightingTest.php
+++ b/tests/Component/RequestBuilder/HighlightingTest.php
@@ -15,9 +15,11 @@ class HighlightingTest extends TestCase
         $request = new Request();
 
         $component = new Component();
+        $component->setMethod($component::METHOD_UNIFIED);
         $component->addField('fieldA');
 
         $field = $component->getField('fieldB');
+        $field->setMethod($component::METHOD_FASTVECTOR);
         $field->setSnippets(3);
         $field->setFragSize(25);
         $field->setMergeContiguous(true);
@@ -29,6 +31,8 @@ class HighlightingTest extends TestCase
         $field->setFragmenter('myFragmenter');
         $field->setUseFastVectorHighlighter(true);
 
+        $component->setQuery('text:myvalue');
+        $component->setQueryParser('myparser');
         $component->setSnippets(2);
         $component->setFragSize(3);
         $component->setMergeContiguous(true);
@@ -40,6 +44,7 @@ class HighlightingTest extends TestCase
         $component->setFormatter('simple');
         $component->setSimplePrefix('<b>');
         $component->setSimplePostfix('</b>');
+        $component->setEncoder($component::ENCODER_HTML);
         $component->setFragmenter('myFragmenter');
         $component->setFragListBuilder('myFragListBuilder');
         $component->setFragmentsBuilder('myFragmentsBuilder');
@@ -49,7 +54,6 @@ class HighlightingTest extends TestCase
         $component->setRegexSlop(1.3);
         $component->setRegexPattern('mypattern');
         $component->setMaxAnalyzedChars(100);
-        $component->setQuery('text:myvalue');
         $component->setPhraseLimit(40);
         $component->setTagPrefix('<i>');
         $component->setTagPostfix('</i>');
@@ -59,14 +63,16 @@ class HighlightingTest extends TestCase
         $component->setBoundaryScannerType($component::BOUNDARYSCANNER_TYPE_WORD);
         $component->setBoundaryScannerCountry('be');
         $component->setBoundaryScannerLanguage('en');
-        $component->setMethod('unified');
 
         $request = $builder->buildComponent($component, $request);
 
         $this->assertEquals(
             [
                 'hl' => 'true',
+                'hl.method' => 'unified',
                 'hl.fl' => 'fieldA,fieldB',
+                'hl.q' => 'text:myvalue',
+                'hl.qparser' => 'myparser',
                 'hl.snippets' => 2,
                 'hl.fragsize' => 3,
                 'hl.mergeContiguous' => 'true',
@@ -80,6 +86,7 @@ class HighlightingTest extends TestCase
                 'hl.simple.post' => '</b>',
                 'hl.tag.pre' => '<i>',
                 'hl.tag.post' => '</i>',
+                'hl.encoder' => 'html',
                 'hl.fragmenter' => 'myFragmenter',
                 'hl.fragListBuilder' => 'myFragListBuilder',
                 'hl.fragmentsBuilder' => 'myFragmentsBuilder',
@@ -88,9 +95,9 @@ class HighlightingTest extends TestCase
                 'hl.highlightMultiTerm' => 'true',
                 'hl.regex.slop' => 1.3,
                 'hl.regex.pattern' => 'mypattern',
-                'hl.q' => 'text:myvalue',
                 'hl.phraseLimit' => 40,
                 'hl.multiValuedSeparatorChar' => '|',
+                'f.fieldB.hl.method' => 'fastVector',
                 'f.fieldB.hl.snippets' => 3,
                 'f.fieldB.hl.fragsize' => 25,
                 'f.fieldB.hl.mergeContiguous' => 'true',
@@ -106,7 +113,6 @@ class HighlightingTest extends TestCase
                 'hl.bs.type' => 'WORD',
                 'hl.bs.country' => 'be',
                 'hl.bs.language' => 'en',
-                'h1.method' => 'unified',
             ],
             $request->getParams()
         );
@@ -118,6 +124,9 @@ class HighlightingTest extends TestCase
         $request = new Request();
 
         $component = new Component();
+        $component->setMethod($component::METHOD_FASTVECTOR);
+        $component->setQuery('text:myvalue');
+        $component->setQueryParser('myparser');
         $component->setSnippets(2);
         $component->setFragSize(3);
         $component->setMergeContiguous(true);
@@ -129,6 +138,7 @@ class HighlightingTest extends TestCase
         $component->setFormatter('simple');
         $component->setSimplePrefix('<b>');
         $component->setSimplePostfix('</b>');
+        $component->setEncoder($component::ENCODER_HTML);
         $component->setFragmenter('myFragmenter');
         $component->setFragListBuilder('myFragListBuilder');
         $component->setFragmentsBuilder('myFragmentsBuilder');
@@ -138,7 +148,6 @@ class HighlightingTest extends TestCase
         $component->setRegexSlop(1.3);
         $component->setRegexPattern('mypattern');
         $component->setMaxAnalyzedChars(100);
-        $component->setQuery('text:myvalue');
         $component->setPhraseLimit(40);
         $component->setTagPrefix('<i>');
         $component->setTagPostfix('</i>');
@@ -154,6 +163,9 @@ class HighlightingTest extends TestCase
         $this->assertEquals(
             [
                 'hl' => 'true',
+                'hl.method' => 'fastVector',
+                'hl.q' => 'text:myvalue',
+                'hl.qparser' => 'myparser',
                 'hl.snippets' => 2,
                 'hl.fragsize' => 3,
                 'hl.mergeContiguous' => 'true',
@@ -167,6 +179,7 @@ class HighlightingTest extends TestCase
                 'hl.simple.post' => '</b>',
                 'hl.tag.pre' => '<i>',
                 'hl.tag.post' => '</i>',
+                'hl.encoder' => 'html',
                 'hl.fragmenter' => 'myFragmenter',
                 'hl.fragListBuilder' => 'myFragListBuilder',
                 'hl.fragmentsBuilder' => 'myFragmentsBuilder',
@@ -175,7 +188,6 @@ class HighlightingTest extends TestCase
                 'hl.highlightMultiTerm' => 'true',
                 'hl.regex.slop' => 1.3,
                 'hl.regex.pattern' => 'mypattern',
-                'hl.q' => 'text:myvalue',
                 'hl.phraseLimit' => 40,
                 'hl.multiValuedSeparatorChar' => '|',
                 'hl.bs.maxScan' => 16,

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -4,6 +4,7 @@ namespace Solarium\Tests\Integration;
 
 use PHPUnit\Framework\TestCase;
 use Solarium\Component\ComponentAwareQueryInterface;
+use Solarium\Component\Highlighting\Highlighting;
 use Solarium\Component\QueryTraits\GroupingTrait;
 use Solarium\Component\QueryTraits\TermsTrait;
 use Solarium\Component\Result\Grouping\FieldGroup;
@@ -555,6 +556,56 @@ abstract class AbstractTechproductsTest extends TestCase
             // The power cord is not in stock! In the techproducts example that is reflected by the string 'false'.
             $this->assertSame(1, $facetField->getValues()['false']);
         }
+    }
+
+    /**
+     * @testWith ["METHOD_UNIFIED"]
+     *           ["METHOD_ORIGINAL"]
+     *           ["METHOD_FASTVECTOR"]
+     */
+    public function testHighlightingComponentMethods(string $method)
+    {
+        $select = self::$client->createSelect();
+        // The "browse" request handler has a highlighting component.
+        $select->setHandler('browse');
+        $select->setQuery('id:F8V7067-APL-KIT');
+
+        $highlighting = $select->getHighlighting();
+        $highlighting->setMethod(\constant(Highlighting::class.'::'.$method));
+        $highlighting->setFields('name, features');
+        $highlighting->getField('features')->setSimplePrefix('<u class="hl">')->setSimplePostfix('</u>');
+        $highlighting->setQuery('(power cord) OR (power adapter)');
+        $highlighting->setQueryParser('edismax');
+        $highlighting->setEncoder(Highlighting::ENCODER_HTML);
+
+        $result = self::$client->select($select);
+        $this->assertSame(1, $result->getNumFound());
+
+        foreach ($result as $document) {
+            $this->assertSame('F8V7067-APL-KIT', $document->id);
+        }
+
+        // html_entity_decode because METHOD_UNIFIED on Solr 7 encodes non-alphanumeric characters as hexadecimal entity references
+
+        $this->assertSame(
+            ['Belkin Mobile <b>Power</b> <b>Cord</b> for iPod w/ Dock'],
+            array_map('html_entity_decode', $result->getHighlighting()->getResult('F8V7067-APL-KIT')->getField('name'))
+        );
+
+        $this->assertSame(
+            ['car <u class="hl">power</u> <u class="hl">adapter</u>, white'],
+            array_map('html_entity_decode', $result->getHighlighting()->getResult('F8V7067-APL-KIT')->getField('features'))
+        );
+
+        $this->assertSame(
+            ['Belkin Mobile <b>Power</b> <b>Cord</b> for iPod w/ Dock'],
+            array_map('html_entity_decode', $result->getHighlighting()->getResult('F8V7067-APL-KIT')->getFields()['name'])
+        );
+
+        $this->assertSame(
+            ['car <u class="hl">power</u> <u class="hl">adapter</u>, white'],
+            array_map('html_entity_decode', $result->getHighlighting()->getResult('F8V7067-APL-KIT')->getFields()['features'])
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes a small bug that was introduced with #856. The request builder set the parameter as `h1.method` (haitch one) instead of `hl.method` (haitch ell).

Added some other parameters that I needed (or thought I'd need) for the integration tests. This is not a comprehensive overhaul of all possible parameters for the component.

This bugfix is necessary for integration tests against Solr 9. The default highlighter was changed from `original` to `unified` so we'll have to set it explicitly going forward for consistent test results across versions.