### PR TITLE
For Solarium 7: set default to JSON formatted update requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+### Changed
+- Update queries use the JSON request format by default
 
 ## [6.2.8]
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,23 +53,17 @@ setlocale(LC_NUMERIC, $currentLocale);
 PHP 8.0 has made the float to string conversion locale-independent and will always use the `.` decimal separator.
 The workaround is no longer necessary with PHP versions ≥ 8.0.
 
-### Future pitfall when upgrading to 7.x
+### Pitfall when upgrading to 7.x
 
-Solarium 7 will change the default request format for update queries from XML to JSON.
+With Solarium 7 update queries use the JSON request format by default.
 
-You can already test your code with JSON requests to ensure a seamless transition.
+If you do require XML specific functionality, set the request format to XML explicitly.
 
 ```php
 // get an update query instance
 $update = $client->createUpdate();
 
-// set JSON request format
-$update->setRequestFormat($update::REQUEST_FORMAT_JSON);
-```
-
-If you do require XML specific functionality, set the request format to XML explicitly instead to avoid issues when upgrading.
-
-```php
+// set XML request format
 $update->setRequestFormat($update::REQUEST_FORMAT_XML);
 ```
 
@@ -156,7 +150,7 @@ In the past, the V1 API endpoint `solr` was not added automatically, so most use
 This bug was discovered with the addition of V2 API support. In almost every setup, the path has to be set to `/`
 instead of `/solr` with this release!
 
-For the same reason it is a must to explicit configure the _core_ or _collection_.
+For the same reason it is a must to explicitly configure the _core_ or _collection_.
 
 So an old setting like
 ```

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -223,7 +223,7 @@ $doc->reaction = $reaction;
 $doc->setField('reaction', $reaction);
 ```
 
-**Note:** You have to use the JSON request format to index a labelled single nested child document. For more info see [known limitations](#known-limitations).
+**Note:** You can't index a labelled single nested child document if you set the request format to XML. For more info see [known limitations](#known-limitations).
 
 #### Anonymous children
 
@@ -231,20 +231,10 @@ If you use `_childDocuments_` as the field name, the child documents are indexed
 
 #### Known limitations
 
-Some child document functionality isn't supported by XML formatted update requests.
+Solarium issues JSON formatted update requests by default. If you change this to XML, some child document functionality isn't supported by Solr.
 
 - It's impossible to index a labelled single nested child document because of [SOLR-16183](https://issues.apache.org/jira/browse/SOLR-16183). Any child document you index this way will end up as an anonymous nested child.
 - Atomic updates of child documents aren't fully supported because of [SOLR-12677](https://issues.apache.org/jira/browse/SOLR-12677).
-
-Make sure to set the request format to JSON if you require this functionality.
-
-```php
-// get an update query instance
-$update = $client->createUpdate();
-
-// set JSON request format
-$update->setRequestFormat($update::REQUEST_FORMAT_JSON);
-```
 
 ### Atomic updates
 
@@ -352,7 +342,15 @@ You can set the document boost with the `setBoost` method.
 
 Field boosts can be set with the `setFieldBoost` method, or with optional parameters of the `setField` and `addField` methods. See the API docs for details.
 
-Index-time boosts have been removed from Solr 7 and will be ignored. Even with older Solr versions, they aren't supported by JSON formatted update requests.
+Index-time boosts have been removed from Solr 7 and will be ignored. Even with older Solr versions, they aren't supported by JSON formatted update requests. Set the request format to XML if you are still using them.
+
+```php
+// get an update query instance
+$update = $client->createUpdate();
+
+// set XML request format
+$update->setRequestFormat($update::REQUEST_FORMAT_XML);
+```
 
 Custom document
 ---------------

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -13,7 +13,7 @@ This can be done very easily with this plugin, you can simply keep feeding docum
 
 ### Some notes
 
--   Solarium issues XML formatted update requests by default. If you don't need XML specific behaviour, you can get better performance by switching to JSON formatted update requests.
+-   Solarium issues JSON formatted update requests by default. If you require XML specific functionality, you can set the request format to XML on the plugin instance. XML requests are slower than JSON.
 -   You can set a custom buffer size. The default is 100 documents, a safe value. By increasing this you can get even better performance, but depending on your document size at some level you will run into memory or request limits. A value of 1000 has been successfully used for indexing 200k documents.
 -   You can use the createDocument method with array input, but you can also manually create document instance and use the addDocument(s) method.
 -   With buffer size X an update request with be sent to Solr for each X docs. You can just keep feeding docs. These buffer flushes don’t include a commit. This is done on purpose. You can add a commit when you’re done, or you can use the Solr auto commit feature.
@@ -60,7 +60,6 @@ htmlHeader();
 // create a client instance and autoload the buffered add plugin
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $buffer = $client->getPlugin('bufferedadd');
-$buffer->setRequestFormat(Query::REQUEST_FORMAT_JSON); // JSON formatted requests are faster than XML
 $buffer->setBufferSize(10); // this is quite low, in most cases you can use a much higher value
 
 // also register an event hook to display what is happening
@@ -111,9 +110,6 @@ When you need to delete a lot of documents, this can also be done in batches.
 
 You can feed the IDs of the documents to delete, queries to delete matching documents, or both.
 
-Solarium issues XML formatted update requests by default. You can get better performance by switching to
-JSON formatted update requests.
-
 The default buffer size is 100 deletes, a safe value. By increasing this you can get even better performance.
 Delete commands send very little data to Solr, so you can set this to a much higher value than the document
 buffer size for `BufferedAdd`.
@@ -160,7 +156,6 @@ htmlHeader();
 // create a client instance and autoload the buffered delete plugin
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $buffer = $client->getPlugin('buffereddelete');
-$buffer->setRequestFormat(Query::REQUEST_FORMAT_JSON); // JSON formatted requests are faster than XML
 $buffer->setBufferSize(10); // this is quite low, in most cases you can use a much higher value
 
 // also register an event hook to display what is happening

--- a/docs/queries/update-query/best-practices-for-updates.md
+++ b/docs/queries/update-query/best-practices-for-updates.md
@@ -30,8 +30,16 @@ While 'optimizing' sounds like it's always a good thing to do, you should use it
 
 ### XML vs JSON formatted update requests
 
-Solarium issues XML formatted update requests by default. This will change to JSON format when Solarium 7 is released. You can set this to JSON if you want to test your code in advance. If you require XML specific functionality, you should already set this to XML explicitly to ensure a seamless transition.
+Solarium issues JSON formatted update requests by default since Solarium 7. If you do require XML specific functionality, set the request format to XML explicitly.
+
+```php
+// get an update query instance
+$update = $client->createUpdate();
+
+// set XML request format
+$update->setRequestFormat($update::REQUEST_FORMAT_XML);
+```
 
 ### Raw XML update commands
 
-Solarium makes it easy to build update commands without having to know the underlying XML structure. If you already have XML formatted update commands, you can add them directly to an update query. Make sure they are valid as Solarium will not check this.
+Solarium makes it easy to build update commands without having to know the underlying XML structure. If you already have XML formatted update commands, you can add them directly to an update query. Make sure they are valid as Solarium will not check this, and set the [XML request format](#xml-vs-json-formatted-update-requests) on the update query.

--- a/docs/queries/update-query/building-an-update-query/building-an-update-query.md
+++ b/docs/queries/update-query/building-an-update-query/building-an-update-query.md
@@ -10,7 +10,7 @@ However, if you do need to customize them for a special case, you can.
 
 ### RequestFormat
 
-Solarium issues XML formatted update requests by default. This will change to JSON format when Solarium 7 is released. You can set this to JSON if you want to test your code in advance. If you require XML specific functionality, you should already set this to XML explicitly to ensure a seamless transition.
+Solarium issues JSON formatted update requests by default. Set this to XML if you require XML specific functionality.
 
 ### ResultClass
 

--- a/examples/7.5.1-plugin-bufferedadd.php
+++ b/examples/7.5.1-plugin-bufferedadd.php
@@ -11,7 +11,6 @@ htmlHeader();
 // create a client instance and autoload the buffered add plugin
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $buffer = $client->getPlugin('bufferedadd'); // or 'bufferedaddlite'
-$buffer->setRequestFormat(Query::REQUEST_FORMAT_JSON); // JSON formatted requests are faster than XML
 $buffer->setBufferSize(10); // this is quite low, in most cases you can use a much higher value
 
 // also register an event hook to display what is happening

--- a/examples/7.5.2-plugin-buffereddelete.php
+++ b/examples/7.5.2-plugin-buffereddelete.php
@@ -11,7 +11,6 @@ htmlHeader();
 // create a client instance and autoload the buffered delete plugin
 $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $buffer = $client->getPlugin('buffereddelete'); // or 'buffereddeletelite'
-$buffer->setRequestFormat(Query::REQUEST_FORMAT_JSON); // JSON formatted requests are faster than XML
 $buffer->setBufferSize(10); // this is quite low, in most cases you can use a much higher value
 
 // also register an event hook to display what is happening

--- a/examples/execute_all.php
+++ b/examples/execute_all.php
@@ -141,6 +141,7 @@ try {
         DIRECTORY_SEPARATOR.'exampledocs';
     foreach (glob($dataDir.DIRECTORY_SEPARATOR.'*.xml') as $file) {
         $update = $client->createUpdate();
+        $update->setRequestFormat($update::REQUEST_FORMAT_XML);
 
         if (null !== $encoding = Utility::getXmlEncoding($file)) {
             $update->setInputEncoding($encoding);

--- a/src/QueryType/Update/Query/Query.php
+++ b/src/QueryType/Update/Query/Query.php
@@ -108,7 +108,7 @@ class Query extends BaseQuery
      */
     protected $options = [
         'handler' => 'update',
-        'requestformat' => self::REQUEST_FORMAT_XML,
+        'requestformat' => self::REQUEST_FORMAT_JSON,
         'resultclass' => Result::class,
         'documentclass' => Document::class,
         'omitheader' => false,

--- a/tests/Plugin/BufferedAdd/BufferedAddLiteTest.php
+++ b/tests/Plugin/BufferedAdd/BufferedAddLiteTest.php
@@ -75,7 +75,7 @@ class BufferedAddLiteTest extends TestCase
     {
         $options = [
             'endpoint' => new Endpoint(),
-            'requestformat' => Query::REQUEST_FORMAT_JSON,
+            'requestformat' => Query::REQUEST_FORMAT_XML,
             'buffersize' => 200,
         ];
 
@@ -300,10 +300,10 @@ class BufferedAddLiteTest extends TestCase
 
     public function testClearKeepsRequestFormat()
     {
-        $this->plugin->setRequestFormat(Query::REQUEST_FORMAT_JSON);
+        $this->plugin->setRequestFormat(Query::REQUEST_FORMAT_XML);
         $this->plugin->clear();
 
-        $this->assertSame(Query::REQUEST_FORMAT_JSON, $this->plugin->getRequestFormat());
+        $this->assertSame(Query::REQUEST_FORMAT_XML, $this->plugin->getRequestFormat());
     }
 
     public function testFlushEmptyBuffer()
@@ -414,13 +414,13 @@ class BufferedAddLiteTest extends TestCase
 
     public function testDefaultRequestFormat()
     {
-        $this->assertSame(Query::REQUEST_FORMAT_XML, $this->plugin->getRequestFormat());
+        $this->assertSame(Query::REQUEST_FORMAT_JSON, $this->plugin->getRequestFormat());
     }
 
     public function testSetAndGetRequestFormat()
     {
-        $this->plugin->setRequestFormat(Query::REQUEST_FORMAT_JSON);
-        $this->assertSame(Query::REQUEST_FORMAT_JSON, $this->plugin->getRequestFormat());
+        $this->plugin->setRequestFormat(Query::REQUEST_FORMAT_XML);
+        $this->assertSame(Query::REQUEST_FORMAT_XML, $this->plugin->getRequestFormat());
     }
 
     public function testSetUnsupportedRequestFormat()

--- a/tests/Plugin/BufferedDelete/BufferedDeleteLiteTest.php
+++ b/tests/Plugin/BufferedDelete/BufferedDeleteLiteTest.php
@@ -78,7 +78,7 @@ class BufferedDeleteLiteTest extends TestCase
     {
         $options = [
             'endpoint' => new Endpoint(),
-            'requestformat' => Query::REQUEST_FORMAT_JSON,
+            'requestformat' => Query::REQUEST_FORMAT_XML,
             'buffersize' => 200,
         ];
 
@@ -311,10 +311,10 @@ class BufferedDeleteLiteTest extends TestCase
 
     public function testClearKeepsRequestFormat()
     {
-        $this->plugin->setRequestFormat(Query::REQUEST_FORMAT_JSON);
+        $this->plugin->setRequestFormat(Query::REQUEST_FORMAT_XML);
         $this->plugin->clear();
 
-        $this->assertSame(Query::REQUEST_FORMAT_JSON, $this->plugin->getRequestFormat());
+        $this->assertSame(Query::REQUEST_FORMAT_XML, $this->plugin->getRequestFormat());
     }
 
     public function testFlushEmptyBuffer()
@@ -396,13 +396,13 @@ class BufferedDeleteLiteTest extends TestCase
 
     public function testDefaultRequestFormat()
     {
-        $this->assertSame(Query::REQUEST_FORMAT_XML, $this->plugin->getRequestFormat());
+        $this->assertSame(Query::REQUEST_FORMAT_JSON, $this->plugin->getRequestFormat());
     }
 
     public function testSetAndGetRequestFormat()
     {
-        $this->plugin->setRequestFormat(Query::REQUEST_FORMAT_JSON);
-        $this->assertSame(Query::REQUEST_FORMAT_JSON, $this->plugin->getRequestFormat());
+        $this->plugin->setRequestFormat(Query::REQUEST_FORMAT_XML);
+        $this->assertSame(Query::REQUEST_FORMAT_XML, $this->plugin->getRequestFormat());
     }
 
     public function testSetUnsupportedRequestFormat()

--- a/tests/QueryType/Update/Query/QueryTest.php
+++ b/tests/QueryType/Update/Query/QueryTest.php
@@ -28,17 +28,17 @@ class QueryTest extends TestCase
     public function testDefaultRequestFormat()
     {
         $this->assertSame(
-            Query::REQUEST_FORMAT_XML,
+            Query::REQUEST_FORMAT_JSON,
             $this->query->getRequestFormat(),
             // some tests will still pass but no longer be reliable if they're suddenly testing against the default
-            'Update all tests that assume REQUEST_FORMAT_XML is the default if this is changed (including tests for plugins)'
+            'Update all tests that assume REQUEST_FORMAT_JSON is the default if this is changed (including tests for plugins)'
         );
     }
 
     public function testSetAndGetRequestFormat()
     {
-        $this->query->setRequestFormat(Query::REQUEST_FORMAT_JSON);
-        $this->assertSame(Query::REQUEST_FORMAT_JSON, $this->query->getRequestFormat());
+        $this->query->setRequestFormat(Query::REQUEST_FORMAT_XML);
+        $this->assertSame(Query::REQUEST_FORMAT_XML, $this->query->getRequestFormat());
     }
 
     public function testSetUnsupportedRequestFormat()
@@ -69,7 +69,7 @@ class QueryTest extends TestCase
     {
         $options = [
             'handler' => 'myHandler',
-            'requestformat' => Query::REQUEST_FORMAT_JSON,
+            'requestformat' => Query::REQUEST_FORMAT_XML,
             'resultclass' => 'myResult',
             'command' => [
                 'key1' => [
@@ -103,7 +103,7 @@ class QueryTest extends TestCase
         );
 
         $this->assertSame(
-            Query::REQUEST_FORMAT_JSON,
+            Query::REQUEST_FORMAT_XML,
             $this->query->getRequestFormat()
         );
 


### PR DESCRIPTION
@mkalkbrenner I'm in no rush for Solarium 7. Just wanted to have this PR ready while I still had a fresh recollection of what needed changing in the docs.