### PR TITLE
Test against Solr 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             matrix:
                 php: [7.3, 7.4, 8.0, 8.1]
-                solr: [7, 8]
+                solr: [7, 8, 9]
                 mode: [cloud, server]
 
         name: PHP ${{ matrix.php }}, Solr ${{ matrix.solr }} ${{ matrix.mode }}
@@ -49,6 +49,14 @@ jobs:
               with:
                 repository: apache/lucene-solr
                 ref: branch_8_11
+                path: lucene-solr
+
+            - name: Checkout solr 9.0
+              if: matrix.solr == 9
+              uses: actions/checkout@v2
+              with:
+                repository: apache/solr
+                ref: branch_9_0
                 path: lucene-solr
 
             - name: Start Solr ${{ matrix.solr }} in ${{ matrix.mode }} mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Symfony 6 support
+- Solr 9 support
 
 ### Fixed
 - Solarium\QueryType\Server\Collections\Query\Action\ClusterStatus::getRoute() always returned NULL even if a route was set

--- a/docs/queries/select-query/building-a-select-query/components/spellcheck-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/spellcheck-component.md
@@ -13,6 +13,7 @@ Options
 | dictionary              | string  | null          | The name of the dictionary to use                                                      |
 | count                   | int     | null          | The maximum number of suggestions to return                                            |
 | onlymorepopular         | boolean | null          | Only return suggestions that result in more hits for the query than the existing query |
+| alternativetermcount    | int     | null          |                                                                                        |
 | extendedresults         | boolean | null          |                                                                                        |
 | collate                 | boolean | null          |                                                                                        |
 | maxcollations           | int     | null          |                                                                                        |

--- a/examples/2.1.5.9-spellcheck.php
+++ b/examples/2.1.5.9-spellcheck.php
@@ -8,11 +8,9 @@ $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 
 // get a select query instance
 $query = $client->createSelect()
-    // Unfortunately the /select handler of the techproducts example doesn't contain a spellchecker anymore.
-    // Therefore we have to use the /browse handler and turn of velocity by forcing json as response writer.
-    ->setHandler('browse')
-    ->setResponseWriter(\Solarium\Core\Query\AbstractQuery::WT_JSON)
-    // Normally we would use 'spellcheck.q'. But the /browse handler checks 'q'.
+    // The /spell handler is used for demonstrating the spellcheck component.
+    // You'll probably want to hook it into the request handler that handles your normal queries.
+    ->setHandler('spell')
     ->setQuery('memori')
     ->setRows(0);
 

--- a/src/Component/ComponentTraits/SpellcheckTrait.php
+++ b/src/Component/ComponentTraits/SpellcheckTrait.php
@@ -148,6 +148,30 @@ trait SpellcheckTrait
     }
 
     /**
+     * Set alternativetermcount option.
+     *
+     * The the number of suggestions to return for each query term existing in the index and/or dictionary.
+     *
+     * @param int $count
+     *
+     * @return SpellcheckInterface Provides fluent interface
+     */
+    public function setAlternativeTermCount(int $count): SpellcheckInterface
+    {
+        return $this->setOption('alternativetermcount', $count);
+    }
+
+    /**
+     * Get alternativetermcount option.
+     *
+     * @return int|null
+     */
+    public function getAlternativeTermCount(): ?int
+    {
+        return $this->getOption('alternativetermcount');
+    }
+
+    /**
      * Set extendedResults option.
      *
      * @param bool $extendedResults

--- a/src/Component/RequestBuilder/Spellcheck.php
+++ b/src/Component/RequestBuilder/Spellcheck.php
@@ -37,6 +37,7 @@ class Spellcheck implements ComponentRequestBuilderInterface
         $request->addParam('spellcheck.dictionary', $component->getDictionary());
         $request->addParam('spellcheck.count', $component->getCount());
         $request->addParam('spellcheck.onlyMorePopular', $component->getOnlyMorePopular());
+        $request->addParam('spellcheck.alternativeTermCount', $component->getAlternativeTermCount());
         $request->addParam('spellcheck.extendedResults', $component->getExtendedResults());
         $request->addParam('spellcheck.collate', $component->getCollate());
         $request->addParam('spellcheck.maxCollations', $component->getMaxCollations());

--- a/src/Component/SpellcheckInterface.php
+++ b/src/Component/SpellcheckInterface.php
@@ -114,6 +114,24 @@ interface SpellcheckInterface extends ConfigurableInterface
     public function getOnlyMorePopular(): ?bool;
 
     /**
+     * Set alternativetermcount option.
+     *
+     * The the number of suggestions to return for each query term existing in the index and/or dictionary.
+     *
+     * @param int $count
+     *
+     * @return self Provides fluent interface
+     */
+    public function setAlternativeTermCount(int $count): self;
+
+    /**
+     * Get alternativetermcount option.
+     *
+     * @return int|null
+     */
+    public function getAlternativeTermCount(): ?int;
+
+    /**
      * Set extendedResults option.
      *
      * @param bool $extendedResults

--- a/tests/Component/RequestBuilder/SpellcheckTest.php
+++ b/tests/Component/RequestBuilder/SpellcheckTest.php
@@ -21,6 +21,7 @@ class SpellcheckTest extends TestCase
         $component->setDictionary('testdict');
         $component->setCount(3);
         $component->setOnlyMorePopular(false);
+        $component->setAlternativeTermCount(5);
         $component->setExtendedResults(true);
         $component->setCollate(true);
         $component->setMaxCollations(2);
@@ -41,6 +42,7 @@ class SpellcheckTest extends TestCase
                 'spellcheck.dictionary' => ['testdict'],
                 'spellcheck.count' => 3,
                 'spellcheck.onlyMorePopular' => 'false',
+                'spellcheck.alternativeTermCount' => 5,
                 'spellcheck.extendedResults' => 'true',
                 'spellcheck.collate' => 'true',
                 'spellcheck.maxCollations' => 2,
@@ -66,6 +68,7 @@ class SpellcheckTest extends TestCase
         $component->setDictionary(['dictionary', 'alt_dictionary']);
         $component->setCount(3);
         $component->setOnlyMorePopular(false);
+        $component->setAlternativeTermCount(5);
         $component->setExtendedResults(true);
         $component->setCollate(true);
         $component->setMaxCollations(2);
@@ -86,6 +89,7 @@ class SpellcheckTest extends TestCase
                 'spellcheck.dictionary' => ['dictionary', 'alt_dictionary'],
                 'spellcheck.count' => 3,
                 'spellcheck.onlyMorePopular' => 'false',
+                'spellcheck.alternativeTermCount' => 5,
                 'spellcheck.extendedResults' => 'true',
                 'spellcheck.collate' => 'true',
                 'spellcheck.maxCollations' => 2,

--- a/tests/Component/SpellcheckTest.php
+++ b/tests/Component/SpellcheckTest.php
@@ -113,6 +113,17 @@ class SpellcheckTest extends TestCase
         );
     }
 
+    public function testSetAndGetAlternativeTermCount()
+    {
+        $value = 5;
+        $this->spellCheck->setAlternativeTermCount($value);
+
+        $this->assertEquals(
+            $value,
+            $this->spellCheck->getAlternativeTermCount()
+        );
+    }
+
     public function testSetAndGetExtendedResults()
     {
         $value = false;

--- a/tests/Integration/ConnectionReuseTest.php
+++ b/tests/Integration/ConnectionReuseTest.php
@@ -58,7 +58,7 @@ class ConnectionReuseTest extends TestCase
             ],
         ];
 
-        self::$client = TestClientFactory::createWithPsr18Adapter();
+        self::$client = TestClientFactory::createWithPsr18Adapter(self::$config);
 
         // get the current log level to restore afterwards to avoid excessive logging in other testcases
         $query = self::$client->createApi([
@@ -125,7 +125,7 @@ class ConnectionReuseTest extends TestCase
         // make sure the next logged timestamp is not on the same millisecond as self::$since
         usleep(1000);
 
-        $client = TestClientFactory::$createFunction();
+        $client = TestClientFactory::$createFunction(self::$config);
 
         // the logging for 5 requests fits within the default logging watcher buffer size
         for ($i = 0; $i < 5; ++$i) {

--- a/tests/Integration/Fixtures/docker/solr9_cloud/docker-compose.yml
+++ b/tests/Integration/Fixtures/docker/solr9_cloud/docker-compose.yml
@@ -1,0 +1,94 @@
+version: '3.7'
+services:
+  solr1:
+    image: solr:9
+    container_name: solr1
+    ports:
+      - "8981:8983"
+    environment:
+      - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
+    networks:
+      - solr
+    depends_on:
+      - zoo1
+      - zoo2
+      - zoo3
+    volumes:
+      - ../../security:/var/security
+    command: bash -c "docker-entrypoint.sh solr zk cp file:/var/security/security.json zk:/security.json && exec solr-foreground"
+
+  solr2:
+    image: solr:9
+    container_name: solr2
+    ports:
+      - "8982:8983"
+    environment:
+      - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
+    networks:
+      - solr
+    depends_on:
+      - solr1
+
+  solr3:
+    image: solr:9
+    container_name: solr3
+    ports:
+      - "8983:8983"
+    environment:
+      - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
+    networks:
+      - solr
+    depends_on:
+      - solr1
+
+
+  zoo1:
+    image: zookeeper:3.7
+    container_name: zoo1
+    restart: always
+    hostname: zoo1
+    ports:
+      - 2181:2181
+      - 7001:7000
+    environment:
+      ZOO_MY_ID: 1
+      ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
+      ZOO_4LW_COMMANDS_WHITELIST: mntr, conf, ruok
+      ZOO_CFG_EXTRA: "metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider metricsProvider.httpPort=7000 metricsProvider.exportJvmInfo=true"
+    networks:
+      - solr
+
+  zoo2:
+    image: zookeeper:3.7
+    container_name: zoo2
+    restart: always
+    hostname: zoo2
+    ports:
+      - 2182:2181
+      - 7002:7000
+    environment:
+      ZOO_MY_ID: 2
+      ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
+      ZOO_4LW_COMMANDS_WHITELIST: mntr, conf, ruok
+      ZOO_CFG_EXTRA: "metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider metricsProvider.httpPort=7000 metricsProvider.exportJvmInfo=true"
+    networks:
+      - solr
+
+  zoo3:
+    image: zookeeper:3.7
+    container_name: zoo3
+    restart: always
+    hostname: zoo3
+    ports:
+      - 2183:2181
+      - 7003:7000
+    environment:
+      ZOO_MY_ID: 3
+      ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
+      ZOO_4LW_COMMANDS_WHITELIST: mntr, conf, ruok
+      ZOO_CFG_EXTRA: "metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider metricsProvider.httpPort=7000 metricsProvider.exportJvmInfo=true"
+    networks:
+      - solr
+
+networks:
+  solr:

--- a/tests/Integration/Fixtures/docker/solr9_server/docker-compose.yml
+++ b/tests/Integration/Fixtures/docker/solr9_server/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  solr9:
+    image: solr:9
+    ports:
+      - "8983:8983"
+    volumes:
+      - ../../../../../lucene-solr/solr/server/solr/configsets/sample_techproducts_configs/conf:/opt/solr/server/solr/configsets/solarium/conf
+    command: bash -c "chown -R solr.solr /opt/solr/server/solr/configsets/solarium; cp -R /opt/solr/server/solr/configsets /var/solr/data/configsets; docker-entrypoint.sh solr start -f"

--- a/tests/Integration/Fixtures/schema9.patch
+++ b/tests/Integration/Fixtures/schema9.patch
@@ -1,0 +1,15 @@
+diff --git a/solr/server/solr/configsets/sample_techproducts_configs/conf/managed-schema b/solr/server/solr/configsets/sample_techproducts_configs/conf/managed-schema
+index aad0c822f34..d0b272c39c2 100644
+--- a/solr/server/solr/configsets/sample_techproducts_configs/conf/managed-schema
++++ b/solr/server/solr/configsets/sample_techproducts_configs/conf/managed-schema
+@@ -118,7 +118,9 @@
+    <!-- points to the root document of a block of nested documents. Required for nested
+       document support, may be removed otherwise
+    -->
+-   <field name="_root_" type="string" indexed="true" stored="false" docValues="false" />
++   <field name="_root_" type="string" indexed="true" stored="true" docValues="false" />
++   <fieldType name="_nest_path_" class="solr.NestPathField" />
++   <field name="_nest_path_" type="_nest_path_" />
+ 
+    <!-- Only remove the "id" field if you have a very good reason to. While not strictly
+      required, it is highly recommended. A <uniqueKey> is present in almost all Solr

--- a/tests/Integration/Fixtures/solrconf.patch
+++ b/tests/Integration/Fixtures/solrconf.patch
@@ -11,13 +11,42 @@ index 06ac9b3d2e6..087287d2339 100644
    <!-- an exact 'path' can be used instead of a 'dir' to specify a
         specific jar file.  This will cause a serious error to be logged
         if it can't be loaded.
-@@ -1008,6 +1010,10 @@
+@@ -1008,6 +1010,39 @@
  
       -->
  
 +  <!-- A request handler for MLT queries.
 +    -->
 +  <requestHandler name="/mlt" class="solr.MoreLikeThisHandler" />
++
++  <!-- A request handler for Facet, Highlight, and Spellcheck components
++    -->
++  <requestHandler name="/componentdemo" class="solr.SearchHandler">
++     <lst name="defaults">
++       <str name="echoParams">explicit</str>
++
++       <!-- Query settings -->
++       <str name="df">text</str>
++       <str name="defType">edismax</str>
++       <str name="qf">
++          text^0.5 features^1.0 name^1.2 sku^1.5 id^10.0 manu^1.1 cat^1.4
++          title^10.0 description^5.0 keywords^5.0 author^2.0 resourcename^1.0
++       </str>
++       <str name="mm">100%</str>
++       <str name="q.alt">*:*</str>
++       <str name="rows">10</str>
++       <str name="fl">*,score</str>
++
++       <str name="facet">on</str>
++       <str name="hl">on</str>
++       <str name="spellcheck">on</str>
++     </lst>
++
++     <!-- append spellchecking to our list of components -->
++     <arr name="last-components">
++       <str>spellcheck</str>
++     </arr>
++  </requestHandler>
 +
     <!-- Spell Check
  

--- a/tests/QueryType/Spellcheck/QueryTest.php
+++ b/tests/QueryType/Spellcheck/QueryTest.php
@@ -72,6 +72,23 @@ class QueryTest extends TestCase
         $this->assertFalse($this->query->getOnlyMorePopular());
     }
 
+    public function testSetAndGetAlternativeTermCount()
+    {
+        $value = 5;
+        $this->query->setAlternativeTermCount($value);
+
+        $this->assertEquals(
+            $value,
+            $this->query->getAlternativeTermCount()
+        );
+    }
+
+    public function testSetAndGetExtendedResults()
+    {
+        $this->query->setExtendedResults(false);
+        $this->assertFalse($this->query->getExtendedResults());
+    }
+
     public function testSetAndGetCollate()
     {
         $this->query->setCollate(false);

--- a/tests/QueryType/Spellcheck/RequestBuilderTest.php
+++ b/tests/QueryType/Spellcheck/RequestBuilderTest.php
@@ -32,6 +32,8 @@ class RequestBuilderTest extends TestCase
         $this->query->setDictionary('suggest');
         $this->query->setQuery('ap ip');
         $this->query->setOnlyMorePopular(true);
+        $this->query->setAlternativeTermCount(5);
+        $this->query->setExtendedResults(true);
         $this->query->setAccuracy(0.45);
 
         $request = $this->builder->build($this->query);
@@ -43,6 +45,8 @@ class RequestBuilderTest extends TestCase
                 'spellcheck.dictionary' => ['suggest'],
                 'spellcheck.count' => 13,
                 'spellcheck.onlyMorePopular' => 'true',
+                'spellcheck.alternativeTermCount' => 5,
+                'spellcheck.extendedResults' => 'true',
                 'spellcheck.collate' => 'true',
                 'spellcheck.build' => 'false',
                 'wt' => 'json',


### PR DESCRIPTION
Closes #996. ;-)

Things mostly worked out-of-the-box.

Solr 9 no longer has a `/browse` handler, I replaced it — for all versions — with a self-defined `/componentdemo` handler that has the components we need. That way the test results aren't dependent on the default parameters that were previously present.

There's [one error](https://github.com/thomascorthals/solarium/runs/6433745092?check_suite_focus=true) I couldn't figure out when setting up the examples. I've skipped the examples that use `/mlt` against Solr 9 for now. Will see if I can figure it out later.