### PR TITLE
Unregister listeners when plugins are removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Plugins unregister event listeners when removed with Client::removePlugin()
 
 ### Changed
 

--- a/docs/customizing-solarium.md
+++ b/docs/customizing-solarium.md
@@ -109,6 +109,7 @@ class BasicDebug extends Solarium\Core\Plugin\AbstractPlugin
     protected $start;
     protected $output = array();
 
+    // This method is called when the plugin is registered with the client.
     protected function initPluginType()
     {
         $this->start = microtime(true);
@@ -124,6 +125,22 @@ class BasicDebug extends Solarium\Core\Plugin\AbstractPlugin
         $dispatcher->addListener(Events::POST_EXECUTE, array($this, 'postExecute'));
         $dispatcher->addListener(Events::PRE_CREATE_QUERY, array($this, 'preCreateQuery'));
         $dispatcher->addListener(Events::POST_CREATE_QUERY, array($this, 'postCreateQuery'));
+    }
+
+    // This method is called if the plugin is removed from the client.
+    public function deinitPlugin()
+    {
+        $dispatcher = $this->client->getEventDispatcher();
+        $dispatcher->removeListener(Events::PRE_CREATE_REQUEST, array($this, 'preCreateRequest'));
+        $dispatcher->removeListener(Events::POST_CREATE_REQUEST, array($this, 'postCreateRequest'));
+        $dispatcher->removeListener(Events::PRE_EXECUTE_REQUEST, array($this, 'preExecuteRequest'));
+        $dispatcher->removeListener(Events::POST_EXECUTE_REQUEST, array($this, 'postExecuteRequest'));
+        $dispatcher->removeListener(Events::PRE_CREATE_RESULT, array($this, 'preCreateResult'));
+        $dispatcher->removeListener(Events::POST_CREATE_RESULT, array($this, 'postCreateResult'));
+        $dispatcher->removeListener(Events::PRE_EXECUTE, array($this, 'preExecute'));
+        $dispatcher->removeListener(Events::POST_EXECUTE, array($this, 'postExecute'));
+        $dispatcher->removeListener(Events::PRE_CREATE_QUERY, array($this, 'preCreateQuery'));
+        $dispatcher->removeListener(Events::POST_CREATE_QUERY, array($this, 'postCreateQuery'));
     }
 
     protected function timer($event)
@@ -147,8 +164,8 @@ class BasicDebug extends Solarium\Core\Plugin\AbstractPlugin
         $this->timer('postCreateRequest');
     }
 
-    // This method uses the aviable param(s) (see plugin abstract class)
-    // You can access or modify data this way
+    // This method uses the aviable param(s) (see plugin abstract class).
+    // You can access or modify data this way.
     public function preExecuteRequest($event)
     {
         $this->timer('preExecuteRequest');

--- a/examples/5.3.1-plugin-event-hooks.php
+++ b/examples/5.3.1-plugin-event-hooks.php
@@ -9,6 +9,7 @@ class BasicDebug extends Solarium\Core\Plugin\AbstractPlugin
     protected $start;
     protected $output = array();
 
+    // This method is called when the plugin is registered with the client.
     protected function initPluginType()
     {
         $this->start = microtime(true);
@@ -24,6 +25,22 @@ class BasicDebug extends Solarium\Core\Plugin\AbstractPlugin
         $dispatcher->addListener(Events::POST_EXECUTE, array($this, 'postExecute'));
         $dispatcher->addListener(Events::PRE_CREATE_QUERY, array($this, 'preCreateQuery'));
         $dispatcher->addListener(Events::POST_CREATE_QUERY, array($this, 'postCreateQuery'));
+    }
+
+    // This method is called if the plugin is removed from the client.
+    public function deinitPlugin()
+    {
+        $dispatcher = $this->client->getEventDispatcher();
+        $dispatcher->removeListener(Events::PRE_CREATE_REQUEST, array($this, 'preCreateRequest'));
+        $dispatcher->removeListener(Events::POST_CREATE_REQUEST, array($this, 'postCreateRequest'));
+        $dispatcher->removeListener(Events::PRE_EXECUTE_REQUEST, array($this, 'preExecuteRequest'));
+        $dispatcher->removeListener(Events::POST_EXECUTE_REQUEST, array($this, 'postExecuteRequest'));
+        $dispatcher->removeListener(Events::PRE_CREATE_RESULT, array($this, 'preCreateResult'));
+        $dispatcher->removeListener(Events::POST_CREATE_RESULT, array($this, 'postCreateResult'));
+        $dispatcher->removeListener(Events::PRE_EXECUTE, array($this, 'preExecute'));
+        $dispatcher->removeListener(Events::POST_EXECUTE, array($this, 'postExecute'));
+        $dispatcher->removeListener(Events::PRE_CREATE_QUERY, array($this, 'preCreateQuery'));
+        $dispatcher->removeListener(Events::POST_CREATE_QUERY, array($this, 'postCreateQuery'));
     }
 
     protected function timer($event)
@@ -47,8 +64,8 @@ class BasicDebug extends Solarium\Core\Plugin\AbstractPlugin
         $this->timer('postCreateRequest');
     }
 
-    // This method uses the aviable param(s) (see plugin abstract class)
-    // You can access or modify data this way
+    // This method uses the aviable param(s) (see plugin abstract class).
+    // You can access or modify data this way.
     public function preExecuteRequest($event)
     {
         $this->timer('preExecuteRequest');

--- a/src/Core/Client/Client.php
+++ b/src/Core/Client/Client.php
@@ -713,12 +713,14 @@ class Client extends Configurable implements ClientInterface
         if (\is_object($plugin)) {
             foreach ($this->pluginInstances as $key => $instance) {
                 if ($instance === $plugin) {
+                    $plugin->deinitPlugin();
                     unset($this->pluginInstances[$key]);
                     break;
                 }
             }
         } else {
             if (isset($this->pluginInstances[$plugin])) {
+                $this->pluginInstances[$plugin]->deinitPlugin();
                 unset($this->pluginInstances[$plugin]);
             }
         }

--- a/src/Core/Event/PostCreateQuery.php
+++ b/src/Core/Event/PostCreateQuery.php
@@ -13,7 +13,7 @@ use Solarium\Core\Query\QueryInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * PostCreateQuery event, see Events for details.
+ * PostCreateQuery event, see {@see Events} for details.
  */
 class PostCreateQuery extends Event
 {

--- a/src/Core/Event/PostCreateRequest.php
+++ b/src/Core/Event/PostCreateRequest.php
@@ -14,7 +14,7 @@ use Solarium\Core\Query\QueryInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * PostCreateRequest event, see Events for details.
+ * PostCreateRequest event, see {@see Events} for details.
  */
 class PostCreateRequest extends Event
 {

--- a/src/Core/Event/PostCreateResult.php
+++ b/src/Core/Event/PostCreateResult.php
@@ -15,7 +15,7 @@ use Solarium\Core\Query\Result\ResultInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * PostCreateResult event, see Events for details.
+ * PostCreateResult event, see {@see Events} for details.
  */
 class PostCreateResult extends Event
 {

--- a/src/Core/Event/PostExecute.php
+++ b/src/Core/Event/PostExecute.php
@@ -14,7 +14,7 @@ use Solarium\Core\Query\Result\ResultInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * PostExecute event, see Events for details.
+ * PostExecute event, see {@see Events} for details.
  */
 class PostExecute extends Event
 {

--- a/src/Core/Event/PostExecuteRequest.php
+++ b/src/Core/Event/PostExecuteRequest.php
@@ -15,7 +15,7 @@ use Solarium\Core\Client\Response;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * PostExecuteRequest event, see Events for details.
+ * PostExecuteRequest event, see {@see Events} for details.
  */
 class PostExecuteRequest extends Event
 {

--- a/src/Core/Event/PreCreateQuery.php
+++ b/src/Core/Event/PreCreateQuery.php
@@ -13,7 +13,7 @@ use Solarium\Core\Query\QueryInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * PreCreateQuery event, see Events for details.
+ * PreCreateQuery event, see {@see Events} for details.
  */
 class PreCreateQuery extends Event
 {

--- a/src/Core/Event/PreCreateRequest.php
+++ b/src/Core/Event/PreCreateRequest.php
@@ -14,7 +14,7 @@ use Solarium\Core\Query\QueryInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * PreCreateRequest event, see Events for details.
+ * PreCreateRequest event, see {@see Events} for details.
  */
 class PreCreateRequest extends Event
 {

--- a/src/Core/Event/PreCreateResult.php
+++ b/src/Core/Event/PreCreateResult.php
@@ -15,7 +15,7 @@ use Solarium\Core\Query\Result\ResultInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * PreCreateResult event, see Events for details.
+ * PreCreateResult event, see {@see Events} for details.
  */
 class PreCreateResult extends Event
 {

--- a/src/Core/Event/PreExecute.php
+++ b/src/Core/Event/PreExecute.php
@@ -14,7 +14,7 @@ use Solarium\Core\Query\Result\ResultInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * PreExecute event, see Events for details.
+ * PreExecute event, see {@see Events} for details.
  */
 class PreExecute extends Event
 {

--- a/src/Core/Event/PreExecuteRequest.php
+++ b/src/Core/Event/PreExecuteRequest.php
@@ -15,7 +15,7 @@ use Solarium\Core\Client\Response;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * PreExecuteRequest event, see Events for details.
+ * PreExecuteRequest event, see {@see Events} for details.
  */
 class PreExecuteRequest extends Event
 {

--- a/src/Core/Plugin/AbstractPlugin.php
+++ b/src/Core/Plugin/AbstractPlugin.php
@@ -27,7 +27,7 @@ abstract class AbstractPlugin extends Configurable implements PluginInterface
     /**
      * Initialize.
      *
-     * This method is called when the plugin is registered to a client instance
+     * This method is called when the plugin is registered to a client instance.
      *
      * @param ClientInterface $client
      * @param array           $options
@@ -47,6 +47,16 @@ abstract class AbstractPlugin extends Configurable implements PluginInterface
      * Will be called as soon as $this->client and options have been set.
      */
     protected function initPluginType()
+    {
+    }
+
+    /**
+     * Plugin cleanup function.
+     *
+     * This is an extension point for plugin implementations.
+     * This method is called if the plugin is removed from a client instance.
+     */
+    public function deinitPlugin()
     {
     }
 }

--- a/src/Core/Plugin/PluginInterface.php
+++ b/src/Core/Plugin/PluginInterface.php
@@ -20,10 +20,17 @@ interface PluginInterface extends ConfigurableInterface
     /**
      * Initialize.
      *
-     * This method is called when the plugin is registered to a client instance
+     * This method is called when the plugin is registered to a client instance.
      *
      * @param ClientInterface $client
      * @param array           $options
      */
     public function initPlugin(ClientInterface $client, array $options);
+
+    /**
+     * Cleanup.
+     *
+     * This method is called if the plugin is removed from a client instance.
+     */
+    public function deinitPlugin();
 }

--- a/src/Plugin/CustomizeRequest/CustomizeRequest.php
+++ b/src/Plugin/CustomizeRequest/CustomizeRequest.php
@@ -252,13 +252,26 @@ class CustomizeRequest extends AbstractPlugin
     /**
      * Plugin init function.
      *
-     * Register event listeners
+     * Register event listeners.
      */
     protected function initPluginType()
     {
         $dispatcher = $this->client->getEventDispatcher();
         if (is_subclass_of($dispatcher, '\Symfony\Component\EventDispatcher\EventDispatcherInterface')) {
             $dispatcher->addListener(Events::POST_CREATE_REQUEST, [$this, 'postCreateRequest']);
+        }
+    }
+
+    /**
+     * Plugin cleanup function.
+     *
+     * Unregister event listeners.
+     */
+    public function deinitPlugin()
+    {
+        $dispatcher = $this->client->getEventDispatcher();
+        if (is_subclass_of($dispatcher, '\Symfony\Component\EventDispatcher\EventDispatcherInterface')) {
+            $dispatcher->removeListener(Events::POST_CREATE_REQUEST, [$this, 'postCreateRequest']);
         }
     }
 }

--- a/src/Plugin/Loadbalancer/Event/EndpointFailure.php
+++ b/src/Plugin/Loadbalancer/Event/EndpointFailure.php
@@ -14,7 +14,7 @@ use Solarium\Exception\HttpException;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * EndpointFailure event, see Events for details.
+ * EndpointFailure event, see {@see Events} for details.
  */
 class EndpointFailure extends Event
 {

--- a/src/Plugin/Loadbalancer/Loadbalancer.php
+++ b/src/Plugin/Loadbalancer/Loadbalancer.php
@@ -550,7 +550,7 @@ class Loadbalancer extends AbstractPlugin
     /**
      * Plugin init function.
      *
-     * Register event listeners
+     * Register event listeners.
      */
     protected function initPluginType()
     {
@@ -559,6 +559,20 @@ class Loadbalancer extends AbstractPlugin
             // The Loadbalancer plugin needs to be the last plugin executed on PRE_EXECUTE_REQUEST. Set Priority to 0.
             $dispatcher->addListener(Events::PRE_EXECUTE_REQUEST, [$this, 'preExecuteRequest'], 0);
             $dispatcher->addListener(Events::PRE_CREATE_REQUEST, [$this, 'preCreateRequest']);
+        }
+    }
+
+    /**
+     * Plugin cleanup function.
+     *
+     * Unregister event listeners.
+     */
+    public function deinitPlugin()
+    {
+        $dispatcher = $this->client->getEventDispatcher();
+        if (is_subclass_of($dispatcher, '\Symfony\Component\EventDispatcher\EventDispatcherInterface')) {
+            $dispatcher->removeListener(Events::PRE_EXECUTE_REQUEST, [$this, 'preExecuteRequest']);
+            $dispatcher->removeListener(Events::PRE_CREATE_REQUEST, [$this, 'preCreateRequest']);
         }
     }
 }

--- a/src/Plugin/MinimumScoreFilter/MinimumScoreFilter.php
+++ b/src/Plugin/MinimumScoreFilter/MinimumScoreFilter.php
@@ -26,7 +26,7 @@ class MinimumScoreFilter extends AbstractPlugin
     /**
      * Plugin init function.
      *
-     * Register event listeners
+     * Register query type.
      */
     protected function initPluginType()
     {

--- a/src/Plugin/ParallelExecution/Event/ExecuteEnd.php
+++ b/src/Plugin/ParallelExecution/Event/ExecuteEnd.php
@@ -12,7 +12,7 @@ namespace Solarium\Plugin\ParallelExecution\Event;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * ExecuteEnd event, see Events for details.
+ * ExecuteEnd event, see {@see Events} for details.
  */
 class ExecuteEnd extends Event
 {

--- a/src/Plugin/ParallelExecution/Event/ExecuteStart.php
+++ b/src/Plugin/ParallelExecution/Event/ExecuteStart.php
@@ -12,7 +12,7 @@ namespace Solarium\Plugin\ParallelExecution\Event;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * ExecuteStart event, see Events for details.
+ * ExecuteStart event, see {@see Events} for details.
  */
 class ExecuteStart extends Event
 {

--- a/src/Plugin/PostBigExtractRequest.php
+++ b/src/Plugin/PostBigExtractRequest.php
@@ -121,11 +121,22 @@ class PostBigExtractRequest extends AbstractPlugin
     /**
      * Plugin init function.
      *
-     * Register event listeners
+     * Register event listeners.
      */
     protected function initPluginType()
     {
         $dispatcher = $this->client->getEventDispatcher();
         $dispatcher->addListener(Events::POST_CREATE_REQUEST, [$this, 'postCreateRequest']);
+    }
+
+    /**
+     * Plugin cleanup function.
+     *
+     * Unregister event listeners.
+     */
+    public function deinitPlugin()
+    {
+        $dispatcher = $this->client->getEventDispatcher();
+        $dispatcher->removeListener(Events::POST_CREATE_REQUEST, [$this, 'postCreateRequest']);
     }
 }

--- a/src/Plugin/PostBigRequest.php
+++ b/src/Plugin/PostBigRequest.php
@@ -89,7 +89,7 @@ class PostBigRequest extends AbstractPlugin
     /**
      * Plugin init function.
      *
-     * Register event listeners
+     * Register event listeners.
      */
     protected function initPluginType()
     {
@@ -97,6 +97,19 @@ class PostBigRequest extends AbstractPlugin
         if (is_subclass_of($dispatcher, '\Symfony\Component\EventDispatcher\EventDispatcherInterface')) {
             // PostBigRequest has to act on PRE_EXECUTE_REQUEST before Loadbalancer (priority 0). Set priority to 10.
             $dispatcher->addListener(Events::PRE_EXECUTE_REQUEST, [$this, 'preExecuteRequest'], 10);
+        }
+    }
+
+    /**
+     * Plugin cleanup function.
+     *
+     * Unregister event listeners.
+     */
+    public function deinitPlugin()
+    {
+        $dispatcher = $this->client->getEventDispatcher();
+        if (is_subclass_of($dispatcher, '\Symfony\Component\EventDispatcher\EventDispatcherInterface')) {
+            $dispatcher->removeListener(Events::PRE_EXECUTE_REQUEST, [$this, 'preExecuteRequest']);
         }
     }
 }

--- a/src/QueryType/Extract/RequestBuilder.php
+++ b/src/QueryType/Extract/RequestBuilder.php
@@ -78,8 +78,12 @@ class RequestBuilder extends BaseRequestBuilder
             $request->addParam('stream.url', $file);
             $request->setMethod(Request::METHOD_GET);
         } elseif (is_readable($file)) {
+            $resourceName = basename($query->getFile());
+            if (0 !== strcasecmp('UTF-8', $charset = $request->getParam('ie') ?? 'UTF-8')) {
+                $resourceName = iconv('UTF-8', $charset, $resourceName);
+            }
             $request->setFileUpload($file);
-            $request->addParam('resource.name', basename($query->getFile()));
+            $request->addParam('resource.name', $resourceName);
             $request->addHeader('Content-Type: multipart/form-data; boundary='.$request->getHash());
         } else {
             throw new RuntimeException(sprintf('Extract query file path/url invalid or not available: %s', $file));

--- a/tests/Core/Client/ClientTest.php
+++ b/tests/Core/Client/ClientTest.php
@@ -458,7 +458,7 @@ class ClientTest extends TestCase
         );
     }
 
-    public function testRemovePluginAndGetPluginsWithObjectInput()
+    public function testDeinitPluginAndGetPluginsWithObjectInput()
     {
         $options = ['option1' => 1];
         $this->client->registerPlugin('testplugin', MyClientPlugin::class, $options);

--- a/tests/Integration/Plugin/EventTimer.php
+++ b/tests/Integration/Plugin/EventTimer.php
@@ -5,6 +5,7 @@ namespace Solarium\Tests\Integration\Plugin;
 use Solarium\Core\Event\Events;
 use Solarium\Core\Plugin\AbstractPlugin;
 use Solarium\Plugin\ParallelExecution\Event\Events as ParallelExecutionEvents;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Plugin that logs the order and timing of dispatched events.
@@ -21,23 +22,55 @@ class EventTimer extends AbstractPlugin
      */
     protected $log = [];
 
+    /**
+     * @var Event[]
+     */
+    protected $events = [];
+
+    /**
+     * Plugin init function.
+     *
+     * Register event listeners and start a timer.
+     */
     protected function initPluginType(): void
     {
-        $this->start = hrtime(true);
-
         $dispatcher = $this->client->getEventDispatcher();
-        $dispatcher->addListener(Events::PRE_CREATE_REQUEST, function () { $this->log('preCreateRequest'); });
-        $dispatcher->addListener(Events::POST_CREATE_REQUEST, function () { $this->log('postCreateRequest'); });
-        $dispatcher->addListener(Events::PRE_EXECUTE_REQUEST, function () { $this->log('preExecuteRequest'); });
-        $dispatcher->addListener(Events::POST_EXECUTE_REQUEST, function () { $this->log('postExecuteRequest'); });
-        $dispatcher->addListener(Events::PRE_CREATE_RESULT, function () { $this->log('preCreateResult'); });
-        $dispatcher->addListener(Events::POST_CREATE_RESULT, function () { $this->log('postCreateResult'); });
-        $dispatcher->addListener(Events::PRE_EXECUTE, function () { $this->log('preExecute'); });
-        $dispatcher->addListener(Events::POST_EXECUTE, function () { $this->log('postExecute'); });
-        $dispatcher->addListener(Events::PRE_CREATE_QUERY, function () { $this->log('preCreateQuery'); });
-        $dispatcher->addListener(Events::POST_CREATE_QUERY, function () { $this->log('postCreateQuery'); });
-        $dispatcher->addListener(ParallelExecutionEvents::EXECUTE_START, function () { $this->log('parallelExecuteStart'); });
-        $dispatcher->addListener(ParallelExecutionEvents::EXECUTE_END, function () { $this->log('parallelExecuteEnd'); });
+        $dispatcher->addListener(Events::PRE_CREATE_REQUEST, $this->events['preCrReq'] = function () { $this->log('preCreateRequest'); });
+        $dispatcher->addListener(Events::POST_CREATE_REQUEST, $this->events['postCrReq'] = function () { $this->log('postCreateRequest'); });
+        $dispatcher->addListener(Events::PRE_EXECUTE_REQUEST, $this->events['preExReq'] = function () { $this->log('preExecuteRequest'); });
+        $dispatcher->addListener(Events::POST_EXECUTE_REQUEST, $this->events['postExReq'] = function () { $this->log('postExecuteRequest'); });
+        $dispatcher->addListener(Events::PRE_CREATE_RESULT, $this->events['preCrRes'] = function () { $this->log('preCreateResult'); });
+        $dispatcher->addListener(Events::POST_CREATE_RESULT, $this->events['postCrRes'] = function () { $this->log('postCreateResult'); });
+        $dispatcher->addListener(Events::PRE_EXECUTE, $this->events['preEx'] = function () { $this->log('preExecute'); });
+        $dispatcher->addListener(Events::POST_EXECUTE, $this->events['postEx'] = function () { $this->log('postExecute'); });
+        $dispatcher->addListener(Events::PRE_CREATE_QUERY, $this->events['preCrQ'] = function () { $this->log('preCreateQuery'); });
+        $dispatcher->addListener(Events::POST_CREATE_QUERY, $this->events['postCrQ'] = function () { $this->log('postCreateQuery'); });
+        $dispatcher->addListener(ParallelExecutionEvents::EXECUTE_START, $this->events['PE_ExStart'] = function () { $this->log('parallelExecuteStart'); });
+        $dispatcher->addListener(ParallelExecutionEvents::EXECUTE_END, $this->events['PE_ExEnd'] = function () { $this->log('parallelExecuteEnd'); });
+
+        $this->start = hrtime(true);
+    }
+
+    /**
+     * Plugin cleanup function.
+     *
+     * Unregister event listeners.
+     */
+    public function deinitPlugin()
+    {
+        $dispatcher = $this->client->getEventDispatcher();
+        $dispatcher->removeListener(Events::PRE_CREATE_REQUEST, $this->events['preCrReq']);
+        $dispatcher->removeListener(Events::POST_CREATE_REQUEST, $this->events['postCrReq']);
+        $dispatcher->removeListener(Events::PRE_EXECUTE_REQUEST, $this->events['preExReq']);
+        $dispatcher->removeListener(Events::POST_EXECUTE_REQUEST, $this->events['postExReq']);
+        $dispatcher->removeListener(Events::PRE_CREATE_RESULT, $this->events['preCrRes']);
+        $dispatcher->removeListener(Events::POST_CREATE_RESULT, $this->events['postCrRes']);
+        $dispatcher->removeListener(Events::PRE_EXECUTE, $this->events['preEx']);
+        $dispatcher->removeListener(Events::POST_EXECUTE, $this->events['postEx']);
+        $dispatcher->removeListener(Events::PRE_CREATE_QUERY, $this->events['preCrQ']);
+        $dispatcher->removeListener(Events::POST_CREATE_QUERY, $this->events['postCrQ']);
+        $dispatcher->removeListener(ParallelExecutionEvents::EXECUTE_START, $this->events['PE_ExStart']);
+        $dispatcher->removeListener(ParallelExecutionEvents::EXECUTE_END, $this->events['PE_ExEnd']);
     }
 
     /**

--- a/tests/Plugin/BufferedAdd/BufferedAddLiteTest.php
+++ b/tests/Plugin/BufferedAdd/BufferedAddLiteTest.php
@@ -33,6 +33,14 @@ class BufferedAddLiteTest extends TestCase
         $this->plugin->initPlugin(TestClientFactory::createWithCurlAdapter(), []);
     }
 
+    public function testInitPlugin()
+    {
+        $client = TestClientFactory::createWithCurlAdapter();
+        $plugin = $client->getPlugin('bufferedaddlite');
+
+        $this->assertInstanceOf(BufferedAddLite::class, $plugin);
+    }
+
     public function testSetAndGetBufferSize()
     {
         $this->plugin->setBufferSize(500);

--- a/tests/Plugin/BufferedAdd/BufferedAddTest.php
+++ b/tests/Plugin/BufferedAdd/BufferedAddTest.php
@@ -5,6 +5,7 @@ namespace Solarium\Tests\Plugin\BufferedAdd;
 use Solarium\Plugin\BufferedAdd\BufferedAdd;
 use Solarium\Plugin\BufferedAdd\Event\AddDocument;
 use Solarium\QueryType\Update\Query\Document;
+use Solarium\Tests\Integration\TestClientFactory;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class BufferedAddTest extends BufferedAddLiteTest
@@ -18,6 +19,14 @@ class BufferedAddTest extends BufferedAddLiteTest
      * @var BufferedAdd
      */
     protected $plugin;
+
+    public function testInitPlugin()
+    {
+        $client = TestClientFactory::createWithCurlAdapter();
+        $plugin = $client->getPlugin('bufferedadd');
+
+        $this->assertInstanceOf(BufferedAdd::class, $plugin);
+    }
 
     public function testAddDocumentEventIsTriggered()
     {

--- a/tests/Plugin/BufferedDelete/BufferedDeleteLiteTest.php
+++ b/tests/Plugin/BufferedDelete/BufferedDeleteLiteTest.php
@@ -36,6 +36,14 @@ class BufferedDeleteLiteTest extends TestCase
         $this->plugin->initPlugin(TestClientFactory::createWithCurlAdapter(), []);
     }
 
+    public function testInitPlugin()
+    {
+        $client = TestClientFactory::createWithCurlAdapter();
+        $plugin = $client->getPlugin('buffereddeletelite');
+
+        $this->assertInstanceOf(BufferedDeleteLite::class, $plugin);
+    }
+
     public function testSetAndGetBufferSize()
     {
         $this->plugin->setBufferSize(500);

--- a/tests/Plugin/BufferedDelete/BufferedDeleteTest.php
+++ b/tests/Plugin/BufferedDelete/BufferedDeleteTest.php
@@ -7,6 +7,7 @@ use Solarium\Plugin\BufferedDelete\Delete\Id as DeleteById;
 use Solarium\Plugin\BufferedDelete\Delete\Query as DeleteQuery;
 use Solarium\Plugin\BufferedDelete\Event\AddDeleteById;
 use Solarium\Plugin\BufferedDelete\Event\AddDeleteQuery;
+use Solarium\Tests\Integration\TestClientFactory;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class BufferedDeleteTest extends BufferedDeleteLiteTest
@@ -20,6 +21,14 @@ class BufferedDeleteTest extends BufferedDeleteLiteTest
      * @var BufferedDelete
      */
     protected $plugin;
+
+    public function testInitPlugin()
+    {
+        $client = TestClientFactory::createWithCurlAdapter();
+        $plugin = $client->getPlugin('buffereddelete');
+
+        $this->assertInstanceOf(BufferedDelete::class, $plugin);
+    }
 
     public function testAddDeleteByIdEventIsTriggered()
     {

--- a/tests/Plugin/MinimumScoreFilter/MinimumScoreFilterTest.php
+++ b/tests/Plugin/MinimumScoreFilter/MinimumScoreFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Solarium\Tests\Plugin\CustomizeRequest;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Plugin\MinimumScoreFilter\MinimumScoreFilter;
+use Solarium\Plugin\MinimumScoreFilter\Query;
+use Solarium\Tests\Integration\TestClientFactory;
+
+class MinimumScoreFilterTest extends TestCase
+{
+    public function testInitPlugin()
+    {
+        $client = TestClientFactory::createWithCurlAdapter();
+        $plugin = $client->getPlugin('minimumscorefilter');
+
+        $this->assertInstanceOf(MinimumScoreFilter::class, $plugin);
+
+        $this->assertSame(
+            Query::class,
+            $client->getQueryTypes()[MinimumScoreFilter::QUERY_TYPE]
+        );
+    }
+}

--- a/tests/Plugin/ParallelExecution/ParallelExecutionTest.php
+++ b/tests/Plugin/ParallelExecution/ParallelExecutionTest.php
@@ -23,6 +23,14 @@ class ParallelExecutionTest extends TestCase
         $this->plugin = new ParallelExecution();
     }
 
+    public function testInitPlugin()
+    {
+        $client = TestClientFactory::createWithCurlAdapter();
+        $plugin = $client->getPlugin('parallelexecution');
+
+        $this->assertInstanceOf(ParallelExecution::class, $plugin);
+    }
+
     public function testInitPluginTypeKeepsCurlAdapter()
     {
         $client = TestClientFactory::createWithCurlAdapter();

--- a/tests/Plugin/PrefetchIteratorTest.php
+++ b/tests/Plugin/PrefetchIteratorTest.php
@@ -48,6 +48,14 @@ class PrefetchIteratorTest extends TestCase
         ];
     }
 
+    public function testInitPlugin()
+    {
+        $client = TestClientFactory::createWithCurlAdapter();
+        $plugin = $client->getPlugin('prefetchiterator');
+
+        $this->assertInstanceOf(PrefetchIterator::class, $plugin);
+    }
+
     public function testSetAndGetPrefetch()
     {
         $this->plugin->setPrefetch(120);

--- a/tests/QueryType/Extract/RequestBuilderTest.php
+++ b/tests/QueryType/Extract/RequestBuilderTest.php
@@ -70,6 +70,19 @@ class RequestBuilderTest extends TestCase
         );
     }
 
+    public function testGetUriWithInputEncoding()
+    {
+        $query = $this->query;
+        $query->setInputEncoding('iso-8859-1');
+        $query->setFile(__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Integration'.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'test iso-8859-1 ¡¢£¤¥¦§¨©ª«¬.xml');
+        $request = $this->builder->build($this->query);
+        $this->assertSame(
+            'update/extract?omitHeader=true&ie=iso-8859-1&param1=value1&wt=json&json.nl=flat&extractOnly=false&fmap.from-field=to-field'.
+            '&resource.name=test+iso-8859-1+%A1%A2%A3%A4%A5%A6%A7%A8%A9%AA%AB%AC.xml',
+            $request->getUri()
+        );
+    }
+
     public function testGetUriWithStreamUrl()
     {
         $query = $this->query;


### PR DESCRIPTION
Was writing an integration test for failover with Loadbalancer. One unreachable and one reachable endpoint. But even after removing the plugin, every subsequent integration test failed on the unreachable endpoint. The event listeners were still acting on every request. `unset()` in `Client::removePlugin()` doesn't destroy the plugin object as long as there are other references to it.

I've added `PluginInterface::deinitPlugin()` that will always be called by `Client::removePlugin()` just before `unset()`. Every one of our plugins that adds listeners overrides this method to remove those listeners. Examples were updated to demonstrate this to users who write their own plugins.

This means our integration tests have been running with plugins still active that were presumed to be removed. And until I added an invalid endpoint in the mix, it didn't cause any problems. That's a vote of confidence for our plugins!

On the other hand, it did hide a (very edge-casey) bug with extract queries and input encoding that was only present with plain GET requests and already mitigated by PostBigExtractRequest.

The fix can break existing code that relies on the event listeners still being active after deliberately removing the plugin. I would argue that you wrote broken code to begin with in that case.