### PR TITLE
Add phpstan/extension-installer to allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,10 @@
     },
     "prefer-stable": true,
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Switched to "summer mode" at work which means updating dependencies and testing what breaks. That's how I found out about [`allow-plugins`](https://getcomposer.org/doc/06-config.md#allow-plugins).

> **allow-plugins**
> 
> Defaults to `null` (allow all plugins implicitly) for backwards compatibility until July 2022. At that point the default will become `{}` and plugins will not load anymore unless allowed.
> 
> As of Composer 2.2.0, the `allow-plugins` option adds a layer of security allowing you to restrict which Composer plugins are able to execute code during a Composer run.

Not a day too late, apparently.

The deadline also shows up in a part of the workflow run that I don't usually check: [Install dependencies](https://github.com/solariumphp/solarium/runs/7129860477?check_suite_focus=true#step:8:127).

```
For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See https://getcomposer.org/allow-plugins
You have until July 2022 to add the setting. Composer will then switch the default behavior to disallow all plugins.
```

Only an issue for our workflow runs and contributors since it only affects `require-dev` in our case. Shouldn't impact end-users.