### PR TITLE
Remove parent::init() if it calls Configurable::init()

### DIFF
--- a/src/Component/FacetSetTrait.php
+++ b/src/Component/FacetSetTrait.php
@@ -201,8 +201,6 @@ trait FacetSetTrait
      */
     protected function init()
     {
-        parent::init();
-
         if (isset($this->options['facet'])) {
             foreach ($this->options['facet'] as $key => $config) {
                 if (!isset($config['local_key'])) {

--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -213,8 +213,6 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
             // @codeCoverageIgnoreEnd
         }
 
-        parent::init();
-
         if (isset($this->options['proxy'])) {
             trigger_error('Setting proxy as an option is deprecated. Use setProxy() instead.', \E_USER_DEPRECATED);
             $this->setProxy($this->options['proxy']);

--- a/src/QueryType/Extract/Query.php
+++ b/src/QueryType/Extract/Query.php
@@ -455,8 +455,6 @@ class Query extends BaseQuery
      */
     protected function init()
     {
-        parent::init();
-
         if (isset($this->options['fmap'])) {
             $this->setFieldMappings($this->options['fmap']);
         }

--- a/src/QueryType/Update/Query/Query.php
+++ b/src/QueryType/Update/Query/Query.php
@@ -528,8 +528,6 @@ class Query extends BaseQuery
      */
     protected function init(): void
     {
-        parent::init();
-
         if (isset($this->options['command'])) {
             foreach ($this->options['command'] as $key => $value) {
                 $type = $value['type'];


### PR DESCRIPTION
There `parent::init()`s don't do anything except calling the empty method `Configurable::init()`.