### PR TITLE
Use GET instead of HEAD for ManagedResources Exists command to avoid SOLR-16274

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Solarium\QueryType\Server\Collections\Query\Action\ClusterStatus::getRoute() always returned NULL even if a route was set
 - Solarium\Component\Highlighting\Highlighting::setMethod() didn't set the correct request parameter
 
+### Changed
+- Managed resources execute GET requests for the Exists command by default to avoid SOLR-15116 and SOLR-16274. Set the 'useHeadRequest' option to `true` to execute HEAD requests instead.
+
 ### Removed
 - Solarium\QueryType\Stream\Expression, use Solarium\QueryType\Stream\ExpressionBuilder instead
 

--- a/docs/queries/managedresources-query/managed-resources.md
+++ b/docs/queries/managedresources-query/managed-resources.md
@@ -1,3 +1,6 @@
+Managed Resources
+=================
+
 A Managed Resources query can be used to get metadata about all ManagedResources registered through Solr's RestManager Endpoint.
 For more info see <https://solr.apache.org/guide/managed-resources.html#restmanager-endpoint>.
 

--- a/docs/queries/managedresources-query/managed-stopwords.md
+++ b/docs/queries/managedresources-query/managed-stopwords.md
@@ -1,3 +1,6 @@
+Managed Stopwords
+=================
+
 A Managed Stopwords query can be used for CRUD operations against Solr's managed resources REST API endpoint.
 For more info see <https://solr.apache.org/guide/managed-resources.html>.
 
@@ -240,4 +243,17 @@ if ($result->getWasSuccessful()) {
 
 htmlFooter();
 
+```
+
+A note on `HEAD` requests
+-------------------------
+
+The "exists" command executes `GET` requests by default because multiple Solr versions
+have bugs in the handling of `HEAD` requests. You can choose to execute `HEAD` requests
+instead if you know that your Solr version isn't affected by
+[SOLR-15116](https://issues.apache.org/jira/browse/SOLR-15116) or
+[SOLR-16274](https://issues.apache.org/jira/browse/SOLR-16274).
+
+```php
+$existsCommand = $query->createCommand($query::COMMAND_EXISTS, ['useHeadRequest' => true]);
 ```

--- a/docs/queries/managedresources-query/managed-synonyms.md
+++ b/docs/queries/managedresources-query/managed-synonyms.md
@@ -1,3 +1,6 @@
+Managed Synonyms
+================
+
 A Managed Synonyms query can be used for CRUD operations against Solr's managed resources REST API endpoint.
 For more info see <https://solr.apache.org/guide/managed-resources.html>.
 
@@ -300,4 +303,17 @@ if ($result->getWasSuccessful()) {
 
 htmlFooter();
 
+```
+
+A note on `HEAD` requests
+-------------------------
+
+The "exists" command executes `GET` requests by default because multiple Solr versions
+have bugs in the handling of `HEAD` requests. You can choose to execute `HEAD` requests
+instead if you know that your Solr version isn't affected by
+[SOLR-15116](https://issues.apache.org/jira/browse/SOLR-15116) or
+[SOLR-16274](https://issues.apache.org/jira/browse/SOLR-16274).
+
+```php
+$existsCommand = $query->createCommand($query::COMMAND_EXISTS, ['useHeadRequest' => true]);
 ```

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -3235,6 +3235,23 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertCount(0, $result);
     }
 
+    /**
+     * Get the options to use for ManagedResources Exists commands.
+     *
+     * @return array
+     */
+    public function getManagedResourcesExistsCommandOptions(): array
+    {
+        // Solr 7 can use HEAD requests because it's unaffected by SOLR-15116 and SOLR-16274
+        if (7 === self::$solrVersion) {
+            return [
+                'useHeadRequest' => true,
+            ];
+        }
+
+        return [];
+    }
+
     public function testManagedStopwords()
     {
         /** @var StopwordsQuery $query */
@@ -3243,7 +3260,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $term = 'managed_stopword_test';
 
         // Check that stopword list exists
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $query->setCommand($exists);
         $result = self::$client->execute($query);
         $this->assertTrue($result->getWasSuccessful());
@@ -3256,7 +3273,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertTrue($result->getWasSuccessful());
 
         // Check that added stopword exists
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $exists->setTerm($term);
         $query->setCommand($exists);
         $result = self::$client->execute($query);
@@ -3284,7 +3301,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertTrue($result->getWasSuccessful());
 
         // Check that added stopword is gone
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $exists->setTerm($term);
         $query->setCommand($exists);
         $result = self::$client->execute($query);
@@ -3314,7 +3331,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $query->setName($name.uniqid());
 
         // Check that stopword list doesn't exist
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $query->setCommand($exists);
         $result = self::$client->execute($query);
         $this->assertFalse($result->getWasSuccessful());
@@ -3335,7 +3352,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertTrue($result->getWasSuccessful());
 
         // Check that stopword list was created
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $query->setCommand($exists);
         $result = self::$client->execute($query);
         $this->assertTrue($result->getWasSuccessful());
@@ -3354,7 +3371,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertTrue($result->getWasSuccessful());
 
         // Check that added stopword exists in its original lowercase form
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $exists->setTerm($term);
         $query->setCommand($exists);
         $result = self::$client->execute($query);
@@ -3373,7 +3390,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertTrue($result->getWasSuccessful());
 
         // Check that stopword list is gone
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $query->setCommand($exists);
         $result = self::$client->execute($query);
         $this->assertFalse($result->getWasSuccessful());
@@ -3393,7 +3410,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $term = 'managed_synonyms_test';
 
         // Check that synonym map exists
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $query->setCommand($exists);
         $result = self::$client->execute($query);
         $this->assertTrue($result->getWasSuccessful());
@@ -3409,7 +3426,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertTrue($result->getWasSuccessful());
 
         // Check that added synonym mapping exsists
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $exists->setTerm($term);
         $query->setCommand($exists);
         $result = self::$client->execute($query);
@@ -3451,7 +3468,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertTrue($result->getWasSuccessful());
 
         // Check that added synonym mapping is gone
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $exists->setTerm($term);
         $query->setCommand($exists);
         $result = self::$client->execute($query);
@@ -3481,7 +3498,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $query->setName($name.uniqid());
 
         // Check that synonym map doesn't exist
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $query->setCommand($exists);
         $result = self::$client->execute($query);
         $this->assertFalse($result->getWasSuccessful());
@@ -3503,7 +3520,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertTrue($result->getWasSuccessful());
 
         // Check that synonym map was created
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $query->setCommand($exists);
         $result = self::$client->execute($query);
         $this->assertTrue($result->getWasSuccessful());
@@ -3526,7 +3543,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertTrue($result->getWasSuccessful());
 
         // Check that synonym exists in its original lowercase form
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $exists->setTerm($term);
         $query->setCommand($exists);
         $result = self::$client->execute($query);
@@ -3545,7 +3562,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertTrue($result->getWasSuccessful());
 
         // Check that synonym map is gone
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $query->setCommand($exists);
         $result = self::$client->execute($query);
         $this->assertFalse($result->getWasSuccessful());
@@ -3669,7 +3686,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertFalse($result->getWasSuccessful(), 'Check if SOLR-6853 is fixed.');
 
         // The resource still exists
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $query->setCommand($exists);
         $result = self::$client->execute($query);
         $this->assertTrue($result->getWasSuccessful());
@@ -3721,7 +3738,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertFalse($result->getWasSuccessful(), 'Check if SOLR-6853 is fixed.');
 
         // The term still exists
-        $exists = $query->createCommand($query::COMMAND_EXISTS);
+        $exists = $query->createCommand($query::COMMAND_EXISTS, $this->getManagedResourcesExistsCommandOptions());
         $exists->setTerm($term);
         $query->setCommand($exists);
         $result = self::$client->execute($query);

--- a/tests/QueryType/ManagedResources/Query/Command/ExistsTest.php
+++ b/tests/QueryType/ManagedResources/Query/Command/ExistsTest.php
@@ -17,29 +17,68 @@ class ExistsTest extends TestCase
         $this->exists = new Exists();
     }
 
+    public function testConstructor()
+    {
+        $exists = new Exists();
+        $this->assertFalse($exists->getUseHeadRequest());
+
+        $exists = new Exists(['useHeadRequest' => true]);
+        $this->assertTrue($exists->getUseHeadRequest());
+    }
+
+    public function testConfigMode()
+    {
+        $options = [
+            'useHeadRequest' => true,
+        ];
+
+        $this->assertFalse($this->exists->getUseHeadRequest());
+        $this->exists->setOptions($options);
+        $this->assertTrue($this->exists->getUseHeadRequest());
+    }
+
     public function testGetType()
     {
         $this->assertSame(Query::COMMAND_EXISTS, $this->exists->getType());
     }
 
-    public function testGetRequestMethod()
-    {
-        $this->assertSame(Request::METHOD_HEAD, $this->exists->getRequestMethod());
-    }
-
     /**
-     * Test workaround for SOLR-15116.
+     * GET requests are used by default to avoid SOLR-15116 and SOLR-16274.
+     *
+     * ==========
+     * SOLR-15116
+     * ==========
      *
      * Affected: Solr 8.7 – Solr 8.11.1, Solr 9.0
      * Fixed: Solr 8.11.2, Solr 9.1
      *
      * A HEAD request for a non-existing term against affected Solr versions returns "200 OK"
-     * instead of "404 Not Found". We execute a GET request if a term is set as a workaround.
+     * instead of "404 Not Found".
+     *
+     * ==========
+     * SOLR-16274
+     * ==========
+     *
+     * Affected: Solr 8.11.2
+     *
+     * A HEAD request for an existing stopword list, synonym map, or term against affected
+     * Solr versions returns "500 Server Error" instead of "200 OK".
      */
-    public function testGetRequestMethodWithTerm()
+    public function testGetRequestMethod()
     {
-        $this->exists->setTerm('test');
         $this->assertSame(Request::METHOD_GET, $this->exists->getRequestMethod());
+    }
+
+    /**
+     * HEAD requests are only used when explicitly instructed to by the user.
+     *
+     * @testWith [true, "METHOD_HEAD"]
+     *           [false, "METHOD_GET"]
+     */
+    public function testGetRequestMethodWithUseHeadRequest(bool $useHeadRequest, string $method)
+    {
+        $this->exists->setUseHeadRequest($useHeadRequest);
+        $this->assertSame(\constant(Request::class.'::'.$method), $this->exists->getRequestMethod());
     }
 
     public function testSetAndGetTerm()
@@ -53,5 +92,12 @@ class ExistsTest extends TestCase
         $this->exists->setTerm('test');
         $this->exists->removeTerm();
         $this->assertNull($this->exists->getTerm());
+    }
+
+    public function testSetAndGetUseHeadRequest()
+    {
+        $this->assertFalse($this->exists->getUseHeadRequest());
+        $this->exists->setUseHeadRequest(true);
+        $this->assertTrue($this->exists->getUseHeadRequest());
     }
 }

--- a/tests/QueryType/ManagedResources/RequestBuilder/StopwordsTest.php
+++ b/tests/QueryType/ManagedResources/RequestBuilder/StopwordsTest.php
@@ -184,7 +184,7 @@ class StopwordsTest extends TestCase
 
         $this->query->setCommand($command);
         $request = $this->builder->build($this->query);
-        // there's a bug since Solr 8.7 with HEAD requests if a term is set (SOLR-15116, fixed in Solr 8.11.2 and Solr 9.1)
+        // SOLR-15116 and SOLR-16274 force us to use GET by default
         $this->assertSame(Request::METHOD_GET, $request->getMethod());
         $this->assertSame('schema/analysis/stopwords/dutch/de', $request->getHandler());
         $this->assertNull($request->getRawData());
@@ -193,6 +193,19 @@ class StopwordsTest extends TestCase
     public function testExistsWithoutTerm()
     {
         $command = new ExistsCommand();
+
+        $this->query->setCommand($command);
+        $request = $this->builder->build($this->query);
+        // SOLR-16274 forces us to use GET by default
+        $this->assertSame(Request::METHOD_GET, $request->getMethod());
+        $this->assertSame('schema/analysis/stopwords/dutch', $request->getHandler());
+        $this->assertNull($request->getRawData());
+    }
+
+    public function testExistsWithUseHeadRequest()
+    {
+        $command = new ExistsCommand();
+        $command->setUseHeadRequest(true);
 
         $this->query->setCommand($command);
         $request = $this->builder->build($this->query);

--- a/tests/QueryType/ManagedResources/RequestBuilder/SynonymsTest.php
+++ b/tests/QueryType/ManagedResources/RequestBuilder/SynonymsTest.php
@@ -203,7 +203,7 @@ class SynonymsTest extends TestCase
 
         $this->query->setCommand($command);
         $request = $this->builder->build($this->query);
-        // there's a bug since Solr 8.7 with HEAD requests if a term is set (SOLR-15116, fixed in Solr 8.11.2 and Solr 9.1)
+        // SOLR-15116 and SOLR-16274 force us to use GET by default
         $this->assertSame(Request::METHOD_GET, $request->getMethod());
         $this->assertSame('schema/analysis/synonyms/dutch/mad', $request->getHandler());
         $this->assertNull($request->getRawData());
@@ -212,6 +212,19 @@ class SynonymsTest extends TestCase
     public function testExistsWithoutTerm()
     {
         $command = new ExistsCommand();
+
+        $this->query->setCommand($command);
+        $request = $this->builder->build($this->query);
+        // SOLR-16274 forces us to use GET by default
+        $this->assertSame(Request::METHOD_GET, $request->getMethod());
+        $this->assertSame('schema/analysis/synonyms/dutch', $request->getHandler());
+        $this->assertNull($request->getRawData());
+    }
+
+    public function testExistsWithUseHeadRequest()
+    {
+        $command = new ExistsCommand();
+        $command->setUseHeadRequest(true);
 
         $this->query->setCommand($command);
         $request = $this->builder->build($this->query);


### PR DESCRIPTION
Closes #1008 and fixes the failing workflow runs.

`GET` is now the default request method for the ManagedResources Exists command because Solr 8.11.2 was shipped with a new bug for `HEAD` requests ([SOLR-16274](https://issues.apache.org/jira/browse/SOLR-16274)) that is probably a side effect of fixing the previous one.

I've introduced an option to use `HEAD` requests if you know that your Solr version is unaffected. The onus is on the user for this one. There is no elegant way to detect which bug would apply and using `GET` is functionally equivalent as far as Solarium is concerned anyway. The main reason you would want to do that is when checking for the existence of synonym maps that can be many megabytes large. (Guess how large some of our synonym maps are?) This option is tested against Solr 7 in the integration tests because both 8 and 9 have versions that are affected by one of the related bugs.