### PR TITLE
JSON serialization of arrays with non-consecutive indices in multivalue fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Fixed
+- JSON serialization of arrays with non-consecutive indices in multivalue fields
 
 
 ## [6.2.8]

--- a/src/QueryType/Update/Query/Document.php
+++ b/src/QueryType/Update/Query/Document.php
@@ -499,6 +499,9 @@ class Document extends AbstractDocument
             if ($value instanceof \DateTimeInterface) {
                 $value = $this->getHelper()->formatDate($value);
             } elseif (\is_array($value) && is_numeric(array_key_first($value))) {
+                // ensure consecutive indices so it doesn't serialize to an object
+                $value = array_values($value);
+
                 foreach ($value as &$multivalue) {
                     if ($multivalue instanceof \DateTimeInterface) {
                         $multivalue = $this->getHelper()->formatDate($multivalue);

--- a/tests/QueryType/Update/RequestBuilder/JsonTest.php
+++ b/tests/QueryType/Update/RequestBuilder/JsonTest.php
@@ -231,6 +231,28 @@ class JsonTest extends TestCase
         );
     }
 
+    public function testBuildAddJsonMultivalueFieldWithNonConsecutiveArrayIndices()
+    {
+        $command = new AddCommand();
+        $command->addDocument(new Document(['id' => [0 => 1, 4 => 2, 6 => 3], 'text' => [1 => 'a', 2 => 'b', 3 => 'c']]));
+        $json = [];
+
+        $this->builder->buildAddJson($command, $json);
+
+        $this->assertCount(1, $json);
+        $this->assertJsonStringEqualsJsonString(
+            '{
+                "add": {
+                    "doc": {
+                        "id": [1, 2, 3],
+                        "text": ["a", "b", "c"]
+                    }
+                }
+            }',
+            '{'.$json[0].'}'
+        );
+    }
+
     public function testBuildAddJsonWithEmptyStrings()
     {
         $command = new AddCommand();
@@ -662,7 +684,7 @@ class JsonTest extends TestCase
         );
     }
 
-    public function testBuildAddJsonWithMultivaluedDateTimes()
+    public function testBuildAddJsonWithMultivalueDateTimes()
     {
         $command = new AddCommand();
         $command->addDocument(

--- a/tests/QueryType/Update/RequestBuilder/XmlTest.php
+++ b/tests/QueryType/Update/RequestBuilder/XmlTest.php
@@ -174,6 +174,26 @@ class XmlTest extends TestCase
         );
     }
 
+    public function testBuildAddXmlMultivalueFieldWithNonConsecutiveArrayIndices()
+    {
+        $command = new AddCommand();
+        $command->addDocument(new Document(['id' => [0 => 1, 4 => 2, 6 => 3], 'text' => [1 => 'a', 2 => 'b', 3 => 'c']]));
+
+        $this->assertSame(
+            '<add>'.
+            '<doc>'.
+            '<field name="id">1</field>'.
+            '<field name="id">2</field>'.
+            '<field name="id">3</field>'.
+            '<field name="text">a</field>'.
+            '<field name="text">b</field>'.
+            '<field name="text">c</field>'.
+            '</doc>'.
+            '</add>',
+            $this->builder->buildAddXml($command)
+        );
+    }
+
     public function testBuildAddXmlWithEmptyStrings()
     {
         $command = new AddCommand();
@@ -489,7 +509,7 @@ class XmlTest extends TestCase
         );
     }
 
-    public function testBuildAddXmlWithMultivaluedDateTimes()
+    public function testBuildAddXmlWithMultivalueDateTimes()
     {
         $command = new AddCommand();
         $command->addDocument(


### PR DESCRIPTION
Ran into an issue with JSON requests with real-life data. It always worked with XML requests so it is or does at least feel like a BC break. PRed against the `6.x` branch because that will need a bugfix release. Will have to go into `master` as well. (If you agree it's something to fix in the library and not leave up to the users.)

Our userland code uses `array_unique()` on some arrays that go into multivalue fields and that results in non-consecutive array indices (unlike some other PHP functions which renumber numeric keys). Same thing could happen with `unset()`. This doesn't matter for XML because the request builder `foreach`es over the values and doesn't even look at the keys. It does matter for JSON because `json_encode()` turns them into objects instead of arrays.

```php
echo json_encode([0, 1, 2]);
// [0,1,2]

echo json_encode(array_unique([0, 1, 1, 2]));
// {"0":0,"1":1,"3":2}
```

This leads to a SolrException:

```json
{
  "responseHeader":{
    "status":400,
    "QTime":0},
  "error":{
    "metadata":[
      "error-class","org.apache.solr.common.SolrException",
      "root-error-class","org.apache.solr.common.SolrException"],
    "msg":"Unknown operation for the an atomic update, operation ignored: 0 for id:SP2514N",
    "code":400}}
```

Unfortunately, there is no flag for `json_encode()` to force it to serialize this as an array regardless. That leaves us with running it through `array_values()` first.

I feel that as a library, that is something that we should do. There is no reason to doubt the user's intent here, and the XML request builder de facto assumed this was the intended behaviour (probably without thinking about it that way, it just happened to work out).

The other option would be to leave it up to the user to ensure array indices are consecutive. Then we'd need to get that point across in the documentation. As a user, I'd rather have the library worrying about such implementation details. Especially since you can luck out 99 times with `array_unique()`/`unset()` happening to delete from the end and only encounter it the 100th time.