### PR TITLE
Test that Helper::formatDate() doesn't modify input

### DIFF
--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -142,7 +142,7 @@ class Helper
     public function formatDate($input)
     {
         switch (true) {
-            // input of datetime object
+            // input of DateTime or DateTimeImmutable object
             case $input instanceof \DateTimeInterface:
                 $input = clone $input;
                 break;
@@ -172,15 +172,10 @@ class Helper
 
         // handle the filtered input
         if ($input) {
-            // when we get here the input is always a datetime object
+            // when we get here $input is always a DateTime or DateTimeImmutable object
             $input = $input->setTimezone(new \DateTimeZone('UTC'));
-            // Solr seems to require the format PHP erroneously declares as ISO8601.
-            /** @noinspection DateTimeConstantsUsageInspection */
-            $iso8601 = $input->format(\DateTimeInterface::ISO8601);
-            $iso8601 = strstr($iso8601, '+', true); // strip timezone
-            $iso8601 .= 'Z';
 
-            return $iso8601;
+            return $input->format('Y-m-d\TH:i:s\Z');
         }
 
         // unsupported input

--- a/tests/Core/Query/HelperTest.php
+++ b/tests/Core/Query/HelperTest.php
@@ -596,6 +596,15 @@ class HelperTest extends TestCase
         );
     }
 
+    public function testFormatDateDoesntModifyPassedObject()
+    {
+        $timezone = new \DateTimeZone('+02:00');
+        $date = new \DateTime('2013-01-15 14:41:58', $timezone);
+
+        $this->assertEquals('2013-01-15T12:41:58Z', $this->helper->formatDate($date));
+        $this->assertEquals('2013-01-15T14:41:58+02:00', $date->format(\DateTimeInterface::ATOM));
+    }
+
     public function testAssemble()
     {
         // test single basic placeholder

--- a/tests/QueryType/Extract/RequestBuilderTest.php
+++ b/tests/QueryType/Extract/RequestBuilderTest.php
@@ -152,7 +152,7 @@ class RequestBuilderTest extends TestCase
 
     public function testDocumentDateTimeField()
     {
-        $timezone = new \DateTimeZone('Europe/London');
+        $timezone = new \DateTimeZone('+07:30');
         $date = new \DateTime('2013-01-15 14:41:58', $timezone);
 
         $document = $this->query->createDocument(['date' => $date]);
@@ -163,7 +163,7 @@ class RequestBuilderTest extends TestCase
         $this->assertEquals(
             [
                 'fmap.from-field' => 'to-field',
-                'literal.date' => '2013-01-15T14:41:58Z',
+                'literal.date' => '2013-01-15T07:11:58Z',
                 'omitHeader' => 'true',
                 'extractOnly' => 'false',
                 'param1' => 'value1',

--- a/tests/QueryType/Update/RequestBuilderTest.php
+++ b/tests/QueryType/Update/RequestBuilderTest.php
@@ -462,28 +462,26 @@ class RequestBuilderTest extends TestCase
     {
         $command = new AddCommand();
         $command->addDocument(
-            new Document(['id' => 1, 'datetime' => new \DateTime('2013-01-15 14:41:58', new \DateTimeZone('Europe/London'))])
+            new Document(['id' => 1, 'datetime' => new \DateTime('2013-01-15 14:41:58', new \DateTimeZone('+02:00'))])
         );
 
         $this->assertSame(
-            '<add><doc><field name="id">1</field><field name="datetime">2013-01-15T14:41:58Z</field></doc></add>',
+            '<add><doc><field name="id">1</field><field name="datetime">2013-01-15T12:41:58Z</field></doc></add>',
             $this->builder->buildAddXml($command)
         );
     }
 
     public function testBuildAddXmlWithDateTimeImmutable()
     {
-        $timezone = new \DateTimeZone('Europe/London');
-        $date = new \DateTime('2013-01-15 14:41:58', $timezone);
-
         $command = new AddCommand();
         $command->addDocument(
-            new Document(['id' => 1, 'datetime' => $date])
+            new Document(['id' => 1, 'datetime' => new \DateTimeImmutable('2013-01-15 14:41:58', new \DateTimeZone('-06:00'))])
         );
 
-        $this->builder->buildAddXml($command);
-
-        $this->assertEquals($timezone->getName(), $date->getTimezone()->getName());
+        $this->assertSame(
+            '<add><doc><field name="id">1</field><field name="datetime">2013-01-15T20:41:58Z</field></doc></add>',
+            $this->builder->buildAddXml($command)
+        );
     }
 
     public function testBuildAddXmlWithFieldModifierAndNullValue()


### PR DESCRIPTION
@wickedOne @mkalkbrenner I think we can close #840 and close #841.

#613 already fixed this:

https://github.com/solariumphp/solarium/blob/2b063e971c1ecddc2a43a4bc6c35fa0ffb0eaf3a/src/Core/Query/Helper.php#L111-L114

The unit test from that PR is easy to miss though because it's not in `HelperTest`. I've moved it and rewritten it to be more "readable" as to what is being tested. Also switched to offset values when testing with timezones because that makes the tests easier to verify (without e.g. having to know about a location's DST rules). Testing 'Europe/London' against 'UTC' is a bad idea anyway, that could mask a hypothetical bug where only the timezone indicator is changed without adjusting the datetime accordingly.

And I changed the date formatting to a one-liner that doesn't require further string manipulation.

As far as the function name is concerned, I think `formatDate()` is perfectly acceptable if you consider its FQN `Solarium\Core\Query\Helper::formatDate()`. It's a method that _helps_ you _format a date_ to use in a _query_, and there's only one format that Solr understands. If you want to do things with your date outside of queries, this is not the namespace you're looking for. _jedi hand wave_