### PR TITLE
RequestBuilders are responsible for setting the Content-Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Plugins unregister event listeners when removed with Client::removePlugin()
 
 ### Changed
+- `RequestBuilder`s must set a Content-Type on the `Request` for POST and PUT requests. `Adapter`s no longer set a default.
 
 ### Removed
 

--- a/src/Component/RequestBuilder/Analytics.php
+++ b/src/Component/RequestBuilder/Analytics.php
@@ -22,16 +22,6 @@ use Solarium\Core\ConfigurableInterface;
 class Analytics implements ComponentRequestBuilderInterface
 {
     /**
-     * Header name.
-     */
-    private const HEADER_NAME = 'Content-Type';
-
-    /**
-     * Content type.
-     */
-    private const HEADER_CONTENT = 'application/x-www-form-urlencoded';
-
-    /**
      * {@inheritdoc}
      *
      * @throws \RuntimeException
@@ -39,9 +29,10 @@ class Analytics implements ComponentRequestBuilderInterface
     public function buildComponent(ConfigurableInterface $component, Request $request): Request
     {
         $raw = sprintf('analytics=%s', json_encode($component));
-        $header = sprintf('%s: %s', self::HEADER_NAME, self::HEADER_CONTENT);
+        $header = sprintf('Content-Type: %s', Request::CONTENT_TYPE_APPLICATION_X_WWW_FORM_URLENCODED);
 
-        if (Request::METHOD_POST !== $request->getMethod()
+        if (
+            Request::METHOD_POST !== $request->getMethod()
             || (null === $data = $request->getRawData())
         ) {
             return $request
@@ -51,10 +42,11 @@ class Analytics implements ComponentRequestBuilderInterface
             ;
         }
 
-        if ((null !== $currentHeader = $request->getHeader(self::HEADER_NAME))
-            && false === strpos($currentHeader, self::HEADER_CONTENT)
+        if (
+            (null !== $currentHeader = $request->getHeader('Content-Type'))
+            && false === strpos($currentHeader, Request::CONTENT_TYPE_APPLICATION_X_WWW_FORM_URLENCODED)
         ) {
-            throw new \RuntimeException(sprintf('Unable to build analytics request. required content type is %s while current header is %s', self::HEADER_CONTENT, $header));
+            throw new \RuntimeException(sprintf('Unable to build analytics request. required content type is %s while current header is %s', Request::CONTENT_TYPE_APPLICATION_X_WWW_FORM_URLENCODED, $currentHeader));
         }
 
         // merge raw data currently present in the request

--- a/src/Core/Client/Adapter/AdapterHelper.php
+++ b/src/Core/Client/Adapter/AdapterHelper.php
@@ -58,7 +58,7 @@ class AdapterHelper
         $baseName = basename($request->getFileUpload());
         $body = "--{$request->getHash()}\r\n";
         $body .= 'Content-Disposition: form-data; name="file"; filename="'.$baseName.'"';
-        $body .= "\r\nContent-Type: application/octet-stream\r\n\r\n";
+        $body .= "\r\nContent-Type: ".Request::CONTENT_TYPE_APPLICATION_OCTET_STREAM."\r\n\r\n";
         $body .= file_get_contents($request->getFileUpload(), 'r');
         $body .= "\r\n--{$request->getHash()}--\r\n";
 

--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -97,16 +97,6 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
             curl_setopt($handler, CURLOPT_PROXY, $options['proxy']);
         }
 
-        if (!isset($options['headers']['Content-Type'])) {
-            $charset = $request->getParam('ie') ?? 'utf-8';
-
-            if (Request::METHOD_GET === $method) {
-                $options['headers']['Content-Type'] = 'application/x-www-form-urlencoded; charset='.$charset;
-            } else {
-                $options['headers']['Content-Type'] = 'application/xml; charset='.$charset;
-            }
-        }
-
         // Try endpoint authentication first, fallback to request for backwards compatibility
         $authData = $endpoint->getAuthentication();
         if (empty($authData['username'])) {
@@ -118,7 +108,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
             curl_setopt($handler, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
         }
 
-        if (\count($options['headers'])) {
+        if (0 !== \count($options['headers'] ?? [])) {
             $headers = [];
             foreach ($options['headers'] as $key => $value) {
                 $headers[] = $key.': '.$value;
@@ -241,7 +231,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
         ];
         foreach ($request->getHeaders() as $headerLine) {
             list($header, $value) = explode(':', $headerLine);
-            if ($header = trim($header)) {
+            if ('' !== $header = trim($header)) {
                 $options['headers'][$header] = trim($value);
             }
         }

--- a/src/Core/Client/Adapter/Http.php
+++ b/src/Core/Client/Adapter/Http.php
@@ -109,7 +109,7 @@ class Http implements AdapterInterface, TimeoutAwareInterface, ProxyAwareInterfa
                 $data = AdapterHelper::buildUploadBodyFromRequest($request);
 
                 $contentLength = \strlen($data);
-                $request->addHeader("Content-Length: $contentLength\r\n");
+                $request->addHeader("Content-Length: $contentLength");
                 stream_context_set_option(
                     $context,
                     'http',
@@ -125,9 +125,6 @@ class Http implements AdapterInterface, TimeoutAwareInterface, ProxyAwareInterfa
                         'content',
                         $data
                     );
-
-                    $charset = $request->getParam('ie') ?? 'utf-8';
-                    $request->addHeader('Content-Type: text/xml; charset='.$charset);
                 }
             }
         } elseif (Request::METHOD_PUT === $method) {
@@ -139,7 +136,6 @@ class Http implements AdapterInterface, TimeoutAwareInterface, ProxyAwareInterfa
                     'content',
                     $data
                 );
-                $request->addHeader('Content-Type: application/json; charset=utf-8');
                 // The stream context automatically adds a "Connection: close" header which fails on Solr 8.5.0
                 $request->addHeader('Connection: Keep-Alive');
             }

--- a/src/Core/Client/Adapter/Psr18Adapter.php
+++ b/src/Core/Client/Adapter/Psr18Adapter.php
@@ -156,18 +156,8 @@ final class Psr18Adapter implements AdapterInterface
 
         foreach ($request->getHeaders() as $headerLine) {
             list($header, $value) = explode(':', $headerLine);
-            if ($header = trim($header)) {
+            if ('' !== $header = trim($header)) {
                 $headers[$header][] = $value;
-            }
-        }
-
-        if (!isset($headers['Content-Type'])) {
-            $charset = $request->getParam('ie') ?? 'utf-8';
-
-            if (Request::METHOD_GET === $request->getMethod()) {
-                $headers['Content-Type'] = ['application/x-www-form-urlencoded; charset='.$charset];
-            } else {
-                $headers['Content-Type'] = ['application/xml; charset='.$charset];
             }
         }
 

--- a/src/Core/Client/Request.php
+++ b/src/Core/Client/Request.php
@@ -47,6 +47,36 @@ class Request extends Configurable implements RequestParamsInterface
     const METHOD_PUT = 'PUT';
 
     /**
+     * Content-Type for JSON payloads.
+     */
+    const CONTENT_TYPE_APPLICATION_JSON = 'application/json';
+
+    /**
+     * Content-Type for arbitrary binary data.
+     */
+    const CONTENT_TYPE_APPLICATION_OCTET_STREAM = 'application/octet-stream';
+
+    /**
+     * Content-Type for percent-encoded name-value pairs.
+     */
+    const CONTENT_TYPE_APPLICATION_X_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded';
+
+    /**
+     * Content-Type for XML payloads.
+     */
+    const CONTENT_TYPE_APPLICATION_XML = 'application/xml';
+
+    /**
+     * Content-Type for multipart data streams.
+     */
+    const CONTENT_TYPE_MULTIPART_FORM_DATA = 'multipart/form-data';
+
+    /**
+     * Content-Type for plaintext payloads.
+     */
+    const CONTENT_TYPE_TEXT_PLAIN = 'text/plain';
+
+    /**
      * V1 API.
      */
     const API_V1 = 'v1';
@@ -88,7 +118,16 @@ class Request extends Configurable implements RequestParamsInterface
      */
     public function __toString()
     {
-        $output = __CLASS__.'::__toString'."\n".'method: '.$this->getMethod()."\n".'header: '.print_r($this->getHeaders(), true).'authentication: '.print_r($this->getAuthentication(), true).'resource: '.$this->getUri()."\n".'resource urldecoded: '.urldecode($this->getUri())."\n".'raw data: '.$this->getRawData()."\n".'file upload: '.$this->getFileUpload()."\n";
+        $output =
+            __CLASS__.'::__toString'."\n"
+            .'method: '.$this->getMethod()."\n"
+            .'header: '.print_r($this->getHeaders(), true)
+            .'authentication: '.print_r($this->getAuthentication(), true)
+            .'resource: '.$this->getUri()."\n"
+            .'resource urldecoded: '.urldecode($this->getUri())."\n"
+            .'raw data: '.$this->getRawData()."\n"
+            .'file upload: '.$this->getFileUpload()."\n"
+        ;
 
         return $output;
     }
@@ -120,7 +159,7 @@ class Request extends Configurable implements RequestParamsInterface
     /**
      * Set request method.
      *
-     * Use one of the constants as value
+     * Use one of the METHOD_* constants as value.
      *
      * @param string $method
      *
@@ -141,6 +180,63 @@ class Request extends Configurable implements RequestParamsInterface
     public function getMethod(): ?string
     {
         return $this->getOption('method');
+    }
+
+    /**
+     * Set request Content-Type.
+     *
+     * Use one of the CONTENT_TYPE_* constants as value.
+     *
+     * Content-Type parameters can be passed in $params or set with {@see setContentTypeParams()}.
+     *
+     * @param string|null $contentType
+     * @param array|null  $params
+     *
+     * @return self Provides fluent interface
+     */
+    public function setContentType(?string $contentType, ?array $params = null): self
+    {
+        $this->setOption('contenttype', $contentType);
+
+        if (null !== $params) {
+            $this->setOption('contenttypeparams', $params);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get request Content-Type.
+     *
+     * @return string|null
+     */
+    public function getContentType(): ?string
+    {
+        return $this->getOption('contenttype');
+    }
+
+    /**
+     * Set Content-Type parameters.
+     *
+     * @param array|null $params
+     *
+     * @return self Provides fluent interface
+     */
+    public function setContentTypeParams(?array $params): self
+    {
+        $this->setOption('contenttypeparams', $params);
+
+        return $this;
+    }
+
+    /**
+     * Get Content-Type parameters.
+     *
+     * @return array|null
+     */
+    public function getContentTypeParams(): ?array
+    {
+        return $this->getOption('contenttypeparams');
     }
 
     /**
@@ -206,7 +302,27 @@ class Request extends Configurable implements RequestParamsInterface
      */
     public function getHeaders(): array
     {
-        return array_unique($this->headers);
+        $headers = array_unique($this->headers);
+
+        if (
+            null === $this->getHeader('Content-Type')
+            && (null !== $contentType = $this->getContentType())
+        ) {
+            $contentTypeHeader = sprintf('Content-Type: %s', $contentType);
+
+            if (null !== $contentTypeParams = $this->getContentTypeParams()) {
+                foreach ($contentTypeParams as $param => $value) {
+                    $contentTypeHeader .= sprintf('; %s=%s', $param, $value);
+                }
+            } else {
+                $charset = $this->getParam('ie') ?? 'utf-8';
+                $contentTypeHeader .= sprintf('; charset=%s', $charset);
+            }
+
+            $headers[] = $contentTypeHeader;
+        }
+
+        return $headers;
     }
 
     /**
@@ -375,6 +491,8 @@ class Request extends Configurable implements RequestParamsInterface
     /**
      * Set Solr API version.
      *
+     * Use one of the API_* constants as value.
+     *
      * @param string $api
      *
      * @return self Provides fluent interface
@@ -427,6 +545,7 @@ class Request extends Configurable implements RequestParamsInterface
                     if (isset($value['username'], $value['password'])) {
                         $this->setAuthentication($value['username'], $value['password']);
                     }
+                    break;
             }
         }
     }

--- a/src/Plugin/PostBigExtractRequest.php
+++ b/src/Plugin/PostBigExtractRequest.php
@@ -10,6 +10,7 @@
 namespace Solarium\Plugin;
 
 use Solarium\Core\Client\Adapter\AdapterHelper;
+use Solarium\Core\Client\Request;
 use Solarium\Core\Event\Events;
 use Solarium\Core\Event\PostCreateRequest as PostCreateRequestEvent;
 use Solarium\Core\Plugin\AbstractPlugin;
@@ -81,7 +82,7 @@ class PostBigExtractRequest extends AbstractPlugin
                     if (is_iterable($value)) {
                         foreach ($value as $arrayVal) {
                             if (\is_string($arrayVal)) {
-                                $additionalBodyHeader = "\r\nContent-Type: text/plain;charset={$charset}";
+                                $additionalBodyHeader = sprintf("\r\nContent-Type: %s;charset=%s", Request::CONTENT_TYPE_TEXT_PLAIN, $charset);
                             } else {
                                 $additionalBodyHeader = '';
                             }
@@ -94,7 +95,7 @@ class PostBigExtractRequest extends AbstractPlugin
                         }
                     } else {
                         if (\is_string($value)) {
-                            $additionalBodyHeader = "\r\nContent-Type: text/plain;charset={$charset}";
+                            $additionalBodyHeader = sprintf("\r\nContent-Type: %s;charset=%s", Request::CONTENT_TYPE_TEXT_PLAIN, $charset);
                         } else {
                             $additionalBodyHeader = '';
                         }

--- a/src/Plugin/PostBigRequest.php
+++ b/src/Plugin/PostBigRequest.php
@@ -69,18 +69,20 @@ class PostBigRequest extends AbstractPlugin
     public function preExecuteRequest($event): self
     {
         // We need to accept event proxies or decorators.
-        /* @var PreExecuteRequest $event */
+        /** @var PreExecuteRequest $event */
         $request = $event->getRequest();
         $queryString = $request->getQueryString();
 
-        if (Request::METHOD_GET === $request->getMethod() &&
-            \strlen($queryString) > $this->getMaxQueryStringLength()) {
+        if (
+            Request::METHOD_GET === $request->getMethod()
+            && \strlen($queryString) > $this->getMaxQueryStringLength()
+        ) {
             $charset = $request->getParam('ie') ?? 'utf-8';
 
             $request->setMethod(Request::METHOD_POST);
+            $request->setContentType(Request::CONTENT_TYPE_APPLICATION_X_WWW_FORM_URLENCODED, ['charset' => $charset]);
             $request->setRawData($queryString);
             $request->clearParams();
-            $request->addHeader('Content-Type: application/x-www-form-urlencoded; charset='.$charset);
         }
 
         return $this;

--- a/src/QueryType/Analysis/RequestBuilder/Document.php
+++ b/src/QueryType/Analysis/RequestBuilder/Document.php
@@ -32,6 +32,7 @@ class Document extends BaseRequestBuilder
         $request = parent::build($query);
         $request->setRawData($this->getRawData($query));
         $request->setMethod(Request::METHOD_POST);
+        $request->setContentType(Request::CONTENT_TYPE_APPLICATION_XML);
 
         return $request;
     }

--- a/src/QueryType/Extract/RequestBuilder.php
+++ b/src/QueryType/Extract/RequestBuilder.php
@@ -32,7 +32,6 @@ class RequestBuilder extends BaseRequestBuilder
     public function build(AbstractQuery $query): Request
     {
         $request = parent::build($query);
-        $request->setMethod(Request::METHOD_POST);
 
         // add common options to request
         $request->addParam('commit', $query->getCommit());
@@ -50,7 +49,7 @@ class RequestBuilder extends BaseRequestBuilder
 
         // add document settings to request
         /** @var \Solarium\QueryType\Update\Query\Document $doc */
-        if (null !== ($doc = $query->getDocument())) {
+        if (null !== $doc = $query->getDocument()) {
             if (null !== $doc->getBoost()) {
                 throw new RuntimeException('Extract does not support document-level boosts, use field boosts instead.');
             }
@@ -84,7 +83,8 @@ class RequestBuilder extends BaseRequestBuilder
             }
             $request->setFileUpload($file);
             $request->addParam('resource.name', $resourceName);
-            $request->addHeader('Content-Type: multipart/form-data; boundary='.$request->getHash());
+            $request->setMethod(Request::METHOD_POST);
+            $request->setContentType(Request::CONTENT_TYPE_MULTIPART_FORM_DATA, ['boundary' => $request->getHash()]);
         } else {
             throw new RuntimeException(sprintf('Extract query file path/url invalid or not available: %s', $file));
         }

--- a/src/QueryType/ManagedResources/RequestBuilder/Resource.php
+++ b/src/QueryType/ManagedResources/RequestBuilder/Resource.php
@@ -40,7 +40,7 @@ class Resource extends AbstractRequestBuilder
         // reserved characters in a REST resource name need to be encoded twice to make it through the servlet (SOLR-6853)
         $request->setHandler($query->getHandler().rawurlencode(rawurlencode($query->getName())));
         if (null !== $query->getCommand()) {
-            $request->addHeader('Content-Type: application/json; charset=utf-8');
+            $request->setContentType(Request::CONTENT_TYPE_APPLICATION_JSON);
             $this->buildCommand($request, $query->getCommand());
         } else {
             // Lists one or all items.

--- a/src/QueryType/MoreLikeThis/RequestBuilder.php
+++ b/src/QueryType/MoreLikeThis/RequestBuilder.php
@@ -48,12 +48,10 @@ class RequestBuilder extends SelectRequestBuilder
 
         // convert query to stream if necessary
         if (true === $query->getQueryStream()) {
-            $charset = $request->getParam('ie') ?? 'utf-8';
-
             $request->removeParam('q');
             $request->setRawData($query->getQuery());
             $request->setMethod(Request::METHOD_POST);
-            $request->addHeader('Content-Type: text/plain; charset='.$charset);
+            $request->setContentType(Request::CONTENT_TYPE_TEXT_PLAIN);
         }
 
         return $request;

--- a/src/QueryType/Server/Api/Query.php
+++ b/src/QueryType/Server/Api/Query.php
@@ -114,27 +114,60 @@ class Query extends AbstractQuery
     }
 
     /**
-     * Set contenttype option.
+     * Set request Content-Type.
      *
-     * @param string $contentType
+     * Use one of the Request::CONTENT_TYPE_* constants as value.
+     *
+     * Content-Type parameters can be passed in $params or set with {@see setContentTypeParams()}.
+     *
+     * @param string|null $contentType
+     * @param array|null  $params
      *
      * @return self Provides fluent interface
      */
-    public function setContentType(string $contentType): self
+    public function setContentType(?string $contentType, ?array $params = null): self
     {
         $this->setOption('contenttype', $contentType);
+
+        if (null !== $params) {
+            $this->setOption('contenttypeparams', $params);
+        }
 
         return $this;
     }
 
     /**
-     * Get contenttype option.
+     * Get request Content-Type.
      *
      * @return string|null
      */
     public function getContentType(): ?string
     {
         return $this->getOption('contenttype');
+    }
+
+    /**
+     * Set Content-Type parameters.
+     *
+     * @param array|null $params
+     *
+     * @return self Provides fluent interface
+     */
+    public function setContentTypeParams(?array $params): self
+    {
+        $this->setOption('contenttypeparams', $params);
+
+        return $this;
+    }
+
+    /**
+     * Get Content-Type parameters.
+     *
+     * @return array|null
+     */
+    public function getContentTypeParams(): ?array
+    {
+        return $this->getOption('contenttypeparams');
     }
 
     /**

--- a/src/QueryType/Server/Api/RequestBuilder.php
+++ b/src/QueryType/Server/Api/RequestBuilder.php
@@ -31,15 +31,23 @@ class RequestBuilder extends BaseRequestBuilder
     {
         $request = parent::build($query);
 
-        $request->setMethod($query->getMethod());
+        $method = $query->getMethod();
+
+        $request->setMethod($method);
         $request->setApi($query->getVersion());
         $request->setIsServerRequest(true);
 
+        if (null !== $contentType = $query->getContentType()) {
+            $request->setContentType($query->getContentType());
+        } elseif (Request::METHOD_POST === $method) {
+            $request->setContentType(Request::CONTENT_TYPE_APPLICATION_JSON);
+        } elseif (Request::METHOD_PUT === $method) {
+            $request->setContentType(Request::CONTENT_TYPE_APPLICATION_OCTET_STREAM);
+        }
+        $request->setContentTypeParams($query->getContentTypeParams());
+
         if ($accept = $query->getAccept()) {
             $request->addHeader('Accept: '.$accept);
-        }
-        if ($contentType = $query->getContentType()) {
-            $request->addHeader('Content-Type: '.$contentType);
         }
         if ($rawData = $query->getRawData()) {
             $request->setRawData($rawData);

--- a/src/QueryType/Server/Configsets/RequestBuilder.php
+++ b/src/QueryType/Server/Configsets/RequestBuilder.php
@@ -34,7 +34,7 @@ class RequestBuilder extends ServerRequestBuilder
         if ($action instanceof Upload) {
             $request->setMethod(Request::METHOD_POST);
             $request->setFileUpload($action->getFile());
-            $request->addHeader('Content-Type: multipart/form-data; boundary='.$request->getHash());
+            $request->setContentType(Request::CONTENT_TYPE_MULTIPART_FORM_DATA, ['boundary' => $request->getHash()]);
         }
 
         return $request;

--- a/src/QueryType/Stream/RequestBuilder.php
+++ b/src/QueryType/Stream/RequestBuilder.php
@@ -27,13 +27,11 @@ class RequestBuilder implements RequestBuilderInterface
      */
     public function build(AbstractQuery $query): Request
     {
-        $charset = $query->getInputEncoding('ie') ?? 'utf-8';
-
         $request = new Request();
         $request->setHandler($query->getHandler());
+        $request->setContentType(Request::CONTENT_TYPE_TEXT_PLAIN);
         $request->addParam('expr', $query->getExpression());
         $request->addParams($query->getParams());
-        $request->addHeader('Content-Type: text/plain; charset='.$charset);
 
         return $request;
     }

--- a/src/QueryType/Update/RequestBuilder.php
+++ b/src/QueryType/Update/RequestBuilder.php
@@ -38,6 +38,7 @@ class RequestBuilder extends BaseRequestBuilder
     {
         $request = parent::build($query);
         $request->setMethod(Request::METHOD_POST);
+        $request->setContentType(Request::CONTENT_TYPE_APPLICATION_XML);
         $request->setRawData($this->getRawData($query));
 
         return $request;

--- a/tests/Component/RequestBuilder/AnalyticsTest.php
+++ b/tests/Component/RequestBuilder/AnalyticsTest.php
@@ -31,7 +31,15 @@ class AnalyticsTest extends TestCase
 
         $request = $builder->buildComponent($component, $request);
 
-        $this->assertSame(Request::METHOD_POST, $request->getMethod());
+        $this->assertSame(
+            Request::METHOD_POST,
+            $request->getMethod()
+        );
+        $this->assertSame(
+            sprintf('Content-Type: %s', Request::CONTENT_TYPE_APPLICATION_X_WWW_FORM_URLENCODED),
+            $request->getHeader('Content-Type')
+        );
+
         parse_str($request->getRawData(), $data);
 
         $this->assertArrayHasKey('analytics', $data);
@@ -62,7 +70,15 @@ class AnalyticsTest extends TestCase
 
         $request = $builder->buildComponent($component, $request);
 
-        $this->assertSame(Request::METHOD_POST, $request->getMethod());
+        $this->assertSame(
+            Request::METHOD_POST,
+            $request->getMethod()
+        );
+        $this->assertSame(
+            sprintf('Content-Type: %s', Request::CONTENT_TYPE_APPLICATION_X_WWW_FORM_URLENCODED),
+            $request->getHeader('Content-Type')
+        );
+
         parse_str($request->getRawData(), $data);
 
         $this->assertArrayHasKey('analytics', $data);

--- a/tests/Core/Client/Adapter/AdapterHelperTest.php
+++ b/tests/Core/Client/Adapter/AdapterHelperTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Solarium\Tests\Core\Client\Adapter;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Adapter\AdapterHelper;
+use Solarium\Core\Client\Endpoint;
+use Solarium\Core\Client\Request;
+use Solarium\Exception\HttpException;
+
+class AdapterHelperTest extends TestCase
+{
+    /**
+     * @var Endpoint
+     */
+    protected $endpoint;
+
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    public function setUp(): void
+    {
+        $this->endpoint = new Endpoint();
+        $this->endpoint->setScheme('scheme');
+        $this->endpoint->setHost('example.org');
+        $this->endpoint->setPort(1701);
+        $this->endpoint->setPath('/testpath/');
+        $this->endpoint->setContext('index');
+
+        $this->request = new Request();
+        $this->request->setHandler('test');
+        $this->request->addParam('foo', 'bar');
+    }
+
+    public function testBuildUriWithCore()
+    {
+        $this->endpoint->setCore('testcore');
+
+        $uri = AdapterHelper::buildUri($this->request, $this->endpoint);
+
+        $this->assertSame('scheme://example.org:1701/testpath/index/testcore/test?foo=bar', $uri);
+    }
+
+    public function testBuildUriWithCollection()
+    {
+        $this->endpoint->setCollection('testcollection');
+
+        $uri = AdapterHelper::buildUri($this->request, $this->endpoint);
+
+        $this->assertSame('scheme://example.org:1701/testpath/index/testcollection/test?foo=bar', $uri);
+    }
+
+    public function testBuildUriApiV1()
+    {
+        $this->request->setIsServerRequest(true);
+        $this->request->setApi(Request::API_V1);
+
+        $uri = AdapterHelper::buildUri($this->request, $this->endpoint);
+
+        $this->assertSame('scheme://example.org:1701/testpath/index/test?foo=bar', $uri);
+    }
+
+    public function testBuildUriApiV2()
+    {
+        $this->request->setIsServerRequest(true);
+        $this->request->setApi(Request::API_V2);
+
+        $uri = AdapterHelper::buildUri($this->request, $this->endpoint);
+
+        $this->assertSame('scheme://example.org:1701/testpath/api/test?foo=bar', $uri);
+    }
+
+    public function testBuildUriWithInvalidBaseUri()
+    {
+        $this->expectException(HttpException::class);
+        AdapterHelper::buildUri($this->request, $this->endpoint);
+    }
+
+    public function testBuildUploadBodyFromRequest(): void
+    {
+        $tmpfname = tempnam(sys_get_temp_dir(), 'tst');
+        file_put_contents($tmpfname, 'Test file contents');
+
+        $expectedBodyRegex = <<<'REGEX'
+~^--([[:xdigit:]]{32})\r\n
+Content-Disposition:\ form-data;\ name="file";\ filename="tst.+?"\r\n
+Content-Type:\ application/octet-stream\r\n
+\r\n
+Test\ file\ contents\r\n
+--\1--\r\n
+$~xD
+REGEX;
+
+        $this->request->setMethod(Request::METHOD_POST);
+        $this->request->setFileUpload($tmpfname);
+
+        $body = AdapterHelper::buildUploadBodyFromRequest($this->request);
+
+        $this->assertMatchesRegularExpression($expectedBodyRegex, $body);
+    }
+}

--- a/tests/Core/Client/Adapter/CurlTest.php
+++ b/tests/Core/Client/Adapter/CurlTest.php
@@ -65,18 +65,18 @@ class CurlTest extends TestCase
     {
         $data = 'data';
         $headers = ['X-dummy: data'];
-        $handler = curl_init();
+        $handle = curl_init();
 
         // this should be ok, no exception
-        $this->adapter->check($data, $headers, $handler);
+        $this->adapter->check($data, $headers, $handle);
 
         $data = '';
         $headers = [];
 
         $this->expectException(HttpException::class);
-        $this->adapter->check($data, $headers, $handler);
+        $this->adapter->check($data, $headers, $handle);
 
-        curl_close($handler);
+        curl_close($handle);
     }
 
     public function testExecute()
@@ -104,6 +104,24 @@ class CurlTest extends TestCase
     }
 
     /**
+     * @testWith [false]
+     *           [null]
+     *
+     * @param mixed $httpResponse
+     */
+    public function testGetResponseWithEmptyHttpResponse($httpResponse)
+    {
+        $handle = curl_init();
+
+        $this->expectException(HttpException::class);
+        $response = $this->adapter->getResponse($handle, $httpResponse);
+
+        curl_close($handle);
+
+        $this->assertEquals(new Response('', []), $response);
+    }
+
+    /**
      * @dataProvider methodProvider
      */
     public function testCreateHandleForRequestMethod(string $method)
@@ -113,14 +131,15 @@ class CurlTest extends TestCase
         $request->setIsServerRequest(true);
         $endpoint = new Endpoint();
 
-        $handler = $this->adapter->createHandle($request, $endpoint);
+        $handle = $this->adapter->createHandle($request, $endpoint);
 
         if (class_exists(\CurlHandle::class)) {
-            $this->assertInstanceOf(\CurlHandle::class, $handler);
+            $this->assertInstanceOf(\CurlHandle::class, $handle);
         } else {
-            $this->assertIsResource($handler);
+            $this->assertIsResource($handle);
         }
-        curl_close($handler);
+
+        curl_close($handle);
     }
 
     public function methodProvider(): array
@@ -143,8 +162,8 @@ class CurlTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('unsupported method: PSOT');
-        $handler = $this->adapter->createHandle($request, $endpoint);
+        $handle = $this->adapter->createHandle($request, $endpoint);
 
-        curl_close($handler);
+        curl_close($handle);
     }
 }

--- a/tests/Core/Client/Adapter/CurlTest.php
+++ b/tests/Core/Client/Adapter/CurlTest.php
@@ -153,6 +153,28 @@ class CurlTest extends TestCase
         ];
     }
 
+    public function testCreateHandleForPostRequestWithFileUpload()
+    {
+        $tmpfname = tempnam(sys_get_temp_dir(), 'tst');
+        file_put_contents($tmpfname, 'Test file contents');
+
+        $request = new Request();
+        $request->setMethod(Request::METHOD_POST);
+        $request->setFileUpload($tmpfname);
+        $request->setIsServerRequest(true);
+        $endpoint = new Endpoint();
+
+        $handle = $this->adapter->createHandle($request, $endpoint);
+
+        if (class_exists(\CurlHandle::class)) {
+            $this->assertInstanceOf(\CurlHandle::class, $handle);
+        } else {
+            $this->assertIsResource($handle);
+        }
+
+        curl_close($handle);
+    }
+
     public function testCreateHandleWithUnknownMethod()
     {
         $request = new Request();

--- a/tests/Core/Client/Adapter/HttpTest.php
+++ b/tests/Core/Client/Adapter/HttpTest.php
@@ -140,39 +140,6 @@ class HttpTest extends TestCase
         );
     }
 
-    public function testCreateContextWithHeaders()
-    {
-        $timeout = 13;
-        $method = Request::METHOD_HEAD;
-        $header1 = 'X-MyHeader-1: dummyvalue 1';
-        $header2 = 'X-MyHeader-2: dummyvalue 2';
-
-        $request = new Request();
-        $request->setMethod($method);
-        $request->setContentType(Request::CONTENT_TYPE_TEXT_PLAIN);
-        $request->addHeader($header1);
-        $request->addHeader($header2);
-        $request->setIsServerRequest(true);
-        $endpoint = new Endpoint();
-        $this->adapter->setTimeout($timeout);
-
-        $context = $this->adapter->createContext($request, $endpoint);
-
-        $this->assertSame(
-            [
-                'http' => [
-                    'method' => $method,
-                    'timeout' => $timeout,
-                    'protocol_version' => 1.0,
-                    'user_agent' => 'Solarium Http Adapter',
-                    'ignore_errors' => true,
-                    'header' => $header1."\r\n".$header2."\r\n".'Content-Type: text/plain; charset=utf-8',
-                ],
-            ],
-            stream_context_get_options($context)
-        );
-    }
-
     public function testCreateContextPostRequest()
     {
         $timeout = 13;
@@ -273,6 +240,66 @@ class HttpTest extends TestCase
         );
     }
 
+    public function testCreateContextDeleteRequest()
+    {
+        $timeout = 22;
+        $method = Request::METHOD_DELETE;
+
+        $request = new Request();
+        $request->setMethod($method);
+        $request->setIsServerRequest(true);
+        $endpoint = new Endpoint();
+        $this->adapter->setTimeout($timeout);
+
+        $context = $this->adapter->createContext($request, $endpoint);
+
+        $this->assertSame(
+            [
+                'http' => [
+                    'method' => $method,
+                    'timeout' => $timeout,
+                    'protocol_version' => 1.0,
+                    'user_agent' => 'Solarium Http Adapter',
+                    'ignore_errors' => true,
+                ],
+            ],
+            stream_context_get_options($context)
+        );
+    }
+
+    public function testCreateContextWithHeaders()
+    {
+        $timeout = 13;
+        $method = Request::METHOD_HEAD;
+        $header1 = 'X-MyHeader-1: dummyvalue 1';
+        $header2 = 'X-MyHeader-2: dummyvalue 2';
+
+        $request = new Request();
+        $request->setMethod($method);
+        $request->setContentType(Request::CONTENT_TYPE_TEXT_PLAIN);
+        $request->addHeader($header1);
+        $request->addHeader($header2);
+        $request->setIsServerRequest(true);
+        $endpoint = new Endpoint();
+        $this->adapter->setTimeout($timeout);
+
+        $context = $this->adapter->createContext($request, $endpoint);
+
+        $this->assertSame(
+            [
+                'http' => [
+                    'method' => $method,
+                    'timeout' => $timeout,
+                    'protocol_version' => 1.0,
+                    'user_agent' => 'Solarium Http Adapter',
+                    'ignore_errors' => true,
+                    'header' => $header1."\r\n".$header2."\r\n".'Content-Type: text/plain; charset=utf-8',
+                ],
+            ],
+            stream_context_get_options($context)
+        );
+    }
+
     public function testCreateContextWithAuthorization()
     {
         $timeout = 13;
@@ -329,33 +356,6 @@ class HttpTest extends TestCase
                     'ignore_errors' => true,
                     'proxy' => $proxy,
                     'request_fulluri' => true,
-                ],
-            ],
-            stream_context_get_options($context)
-        );
-    }
-
-    public function testCreateContextDeleteRequest()
-    {
-        $timeout = 22;
-        $method = Request::METHOD_DELETE;
-
-        $request = new Request();
-        $request->setMethod($method);
-        $request->setIsServerRequest(true);
-        $endpoint = new Endpoint();
-        $this->adapter->setTimeout($timeout);
-
-        $context = $this->adapter->createContext($request, $endpoint);
-
-        $this->assertSame(
-            [
-                'http' => [
-                    'method' => $method,
-                    'timeout' => $timeout,
-                    'protocol_version' => 1.0,
-                    'user_agent' => 'Solarium Http Adapter',
-                    'ignore_errors' => true,
                 ],
             ],
             stream_context_get_options($context)

--- a/tests/Core/Client/Adapter/Psr18AdapterTest.php
+++ b/tests/Core/Client/Adapter/Psr18AdapterTest.php
@@ -27,7 +27,6 @@ class Psr18AdapterTest extends TestCase
                 $this->assertSame([
                     'Host' => ['127.0.0.1:8983'],
                     'X-Request-Header' => ['some value', 'and another one'],
-                    'Content-Type' => ['application/x-www-form-urlencoded; charset=utf-8'],
                 ], $request->getHeaders());
 
                 return true;
@@ -63,7 +62,7 @@ class Psr18AdapterTest extends TestCase
                 $this->assertSame('some data', (string) $request->getBody());
                 $this->assertSame([
                     'Host' => ['127.0.0.1:8983'],
-                    'Content-Type' => ['application/xml; charset=utf-8'],
+                    'Content-Type' => ['application/xml; charset=us-ascii'],
                 ], $request->getHeaders());
 
                 return true;
@@ -76,6 +75,8 @@ class Psr18AdapterTest extends TestCase
 
         $request = new Request();
         $request->setMethod(Request::METHOD_POST);
+        $request->setContentType(Request::CONTENT_TYPE_APPLICATION_XML);
+        $request->addParam('ie', 'us-ascii', true);
         $request->setRawData('some data');
         $request->setIsServerRequest(true);
 
@@ -107,7 +108,6 @@ REGEX;
                 $this->assertMatchesRegularExpression($expectedBodyRegex, (string) $request->getBody());
                 $this->assertSame([
                     'Host' => ['127.0.0.1:8983'],
-                    'Content-Type' => ['application/xml; charset=utf-8'],
                 ], $request->getHeaders());
 
                 return true;
@@ -138,7 +138,7 @@ REGEX;
                 $this->assertSame('some data', (string) $request->getBody());
                 $this->assertSame([
                     'Host' => ['127.0.0.1:8983'],
-                    'Content-Type' => ['application/xml; charset=utf-8'],
+                    'Content-Type' => ['application/json; charset=utf-8'],
                 ], $request->getHeaders());
 
                 return true;
@@ -151,6 +151,7 @@ REGEX;
 
         $request = new Request();
         $request->setMethod(Request::METHOD_PUT);
+        $request->setContentType(Request::CONTENT_TYPE_APPLICATION_JSON);
         $request->setRawData('some data');
         $request->setIsServerRequest(true);
 

--- a/tests/Core/Client/RequestTest.php
+++ b/tests/Core/Client/RequestTest.php
@@ -21,8 +21,10 @@ class RequestTest extends TestCase
     public function testConfigMode()
     {
         $options = [
-            'method' => Request::METHOD_POST,
             'handler' => 'myHandler',
+            'method' => Request::METHOD_POST,
+            'contenttype' => 'example/test',
+            'contenttypeparams' => ['param' => 'value'],
             'param' => [
                 'param1' => 1,
                 'param2' => 'test',
@@ -41,13 +43,23 @@ class RequestTest extends TestCase
         $this->request->setOptions($options);
 
         $this->assertSame(
+            $options['handler'],
+            $this->request->getHandler()
+        );
+
+        $this->assertSame(
             $options['method'],
             $this->request->getMethod()
         );
 
         $this->assertSame(
-            $options['handler'],
-            $this->request->getHandler()
+            $options['contenttype'],
+            $this->request->getContentType()
+        );
+
+        $this->assertSame(
+            $options['contenttypeparams'],
+            $this->request->getContentTypeParams()
         );
 
         $this->assertSame(
@@ -56,14 +68,15 @@ class RequestTest extends TestCase
         );
 
         $this->assertSame(
-            $options['param'],
-            $this->request->getParams()
+            $options['file'],
+            $this->request->getFileUpload()
         );
 
         $this->assertSame(
             [
                 $options['header']['myHeader1'],
                 $options['header']['myHeader2'],
+                'Content-Type: example/test; param=value',
             ],
             $this->request->getHeaders()
         );
@@ -77,8 +90,66 @@ class RequestTest extends TestCase
         );
 
         $this->assertSame(
-            $options['file'],
-            $this->request->getFileUpload()
+            $options['param'],
+            $this->request->getParams()
+        );
+    }
+
+    public function testToString()
+    {
+        $options = [
+            'handler' => '/myHandler',
+            'method' => Request::METHOD_POST,
+            'contenttype' => 'example/test',
+            'contenttypeparams' => ['param1' => 'value1', 'param2' => 'value2'],
+            'param' => [
+                'param1' => 1,
+                'param2' => 'test content',
+            ],
+            'rawdata' => 'post data',
+            'header' => [
+                'myHeader1' => 'X-myHeader1: value1',
+                'myHeader2' => 'X-myHeader2: value2',
+            ],
+            'authentication' => [
+                'username' => 'testuser',
+                'password' => 'testpass',
+            ],
+            'file' => __FILE__,
+        ];
+        $this->request->setOptions($options);
+
+        $request = <<<EOF
+Solarium\Core\Client\Request::__toString
+method: POST
+header: Array
+(
+    [0] => X-myHeader1: value1
+    [1] => X-myHeader2: value2
+    [2] => Content-Type: example/test; param1=value1; param2=value2
+)
+authentication: Array
+(
+    [username] => testuser
+    [password] => testpass
+)
+resource: /myHandler?param1=1&param2=test+content
+resource urldecoded: /myHandler?param1=1&param2=test content
+raw data: post data
+file upload: %s
+
+EOF;
+
+        $this->assertSame(sprintf($request, __FILE__), (string) $this->request);
+    }
+
+    public function testSetAndGetHandler()
+    {
+        $this->request->setHandler('myhandler');
+
+        $this->assertSame(
+            'myhandler',
+            $this->request->getHandler()
         );
     }
 
@@ -100,13 +171,378 @@ class RequestTest extends TestCase
         );
     }
 
-    public function testSetAndGetHandler()
+    public function testSetAndGetContentType()
     {
-        $this->request->setHandler('myhandler');
+        $this->request->setContentType('example/test');
 
         $this->assertSame(
-            'myhandler',
-            $this->request->getHandler()
+            'example/test',
+            $this->request->getContentType()
+        );
+
+        $this->assertNull(
+            $this->request->getContentTypeParams()
+        );
+    }
+
+    public function testSetContentTypeWithParams()
+    {
+        $this->request->setContentType('example/params', ['param' => 'value']);
+
+        $this->assertSame(
+            'example/params',
+            $this->request->getContentType()
+        );
+
+        $this->assertSame(
+            ['param' => 'value'],
+            $this->request->getContentTypeParams()
+        );
+    }
+
+    public function testSetContentTypeWithParamsOverridesParams()
+    {
+        $this->request->setContentTypeParams(['param' => 'value']);
+        $this->request->setContentType('example/params', ['newparam' => 'newvalue']);
+
+        $this->assertSame(
+            'example/params',
+            $this->request->getContentType()
+        );
+
+        $this->assertSame(
+            ['newparam' => 'newvalue'],
+            $this->request->getContentTypeParams()
+        );
+    }
+
+    /**
+     * Test that we don't lose the parameters if they are set before the Content-Type.
+     */
+    public function testSetContentTypeWithoutParamsDoesntOverrideParams()
+    {
+        $this->request->setContentTypeParams(['param' => 'value']);
+        $this->request->setContentType('example/params');
+
+        $this->assertSame(
+            'example/params',
+            $this->request->getContentType()
+        );
+
+        $this->assertSame(
+            ['param' => 'value'],
+            $this->request->getContentTypeParams()
+        );
+    }
+
+    public function testSetAndGetContentTypeParams()
+    {
+        $this->request->setContentTypeParams(['param' => 'value']);
+
+        $this->assertSame(
+            ['param' => 'value'],
+            $this->request->getContentTypeParams()
+        );
+    }
+
+    public function testSetAndGetRawData()
+    {
+        $data = '1234567890';
+        $this->request->setRawData($data);
+
+        $this->assertSame(
+            $data,
+            $this->request->getRawData()
+        );
+    }
+
+    public function testSetAndGetFileUpload()
+    {
+        $this->request->setFileUpload(__FILE__);
+        $this->assertSame(
+            __FILE__,
+            $this->request->getFileUpload()
+        );
+    }
+
+    public function testSetAndGetFileUploadWithInvalidFile()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->request->setFileUpload('invalid-filename.dummy');
+    }
+
+    public function testSetAndGetHeaders()
+    {
+        $headers = [
+            'User-Agent: My Agent',
+            'Cache-Control: no-cache',
+        ];
+        $this->request->setHeaders($headers);
+
+        $this->assertSame(
+            $headers,
+            $this->request->getHeaders()
+        );
+    }
+
+    public function testGetHeadersUnique()
+    {
+        $headers = [
+            'X-MyHeader: value',
+            'X-MyHeader: value',
+        ];
+        $this->request->setHeaders($headers);
+
+        $this->assertSame(
+            [
+                'X-MyHeader: value',
+            ],
+            $this->request->getHeaders()
+        );
+    }
+
+    public function testGetHeadersWithContentTypeAndContentTypeParams()
+    {
+        $this->request->addParam('ie', 'us-ascii');
+        $this->request->setContentType('example/test');
+        $this->request->setContentTypeParams(['param1' => 'value1', 'param2' => 'value2']);
+
+        $this->assertSame(
+            [
+                'Content-Type: example/test; param1=value1; param2=value2',
+            ],
+            $this->request->getHeaders()
+        );
+    }
+
+    public function testGetHeadersWithContentTypeWithoutContentTypeParams()
+    {
+        $this->request->addParam('ie', 'us-ascii');
+        $this->request->setContentType('example/test');
+
+        $this->assertSame(
+            [
+                'Content-Type: example/test; charset=us-ascii',
+            ],
+            $this->request->getHeaders()
+        );
+    }
+
+    public function testGetHeadersWithContentTypeWithoutContentTypeParamsWithDefaultCharset()
+    {
+        $this->request->setContentType('example/test');
+
+        $this->assertSame(
+            [
+                'Content-Type: example/test; charset=utf-8',
+            ],
+            $this->request->getHeaders()
+        );
+    }
+
+    public function testGetHeadersWithContentTypeWithEmptyContentTypeParams()
+    {
+        $this->request->addParam('ie', 'us-ascii');
+        $this->request->setContentType('example/test');
+        $this->request->setContentTypeParams([]);
+
+        $this->assertSame(
+            [
+                'Content-Type: example/test',
+            ],
+            $this->request->getHeaders()
+        );
+    }
+
+    /**
+     * Test that a raw Content-Type header always takes precedence over the 'contenttype' option.
+     */
+    public function testGetHeadersWithRawContentTypeHeaderAndContentType()
+    {
+        $this->request->addHeader('Content-Type: example/raw');
+        $this->request->setContentType('example/option');
+
+        $this->assertSame(
+            [
+                'Content-Type: example/raw',
+            ],
+            $this->request->getHeaders()
+        );
+    }
+
+    /**
+     * Test that a raw Content-Type header always takes precedence over the 'contenttype' option.
+     */
+    public function testGetHeadersWithContentTypeAndRawContentTypeHeader()
+    {
+        $this->request->setContentType('example/option');
+        $this->request->addHeader('Content-Type: example/raw');
+
+        $this->assertSame(
+            [
+                'Content-Type: example/raw',
+            ],
+            $this->request->getHeaders()
+        );
+    }
+
+    public function testAddHeader()
+    {
+        $headers = [
+            'User-Agent: My Agent',
+        ];
+
+        $this->request->setHeaders($headers);
+        $this->request->addHeader('Cache-Control: no-cache');
+
+        $headers[] = 'Cache-Control: no-cache';
+
+        $this->assertSame(
+            $headers,
+            $this->request->getHeaders()
+        );
+    }
+
+    public function testAddHeaders()
+    {
+        $headers = [
+            'User-Agent: My Agent',
+        ];
+
+        $extraHeaders = [
+            'Cache-Control: no-cache',
+            'X-custom: 123',
+        ];
+
+        $this->request->setHeaders($headers);
+        $this->request->addHeaders($extraHeaders);
+
+        $this->assertSame(
+            array_merge($headers, $extraHeaders),
+            $this->request->getHeaders()
+        );
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testReplaceHeaders(): void
+    {
+        $original = 'Content-Type: application/xml';
+        $replacement = 'Content-Type: application/json';
+
+        $this->request->replaceOrAddHeader($original);
+
+        $this->assertSame($original, $this->request->getHeader('Content-Type'));
+
+        $this->request->replaceOrAddHeader($replacement);
+
+        $this->assertSame($replacement, $this->request->getHeader('Content-Type'));
+    }
+
+    public function testClearHeaders()
+    {
+        $headers = [
+            'User-Agent: My Agent',
+            'Cache-Control: no-cache',
+        ];
+
+        $this->request->setHeaders($headers);
+
+        $this->assertSame(
+            $headers,
+            $this->request->getHeaders()
+        );
+
+        $this->request->clearHeaders();
+
+        $this->assertSame(
+            [],
+            $this->request->getHeaders()
+        );
+    }
+
+    public function testGetUri()
+    {
+        $this->assertSame(
+            '?',
+            $this->request->getUri()
+        );
+    }
+
+    public function testGetUriWithHandlerAndParams()
+    {
+        $params = [
+            'param1' => 1,
+            'param2' => [2, 3],
+        ];
+
+        $this->request->setHandler('myHandler');
+        $this->request->addParams($params);
+
+        $this->assertSame(
+            'myHandler?param1=1&param2=2&param2=3',
+            $this->request->getUri()
+        );
+    }
+
+    public function testSetAndGetAuthentication()
+    {
+        $user = 'someone';
+        $pass = 'S0M3p455';
+
+        $this->request->setAuthentication($user, $pass);
+
+        $this->assertSame(
+            [
+                'username' => $user,
+                'password' => $pass,
+            ],
+            $this->request->getAuthentication()
+        );
+    }
+
+    public function testSetAndGetIsServerRequest()
+    {
+        $this->request->setIsServerRequest();
+
+        $this->assertFalse(
+            $this->request->getIsServerRequest()
+        );
+
+        $this->request->setIsServerRequest(true);
+
+        $this->assertTrue(
+            $this->request->getIsServerRequest()
+        );
+    }
+
+    public function testGetDefaultApi()
+    {
+        $this->assertSame(
+            Request::API_V1,
+            $this->request->getApi()
+        );
+    }
+
+    public function testSetAndGetApi()
+    {
+        $this->request->setApi(Request::API_V2);
+
+        $this->assertSame(
+            Request::API_V2,
+            $this->request->getApi()
+        );
+    }
+
+    public function testGetHash()
+    {
+        $hash1 = $this->request->getHash();
+        $hash2 = (new Request())->getHash();
+
+        $this->assertNotEquals(
+            $hash2,
+            $hash1
         );
     }
 
@@ -317,206 +753,5 @@ class RequestTest extends TestCase
             [],
             $this->request->getParams()
         );
-    }
-
-    public function testGetAndSetRawData()
-    {
-        $data = '1234567890';
-        $this->request->setRawData($data);
-
-        $this->assertSame(
-            $data,
-            $this->request->getRawData()
-        );
-    }
-
-    public function testSetAndGetHeaders()
-    {
-        $headers = [
-            'User-Agent: My Agent',
-            'Cache-Control: no-cache',
-        ];
-        $this->request->setHeaders($headers);
-
-        $this->assertSame(
-            $headers,
-            $this->request->getHeaders()
-        );
-    }
-
-    public function testAddHeader()
-    {
-        $headers = [
-            'User-Agent: My Agent',
-        ];
-
-        $this->request->setHeaders($headers);
-        $this->request->addHeader('Cache-Control: no-cache');
-
-        $headers[] = 'Cache-Control: no-cache';
-
-        $this->assertSame(
-            $headers,
-            $this->request->getHeaders()
-        );
-    }
-
-    public function testAddHeaders()
-    {
-        $headers = [
-            'User-Agent: My Agent',
-        ];
-
-        $extraHeaders = [
-            'Cache-Control: no-cache',
-            'X-custom: 123',
-        ];
-
-        $this->request->setHeaders($headers);
-        $this->request->addHeaders($extraHeaders);
-
-        $this->assertSame(
-            array_merge($headers, $extraHeaders),
-            $this->request->getHeaders()
-        );
-    }
-
-    /**
-     * @throws \PHPUnit\Framework\ExpectationFailedException
-     */
-    public function testReplaceHeaders(): void
-    {
-        $original = 'Content-Type: application/xml';
-        $replacement = 'Content-Type: application/json';
-
-        $this->request->replaceOrAddHeader($original);
-
-        $this->assertSame($original, $this->request->getHeader('Content-Type'));
-
-        $this->request->replaceOrAddHeader($replacement);
-
-        $this->assertSame($replacement, $this->request->getHeader('Content-Type'));
-    }
-
-    public function testClearHeaders()
-    {
-        $headers = [
-            'User-Agent: My Agent',
-            'Cache-Control: no-cache',
-        ];
-
-        $this->request->setHeaders($headers);
-
-        $this->assertSame(
-            $headers,
-            $this->request->getHeaders()
-        );
-
-        $this->request->clearHeaders();
-
-        $this->assertSame(
-            [],
-            $this->request->getHeaders()
-        );
-    }
-
-    public function testGetUri()
-    {
-        $this->assertSame(
-            '?',
-            $this->request->getUri()
-        );
-    }
-
-    public function testGetUriWithHandlerAndParams()
-    {
-        $params = [
-            'param1' => 1,
-            'param2' => [2, 3],
-        ];
-
-        $this->request->setHandler('myHandler');
-        $this->request->addParams($params);
-
-        $this->assertSame(
-            'myHandler?param1=1&param2=2&param2=3',
-            $this->request->getUri()
-        );
-    }
-
-    public function testToString()
-    {
-        $options = [
-            'method' => Request::METHOD_POST,
-            'handler' => '/myHandler',
-            'param' => [
-                'param1' => 1,
-                'param2' => 'test content',
-            ],
-            'rawdata' => 'post data',
-            'header' => [
-                'myHeader1' => 'X-myHeader1: value1',
-                'myHeader2' => 'X-myHeader2: value2',
-            ],
-            'authentication' => [
-                'username' => 'testuser',
-                'password' => 'testpass',
-            ],
-            'file' => __FILE__,
-        ];
-        $this->request->setOptions($options);
-
-        $request = <<<EOF
-Solarium\Core\Client\Request::__toString
-method: POST
-header: Array
-(
-    [0] => X-myHeader1: value1
-    [1] => X-myHeader2: value2
-)
-authentication: Array
-(
-    [username] => testuser
-    [password] => testpass
-)
-resource: /myHandler?param1=1&param2=test+content
-resource urldecoded: /myHandler?param1=1&param2=test content
-raw data: post data
-file upload: %s
-
-EOF;
-
-        $this->assertSame(sprintf($request, __FILE__), (string) $this->request);
-    }
-
-    public function testGetAndSetAuthentication()
-    {
-        $user = 'someone';
-        $pass = 'S0M3p455';
-
-        $this->request->setAuthentication($user, $pass);
-
-        $this->assertSame(
-            [
-                'username' => $user,
-                'password' => $pass,
-            ],
-            $this->request->getAuthentication()
-        );
-    }
-
-    public function testSetAndGetFileUpload()
-    {
-        $this->request->setFileUpload(__FILE__);
-        $this->assertSame(
-            __FILE__,
-            $this->request->getFileUpload()
-        );
-    }
-
-    public function testSetAndGetFileUploadWithInvalidFile()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->request->setFileUpload('invalid-filename.dummy');
     }
 }

--- a/tests/Plugin/PostBigRequestTest.php
+++ b/tests/Plugin/PostBigRequestTest.php
@@ -89,6 +89,7 @@ class PostBigRequestTest extends TestCase
         }
         $fq = substr($fq, 4);
         $this->query->createFilterQuery('fq')->setQuery($fq);
+        $this->query->setInputEncoding('us-ascii');
 
         $requestOutput = $this->client->createRequest($this->query);
         $requestInput = clone $requestOutput;
@@ -98,6 +99,8 @@ class PostBigRequestTest extends TestCase
 
         $this->assertSame(Request::METHOD_GET, $requestInput->getMethod());
         $this->assertSame(Request::METHOD_POST, $requestOutput->getMethod());
+        $this->assertSame(Request::CONTENT_TYPE_APPLICATION_X_WWW_FORM_URLENCODED, $requestOutput->getContentType());
+        $this->assertSame(['charset' => 'us-ascii'], $requestOutput->getContentTypeParams());
         $this->assertSame($requestInput->getQueryString(), $requestOutput->getRawData());
         $this->assertSame('', $requestOutput->getQueryString());
     }

--- a/tests/QueryType/Analysis/RequestBuilder/DocumentTest.php
+++ b/tests/QueryType/Analysis/RequestBuilder/DocumentTest.php
@@ -31,6 +31,7 @@ class DocumentTest extends TestCase
         $request = $this->builder->build($this->query);
 
         $this->assertSame(Request::METHOD_POST, $request->getMethod());
+        $this->assertSame(Request::CONTENT_TYPE_APPLICATION_XML, $request->getContentType());
         $this->assertSame($this->builder->getRawData($this->query), $request->getRawData());
     }
 

--- a/tests/QueryType/Extract/RequestBuilderTest.php
+++ b/tests/QueryType/Extract/RequestBuilderTest.php
@@ -29,11 +29,22 @@ class RequestBuilderTest extends TestCase
         $this->builder = new RequestBuilder();
     }
 
-    public function testGetMethod()
+    public function testGetMethodWithFileUpload()
     {
         $request = $this->builder->build($this->query);
         $this->assertSame(
             Request::METHOD_POST,
+            $request->getMethod()
+        );
+    }
+
+    public function testGetMethodWithStreamUrl()
+    {
+        $query = $this->query;
+        $query->setFile('http://solarium-project.org/');
+        $request = $this->builder->build($query);
+        $this->assertSame(
+            Request::METHOD_GET,
             $request->getMethod()
         );
     }
@@ -134,11 +145,9 @@ class RequestBuilderTest extends TestCase
     public function testContentTypeHeader()
     {
         $request = $this->builder->build($this->query);
-        $headers = [
-            'Content-Type: multipart/form-data; boundary='.$request->getHash(),
-        ];
 
-        $this->assertSame($headers, $request->getHeaders());
+        $this->assertSame(Request::CONTENT_TYPE_MULTIPART_FORM_DATA, $request->getContentType());
+        $this->assertSame(['boundary' => $request->getHash()], $request->getContentTypeParams());
     }
 
     public function testDocumentDateTimeField()

--- a/tests/QueryType/ManagedResources/RequestBuilder/ResourcesTest.php
+++ b/tests/QueryType/ManagedResources/RequestBuilder/ResourcesTest.php
@@ -3,6 +3,7 @@
 namespace Solarium\Tests\QueryType\ManagedResources\RequestBuilder;
 
 use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Request;
 use Solarium\QueryType\ManagedResources\Query\Resources as ResourcesQuery;
 use Solarium\QueryType\ManagedResources\RequestBuilder\Resources as ResourcesRequestBuilder;
 
@@ -40,5 +41,6 @@ class ResourcesTest extends TestCase
         );
 
         $this->assertSame($handler, $request->getHandler());
+        $this->assertSame(Request::METHOD_GET, $request->getMethod());
     }
 }

--- a/tests/QueryType/ManagedResources/RequestBuilder/StopwordsTest.php
+++ b/tests/QueryType/ManagedResources/RequestBuilder/StopwordsTest.php
@@ -95,6 +95,7 @@ class StopwordsTest extends TestCase
         $this->query->setCommand($command);
         $request = $this->builder->build($this->query);
         $this->assertSame(Request::METHOD_PUT, $request->getMethod());
+        $this->assertSame(Request::CONTENT_TYPE_APPLICATION_JSON, $request->getContentType());
         $this->assertSame('schema/analysis/stopwords/dutch', $request->getHandler());
         $this->assertSame('["de"]', $request->getRawData());
     }
@@ -120,6 +121,7 @@ class StopwordsTest extends TestCase
         $this->query->setCommand($command);
         $request = $this->builder->build($this->query);
         $this->assertSame(Request::METHOD_PUT, $request->getMethod());
+        $this->assertSame(Request::CONTENT_TYPE_APPLICATION_JSON, $request->getContentType());
         $this->assertSame('schema/analysis/stopwords/dutch', $request->getHandler());
         $this->assertSame('{"initArgs":{"ignoreCase":true}}', $request->getRawData());
     }
@@ -141,6 +143,7 @@ class StopwordsTest extends TestCase
         $this->query->setCommand($command);
         $request = $this->builder->build($this->query);
         $this->assertSame(Request::METHOD_PUT, $request->getMethod());
+        $this->assertSame(Request::CONTENT_TYPE_APPLICATION_JSON, $request->getContentType());
         $this->assertSame('schema/analysis/stopwords/dutch', $request->getHandler());
         $this->assertSame('{"class":"org.apache.solr.rest.schema.analysis.ManagedWordSetResource"}', $request->getRawData());
     }

--- a/tests/QueryType/ManagedResources/RequestBuilder/SynonymsTest.php
+++ b/tests/QueryType/ManagedResources/RequestBuilder/SynonymsTest.php
@@ -99,6 +99,7 @@ class SynonymsTest extends TestCase
         $this->query->setCommand($command);
         $request = $this->builder->build($this->query);
         $this->assertSame(Request::METHOD_PUT, $request->getMethod());
+        $this->assertSame(Request::CONTENT_TYPE_APPLICATION_JSON, $request->getContentType());
         $this->assertSame('schema/analysis/synonyms/dutch', $request->getHandler());
         $this->assertSame('{"mad":["angry","upset"]}', $request->getRawData());
     }
@@ -114,6 +115,7 @@ class SynonymsTest extends TestCase
         $this->query->setCommand($command);
         $request = $this->builder->build($this->query);
         $this->assertSame(Request::METHOD_PUT, $request->getMethod());
+        $this->assertSame(Request::CONTENT_TYPE_APPLICATION_JSON, $request->getContentType());
         $this->assertSame('schema/analysis/synonyms/dutch', $request->getHandler());
         $this->assertSame('["funny","entertaining","whimsical","jocular"]', $request->getRawData());
     }
@@ -139,6 +141,7 @@ class SynonymsTest extends TestCase
         $this->query->setCommand($command);
         $request = $this->builder->build($this->query);
         $this->assertSame(Request::METHOD_PUT, $request->getMethod());
+        $this->assertSame(Request::CONTENT_TYPE_APPLICATION_JSON, $request->getContentType());
         $this->assertSame('schema/analysis/synonyms/dutch', $request->getHandler());
         $this->assertSame('{"initArgs":{"ignoreCase":true,"format":"solr"}}', $request->getRawData());
     }
@@ -160,6 +163,7 @@ class SynonymsTest extends TestCase
         $this->query->setCommand($command);
         $request = $this->builder->build($this->query);
         $this->assertSame(Request::METHOD_PUT, $request->getMethod());
+        $this->assertSame(Request::CONTENT_TYPE_APPLICATION_JSON, $request->getContentType());
         $this->assertSame('schema/analysis/synonyms/dutch', $request->getHandler());
         $this->assertSame('{"class":"org.apache.solr.rest.schema.analysis.ManagedSynonymGraphFilterFactory$SynonymManager"}', $request->getRawData());
     }

--- a/tests/QueryType/MoreLikeThis/RequestBuilderTest.php
+++ b/tests/QueryType/MoreLikeThis/RequestBuilderTest.php
@@ -84,9 +84,9 @@ class RequestBuilderTest extends TestCase
 
         $request = $this->builder->build($this->query);
 
-        $this->assertSame(Request::METHOD_POST, $request->getMethod());
         $this->assertNull($request->getParam('q'));
         $this->assertSame($content, $request->getRawData());
-        $this->assertTrue(in_array('Content-Type: text/plain; charset=utf-8', $request->getHeaders(), true));
+        $this->assertSame(Request::METHOD_POST, $request->getMethod());
+        $this->assertSame(Request::CONTENT_TYPE_TEXT_PLAIN, $request->getContentType());
     }
 }

--- a/tests/QueryType/Server/Api/QueryTest.php
+++ b/tests/QueryType/Server/Api/QueryTest.php
@@ -35,6 +35,100 @@ class QueryTest extends TestCase
         $this->assertSame(Request::API_V2, $this->query->getVersion());
     }
 
+    public function testSetGetMethod()
+    {
+        $this->assertSame(Request::METHOD_GET, $this->query->getMethod());
+
+        $this->query->setMethod(Request::METHOD_POST);
+        $this->assertSame(Request::METHOD_POST, $this->query->getMethod());
+    }
+
+    public function testSetGetAccept()
+    {
+        $this->query->setAccept('example/accept');
+        $this->assertSame('example/accept', $this->query->getAccept());
+    }
+
+    public function testSetAndGetContentType()
+    {
+        $this->query->setContentType('example/test');
+
+        $this->assertSame(
+            'example/test',
+            $this->query->getContentType()
+        );
+
+        $this->assertNull(
+            $this->query->getContentTypeParams()
+        );
+    }
+
+    public function testSetContentTypeWithParams()
+    {
+        $this->query->setContentType('example/params', ['param' => 'value']);
+
+        $this->assertSame(
+            'example/params',
+            $this->query->getContentType()
+        );
+
+        $this->assertSame(
+            ['param' => 'value'],
+            $this->query->getContentTypeParams()
+        );
+    }
+
+    public function testSetContentTypeWithParamsOverridesParams()
+    {
+        $this->query->setContentTypeParams(['param' => 'value']);
+        $this->query->setContentType('example/params', ['newparam' => 'newvalue']);
+
+        $this->assertSame(
+            'example/params',
+            $this->query->getContentType()
+        );
+
+        $this->assertSame(
+            ['newparam' => 'newvalue'],
+            $this->query->getContentTypeParams()
+        );
+    }
+
+    /**
+     * Test that we don't lose the parameters if they are set before the Content-Type.
+     */
+    public function testSetContentTypeWithoutParamsDoesntOverrideParams()
+    {
+        $this->query->setContentTypeParams(['param' => 'value']);
+        $this->query->setContentType('example/params');
+
+        $this->assertSame(
+            'example/params',
+            $this->query->getContentType()
+        );
+
+        $this->assertSame(
+            ['param' => 'value'],
+            $this->query->getContentTypeParams()
+        );
+    }
+
+    public function testSetAndGetContentTypeParams()
+    {
+        $this->query->setContentTypeParams(['param' => 'value']);
+
+        $this->assertSame(
+            ['param' => 'value'],
+            $this->query->getContentTypeParams()
+        );
+    }
+
+    public function testSetGetRawData()
+    {
+        $this->query->setRawData('raw data');
+        $this->assertSame('raw data', $this->query->getRawData());
+    }
+
     public function testGetRequestBuilder()
     {
         $this->assertInstanceOf(RequestBuilder::class, $this->query->getRequestBuilder());

--- a/tests/QueryType/Server/Api/RequestBuilderTest.php
+++ b/tests/QueryType/Server/Api/RequestBuilderTest.php
@@ -36,72 +36,170 @@ class RequestBuilderTest extends TestCase
             ],
             $request->getParams()
         );
-        $this->assertSame(Request::METHOD_GET, $request->getMethod());
-        $this->assertTrue($request->getIsServerRequest());
         $this->assertSame('?wt=json&json.nl=flat', $request->getUri());
+    }
 
+    public function testBuildHandler()
+    {
         $this->query->setHandler('dummy');
         $request = $this->builder->build($this->query);
 
-        $this->assertEquals(
-            [
-                'wt' => 'json',
-                'json.nl' => 'flat',
-            ],
-            $request->getParams()
-        );
-        $this->assertSame(Request::METHOD_GET, $request->getMethod());
-        $this->assertTrue($request->getIsServerRequest());
         $this->assertSame('dummy?wt=json&json.nl=flat', $request->getUri());
+    }
 
-        $this->query->setAccept('foo/bar');
+    public function testBuildIsServerRequest()
+    {
         $request = $this->builder->build($this->query);
 
-        $this->assertEquals(
-            [
-                'wt' => 'json',
-                'json.nl' => 'flat',
-            ],
-            $request->getParams()
-        );
-        $this->assertSame(Request::METHOD_GET, $request->getMethod());
         $this->assertTrue($request->getIsServerRequest());
-        $this->assertSame('dummy?wt=json&json.nl=flat', $request->getUri());
-        $this->assertArrayHasKey('Accept: foo/bar', array_flip($request->getHeaders()));
+    }
 
-        $this->query->setContentType('foo;bar');
+    public function testBuildApiDefault()
+    {
         $request = $this->builder->build($this->query);
 
-        $this->assertEquals(
-            [
-                'wt' => 'json',
-                'json.nl' => 'flat',
-            ],
-            $request->getParams()
-        );
-        $this->assertSame(Request::METHOD_GET, $request->getMethod());
-        $this->assertTrue($request->getIsServerRequest());
-        $this->assertSame('dummy?wt=json&json.nl=flat', $request->getUri());
-        $this->assertArrayHasKey('Accept: foo/bar', array_flip($request->getHeaders()));
-        $this->assertArrayHasKey('Content-Type: foo;bar', array_flip($request->getHeaders()));
+        $this->assertSame(Request::API_V1, $request->getApi());
+    }
 
+    public function testBuildApiV1()
+    {
+        $this->query->setVersion(Request::API_V1);
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame(Request::API_V1, $request->getApi());
+    }
+
+    public function testBuildApiV2()
+    {
+        $this->query->setVersion(Request::API_V2);
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame(Request::API_V2, $request->getApi());
+    }
+
+    public function testBuildMethodDefault()
+    {
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame(Request::METHOD_GET, $request->getMethod());
+    }
+
+    public function testBuildMethodGet()
+    {
+        $this->query->setMethod(Request::METHOD_GET);
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame(Request::METHOD_GET, $request->getMethod());
+    }
+
+    public function testBuildMethodHead()
+    {
         $this->query->setMethod(Request::METHOD_HEAD);
         $request = $this->builder->build($this->query);
 
-        $this->assertEquals(
-            [
-                'wt' => 'json',
-                'json.nl' => 'flat',
-            ],
-            $request->getParams()
-        );
         $this->assertSame(Request::METHOD_HEAD, $request->getMethod());
-        $this->assertTrue($request->getIsServerRequest());
-        $this->assertSame('dummy?wt=json&json.nl=flat', $request->getUri());
+    }
+
+    public function testBuildMethodPost()
+    {
+        $this->query->setMethod(Request::METHOD_POST);
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame(Request::METHOD_POST, $request->getMethod());
+        $this->assertSame(Request::CONTENT_TYPE_APPLICATION_JSON, $request->getContentType());
+    }
+
+    public function testBuildMethodPut()
+    {
+        $this->query->setMethod(Request::METHOD_PUT);
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame(Request::METHOD_PUT, $request->getMethod());
+        $this->assertSame(Request::CONTENT_TYPE_APPLICATION_OCTET_STREAM, $request->getContentType());
+    }
+
+    public function testBuildAccept()
+    {
+        $this->query->setAccept('foo/bar');
+        $request = $this->builder->build($this->query);
+
         $this->assertArrayHasKey('Accept: foo/bar', array_flip($request->getHeaders()));
-        $this->assertArrayHasKey('Content-Type: foo;bar', array_flip($request->getHeaders()));
+    }
+
+    public function testBuildContentType()
+    {
+        $this->query->setContentType('example/test');
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame('example/test', $request->getContentType());
 
         $this->query->setMethod(Request::METHOD_POST);
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame('example/test', $request->getContentType());
+
+        $this->query->setMethod(Request::METHOD_PUT);
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame('example/test', $request->getContentType());
+    }
+
+    public function testBuildContentTypeWithParams()
+    {
+        $this->query->setContentType('example/test', ['foo' => 'bar']);
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame('example/test', $request->getContentType());
+        $this->assertSame(['foo' => 'bar'], $request->getContentTypeParams());
+
+        $this->query->setMethod(Request::METHOD_POST);
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame('example/test', $request->getContentType());
+        $this->assertSame(['foo' => 'bar'], $request->getContentTypeParams());
+
+        $this->query->setMethod(Request::METHOD_PUT);
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame('example/test', $request->getContentType());
+        $this->assertSame(['foo' => 'bar'], $request->getContentTypeParams());
+    }
+
+    public function testBuildContentTypeParams()
+    {
+        $this->query->setContentTypeParams(['foo' => 'bar']);
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame(['foo' => 'bar'], $request->getContentTypeParams());
+
+        $this->query->setMethod(Request::METHOD_POST);
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame(Request::CONTENT_TYPE_APPLICATION_JSON, $request->getContentType());
+        $this->assertSame(['foo' => 'bar'], $request->getContentTypeParams());
+
+        $this->query->setMethod(Request::METHOD_PUT);
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame(Request::CONTENT_TYPE_APPLICATION_OCTET_STREAM, $request->getContentType());
+        $this->assertSame(['foo' => 'bar'], $request->getContentTypeParams());
+    }
+
+    public function testBuildRawData()
+    {
+        $this->query->setRawData('some data');
+        $request = $this->builder->build($this->query);
+
+        $this->assertSame('some data', $request->getRawData());
+    }
+
+    public function testBuild()
+    {
+        $this->query->setHandler('dummy');
+        $this->query->setVersion(Request::API_V2);
+        $this->query->setMethod(Request::METHOD_POST);
+        $this->query->setAccept('foo/bar');
+        $this->query->setContentType('example/test', ['foo' => 'bar']);
         $this->query->setRawData('some data');
         $request = $this->builder->build($this->query);
 
@@ -112,11 +210,13 @@ class RequestBuilderTest extends TestCase
             ],
             $request->getParams()
         );
+        $this->assertSame(Request::API_V2, $request->getApi());
         $this->assertSame(Request::METHOD_POST, $request->getMethod());
         $this->assertTrue($request->getIsServerRequest());
         $this->assertSame('dummy?wt=json&json.nl=flat', $request->getUri());
         $this->assertArrayHasKey('Accept: foo/bar', array_flip($request->getHeaders()));
-        $this->assertArrayHasKey('Content-Type: foo;bar', array_flip($request->getHeaders()));
+        $this->assertSame('example/test', $request->getContentType());
+        $this->assertSame(['foo' => 'bar'], $request->getContentTypeParams());
         $this->assertSame('some data', $request->getRawData());
     }
 }

--- a/tests/QueryType/Server/Configsets/RequestBuilderTest.php
+++ b/tests/QueryType/Server/Configsets/RequestBuilderTest.php
@@ -97,7 +97,8 @@ class RequestBuilderTest extends TestCase
             '&filePath=path%2Fto%2Ffile'.
             '&cleanup=true';
         $this->assertSame($expectedUri, $request->getUri());
-        $this->assertStringStartsWith('Content-Type: multipart/form-data; boundary=', $request->getHeader('Content-Type'));
+        $this->assertSame(Request::CONTENT_TYPE_MULTIPART_FORM_DATA, $request->getContentType());
+        $this->assertSame(['boundary' => $request->getHash()], $request->getContentTypeParams());
         $this->assertSame(__FILE__, $request->getFileUpload());
     }
 }

--- a/tests/QueryType/Stream/RequestBuilderTest.php
+++ b/tests/QueryType/Stream/RequestBuilderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Stream;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Request;
+use Solarium\QueryType\Stream\Query;
+use Solarium\QueryType\Stream\RequestBuilder;
+
+class RequestBuilderTest extends TestCase
+{
+    /**
+     * @var Query
+     */
+    protected $query;
+
+    /**
+     * @var RequestBuilder
+     */
+    protected $builder;
+
+    public function setUp(): void
+    {
+        $this->query = new Query();
+        $this->builder = new RequestBuilder();
+    }
+
+    public function testBuildParams()
+    {
+        $this->query->setExpression('testexpression');
+
+        $request = $this->builder->build($this->query);
+
+        $this->assertEquals(
+            [
+                'expr' => 'testexpression',
+            ],
+            $request->getParams()
+        );
+
+        $this->assertSame(Request::METHOD_GET, $request->getMethod());
+        $this->assertSame(Request::CONTENT_TYPE_TEXT_PLAIN, $request->getContentType());
+        $this->assertSame('stream?expr=testexpression', $request->getUri());
+    }
+}

--- a/tests/QueryType/Update/RequestBuilderTest.php
+++ b/tests/QueryType/Update/RequestBuilderTest.php
@@ -42,6 +42,15 @@ class RequestBuilderTest extends TestCase
         );
     }
 
+    public function testGetContentType()
+    {
+        $request = $this->builder->build($this->query);
+        $this->assertSame(
+            Request::CONTENT_TYPE_APPLICATION_XML,
+            $request->getContentType()
+        );
+    }
+
     public function testGetUri()
     {
         $request = $this->builder->build($this->query);


### PR DESCRIPTION
If we want to support JSON updates alongside XML updates, it no longer makes sense to have the Adapters set a default Content-Type for POSTs. There were already a number of RequestBuilders that set it explicitly to another value anyway. And GETs don't really need a Content-Type. I've made the RequestBuilders responsible to always set it if necessary. They can now set it with `Request::setContentType()` (as was already the case for API Requests).

None of the integration tests or examples had to be changed. It should be fully backward compatible except for users who wrote custom RequestBuilders.