### PR TITLE
Fix bug with empty array for multiValued field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- An empty array for a multiValued field was wrongly interpreted as an empty child document by the Update request builder in 6.2.5
 
 ### Changed
 

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -128,7 +128,7 @@ htmlFooter();
 
 ### Multivalue fields
 
-If you set field values by property, array entry or by using the `setField` method you need to supply an array of values for a multivalue field. Any existing field values will be overwritten.
+If you set field values by property, array entry or by using the `setField` method you need to supply a *numerically indexed* array of values for a multivalue field. Any existing field values will be overwritten.
 
 If you want to add an extra value to an existing field, without overwriting, you should use the `addField` method. If you use this method on a field with a single value it will automatically be converted into a multivalue field, preserving the current value. You will need to call this method once for each value you want to add, it doesn't support arrays. You can also use this method for creating a new field, so you don't need to use a special method for the first field value.
 

--- a/src/QueryType/Update/Query/Document.php
+++ b/src/QueryType/Update/Query/Document.php
@@ -157,7 +157,7 @@ class Document extends AbstractDocument
      * object, by field name.
      *
      * If you supply NULL as the value the field will be removed
-     * If you supply an array of values a multivalue field will be created.
+     * If you supply a numerically indexed array of values a multivalue field will be created.
      * In all cases any existing (multi)value or child document(s) will be overwritten.
      *
      * @param string $name
@@ -229,7 +229,7 @@ class Document extends AbstractDocument
      * Set a field value.
      *
      * If you supply NULL as the value and no modifier the field will be removed
-     * If you supply an array of values a multivalue field will be created.
+     * If you supply a numerically indexed array of values a multivalue field will be created.
      * In all cases any existing (multi)value or child document(s) will be overwritten.
      *
      * @param string      $key

--- a/src/QueryType/Update/Query/Document.php
+++ b/src/QueryType/Update/Query/Document.php
@@ -228,7 +228,7 @@ class Document extends AbstractDocument
     /**
      * Set a field value.
      *
-     * If you supply NULL as the value the field will be removed
+     * If you supply NULL as the value and no modifier the field will be removed
      * If you supply an array of values a multivalue field will be created.
      * In all cases any existing (multi)value or child document(s) will be overwritten.
      *

--- a/src/QueryType/Update/RequestBuilder.php
+++ b/src/QueryType/Update/RequestBuilder.php
@@ -269,7 +269,9 @@ class RequestBuilder extends BaseRequestBuilder
         }
 
         if (\is_array($value)) {
-            if (is_numeric(array_key_first($value))) {
+            if (empty($value)) {
+                return '';
+            } elseif (is_numeric(array_key_first($value))) {
                 $nestedXml = '';
 
                 foreach ($value as $multival) {

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -1279,7 +1279,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $select = self::$client->createSelect();
         $select->setQuery('cat:solarium-test');
         $select->addSort('id', $select::SORT_ASC);
-        $select->setFields('id,name,price');
+        $select->setFields('id,name,price,content');
 
         // add, but don't commit
         $update = self::$client->createUpdate();
@@ -1288,11 +1288,13 @@ abstract class AbstractTechproductsTest extends TestCase
         $doc1->setField('name', 'Solarium Test 1');
         $doc1->setField('cat', 'solarium-test');
         $doc1->setField('price', 3.14);
+        $doc1->setField('content', ['foo', 'bar']);
         $doc2 = $update->createDocument();
         $doc2->setField('id', 'solarium-test-2');
         $doc2->setField('name', 'Solarium Test 2');
         $doc2->setField('cat', 'solarium-test');
         $doc2->setField('price', 42.0);
+        $doc2->setField('content', []);
         $update->addDocuments([$doc1, $doc2]);
         self::$client->update($update);
         $result = self::$client->select($select);
@@ -1309,6 +1311,10 @@ abstract class AbstractTechproductsTest extends TestCase
             'id' => 'solarium-test-1',
             'name' => 'Solarium Test 1',
             'price' => 3.14,
+            'content' => [
+                'foo',
+                'bar',
+            ],
         ], $iterator->current()->getFields());
         $iterator->next();
         $this->assertSame([

--- a/tests/QueryType/Update/RequestBuilderTest.php
+++ b/tests/QueryType/Update/RequestBuilderTest.php
@@ -151,6 +151,22 @@ class RequestBuilderTest extends TestCase
         );
     }
 
+    public function testBuildAddXmlWithEmptyStrings()
+    {
+        $command = new AddCommand();
+        $command->addDocument(new Document(['id' => '', 'text' => ['']]));
+
+        $this->assertSame(
+            '<add>'.
+            '<doc>'.
+            '<field name="id"></field>'.
+            '<field name="text"></field>'.
+            '</doc>'.
+            '</add>',
+            $this->builder->buildAddXml($command)
+        );
+    }
+
     public function testBuildAddXmlWithSingleNestedDocument()
     {
         $command = new AddCommand();

--- a/tests/QueryType/Update/RequestBuilderTest.php
+++ b/tests/QueryType/Update/RequestBuilderTest.php
@@ -85,11 +85,11 @@ class RequestBuilderTest extends TestCase
     public function testBuildAddXmlWithEmptyValues()
     {
         $command = new AddCommand();
-        $command->addDocument(new Document(['id' => 1, 'empty_string' => '', 'array_of_empty_string' => [''], 'null' => null]));
+        $command->addDocument(new Document(['id' => 0, 'empty_string' => '', 'array_of_empty_string' => [''], 'null' => null]));
 
         // Empty values must be added to the document as empty fields, NULL values are skipped.
         $this->assertSame(
-            '<add><doc><field name="id">1</field><field name="empty_string"></field><field name="array_of_empty_string"></field></doc></add>',
+            '<add><doc><field name="id">0</field><field name="empty_string"></field><field name="array_of_empty_string"></field></doc></add>',
             $this->builder->buildAddXml($command)
         );
     }

--- a/tests/QueryType/Update/RequestBuilderTest.php
+++ b/tests/QueryType/Update/RequestBuilderTest.php
@@ -134,6 +134,23 @@ class RequestBuilderTest extends TestCase
         );
     }
 
+    public function testBuildAddXmlMultivalueFieldWithEmptyArray()
+    {
+        $command = new AddCommand();
+        $command->addDocument(new Document(['id' => [1, 2, 3], 'text' => []]));
+
+        $this->assertSame(
+            '<add>'.
+            '<doc>'.
+            '<field name="id">1</field>'.
+            '<field name="id">2</field>'.
+            '<field name="id">3</field>'.
+            '</doc>'.
+            '</add>',
+            $this->builder->buildAddXml($command)
+        );
+    }
+
     public function testBuildAddXmlWithSingleNestedDocument()
     {
         $command = new AddCommand();


### PR DESCRIPTION
Fixes #1023.

@mkalkbrenner Can we release 6.2.6 ASAP if this passes review? It's something I overlooked when fixing a nested child bug that's already causing issues for our users. :-(

Should we also delete release 6.2.5?