### PR TITLE
ExceptionInterface must extends Throwable

### DIFF
--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -14,6 +14,6 @@ namespace Solarium\Exception;
  *
  * For background info see http://ralphschindler.com/2010/09/15/exception-best-practices-in-php-5-3
  */
-interface ExceptionInterface
+interface ExceptionInterface extends \Throwable
 {
 }


### PR DESCRIPTION
Hi @mkalkbrenner 

The ExceptionInterface must extends \Throwable even if all the implementation extends \Exception.

This guarantee that
```
/** @throws ExceptionInterface */
function foo() {}
```
is a valid annotation and

```
try {} catch (\Throwable) {}
```
will catch them.