### PR TITLE
Integration tests for JSON request format

### DIFF
--- a/src/QueryType/Update/RequestBuilder/Json.php
+++ b/src/QueryType/Update/RequestBuilder/Json.php
@@ -30,10 +30,19 @@ class Json extends AbstractRequestBuilder
      *
      * @param QueryInterface|AbstractQuery|UpdateQuery $query
      *
+     * @throws RuntimeException
+     *
      * @return Request
      */
     public function build(AbstractQuery $query): Request
     {
+        $inputEncoding = $query->getInputEncoding();
+
+        if (null !== $inputEncoding && 0 !== strcasecmp('UTF-8', $inputEncoding)) {
+            // @see https://www.rfc-editor.org/rfc/rfc8259#section-8.1
+            throw new RuntimeException('JSON requests can only be UTF-8');
+        }
+
         $request = parent::build($query);
         $request->setMethod(Request::METHOD_POST);
         $request->setContentType(Request::CONTENT_TYPE_APPLICATION_JSON);

--- a/tests/Integration/Proxy/AbstractProxyTest.php
+++ b/tests/Integration/Proxy/AbstractProxyTest.php
@@ -29,7 +29,7 @@ abstract class AbstractProxyTest extends TestCase
     protected static $proxy_server;
 
     /**
-     * @var string
+     * @var int
      */
     protected static $proxy_port;
 

--- a/tests/QueryType/Update/RequestBuilder/JsonTest.php
+++ b/tests/QueryType/Update/RequestBuilder/JsonTest.php
@@ -61,6 +61,30 @@ class JsonTest extends TestCase
         );
     }
 
+    /**
+     * Update queries with a different input encoding than the default UTF-8
+     * aren't supported by the JSON request format.
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc8259#section-8.1
+     */
+    public function testBuildWithInputEncoding()
+    {
+        // not setting an input encoding is fine
+        $this->builder->build($this->query);
+
+        $this->query->setInputEncoding('utf-8');
+
+        // setting UTF-8 input encoding explicitly is fine (but superfluous)
+        $this->builder->build($this->query);
+
+        $this->query->setInputEncoding('us-ascii');
+
+        // setting a different input encoding is prohibited
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('JSON requests can only be UTF-8');
+        $this->builder->build($this->query);
+    }
+
     public function testBuildWithUnsupportedCommandType()
     {
         $this->query->add(null, new RawXmlCommand());


### PR DESCRIPTION
Nested documents were fun to get working consistently across Solr versions. I had to switch from price to weight because of [a possible bug with currency fields?](https://lists.apache.org/thread/z32ogb5t35zrjrhwgqz7mdpomh69sy9q)

One small addition to the codebase is a check that you didn't set a non-UTF-8 input encoding for a JSON request. Will probably only happen if you're upgrading legacy code.