### PR TITLE
JSON requests for BufferedAdd/BufferedDelete

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -13,6 +13,7 @@ This can be done very easily with this plugin, you can simply keep feeding docum
 
 ### Some notes
 
+-   Solarium issues XML formatted update requests by default. If you don't need XML specific behaviour, you can get better performance by switching to JSON formatted update requests.
 -   You can set a custom buffer size. The default is 100 documents, a safe value. By increasing this you can get even better performance, but depending on your document size at some level you will run into memory or request limits. A value of 1000 has been successfully used for indexing 200k documents.
 -   You can use the createDocument method with array input, but you can also manually create document instance and use the addDocument(s) method.
 -   With buffer size X an update request with be sent to Solr for each X docs. You can just keep feeding docs. These buffer flushes don’t include a commit. This is done on purpose. You can add a commit when you’re done, or you can use the Solr auto commit feature.
@@ -52,12 +53,14 @@ require_once(__DIR__.'/init.php');
 
 use Solarium\Plugin\BufferedAdd\Event\Events;
 use Solarium\Plugin\BufferedAdd\Event\PreFlush as PreFlushEvent;
+use Solarium\QueryType\Update\Query\Query;
 
 htmlHeader();
 
 // create a client instance and autoload the buffered add plugin
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $buffer = $client->getPlugin('bufferedadd');
+$buffer->setRequestFormat(Query::REQUEST_FORMAT_JSON); // JSON formatted requests are faster than XML
 $buffer->setBufferSize(10); // this is quite low, in most cases you can use a much higher value
 
 // also register an event hook to display what is happening
@@ -108,6 +111,13 @@ When you need to delete a lot of documents, this can also be done in batches.
 
 You can feed the IDs of the documents to delete, queries to delete matching documents, or both.
 
+Solarium issues XML formatted update requests by default. You can get better performance by switching to
+JSON formatted update requests.
+
+The default buffer size is 100 deletes, a safe value. By increasing this you can get even better performance.
+Delete commands send very little data to Solr, so you can set this to a much higher value than the document
+buffer size for `BufferedAdd`.
+
 ### Events
 
 #### solarium.bufferedDelete.addDeleteById
@@ -143,12 +153,14 @@ require_once(__DIR__.'/init.php');
 
 use Solarium\Plugin\BufferedDelete\Event\Events;
 use Solarium\Plugin\BufferedDelete\Event\PreFlush as PreFlushEvent;
+use Solarium\QueryType\Update\Query\Query;
 
 htmlHeader();
 
 // create a client instance and autoload the buffered delete plugin
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $buffer = $client->getPlugin('buffereddelete');
+$buffer->setRequestFormat(Query::REQUEST_FORMAT_JSON); // JSON formatted requests are faster than XML
 $buffer->setBufferSize(10); // this is quite low, in most cases you can use a much higher value
 
 // also register an event hook to display what is happening

--- a/examples/7.5.1-plugin-bufferedadd.php
+++ b/examples/7.5.1-plugin-bufferedadd.php
@@ -4,12 +4,14 @@ require_once(__DIR__.'/init.php');
 
 use Solarium\Plugin\BufferedAdd\Event\Events;
 use Solarium\Plugin\BufferedAdd\Event\PreFlush as PreFlushEvent;
+use Solarium\QueryType\Update\Query\Query;
 
 htmlHeader();
 
 // create a client instance and autoload the buffered add plugin
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $buffer = $client->getPlugin('bufferedadd'); // or 'bufferedaddlite'
+$buffer->setRequestFormat(Query::REQUEST_FORMAT_JSON); // JSON formatted requests are faster than XML
 $buffer->setBufferSize(10); // this is quite low, in most cases you can use a much higher value
 
 // also register an event hook to display what is happening

--- a/examples/7.5.2-plugin-buffereddelete.php
+++ b/examples/7.5.2-plugin-buffereddelete.php
@@ -4,12 +4,14 @@ require_once(__DIR__.'/init.php');
 
 use Solarium\Plugin\BufferedDelete\Event\Events;
 use Solarium\Plugin\BufferedDelete\Event\PreFlush as PreFlushEvent;
+use Solarium\QueryType\Update\Query\Query;
 
 htmlHeader();
 
 // create a client instance and autoload the buffered delete plugin
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $buffer = $client->getPlugin('buffereddelete'); // or 'buffereddeletelite'
+$buffer->setRequestFormat(Query::REQUEST_FORMAT_JSON); // JSON formatted requests are faster than XML
 $buffer->setBufferSize(10); // this is quite low, in most cases you can use a much higher value
 
 // also register an event hook to display what is happening

--- a/examples/7.5.3.1-plugin-bufferedupdate-benchmarks-xml.php
+++ b/examples/7.5.3.1-plugin-bufferedupdate-benchmarks-xml.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once(__DIR__.'/init.php');
+
+use Solarium\QueryType\Update\Query\Query;
+
+$weight = '';
+$requestFormat = Query::REQUEST_FORMAT_XML;
+
+require(__DIR__.'/7.5.3-plugin-bufferedupdate-benchmarks.php');

--- a/examples/7.5.3.2-plugin-bufferedupdate-lite-benchmarks-xml.php
+++ b/examples/7.5.3.2-plugin-bufferedupdate-lite-benchmarks-xml.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once(__DIR__.'/init.php');
+
+use Solarium\QueryType\Update\Query\Query;
+
+$weight = 'lite';
+$requestFormat = Query::REQUEST_FORMAT_XML;
+
+require(__DIR__.'/7.5.3-plugin-bufferedupdate-benchmarks.php');

--- a/examples/7.5.3.3-plugin-bufferedupdate-benchmarks-json.php
+++ b/examples/7.5.3.3-plugin-bufferedupdate-benchmarks-json.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once(__DIR__.'/init.php');
+
+use Solarium\QueryType\Update\Query\Query;
+
+$weight = '';
+$requestFormat = Query::REQUEST_FORMAT_JSON;
+
+require(__DIR__.'/7.5.3-plugin-bufferedupdate-benchmarks.php');

--- a/examples/7.5.3.4-plugin-bufferedupdate-lite-benchmarks-json.php
+++ b/examples/7.5.3.4-plugin-bufferedupdate-lite-benchmarks-json.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once(__DIR__.'/init.php');
+
+use Solarium\QueryType\Update\Query\Query;
+
+$weight = 'lite';
+$requestFormat = Query::REQUEST_FORMAT_JSON;
+
+require(__DIR__.'/7.5.3-plugin-bufferedupdate-benchmarks.php');

--- a/examples/execute_all.php
+++ b/examples/execute_all.php
@@ -131,7 +131,11 @@ try {
     // examples that can't be run against techproducts
     $skipAltogether = [
         '2.1.5.8-distributed-search.php',
-        '7.5.3-plugin-bufferedupdate-benchmarks.php', // takes too long for a workflow, can be run manually
+        '7.5.3-plugin-bufferedupdate-benchmarks.php', // intended to be included, not to be run standalone
+        '7.5.3.1-plugin-bufferedupdate-benchmarks-xml.php', // takes too long for a workflow, can be run manually
+        '7.5.3.2-plugin-bufferedupdate-lite-benchmarks-xml.php', // takes too long for a workflow, can be run manually
+        '7.5.3.3-plugin-bufferedupdate-benchmarks-json.php', // takes too long for a workflow, can be run manually
+        '7.5.3.4-plugin-bufferedupdate-lite-benchmarks-json.php', // takes too long for a workflow, can be run manually
     ];
 
     // examples that can't be run against this Solr version

--- a/examples/index.html
+++ b/examples/index.html
@@ -174,7 +174,13 @@
                 <ul style="list-style:none;">
                     <li><a href="7.5.1-plugin-bufferedadd.php">7.5.1 Buffered Add for documents</a></li>
                     <li><a href="7.5.2-plugin-buffereddelete.php">7.5.2 Buffered Delete by ID and query</a></li>
-                    <li><a href="7.5.3-plugin-bufferedupdate-benchmarks.php">7.5.3 Benchmarks (can take some time to run!)</a></li>
+                    <li>7.5.3 Benchmarks (can take some time to run!)</li>
+                    <ul style="list-style:none;">
+                        <li><a href="7.5.3.1-plugin-bufferedupdate-benchmarks-xml.php">7.5.3.1 Regular plugins with XML requests</a></li>
+                        <li><a href="7.5.3.2-plugin-bufferedupdate-lite-benchmarks-xml.php">7.5.3.2 Lite plugins with XML requests</a></li>
+                        <li><a href="7.5.3.3-plugin-bufferedupdate-benchmarks-json.php">7.5.3.3 Regular plugins with JSON requests</a></li>
+                        <li><a href="7.5.3.4-plugin-bufferedupdate-lite-benchmarks-json.php">7.5.3.4 Lite plugins with JSON requests</a></li>
+                    </ul>
                 </ul>
                 <li><a href="7.6-plugin-prefetchiterator.php">7.6 Prefetch iterator for select queries</a></li>
                 <li><a href="7.7-plugin-minimumscorefilter.php">7.7 Minimum score filter for select queries</a></li>

--- a/src/Plugin/AbstractBufferedUpdate/AbstractBufferedUpdate.php
+++ b/src/Plugin/AbstractBufferedUpdate/AbstractBufferedUpdate.php
@@ -11,6 +11,7 @@ namespace Solarium\Plugin\AbstractBufferedUpdate;
 
 use Solarium\Core\Client\Endpoint;
 use Solarium\Core\Plugin\AbstractPlugin;
+use Solarium\Exception\InvalidArgumentException;
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 use Solarium\QueryType\Update\Result as UpdateResult;
 
@@ -67,6 +68,34 @@ abstract class AbstractBufferedUpdate extends AbstractPlugin
     }
 
     /**
+     * Set the request format for the updates.
+     *
+     * Use one of the UpdateQuery::REQUEST_FORMAT_* constants as value.
+     *
+     * @param string $requestFormat
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return self Provides fluent interface
+     */
+    public function setRequestFormat(string $requestFormat): self
+    {
+        $this->updateQuery->setRequestFormat($requestFormat);
+
+        return $this;
+    }
+
+    /**
+     * Get the request format for the updates.
+     *
+     * @return string|null
+     */
+    public function getRequestFormat(): ?string
+    {
+        return $this->updateQuery->getRequestFormat();
+    }
+
+    /**
      * Set buffer size option.
      *
      * @param int $size
@@ -111,7 +140,11 @@ abstract class AbstractBufferedUpdate extends AbstractPlugin
      */
     public function clear(): self
     {
+        // keep request format
+        $requestFormat = $this->updateQuery->getRequestFormat();
         $this->updateQuery = $this->client->createUpdate();
+        $this->updateQuery->setRequestFormat($requestFormat);
+
         $this->buffer = [];
 
         return $this;
@@ -142,5 +175,9 @@ abstract class AbstractBufferedUpdate extends AbstractPlugin
     protected function initPluginType(): void
     {
         $this->updateQuery = $this->client->createUpdate();
+
+        if (null !== $requestFormat = $this->getOption('requestformat')) {
+            $this->updateQuery->setRequestFormat($requestFormat);
+        }
     }
 }

--- a/tests/QueryType/Update/Query/QueryTest.php
+++ b/tests/QueryType/Update/Query/QueryTest.php
@@ -27,7 +27,12 @@ class QueryTest extends TestCase
 
     public function testDefaultRequestFormat()
     {
-        $this->assertSame(Query::REQUEST_FORMAT_XML, $this->query->getRequestFormat());
+        $this->assertSame(
+            Query::REQUEST_FORMAT_XML,
+            $this->query->getRequestFormat(),
+            // some tests will still pass but no longer be reliable if they're suddenly testing against the default
+            'Update all tests that assume REQUEST_FORMAT_XML is the default if this is changed (including tests for plugins)'
+        );
     }
 
     public function testSetAndGetRequestFormat()


### PR DESCRIPTION
JSON requests show a performance benefit over XML in the benchmarks.

Had to split out those benchmarks to run them separately. If run in the same script, the first one has different starting conditions (a "cleaner slate") than subsequent runs.