### PR TITLE
Fix deprecations for PHPUnit 9.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "roave/security-advisories": "dev-master",
         "symfony/event-dispatcher": "^4.3 || ^5.0 || ^6.0"
     },

--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -175,8 +175,8 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
     public function setOption(string $name, $value): Configurable
     {
         if ('proxy' === $name) {
-            trigger_error('Setting proxy as an option is deprecated. Use setProxy() instead.', \E_USER_DEPRECATED);
             $this->setProxy($value);
+            trigger_error('Setting proxy as an option is deprecated. Use setProxy() instead.', \E_USER_DEPRECATED);
         }
 
         return parent::setOption($name, $value);
@@ -215,8 +215,8 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
         }
 
         if (isset($this->options['proxy'])) {
-            trigger_error('Setting proxy as an option is deprecated. Use setProxy() instead.', \E_USER_DEPRECATED);
             $this->setProxy($this->options['proxy']);
+            trigger_error('Setting proxy as an option is deprecated. Use setProxy() instead.', \E_USER_DEPRECATED);
         }
     }
 

--- a/tests/Component/Result/Debug/DetailTest.php
+++ b/tests/Component/Result/Debug/DetailTest.php
@@ -112,8 +112,14 @@ class DetailTest extends TestCase
 
     public function testOffsetGetUnknown()
     {
-        $this->expectError();
+        set_error_handler(static function (int $errno, string $errstr): never {
+            throw new \Exception($errstr, $errno);
+        }, \E_NOTICE /* PHP 7 */ | \E_WARNING /* PHP 8 */);
+
+        $this->expectExceptionMessage('Undefined property');
         $this->result->offsetGet('unknown');
+
+        restore_error_handler();
     }
 
     public function testOffsetSetImmutable()

--- a/tests/Core/Client/Adapter/CurlTest.php
+++ b/tests/Core/Client/Adapter/CurlTest.php
@@ -70,6 +70,15 @@ class CurlTest extends TestCase
         restore_error_handler();
     }
 
+    /**
+     * Verify that options besides 'proxy' are handled as usual.
+     */
+    public function testSetNonProxyOption()
+    {
+        $this->adapter->setOption('foo', 'bar');
+        $this->assertSame('bar', $this->adapter->getOption('foo'));
+    }
+
     public function testCheck()
     {
         $data = 'data';

--- a/tests/Core/Client/Adapter/CurlTest.php
+++ b/tests/Core/Client/Adapter/CurlTest.php
@@ -33,32 +33,41 @@ class CurlTest extends TestCase
 
     public function testSetProxyConstructor()
     {
-        $adapter = @new Curl(['proxy' => 'proxy.example.org:1234']);
+        set_error_handler(static function (int $errno, string $errstr): never {
+            throw new \Exception($errstr, $errno);
+        }, \E_USER_DEPRECATED);
+
+        $this->expectExceptionMessage('Setting proxy as an option is deprecated. Use setProxy() instead.');
+        $adapter = new Curl(['proxy' => 'proxy.example.org:1234']);
         $this->assertSame('proxy.example.org:1234', $adapter->getProxy());
 
-        $this->expectDeprecation();
-        $this->expectDeprecationMessage('Setting proxy as an option is deprecated. Use setProxy() instead.');
-        new Curl(['proxy' => 'proxy.example.org:1234']);
+        restore_error_handler();
     }
 
     public function testSetProxyConfigMode()
     {
-        @$this->adapter->setOptions(['proxy' => 'proxy.example.org:5678']);
+        set_error_handler(static function (int $errno, string $errstr): never {
+            throw new \Exception($errstr, $errno);
+        }, \E_USER_DEPRECATED);
+
+        $this->expectExceptionMessage('Setting proxy as an option is deprecated. Use setProxy() instead.');
+        $this->adapter->setOptions(['proxy' => 'proxy.example.org:5678']);
         $this->assertSame('proxy.example.org:5678', $this->adapter->getProxy());
 
-        $this->expectDeprecation();
-        $this->expectDeprecationMessage('Setting proxy as an option is deprecated. Use setProxy() instead.');
-        $this->adapter->setOptions(['proxy' => 'proxy.example.org:5678']);
+        restore_error_handler();
     }
 
     public function testSetProxyOption()
     {
-        @$this->adapter->setOption('proxy', 'proxy.example.org:9012');
+        set_error_handler(static function (int $errno, string $errstr): never {
+            throw new \Exception($errstr, $errno);
+        }, \E_USER_DEPRECATED);
+
+        $this->expectExceptionMessage('Setting proxy as an option is deprecated. Use setProxy() instead.');
+        $this->adapter->setOption('proxy', 'proxy.example.org:9012');
         $this->assertSame('proxy.example.org:9012', $this->adapter->getProxy());
 
-        $this->expectDeprecation();
-        $this->expectDeprecationMessage('Setting proxy as an option is deprecated. Use setProxy() instead.');
-        $this->adapter->setOption('proxy', 'proxy.example.org:9012');
+        restore_error_handler();
     }
 
     public function testCheck()

--- a/tests/Core/Client/Adapter/HttpTest.php
+++ b/tests/Core/Client/Adapter/HttpTest.php
@@ -79,11 +79,8 @@ class HttpTest extends TestCase
 
     public function testCheckOk()
     {
-        $value = $this->adapter->check('dummydata', ['HTTP 1.1 200 OK']);
-
-        $this->assertNull(
-            $value
-        );
+        $this->expectNotToPerformAssertions();
+        $this->adapter->check('dummydata', ['HTTP 1.1 200 OK']);
     }
 
     public function testCreateContextGetRequest()

--- a/tests/Core/ConfigurableTest.php
+++ b/tests/Core/ConfigurableTest.php
@@ -124,7 +124,7 @@ class ConfigurableTest extends TestCase
         $configTest = new ConfigTest();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectErrorMessage('Options value given to the setOptions() method must be an array or a Zend_Config object');
+        $this->expectExceptionMessage('Options value given to the setOptions() method must be an array or a Zend_Config object');
         $configTest->setOptions('option2=2&option3=3');
     }
 }

--- a/tests/Plugin/BufferedAdd/BufferedAddLiteTest.php
+++ b/tests/Plugin/BufferedAdd/BufferedAddLiteTest.php
@@ -180,12 +180,18 @@ class BufferedAddLiteTest extends TestCase
         $doc2->id = '234';
         $doc2->name = 'test2';
 
+        $docs = [$doc1, $doc2];
+
         $updateQuery = $this->createMock(Query::class);
         $updateQuery->expects($this->exactly(2))
             ->method('add')
-            ->withConsecutive(
-                [null, (new AddCommand())->addDocument($doc1)],
-                [null, (new AddCommand())->addDocument($doc2)],
+            ->with(
+                $this->equalTo(null),
+                $this->callback(function (AddCommand $command) use ($docs): bool {
+                    static $i = 0;
+
+                    return [$docs[$i++]] === $command->getDocuments();
+                })
             );
 
         $mockResult = $this->createMock(Result::class);
@@ -203,7 +209,7 @@ class BufferedAddLiteTest extends TestCase
         $plugin = new $pluginClass();
         $plugin->initPlugin($client, []);
         $plugin->setBufferSize(1);
-        $plugin->addDocuments([$doc1, $doc2]);
+        $plugin->addDocuments($docs);
     }
 
     public function testSetBufferSizeAutoFlush()

--- a/tests/Plugin/BufferedDelete/BufferedDeleteLiteTest.php
+++ b/tests/Plugin/BufferedDelete/BufferedDeleteLiteTest.php
@@ -150,12 +150,18 @@ class BufferedDeleteLiteTest extends TestCase
 
     public function testAddDeleteByIdAutoFlush()
     {
+        $ids = [123, 'abc'];
+
         $updateQuery = $this->createMock(Query::class);
         $updateQuery->expects($this->exactly(2))
             ->method('add')
-            ->withConsecutive(
-                [null, (new DeleteCommand())->addId(123)],
-                [null, (new DeleteCommand())->addId('abc')],
+            ->with(
+                $this->equalTo(null),
+                $this->callback(function (DeleteCommand $command) use ($ids): bool {
+                    static $i = 0;
+
+                    return [$ids[$i++]] === $command->getIds();
+                })
             );
 
         $mockResult = $this->createMock(Result::class);
@@ -173,7 +179,7 @@ class BufferedDeleteLiteTest extends TestCase
         $plugin = new $pluginClass();
         $plugin->initPlugin($client, []);
         $plugin->setBufferSize(1);
-        $plugin->addDeleteByIds([123, 'abc']);
+        $plugin->addDeleteByIds($ids);
     }
 
     public function testAddDeleteQuery()
@@ -201,12 +207,18 @@ class BufferedDeleteLiteTest extends TestCase
 
     public function testAddDeleteQueryAutoFlush()
     {
+        $queries = ['cat:abc', 'cat:def'];
+
         $updateQuery = $this->createMock(Query::class);
         $updateQuery->expects($this->exactly(2))
             ->method('add')
-            ->withConsecutive(
-                [null, (new DeleteCommand())->addQuery('cat:abc')],
-                [null, (new DeleteCommand())->addQuery('cat:def')],
+            ->with(
+                $this->equalTo(null),
+                $this->callback(function (DeleteCommand $command) use ($queries): bool {
+                    static $i = 0;
+
+                    return [$queries[$i++]] === $command->getQueries();
+                })
             );
 
         $mockResult = $this->createMock(Result::class);
@@ -224,7 +236,7 @@ class BufferedDeleteLiteTest extends TestCase
         $plugin = new $pluginClass();
         $plugin->initPlugin($client, []);
         $plugin->setBufferSize(1);
-        $plugin->addDeleteQueries(['cat:abc', 'cat:def']);
+        $plugin->addDeleteQueries($queries);
     }
 
     public function testSetBufferSizeAutoFlush()
@@ -354,7 +366,7 @@ class BufferedDeleteLiteTest extends TestCase
         $plugin->addUnknownDeleteType();
 
         $this->expectException(RuntimeException::class);
-        $this->expectErrorMessage('Unsupported delete type in buffer');
+        $this->expectExceptionMessage('Unsupported delete type in buffer');
         $plugin->flush();
     }
 

--- a/tests/Plugin/MinimumScoreFilter/QueryTest.php
+++ b/tests/Plugin/MinimumScoreFilter/QueryTest.php
@@ -79,9 +79,19 @@ class QueryTest extends AbstractQueryTest
 
         $mock->expects($this->exactly(2))
             ->method('setOption')
-            ->withConsecutive(
-                ['resultquerygroupclass', QueryGroupResult::class],
-                ['resultvaluegroupclass', ValueGroupResult::class],
+            ->with(
+                $this->callback(function (string $option): bool {
+                    static $i = 0;
+                    static $options = ['resultquerygroupclass', 'resultvaluegroupclass'];
+
+                    return $options[$i++] === $option;
+                }),
+                $this->callback(function (string $className): bool {
+                    static $j = 0;
+                    static $classNames = [QueryGroupResult::class, ValueGroupResult::class];
+
+                    return $classNames[$j++] === $className;
+                })
             );
 
         $this->query->setComponent(Query::COMPONENT_GROUPING, $mock);

--- a/tests/Plugin/PrefetchIteratorTest.php
+++ b/tests/Plugin/PrefetchIteratorTest.php
@@ -183,10 +183,13 @@ class PrefetchIteratorTest extends TestCase
         // every time the query is executed
         $mockQuery->expects($this->exactly(3))
                   ->method('setStart')
-                  ->withConsecutive(
-                      [$this->equalTo(0)],
-                      [$this->equalTo(2)],
-                      [$this->equalTo(4)],
+                  ->with(
+                      $this->callback(function (int $start): bool {
+                          static $i = 0;
+                          static $starts = [0, 2, 4];
+
+                          return $starts[$i++] === $start;
+                      })
                   )
                   ->willReturnSelf();
         $mockQuery->expects($this->never())
@@ -231,11 +234,13 @@ class PrefetchIteratorTest extends TestCase
         // initial manual setCursorMark('*') + every time the query is executed
         $mockQuery->expects($this->exactly(4))
                   ->method('setCursorMark')
-                  ->withConsecutive(
-                      [$this->equalTo('*')],
-                      [$this->equalTo('*')],
-                      [$this->equalTo('AoEhMg==')],
-                      [$this->equalTo('AoEhNA==')],
+                  ->with(
+                      $this->callback(function (string $cursorMark): bool {
+                          static $i = 0;
+                          static $cursorMarks = ['*', '*', 'AoEhMg==', 'AoEhNA=='];
+
+                          return $cursorMarks[$i++] === $cursorMark;
+                      })
                   )
                   ->willReturnSelf();
         // won't be '*' on consecutive calls, only matters that it isn't NULL for this test
@@ -284,11 +289,13 @@ class PrefetchIteratorTest extends TestCase
         // every time the query is executed
         $mockQuery->expects($this->exactly(4))
                   ->method('setStart')
-                  ->withConsecutive(
-                      [$this->equalTo(0)],
-                      [$this->equalTo(2)],
-                      [$this->equalTo(4)],
-                      [$this->equalTo(6)],
+                  ->with(
+                      $this->callback(function (int $start): bool {
+                          static $i = 0;
+                          static $starts = [0, 2, 4, 6];
+
+                          return $starts[$i++] === $start;
+                      })
                   )
                   ->willReturnSelf();
         $mockQuery->expects($this->never())
@@ -338,12 +345,13 @@ class PrefetchIteratorTest extends TestCase
         // initial manual setCursorMark('*') + every time the query is executed
         $mockQuery->expects($this->exactly(5))
                   ->method('setCursorMark')
-                  ->withConsecutive(
-                      [$this->equalTo('*')],
-                      [$this->equalTo('*')],
-                      [$this->equalTo('AoEhMg==')],
-                      [$this->equalTo('AoEhNA==')],
-                      [$this->equalTo('AoEhNg==')],
+                  ->with(
+                      $this->callback(function (string $cursorMark): bool {
+                          static $i = 0;
+                          static $cursorMarks = ['*', '*', 'AoEhMg==', 'AoEhNA==', 'AoEhNg=='];
+
+                          return $cursorMarks[$i++] === $cursorMark;
+                      })
                   )
                   ->willReturnSelf();
         // won't be '*' on consecutive calls, only matters that it isn't NULL for this test
@@ -432,11 +440,13 @@ class PrefetchIteratorTest extends TestCase
         // every time the query is executed
         $mockQuery->expects($this->exactly(4))
                   ->method('setStart')
-                  ->withConsecutive(
-                      [$this->equalTo(0)],
-                      [$this->equalTo(3)],
-                      [$this->equalTo(0)],
-                      [$this->equalTo(3)],
+                  ->with(
+                      $this->callback(function (int $start): bool {
+                          static $i = 0;
+                          static $starts = [0, 3, 0, 3];
+
+                          return $starts[$i++] === $start;
+                      })
                   )
                   ->willReturnSelf();
         $mockQuery->expects($this->never())
@@ -487,12 +497,13 @@ class PrefetchIteratorTest extends TestCase
         // initial manual setCursorMark('*') + every time the query is executed
         $mockQuery->expects($this->exactly(5))
                   ->method('setCursorMark')
-                  ->withConsecutive(
-                      [$this->equalTo('*')],
-                      [$this->equalTo('*')],
-                      [$this->equalTo('AoEhMw==')],
-                      [$this->equalTo('*')],
-                      [$this->equalTo('AoEhMw==')],
+                  ->with(
+                      $this->callback(function (string $cursorMark): bool {
+                          static $i = 0;
+                          static $cursorMarks = ['*', '*', 'AoEhMw==', '*', 'AoEhMw=='];
+
+                          return $cursorMarks[$i++] === $cursorMark;
+                      })
                   )
                   ->willReturnSelf();
         // won't be '*' on consecutive calls, only matters that it isn't NULL for this test

--- a/tests/Support/UtilityTest.php
+++ b/tests/Support/UtilityTest.php
@@ -19,10 +19,16 @@ class UtilityTest extends TestCase
 
     public function testGetXmlEncodingNoFile()
     {
-        $this->expectError();
+        set_error_handler(static function (int $errno, string $errstr): never {
+            throw new \Exception($errstr, $errno);
+        }, \E_WARNING);
+
+        $this->expectExceptionMessage('No such file or directory');
         $this->assertNull(
             Utility::getXmlEncoding('nosuchfile')
         );
+
+        restore_error_handler();
     }
 
     public function testGetXmlEncodingWithoutUtf8BomWithoutXmlDeclaration()


### PR DESCRIPTION
PHPUnit 9.6 deprecated some methods that are removed in PHPUnit 10.0.

PHPUnit 10 requires PHP >=8.1, didn't test yet if it will cause BC issues if we run both 9 and 10 depending on PHP version.