### PR TITLE
Skip local tests for Client::getVersion()

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -75,6 +75,7 @@ jobs:
             - name: Install dependencies
               run: |
                 composer update
+                sed -i "s/'dev-.*'/'76.5.4'/g" vendor/composer/installed.php
 
             - name: Run tests
               run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -75,8 +75,6 @@ jobs:
             - name: Install dependencies
               run: |
                 composer update
-                sed -i "s/'dev-.*'/'76.5.4'/g" vendor/composer/installed.php
-                cat vendor/composer/installed.php
 
             - name: Run tests
               run: |

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -19,7 +19,12 @@ class ClientTest extends TestCase
     {
         $installedVersion = InstalledVersions::getPrettyVersion('solarium/solarium');
 
-        if ('dev-master' === $installedVersion) {
+        // @see https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        $semverRegex =
+            '/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/'
+        ;
+
+        if (!preg_match($semverRegex, $installedVersion)) {
             self::assertSame($installedVersion, Client::getVersion());
             self::markTestSkipped(sprintf('Testing on %s, skipping tests against version tag %s.', $installedVersion, self::$versionTag));
         }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,15 +2,37 @@
 
 namespace Solarium\Tests;
 
+use Composer\InstalledVersions;
 use PHPUnit\Framework\TestCase;
 use Solarium\Client;
 
 class ClientTest extends TestCase
 {
+    /**
+     * The version tag we use for testing within github actions.
+     *
+     * @var string
+     */
+    protected static $versionTag = '76.5.4';
+
+    public static function setUpBeforeClass(): void
+    {
+        $installedVersion = InstalledVersions::getPrettyVersion('solarium/solarium');
+
+        if ('dev-master' === $installedVersion) {
+            self::assertSame($installedVersion, Client::getVersion());
+            self::markTestSkipped(sprintf('Testing on %s, skipping tests against version tag %s.', $installedVersion, self::$versionTag));
+        }
+
+        parent::setUpBeforeClass();
+    }
+
     public function testGetVersion()
     {
-        $version = Client::getVersion();
-        $this->assertNotNull($version);
+        $this->assertSame(
+            self::$versionTag,
+            Client::getVersion()
+        );
     }
 
     /**
@@ -18,28 +40,23 @@ class ClientTest extends TestCase
      */
     public function testVersionConstant()
     {
-        $this->assertSame(Client::getVersion(), Client::VERSION);
+        $this->assertSame(
+            self::$versionTag,
+            Client::VERSION
+        );
     }
 
     public function testCheckExact()
     {
         $this->assertTrue(
-            Client::checkExact(Client::getVersion())
-        );
-    }
-
-    public function test76_5_4()
-    {
-        $this->assertTrue(
-            // 76.5.4 is the version tag we use within github actions.
-            Client::checkExact('76.5.4')
+            Client::checkExact(self::$versionTag)
         );
     }
 
     public function testCheckExactPartial()
     {
         $this->assertTrue(
-            Client::checkExact(substr(Client::getVersion(), 0, 1))
+            Client::checkExact(substr(self::$versionTag, 0, 1))
         );
     }
 
@@ -60,16 +77,14 @@ class ClientTest extends TestCase
     public function testCheckMinimal()
     {
         $this->assertTrue(
-            Client::checkMinimal(Client::getVersion())
+            Client::checkMinimal(self::$versionTag)
         );
     }
 
     public function testCheckMinimalPartial()
     {
-        $version = substr(Client::getVersion(), 0, 1);
-
         $this->assertTrue(
-            Client::checkMinimal($version)
+            Client::checkMinimal(substr(self::$versionTag, 0, 1))
         );
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -9,24 +9,22 @@ use Solarium\Client;
 class ClientTest extends TestCase
 {
     /**
-     * The version tag we use for testing within github actions.
-     *
      * @var string
      */
-    protected static $versionTag = '76.5.4';
+    protected static $installedVersion;
 
     public static function setUpBeforeClass(): void
     {
-        $installedVersion = InstalledVersions::getPrettyVersion('solarium/solarium');
+        self::$installedVersion = InstalledVersions::getPrettyVersion('solarium/solarium');
 
         // @see https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         $semverRegex =
             '/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/'
         ;
 
-        if (!preg_match($semverRegex, $installedVersion)) {
-            self::assertSame($installedVersion, Client::getVersion());
-            self::markTestSkipped(sprintf('Testing on %s, skipping tests against version tag %s.', $installedVersion, self::$versionTag));
+        if (!preg_match($semverRegex, self::$installedVersion)) {
+            self::assertSame(self::$installedVersion, Client::getVersion());
+            self::markTestSkipped(sprintf('Skipping tests against non-semantic version string %s.', self::$installedVersion));
         }
 
         parent::setUpBeforeClass();
@@ -35,7 +33,7 @@ class ClientTest extends TestCase
     public function testGetVersion()
     {
         $this->assertSame(
-            self::$versionTag,
+            self::$installedVersion,
             Client::getVersion()
         );
     }
@@ -46,7 +44,7 @@ class ClientTest extends TestCase
     public function testVersionConstant()
     {
         $this->assertSame(
-            self::$versionTag,
+            self::$installedVersion,
             Client::VERSION
         );
     }
@@ -54,14 +52,14 @@ class ClientTest extends TestCase
     public function testCheckExact()
     {
         $this->assertTrue(
-            Client::checkExact(self::$versionTag)
+            Client::checkExact(self::$installedVersion)
         );
     }
 
     public function testCheckExactPartial()
     {
         $this->assertTrue(
-            Client::checkExact(substr(self::$versionTag, 0, 1))
+            Client::checkExact(substr(self::$installedVersion, 0, 1))
         );
     }
 
@@ -82,14 +80,14 @@ class ClientTest extends TestCase
     public function testCheckMinimal()
     {
         $this->assertTrue(
-            Client::checkMinimal(self::$versionTag)
+            Client::checkMinimal(self::$installedVersion)
         );
     }
 
     public function testCheckMinimalPartial()
     {
         $this->assertTrue(
-            Client::checkMinimal(substr(self::$versionTag, 0, 1))
+            Client::checkMinimal(substr(self::$installedVersion, 0, 1))
         );
     }
 


### PR DESCRIPTION
@mkalkbrenner I found a way to pass the tests for `Client::getVersion()` locally. But I don't like it. I've still opened a PR for it because maybe it can lead to a better idea?

It uses `composer.json`. That takes it out of the realm of our "internal affairs" and "out into the open". That's not where we should be fiddling around for testing purposes. To make matters worse, there is no `scripts-dev` so it has to rely on an environment variable. And that variable has to be accessed with a slightly different syntax on Windows so you can't simply test with `[ $COMPOSER_DEV_MODE -eq 1 ]`.

Another thing I tried in `composer.json` felt more acceptable: using `autoload-dev` to load a mock for `Composer\InstalledVersions`. It doesn't seem possible to prepend it before the real vendor namespace though. The actual implementation is always discovered first.