### PR TITLE
Mark init() DocBlocks for internal use

### DIFF
--- a/src/Component/DistributedSearch.php
+++ b/src/Component/DistributedSearch.php
@@ -377,8 +377,8 @@ class DistributedSearch extends AbstractComponent
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal Several options need some extra checks or setup work,
+     *            for these options the setters are called.}
      */
     protected function init()
     {

--- a/src/Component/Facet/AbstractRange.php
+++ b/src/Component/Facet/AbstractRange.php
@@ -290,8 +290,8 @@ abstract class AbstractRange extends AbstractFacet
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal Several options need some extra checks or setup work,
+     *            for these options the setters are called.}
      */
     protected function init()
     {

--- a/src/Component/Facet/Interval.php
+++ b/src/Component/Facet/Interval.php
@@ -92,8 +92,8 @@ class Interval extends AbstractFacet
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal Several options need some extra checks or setup work,
+     *            for these options the setters are called.}
      */
     protected function init()
     {

--- a/src/Component/Facet/JsonRange.php
+++ b/src/Component/Facet/JsonRange.php
@@ -35,8 +35,8 @@ class JsonRange extends AbstractRange implements JsonFacetInterface, FacetSetInt
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal Both the parent's and JsonFacetTrait's init() are needed
+     *            to properly initialize all options.}
      */
     protected function init()
     {

--- a/src/Component/Facet/MultiQuery.php
+++ b/src/Component/Facet/MultiQuery.php
@@ -279,8 +279,7 @@ class MultiQuery extends AbstractFacet
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal The 'query' option needs additional setup work.}
      */
     protected function init()
     {

--- a/src/Component/Facet/Pivot.php
+++ b/src/Component/Facet/Pivot.php
@@ -405,6 +405,9 @@ class Pivot extends AbstractFacet
 
     /**
      * Initialize options.
+     *
+     * {@internal Options that set a list of fields need additional setup work
+     *            because they can be an array or a comma separated string.}
      */
     protected function init()
     {

--- a/src/Component/Facet/Range.php
+++ b/src/Component/Facet/Range.php
@@ -55,8 +55,8 @@ class Range extends AbstractRange
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal Several options need some extra checks or setup work,
+     *            for these options the setters are called.}
      */
     protected function init()
     {

--- a/src/Component/FacetSetTrait.php
+++ b/src/Component/FacetSetTrait.php
@@ -196,8 +196,7 @@ trait FacetSetTrait
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal The 'facet' option needs additional setup work.}
      */
     protected function init()
     {

--- a/src/Component/Grouping.php
+++ b/src/Component/Grouping.php
@@ -571,8 +571,9 @@ class Grouping extends AbstractComponent
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal The 'query' option needs additional setup work.
+     *            Options that set a list of fields need additional setup work
+     *            because they can be an array or a comma separated string.}
      */
     protected function init()
     {

--- a/src/Component/Highlighting/Highlighting.php
+++ b/src/Component/Highlighting/Highlighting.php
@@ -280,7 +280,8 @@ class Highlighting extends AbstractComponent implements HighlightingInterface, Q
     /**
      * Initialize options.
      *
-     * Options that can be an array or string with fieldnames need work.
+     * {@internal Options that set a list of fields need additional setup work
+     *            because they can be an array or a comma separated string.}
      */
     protected function init()
     {

--- a/src/Component/MoreLikeThis.php
+++ b/src/Component/MoreLikeThis.php
@@ -193,6 +193,9 @@ class MoreLikeThis extends AbstractComponent implements MoreLikeThisInterface
 
     /**
      * Initialize options.
+     *
+     * {@internal Options that set a list of fields need additional setup work
+     *            because they can be an array or a comma separated string.}
      */
     protected function init()
     {

--- a/src/Component/QueryElevation.php
+++ b/src/Component/QueryElevation.php
@@ -334,8 +334,9 @@ class QueryElevation extends AbstractComponent
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal Options that influence transformers need additional setup work.
+     *            Options that set a list of ids need additional setup work
+     *            because they can be an array or a comma separated string.}
      */
     protected function init()
     {

--- a/src/Component/Stats/Field.php
+++ b/src/Component/Stats/Field.php
@@ -144,8 +144,8 @@ class Field extends Configurable
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal Options that set a list of facet names need additional setup work
+     *            because they can be an array or a comma separated string.}
      */
     protected function init()
     {

--- a/src/Component/Stats/Stats.php
+++ b/src/Component/Stats/Stats.php
@@ -224,8 +224,8 @@ class Stats extends AbstractComponent
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal Options that set a list of field or facet names need additional setup work
+     *            because they can be an array or a comma separated string.}
      */
     protected function init()
     {

--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -201,7 +201,8 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
     /**
      * Initialization hook.
      *
-     * Checks the availability of Curl_http
+     * {@internal Check if PHP was compiled with cURL support.
+     *            Check for deprecated use of 'proxy' option.}
      *
      * @throws RuntimeException
      */

--- a/src/Core/Client/Endpoint.php
+++ b/src/Core/Client/Endpoint.php
@@ -437,8 +437,8 @@ class Endpoint extends Configurable
     /**
      * Initialization hook.
      *
-     * In this case the path needs to be cleaned of trailing slashes.
-     * The context needs to be cleaned of leading and trailing slashes.
+     * The path will be cleaned of trailing slashes.
+     * The context will be cleaned of leading and trailing slashes.
      *
      * @see setPath()
      * @see setContext()

--- a/src/Plugin/Loadbalancer/Loadbalancer.php
+++ b/src/Plugin/Loadbalancer/Loadbalancer.php
@@ -530,8 +530,8 @@ class Loadbalancer extends AbstractPlugin
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal Several options need some extra checks or setup work,
+     *            for these options the setters are called.}
      */
     protected function init()
     {

--- a/src/QueryType/Extract/Query.php
+++ b/src/QueryType/Extract/Query.php
@@ -450,8 +450,7 @@ class Query extends BaseQuery
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal The 'fmap' option needs additional setup work.}
      */
     protected function init()
     {

--- a/src/QueryType/Select/Query/Query.php
+++ b/src/QueryType/Select/Query/Query.php
@@ -847,8 +847,8 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface, Query
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal Several options need some extra checks or setup work,
+     *            for these options the setters are called.}
      */
     protected function init()
     {

--- a/src/QueryType/Update/Query/Query.php
+++ b/src/QueryType/Update/Query/Query.php
@@ -579,8 +579,8 @@ class Query extends BaseQuery
     /**
      * Initialize options.
      *
-     * Several options need some extra checks or setup work, for these options
-     * the setters are called.
+     * {@internal Several options need some extra checks or setup work,
+     *            for these options the setters are called.}
      *
      * @throws InvalidArgumentException
      * @throws RuntimeException


### PR DESCRIPTION
Fixes #1045.

The issue makes a valid point. The docs on init() functions can be confusing for users and are mostly only relevant to contributors or users who extend the codebase. I've tried to add some clarity here and there and marked the parts that are irrelevant to end users as `{@internal ...}`.