### PR TITLE
Cleanup for cursorMark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Solarium\QueryType\Server\Collections\Query\Action\ClusterStatus::getRoute() always returned NULL even if a route was set
 - Solarium\Component\Highlighting\Highlighting::setMethod() didn't set the correct request parameter
 
+### Changed
+- Solarium\QueryType\Select\Query\Query::setCursormark() and getCursormark() are now setCursorMark() and getCursorMark() with uppercase M
+
 ### Removed
 - Solarium\QueryType\Stream\Expression, use Solarium\QueryType\Stream\ExpressionBuilder instead
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -571,17 +571,17 @@ you tell it ‘this is where I got to, give me the next part’ by using the `ne
 
 ```php
 // first request
-$query->setSorts([...])->setRows($num)->setCursormark('*');
+$query->setSorts([...])->setRows($num)->setCursorMark('*');
 
 // subsequent requests 
-$query->setSorts([...])->setRows($num)->setCursormark($result->getNextCursorMark());
+$query->setSorts([...])->setRows($num)->setCursorMark($result->getNextCursorMark());
 ```
 
 PrefetchIterator makes it set-and-forget by handling that logic for you when repeating the query. Because it can't know whether your sort includes the `uniqueKey` field
 for your schema, you do need to set it to `*` on the query yourself in order to use a cursor instead of basic pagination.
 
 ```php
-$query->setSorts([...])->setCursormark('*');
+$query->setSorts([...])->setCursorMark('*');
 $prefetch->setPrefetch($num)->setQuery($query);
 ```
 
@@ -618,7 +618,7 @@ $query = $client->createSelect();
 $query->setFields(array('id'));
 
 // cursor functionality can be used for efficient deep paging (since Solr 4.7)
-$query->setCursormark('*');
+$query->setCursorMark('*');
 // cursor functionality requires a sort containing a uniqueKey field as tie breaker on top of your desired sorts for the query
 $query->addSort('id', $query::SORT_ASC);
 

--- a/examples/7.6-plugin-prefetchiterator.php
+++ b/examples/7.6-plugin-prefetchiterator.php
@@ -11,7 +11,7 @@ $query = $client->createSelect();
 $query->setFields(array('id'));
 
 // cursor functionality can be used for efficient deep paging (since Solr 4.7)
-$query->setCursormark('*');
+$query->setCursorMark('*');
 // cursor functionality requires a sort containing a uniqueKey field as tie breaker on top of your desired sorts for the query
 $query->addSort('id', $query::SORT_ASC);
 

--- a/src/Plugin/PrefetchIterator.php
+++ b/src/Plugin/PrefetchIterator.php
@@ -240,14 +240,14 @@ class PrefetchIterator extends AbstractPlugin implements \Iterator, \Countable
      */
     protected function fetchNext(): self
     {
-        if (null === $this->cursormark && null !== $this->query->getCursormark()) {
+        if (null === $this->cursormark && null !== $this->query->getCursorMark()) {
             $this->cursormark = '*';
         }
 
         if (null === $this->cursormark) {
             $this->query->setStart($this->start)->setRows($this->getPrefetch());
         } else {
-            $this->query->setCursormark($this->cursormark)->setRows($this->getPrefetch());
+            $this->query->setCursorMark($this->cursormark)->setRows($this->getPrefetch());
         }
 
         $this->result = $this->client->execute($this->query, $this->getOption('endpoint'));

--- a/src/QueryType/Select/Query/Query.php
+++ b/src/QueryType/Select/Query/Query.php
@@ -786,7 +786,7 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface, Query
      *
      * @return self Provides fluent interface
      */
-    public function setCursormark(string $cursormark): self
+    public function setCursorMark(string $cursormark): self
     {
         $this->setOption('cursormark', $cursormark);
 
@@ -798,7 +798,7 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface, Query
      *
      * @return string|null
      */
-    public function getCursormark(): ?string
+    public function getCursorMark(): ?string
     {
         return $this->getOption('cursormark');
     }
@@ -808,7 +808,7 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface, Query
      *
      * @return self Provides fluent interface
      */
-    public function clearCursormark(): self
+    public function clearCursorMark(): self
     {
         $this->setOption('cursormark', null);
 
@@ -874,9 +874,6 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface, Query
                     break;
                 case 'component':
                     $this->createComponents($value);
-                    break;
-                case 'cursormark':
-                    $this->setCursormark($value);
                     break;
             }
         }

--- a/src/QueryType/Select/RequestBuilder.php
+++ b/src/QueryType/Select/RequestBuilder.php
@@ -44,7 +44,7 @@ class RequestBuilder extends BaseRequestBuilder
         $request->addParam('fl', implode(',', $query->getFields()));
         $request->addParam('q.op', $query->getQueryDefaultOperator());
         $request->addParam('df', $query->getQueryDefaultField());
-        $request->addParam('cursorMark', $query->getCursormark());
+        $request->addParam('cursorMark', $query->getCursorMark());
         $request->addParam('sow', $query->getSplitOnWhitespace());
 
         // add sort fields to request

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -2706,10 +2706,10 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertSame(32, $i);
     }
 
-    public function testPrefetchIteratorWithCursormark()
+    public function testPrefetchIteratorWithCursorMark()
     {
         $select = self::$client->createSelect();
-        $select->setCursormark('*');
+        $select->setCursorMark('*');
         $select->addSort('id', SelectQuery::SORT_ASC);
         /** @var PrefetchIterator $prefetch */
         $prefetch = self::$client->getPlugin('prefetchiterator');
@@ -2727,7 +2727,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertSame(32, $i);
     }
 
-    public function testPrefetchIteratorWithoutAndWithCursormark()
+    public function testPrefetchIteratorWithoutAndWithCursorMark()
     {
         $select = self::$client->createSelect();
         $select->addSort('id', SelectQuery::SORT_ASC);
@@ -2742,7 +2742,7 @@ abstract class AbstractTechproductsTest extends TestCase
         }
 
         $select = self::$client->createSelect();
-        $select->setCursormark('*');
+        $select->setCursorMark('*');
         $select->addSort('id', SelectQuery::SORT_ASC);
         $prefetch->setQuery($select);
 

--- a/tests/QueryType/Select/Query/AbstractQueryTest.php
+++ b/tests/QueryType/Select/Query/AbstractQueryTest.php
@@ -441,7 +441,7 @@ abstract class AbstractQueryTest extends TestCase
         $this->assertSame($config['start'], $query->getStart());
         $this->assertSame($config['documentclass'], $query->getDocumentClass());
         $this->assertSame($config['resultclass'], $query->getResultClass());
-        $this->assertSame($config['cursormark'], $query->getCursormark());
+        $this->assertSame($config['cursormark'], $query->getCursorMark());
         $this->assertFalse($query->getSplitOnWhitespace());
         $this->assertSame('published:true', $query->getFilterQuery('pub')->getQuery());
         $this->assertSame('online:true', $query->getFilterQuery('online')->getQuery());
@@ -740,17 +740,17 @@ abstract class AbstractQueryTest extends TestCase
         $this->assertSame(['t3', 't4'], $this->query->getTags());
     }
 
-    public function testSetCursormark()
+    public function testSetCursorMark()
     {
-        $this->query->setCursormark('*');
-        $this->assertSame('*', $this->query->getCursormark());
+        $this->query->setCursorMark('*');
+        $this->assertSame('*', $this->query->getCursorMark());
     }
 
-    public function testClearCursormark()
+    public function testClearCursorMark()
     {
-        $this->query->setCursormark('*');
-        $this->query->clearCursormark();
-        $this->assertNull($this->query->getCursormark());
+        $this->query->setCursorMark('*');
+        $this->query->clearCursorMark();
+        $this->assertNull($this->query->getCursorMark());
     }
 
     public function testSetAndGetSplitOnWhitespace()

--- a/tests/QueryType/Select/RequestBuilderTest.php
+++ b/tests/QueryType/Select/RequestBuilderTest.php
@@ -160,9 +160,9 @@ class RequestBuilderTest extends TestCase
         $this->assertSame('{!tag=t1,t2}cat:1', $request->getParam('q'));
     }
 
-    public function testWithCursormark()
+    public function testWithCursorMark()
     {
-        $this->query->setCursormark('*');
+        $this->query->setCursorMark('*');
         $request = $this->builder->build($this->query);
 
         $this->assertSame('*', $request->getParam('cursorMark'));


### PR DESCRIPTION
Setting `'cursormark'` in config mode doesn't require special treatment in `init()`.

Also renamed all of the `*Cursormark()` methods to `*CursorMark()` for consistency with Solr's `cursorMark` parameter and the `Result::getNextCursorMark()` method. Doesn't break BC because PHP is case-insensitive about method names.