### PR TITLE
Update phpdoc for `Helper::formatDate`

### DIFF
--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -137,7 +137,7 @@ class Helper
      * @param int|string|\DateTimeInterface $input Accepted formats: timestamp, date string, DateTime or
      *                                             DateTimeImmutable
      *
-     * @return string|bool false is returned in case of invalid input
+     * @return string|false false is returned in case of invalid input
      */
     public function formatDate($input)
     {


### PR DESCRIPTION
The method will never return `true`. So `@return string|false` works fine and helps tools like phpstan to properly understand what it might actually return.