### PR TITLE
PHP 8.2 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [7.3, 7.4, 8.0, 8.1]
+                php: [7.3, 7.4, 8.0, 8.1, 8.2]
                 solr: [7, 8, 9]
                 mode: [cloud, server]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Solarium library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+### Added
+- PHP 8.2 support
+
+
 ## [6.2.7]
 ### Added
 - Core\Client\Adapter\Curl::setProxy() to set proxy (instead of through options)

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,14 @@
         "composer-runtime-api": ">=2.0"
     },
     "require-dev": {
+        "ext-iconv": "*",
         "escapestudios/symfony2-coding-standard": "^3.11",
         "guzzlehttp/guzzle": "^7.2",
         "nyholm/psr7": "^1.2",
         "php-http/guzzle7-adapter": "^0.1",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5",
         "roave/security-advisories": "dev-master",

--- a/tests/Component/RequestBuilder/HighlightingTest.php
+++ b/tests/Component/RequestBuilder/HighlightingTest.php
@@ -15,12 +15,10 @@ class HighlightingTest extends TestCase
         $request = new Request();
 
         $component = new Component();
-        $component->setUseFastVectorHighlighter(true);
         $component->setMethod($component::METHOD_FASTVECTOR);
         $component->addField('fieldA');
 
         $field = $component->getField('fieldB');
-        $field->setUseFastVectorHighlighter(false);
         $field->setMethod($component::METHOD_ORIGINAL);
         $field->setUsePhraseHighlighter(false);
         $field->setHighlightMultiTerm(false);
@@ -68,7 +66,6 @@ class HighlightingTest extends TestCase
         $this->assertSame(
             [
                 'hl' => 'true',
-                'hl.useFastVectorHighlighter' => 'true',
                 'hl.method' => 'fastVector',
                 'hl.fl' => 'fieldA,fieldB',
                 'hl.q' => 'text:myvalue',
@@ -95,7 +92,6 @@ class HighlightingTest extends TestCase
                 'hl.bs.chars' => '.,',
                 'hl.phraseLimit' => 40,
                 'hl.multiValuedSeparatorChar' => '|',
-                'f.fieldB.hl.useFastVectorHighlighter' => 'false',
                 'f.fieldB.hl.method' => 'original',
                 'f.fieldB.hl.usePhraseHighlighter' => 'false',
                 'f.fieldB.hl.highlightMultiTerm' => 'false',
@@ -112,6 +108,34 @@ class HighlightingTest extends TestCase
                 'f.fieldB.hl.regex.maxAnalyzedChars' => 500,
                 'f.fieldB.hl.preserveMulti' => 'true',
                 'f.fieldB.hl.payloads' => 'false',
+            ],
+            $request->getParams()
+        );
+    }
+
+    /**
+     * @deprecated Since Solr 6.4
+     */
+    public function testBuildComponentWithUseFastVectorHighlighter()
+    {
+        $builder = new RequestBuilder();
+        $request = new Request();
+
+        $component = new Component();
+        $component->setUseFastVectorHighlighter(true);
+        $component->addField('fieldA');
+
+        $field = $component->getField('fieldB');
+        $field->setUseFastVectorHighlighter(false);
+
+        $request = $builder->buildComponent($component, $request);
+
+        $this->assertSame(
+            [
+                'hl' => 'true',
+                'hl.useFastVectorHighlighter' => 'true',
+                'hl.fl' => 'fieldA,fieldB',
+                'f.fieldB.hl.useFastVectorHighlighter' => 'false',
             ],
             $request->getParams()
         );
@@ -253,14 +277,13 @@ class HighlightingTest extends TestCase
         );
     }
 
-    public function testBuildComponentWitFastVectorHighlighter()
+    public function testBuildComponentWithFastVectorHighlighter()
     {
         $builder = new RequestBuilder();
         $request = new Request();
 
         $component = new Component();
-        $component->setUseFastVectorHighlighter(true); // old way
-        $component->setMethod($component::METHOD_FASTVECTOR); // the new way
+        $component->setMethod($component::METHOD_FASTVECTOR);
         $component->setQuery('text:myvalue');
         $component->setQueryParser('myparser');
         $component->setRequireFieldMatch(false);
@@ -291,7 +314,6 @@ class HighlightingTest extends TestCase
         $this->assertSame(
             [
                 'hl' => 'true',
-                'hl.useFastVectorHighlighter' => 'true',
                 'hl.method' => 'fastVector',
                 'hl.q' => 'text:myvalue',
                 'hl.qparser' => 'myparser',

--- a/tests/Core/Query/HelperTest.php
+++ b/tests/Core/Query/HelperTest.php
@@ -670,6 +670,9 @@ class HelperTest extends TestCase
         );
     }
 
+    /**
+     * @deprecated Will be removed in Solarium 6
+     */
     public function testCacheControlWithCost()
     {
         $this->assertSame(
@@ -678,6 +681,9 @@ class HelperTest extends TestCase
         );
     }
 
+    /**
+     * @deprecated Will be removed in Solarium 6
+     */
     public function testCacheControlWithoutCost()
     {
         $this->assertSame(

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -3485,7 +3485,7 @@ abstract class AbstractTechproductsTest extends TestCase
 
         // input encoding: ISO-8859-1
         // output encoding: UTF-8 (always)
-        $select->setQuery('cat:'.utf8_decode('áéíóú'));
+        $select->setQuery('cat:'.iconv('UTF-8', 'ISO-8859-1', 'áéíóú'));
         $select->setInputEncoding('ISO-8859-1');
         $result = self::$client->select($select);
         $this->assertCount(1, $result);
@@ -3499,9 +3499,9 @@ abstract class AbstractTechproductsTest extends TestCase
         $update = self::$client->createUpdate();
         $update->setInputEncoding('ISO-8859-1');
         $doc = $update->createDocument();
-        $doc->setField('id', utf8_decode('solarium-test-2'));
-        $doc->setField('name', utf8_decode('Sølåríùm Tëst 2'));
-        $doc->setField('cat', [utf8_decode('solarium-test'), utf8_decode('áéíóú')]);
+        $doc->setField('id', iconv('UTF-8', 'ISO-8859-1', 'solarium-test-2'));
+        $doc->setField('name', iconv('UTF-8', 'ISO-8859-1', 'Sølåríùm Tëst 2'));
+        $doc->setField('cat', [iconv('UTF-8', 'ISO-8859-1', 'solarium-test'), iconv('UTF-8', 'ISO-8859-1', 'áéíóú')]);
         $doc->setField('price', 42.0);
         $update->addDocument($doc);
         $update->addCommit(true, true);

--- a/tests/QueryType/Update/Query/DocumentTest.php
+++ b/tests/QueryType/Update/Query/DocumentTest.php
@@ -533,6 +533,9 @@ class DocumentTest extends TestCase
         );
     }
 
+    /**
+     * @deprecated No longer supported since Solr 7
+     */
     public function testSetAndGetBoost()
     {
         $this->doc->setBoost(2.5);

--- a/tests/QueryType/Update/RequestBuilderTest.php
+++ b/tests/QueryType/Update/RequestBuilderTest.php
@@ -352,6 +352,9 @@ class RequestBuilderTest extends TestCase
         );
     }
 
+    /**
+     * @deprecated No longer supported since Solr 7
+     */
     public function testBuildAddXmlSingleDocumentWithBoost()
     {
         $doc = new Document(['id' => 1]);


### PR DESCRIPTION
We had a few deprecations reported by users for PHP 8.1. I've added `phpstan/phpstan-deprecation-rules` to preempt this for 8.2.

Only needed changes in tests:
- One deprecated PHP function was replaced in an integration test.
- Tests for our own deprecated functions need to be marked as @deprecated. One larger test was split up to isolate the deprecated functionality lest we inadvertently mask future deprecations. 