### PR TITLE
Solr 9.0 → 9.1 for integration tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,12 +51,12 @@ jobs:
                 ref: branch_8_11
                 path: lucene-solr
 
-            - name: Checkout solr 9.0
+            - name: Checkout solr 9.1
               if: matrix.solr == 9
               uses: actions/checkout@v2
               with:
                 repository: apache/solr
-                ref: branch_9_0
+                ref: branch_9_1
                 path: lucene-solr
 
             - name: Start Solr ${{ matrix.solr }} in ${{ matrix.mode }} mode

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -3782,6 +3782,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $doc = $extract->createDocument();
         $doc->id = 'extract-test-1-pdf';
         $doc->cat = ['extract-test'];
+        $doc->foo_1 = 'bar 1';
         $extract->setDocument($doc);
         self::$client->extract($extract);
 
@@ -3790,6 +3791,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $doc = $extract->createDocument();
         $doc->id = 'extract-test-2-html';
         $doc->cat = ['extract-test'];
+        $doc->foo_2 = 'bar 2';
         $extract->setDocument($doc);
         self::$client->extract($extract);
 
@@ -3805,11 +3807,13 @@ abstract class AbstractTechproductsTest extends TestCase
         $document = $iterator->current();
         $this->assertSame('application/pdf', $document['content_type'][0], 'Written document does not contain extracted content type');
         $this->assertSame('PDF Test', trim($document['content'][0]), 'Written document does not contain extracted result');
+        $this->assertSame(['bar 1'], $document['attr_foo_1']);
         $iterator->next();
         $document = $iterator->current();
         $this->assertSame('text/html; charset=UTF-8', $document['content_type'][0], 'Written document does not contain extracted content type');
         $this->assertSame('HTML Test Title', $document['title'][0], 'Written document does not contain extracted title');
         $this->assertMatchesRegularExpression('/^HTML Test Title\s+HTML Test Body$/', trim($document['content'][0]), 'Written document does not contain extracted result');
+        $this->assertSame(['bar 2'], $document['attr_foo_2']);
 
         // now cleanup the documents to have the initial index state
         $update = self::$client->createUpdate();

--- a/tests/Integration/Fixtures/schema9.patch
+++ b/tests/Integration/Fixtures/schema9.patch
@@ -1,7 +1,7 @@
-diff --git a/solr/server/solr/configsets/sample_techproducts_configs/conf/managed-schema b/solr/server/solr/configsets/sample_techproducts_configs/conf/managed-schema
-index aad0c822f34..d0b272c39c2 100644
---- a/solr/server/solr/configsets/sample_techproducts_configs/conf/managed-schema
-+++ b/solr/server/solr/configsets/sample_techproducts_configs/conf/managed-schema
+diff --git a/solr/server/solr/configsets/sample_techproducts_configs/conf/managed-schema.xml b/solr/server/solr/configsets/sample_techproducts_configs/conf/managed-schema.xml
+index 190214aebad..7a76a28276a 100644
+--- a/solr/server/solr/configsets/sample_techproducts_configs/conf/managed-schema.xml
++++ b/solr/server/solr/configsets/sample_techproducts_configs/conf/managed-schema.xml
 @@ -118,7 +118,9 @@
     <!-- points to the root document of a block of nested documents. Required for nested
        document support, may be removed otherwise
@@ -13,3 +13,10 @@ index aad0c822f34..d0b272c39c2 100644
  
     <!-- Only remove the "id" field if you have a very good reason to. While not strictly
       required, it is highly recommended. A <uniqueKey> is present in almost all Solr
+@@ -218,6 +220,7 @@
+
+    <dynamicField name="random_*" type="random"/>
+    <dynamicField name="ignored_*" type="ignored"/>
++   <dynamicField name="attr_*" type="text_general" indexed="true" stored="true" multiValued="true"/>
+ 
+    <dynamicField name="*_c"   type="currency" indexed="true"  stored="true"/>


### PR DESCRIPTION
Two of the examples fail with Solr 9.1 because the `attr_*` dynamic field definition was removed in Solr [PR 484](https://github.com/apache/solr/pull/484).

I've added it back with an API call if it doesn't exist to keep the examples running.

Also switched from Solr 9.0 to 9.1 for the integration tests and added it to schema patch, which also needed to be updated to add `.xml` to the filename.

The integration test set a `uprefix` but never actually tested its use. That's added too.