### PR TITLE
Use PHPStan 1.x instead of 0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "nyholm/psr7": "^1.2",
         "php-http/guzzle7-adapter": "^0.1",
         "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan": "^0.12",
-        "phpstan/phpstan-phpunit": "^0.12",
+        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5",
         "roave/security-advisories": "dev-master",
         "symfony/event-dispatcher": "^4.3 || ^5.0 || ^6.0"

--- a/src/Core/Client/Adapter/Http.php
+++ b/src/Core/Client/Adapter/Http.php
@@ -160,7 +160,8 @@ class Http implements AdapterInterface, TimeoutAwareInterface
     {
         $data = @file_get_contents($uri, false, $context);
 
-        // @ see https://www.php.net/manual/en/reserved.variables.httpresponseheader.php
+        // @see https://www.php.net/manual/en/reserved.variables.httpresponseheader.php
+        // @phpstan-ignore-next-line https://github.com/phpstan/phpstan/issues/3213
         return [$data, $http_response_header ?? []];
     }
 }

--- a/tests/Plugin/BufferedAdd/BufferedAddLiteTest.php
+++ b/tests/Plugin/BufferedAdd/BufferedAddLiteTest.php
@@ -18,13 +18,18 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class BufferedAddLiteTest extends TestCase
 {
     /**
+     * @var string
+     */
+    protected $pluginClass = BufferedAddLite::class;
+
+    /**
      * @var BufferedAddLite
      */
     protected $plugin;
 
     public function setUp(): void
     {
-        $this->plugin = new BufferedAddLite();
+        $this->plugin = new $this->pluginClass();
         $this->plugin->initPlugin(TestClientFactory::createWithCurlAdapter(), []);
     }
 

--- a/tests/Plugin/BufferedAdd/BufferedAddTest.php
+++ b/tests/Plugin/BufferedAdd/BufferedAddTest.php
@@ -5,21 +5,19 @@ namespace Solarium\Tests\Plugin\BufferedAdd;
 use Solarium\Plugin\BufferedAdd\BufferedAdd;
 use Solarium\Plugin\BufferedAdd\Event\AddDocument;
 use Solarium\QueryType\Update\Query\Document;
-use Solarium\Tests\Integration\TestClientFactory;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class BufferedAddTest extends BufferedAddLiteTest
 {
     /**
+     * @var string
+     */
+    protected $pluginClass = BufferedAdd::class;
+
+    /**
      * @var BufferedAdd
      */
     protected $plugin;
-
-    public function setUp(): void
-    {
-        $this->plugin = new BufferedAdd();
-        $this->plugin->initPlugin(TestClientFactory::createWithCurlAdapter(), []);
-    }
 
     public function testAddDocumentEventIsTriggered()
     {

--- a/tests/Plugin/BufferedDelete/BufferedDeleteLiteTest.php
+++ b/tests/Plugin/BufferedDelete/BufferedDeleteLiteTest.php
@@ -21,13 +21,18 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class BufferedDeleteLiteTest extends TestCase
 {
     /**
+     * @var string
+     */
+    protected $pluginClass = BufferedDeleteLite::class;
+
+    /**
      * @var BufferedDeleteLite
      */
     protected $plugin;
 
     public function setUp(): void
     {
-        $this->plugin = new BufferedDeleteLite();
+        $this->plugin = new $this->pluginClass();
         $this->plugin->initPlugin(TestClientFactory::createWithCurlAdapter(), []);
     }
 

--- a/tests/Plugin/BufferedDelete/BufferedDeleteTest.php
+++ b/tests/Plugin/BufferedDelete/BufferedDeleteTest.php
@@ -7,21 +7,19 @@ use Solarium\Plugin\BufferedDelete\Delete\Id as DeleteById;
 use Solarium\Plugin\BufferedDelete\Delete\Query as DeleteQuery;
 use Solarium\Plugin\BufferedDelete\Event\AddDeleteById;
 use Solarium\Plugin\BufferedDelete\Event\AddDeleteQuery;
-use Solarium\Tests\Integration\TestClientFactory;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class BufferedDeleteTest extends BufferedDeleteLiteTest
 {
     /**
+     * @var string
+     */
+    protected $pluginClass = BufferedDelete::class;
+
+    /**
      * @var BufferedDelete
      */
     protected $plugin;
-
-    public function setUp(): void
-    {
-        $this->plugin = new BufferedDelete();
-        $this->plugin->initPlugin(TestClientFactory::createWithCurlAdapter(), []);
-    }
 
     public function testAddDeleteByIdEventIsTriggered()
     {


### PR DESCRIPTION
PHPStan 0.12 has given up on PHP 8.1.

Switching caused only two small issues.

- Two test cases that extend a parent class didn't call `parent::setUp()`. I worked around this to eliminate the need for a "`child::setUp()`" altogether.
- PHPStan treats `$http_response_header` as always set, which is a flawed assumption. Per the advice in https://github.com/phpstan/phpstan/issues/3213, I've ignored the line where this was reported as an error.