### PR TITLE
Implement JsonSerializable on Results and Documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to the Solarium library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [Unreleased]
 ### Added
+- Results and Documents implement [JsonSerializable](https://www.php.net/manual/en/class.jsonserializable)
 
 ### Fixed
 - Adding nested child documents through `Document::setField()` and `Document::addField()`

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -11,7 +11,7 @@ In the following sections the usage of both document types and the use of custom
 Read-only document
 ------------------
 
-This is the default document type for a [select query result](queries/select-query/result-of-a-select-query/result-of-a-select-query.md). This is an immutable object that allows access to the field values by name or by iterating over the document. This object implements the `Iterator`, `Countable` and `ArrayAccess` interfaces. You can use the document in multiple ways:
+This is the default document type for a [select query result](queries/select-query/result-of-a-select-query/result-of-a-select-query.md). This is an immutable object that allows access to the field values by name or by iterating over the document. This object implements the `Iterator`, `Countable`, `ArrayAccess` and `JsonSerializable` interfaces. You can use the document in multiple ways:
 
 -   access fields as object vars (fieldname as varname)
 -   access fields as array entries (fieldname as key)
@@ -239,11 +239,11 @@ If you use `_childDocuments_` as the field name, the child documents are indexed
 You can create atomic updates by using the `setFieldModifier` method. Set a modifier on the field you want to update. The supported modifiers are:
 
 -   `MODIFIER_SET`
--   `MODIFIER_INC`
 -   `MODIFIER_ADD`
 -   `MODIFIER_ADD_DISTINCT`
 -   `MODIFIER_REMOVE`
 -   `MODIFIER_REMOVEREGEX`
+-   `MODIFIER_INC`
 
 The `addField` and `setField` methods also support modifiers as an optional argument. Any document that uses modifiers MUST have a key, you can set the key using the `setKey` method.
 

--- a/src/Component/Analytics/Analytics.php
+++ b/src/Component/Analytics/Analytics.php
@@ -181,6 +181,7 @@ class Analytics extends AbstractComponent implements \JsonSerializable
         return $this;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * {@inheritdoc}
      */

--- a/src/Component/Analytics/Facet/Pivot.php
+++ b/src/Component/Analytics/Facet/Pivot.php
@@ -99,6 +99,7 @@ class Pivot extends Configurable implements \JsonSerializable
         return $this;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * {@inheritdoc}
      */

--- a/src/Component/Analytics/Facet/PivotFacet.php
+++ b/src/Component/Analytics/Facet/PivotFacet.php
@@ -67,6 +67,7 @@ class PivotFacet extends AbstractFacet
         return $this;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * {@inheritdoc}
      */

--- a/src/Component/Analytics/Facet/QueryFacet.php
+++ b/src/Component/Analytics/Facet/QueryFacet.php
@@ -66,6 +66,7 @@ class QueryFacet extends AbstractFacet
         return $this;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * {@inheritdoc}
      */

--- a/src/Component/Analytics/Facet/RangeFacet.php
+++ b/src/Component/Analytics/Facet/RangeFacet.php
@@ -276,6 +276,7 @@ class RangeFacet extends AbstractFacet
         return $this;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * {@inheritdoc}
      */

--- a/src/Component/Analytics/Facet/Sort/Criterion.php
+++ b/src/Component/Analytics/Facet/Sort/Criterion.php
@@ -118,6 +118,7 @@ class Criterion extends Configurable implements \JsonSerializable
         return $this;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * {@inheritdoc}
      */

--- a/src/Component/Analytics/Facet/Sort/Sort.php
+++ b/src/Component/Analytics/Facet/Sort/Sort.php
@@ -114,6 +114,7 @@ class Sort extends Configurable implements \JsonSerializable
         return $this;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * {@inheritdoc}
      */

--- a/src/Component/Analytics/Facet/ValueFacet.php
+++ b/src/Component/Analytics/Facet/ValueFacet.php
@@ -80,6 +80,7 @@ class ValueFacet extends AbstractFacet
         return $this;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * {@inheritdoc}
      */

--- a/src/Component/Analytics/Grouping.php
+++ b/src/Component/Analytics/Grouping.php
@@ -134,6 +134,7 @@ class Grouping extends Configurable implements \JsonSerializable
         return $this;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * {@inheritdoc}
      */

--- a/src/Core/Query/AbstractDocument.php
+++ b/src/Core/Query/AbstractDocument.php
@@ -12,7 +12,7 @@ namespace Solarium\Core\Query;
 /**
  * Document base functionality, used by readonly and readwrite documents.
  */
-abstract class AbstractDocument implements DocumentInterface, \IteratorAggregate, \Countable, \ArrayAccess
+abstract class AbstractDocument implements DocumentInterface, \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
 {
     /**
      * All fields in this document.
@@ -132,4 +132,10 @@ abstract class AbstractDocument implements DocumentInterface, \IteratorAggregate
     {
         return $this->__get($offset);
     }
+
+    #[\ReturnTypeWillChange]
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function jsonSerialize();
 }

--- a/src/Core/Query/Result/Result.php
+++ b/src/Core/Query/Result/Result.php
@@ -22,7 +22,7 @@ use Solarium\Exception\UnexpectedValueException;
  * This base class provides access to the response and decoded data. If you need more functionality
  * like resultset parsing use one of the subclasses
  */
-class Result implements ResultInterface
+class Result implements ResultInterface, \JsonSerializable
 {
     /**
      * Response object.
@@ -126,5 +126,14 @@ class Result implements ResultInterface
         }
 
         return $this->data;
+    }
+
+    #[\ReturnTypeWillChange]
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return $this->getData();
     }
 }

--- a/src/Plugin/MinimumScoreFilter/Document.php
+++ b/src/Plugin/MinimumScoreFilter/Document.php
@@ -18,7 +18,7 @@ use Solarium\QueryType\Select\Result\Document as SelectDocument;
  *
  * Decorates the original document with a filter indicator
  */
-class Document implements DocumentInterface, \IteratorAggregate, \Countable, \ArrayAccess
+class Document implements DocumentInterface, \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
 {
     /**
      * Original document.
@@ -183,5 +183,14 @@ class Document implements DocumentInterface, \IteratorAggregate, \Countable, \Ar
     public function getFields(): array
     {
         return $this->document->getFields();
+    }
+
+    #[\ReturnTypeWillChange]
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return $this->document;
     }
 }

--- a/src/QueryType/Select/Result/Document.php
+++ b/src/QueryType/Select/Result/Document.php
@@ -52,4 +52,13 @@ class Document extends AbstractDocument
     {
         throw new RuntimeException('A readonly document cannot be altered');
     }
+
+    #[\ReturnTypeWillChange]
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return $this->getFields();
+    }
 }

--- a/src/QueryType/Update/Query/Document.php
+++ b/src/QueryType/Update/Query/Document.php
@@ -39,13 +39,6 @@ class Document extends AbstractDocument
     const MODIFIER_SET = 'set';
 
     /**
-     * Directive to increment a numeric value by a specific amount. Must be specified as a single numeric value.
-     *
-     * @var string
-     */
-    const MODIFIER_INC = 'inc';
-
-    /**
      * Directive to add the specified values to a multiValued field. May be specified as a single value, or as a list.
      *
      * @var string
@@ -75,6 +68,13 @@ class Document extends AbstractDocument
      * @var string
      */
     const MODIFIER_REMOVEREGEX = 'removeregex';
+
+    /**
+     * Directive to increment a numeric value by a specific amount. Must be specified as a single numeric value.
+     *
+     * @var string
+     */
+    const MODIFIER_INC = 'inc';
 
     /**
      * This value has the same effect as not setting a version.
@@ -417,7 +417,7 @@ class Document extends AbstractDocument
      */
     public function setFieldModifier(string $key, string $modifier = null): self
     {
-        if (!\in_array($modifier, [self::MODIFIER_ADD, self::MODIFIER_ADD_DISTINCT, self::MODIFIER_REMOVE, self::MODIFIER_REMOVEREGEX, self::MODIFIER_INC, self::MODIFIER_SET], true)) {
+        if (!\in_array($modifier, [self::MODIFIER_SET, self::MODIFIER_ADD, self::MODIFIER_ADD_DISTINCT, self::MODIFIER_REMOVE, self::MODIFIER_REMOVEREGEX, self::MODIFIER_INC], true)) {
             throw new RuntimeException('Attempt to set an atomic update modifier that is not supported');
         }
         $this->modifiers[$key] = $modifier;
@@ -477,5 +477,23 @@ class Document extends AbstractDocument
     public function getVersion(): ?int
     {
         return $this->version;
+    }
+
+    #[\ReturnTypeWillChange]
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        $fields = $this->getFields();
+
+        foreach ($this->modifiers as $key => $modifier) {
+            // isset($fields[$key]) wouldn't let you set a field to null
+            if (\array_key_exists($key, $fields)) {
+                $fields[$key] = [$modifier => $fields[$key]];
+            }
+        }
+
+        return $fields;
     }
 }

--- a/tests/Core/Query/Result/ResultTest.php
+++ b/tests/Core/Query/Result/ResultTest.php
@@ -27,6 +27,8 @@ class ResultTest extends TestCase
 
     protected $response;
 
+    protected $data;
+
     protected $headers;
 
     public function setUp(): void
@@ -34,9 +36,9 @@ class ResultTest extends TestCase
         $this->client = TestClientFactory::createWithCurlAdapter();
         $this->query = new SelectQuery();
         $this->headers = ['HTTP/1.0 304 Not Modified'];
-        $data = '{"responseHeader":{"status":0,"QTime":1,"params":{"wt":"json","q":"xyz"}},'.
+        $this->data = '{"responseHeader":{"status":0,"QTime":1,"params":{"wt":"json","q":"xyz"}},'.
             '"response":{"numFound":0,"start":0,"docs":[]}}';
-        $this->response = new Response($data, $this->headers);
+        $this->response = new Response($this->data, $this->headers);
 
         $this->result = new Result($this->query, $this->response);
     }
@@ -128,5 +130,10 @@ class ResultTest extends TestCase
 
         $this->expectException(UnexpectedValueException::class);
         $this->result->getData();
+    }
+
+    public function testJsonSerialize()
+    {
+        $this->assertJsonStringEqualsJsonString($this->data, json_encode($this->result));
     }
 }

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -40,6 +40,7 @@ use Solarium\QueryType\ManagedResources\Result\Resources\Resource as ResourceRes
 use Solarium\QueryType\ManagedResources\Result\Synonyms\Synonyms as SynonymsResultItem;
 use Solarium\QueryType\Select\Query\Query as SelectQuery;
 use Solarium\QueryType\Select\Result\Document;
+use Solarium\QueryType\Select\Result\Result as SelectResult;
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 use Solarium\QueryType\Update\RequestBuilder as UpdateRequestBuilder;
 use Solarium\Support\Utility;
@@ -195,7 +196,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertSame(0, $result->getStatus());
     }
 
-    public function testSelect()
+    public function testSelect(): SelectResult
     {
         $select = self::$client->createSelect();
         $select->setSorts(['id' => SelectQuery::SORT_ASC]);
@@ -204,7 +205,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertCount(10, $result);
 
         $ids = [];
-        /** @var \Solarium\QueryType\Select\Result\Document $document */
+        /** @var Document $document */
         foreach ($result as $document) {
             $ids[] = $document->id;
         }
@@ -220,6 +221,26 @@ abstract class AbstractTechproductsTest extends TestCase
             'GB18030TEST',
             'GBP',
             ], $ids);
+
+        return $result;
+    }
+
+    /**
+     * @depends testSelect
+     *
+     * @param SelectResult $result
+     */
+    public function testJsonSerializeSelectResult(SelectResult $result)
+    {
+        $expectedJson = $result->getResponse()->getBody();
+
+        // this only calls SelectResult::jsonSerialize() which gets the document data from the parsed response
+        $json = json_encode($result);
+        $this->assertJsonStringEqualsJsonString($expectedJson, $json);
+
+        // this calls Document::jsonSerialize() on every document instead
+        $documents = json_encode($result->getDocuments());
+        $this->assertStringContainsString($documents, $json);
     }
 
     /**

--- a/tests/QueryType/Select/Result/AbstractDocumentTest.php
+++ b/tests/QueryType/Select/Result/AbstractDocumentTest.php
@@ -115,4 +115,12 @@ abstract class AbstractDocumentTest extends TestCase
     {
         $this->assertCount(count($this->fields), $this->doc);
     }
+
+    public function testJsonSerialize()
+    {
+        $this->assertJsonStringEqualsJsonString(
+            '{"id":123,"name":"Test document","categories":[1,2,3],"empty_field":""}',
+            json_encode($this->doc)
+        );
+    }
 }


### PR DESCRIPTION
Closes #603 for read-only documents. Integration test included in this PR.

Implements generating [Solr-Style JSON](https://solr.apache.org/guide/solr/latest/indexing-guide/indexing-with-update-handlers.html#solr-style-json) for read-write documents. Integration test will be part of the future work for #1004.

Also fixes a PHP 8.1 deprecation for all existing `JsonSerializable` implementations in the codebase.