### PR TITLE
Trailing question mark when query string is empty

### DIFF
--- a/src/Core/Client/Request.php
+++ b/src/Core/Client/Request.php
@@ -425,7 +425,7 @@ class Request extends Configurable implements RequestParamsInterface
     /**
      * Get an URI for this request.
      *
-     * @return string|null
+     * @return string
      */
     public function getUri(): string
     {

--- a/src/Core/Client/Request.php
+++ b/src/Core/Client/Request.php
@@ -427,11 +427,11 @@ class Request extends Configurable implements RequestParamsInterface
      *
      * @return string|null
      */
-    public function getUri(): ?string
+    public function getUri(): string
     {
         $queryString = $this->getQueryString();
         if ('' === $queryString) {
-            return $this->getHandler();
+            return $this->getHandler() ?? '';
         }
 
         return $this->getHandler().'?'.$queryString;

--- a/src/Core/Client/Request.php
+++ b/src/Core/Client/Request.php
@@ -429,7 +429,12 @@ class Request extends Configurable implements RequestParamsInterface
      */
     public function getUri(): ?string
     {
-        return $this->getHandler().'?'.$this->getQueryString();
+        $queryString = $this->getQueryString();
+        if ('' === $queryString) {
+            return $this->getHandler();
+        }
+
+        return $this->getHandler().'?'.$queryString;
     }
 
     /**

--- a/tests/Core/Client/Adapter/HttpTest.php
+++ b/tests/Core/Client/Adapter/HttpTest.php
@@ -40,7 +40,7 @@ class HttpTest extends TestCase
 
         $mock->expects($this->once())
              ->method('getData')
-             ->with($this->equalTo('http://127.0.0.1:8983/solr/?'), $this->isType('resource'))
+             ->with($this->equalTo('http://127.0.0.1:8983/solr/'), $this->isType('resource'))
              ->willReturn([$data, ['HTTP 1.1 200 OK']]);
 
         $mock->execute($request, $endpoint);
@@ -61,7 +61,7 @@ class HttpTest extends TestCase
 
         $mock->expects($this->once())
              ->method('getData')
-             ->with($this->equalTo('http://127.0.0.1:8983/solr/?'), $this->isType('resource'))
+             ->with($this->equalTo('http://127.0.0.1:8983/solr/'), $this->isType('resource'))
              ->willReturn([$data, ['HTTP 1.1 200 OK']]);
         $mock->expects($this->once())
              ->method('check')

--- a/tests/Core/Client/RequestTest.php
+++ b/tests/Core/Client/RequestTest.php
@@ -464,7 +464,10 @@ EOF;
 
     public function testGetUri()
     {
-        $this->assertNull($this->request->getUri());
+        $this->assertSame(
+            '',
+            $this->request->getUri()
+        );
     }
 
     public function testGetUriWithHandler()

--- a/tests/Core/Client/RequestTest.php
+++ b/tests/Core/Client/RequestTest.php
@@ -464,8 +464,14 @@ EOF;
 
     public function testGetUri()
     {
+        $this->assertNull($this->request->getUri());
+    }
+
+    public function testGetUriWithHandler()
+    {
+        $this->request->setHandler('myHandler');
         $this->assertSame(
-            '?',
+            'myHandler',
             $this->request->getUri()
         );
     }


### PR DESCRIPTION
Currently, a request without GET parameters will still include a trailing `?` character in the URL. This commonly occurs when using the `PostBigRequest` plugin, and can lead to unnecessary problems in combination with a server that forbids the mixing of GET and POST parameters.

While it is clear that, normally, a web server should be expected to treat an empty query string the same as a completely missing query (that is, the trailing `?` shouldn’t matter), I think we can also agree that the URL looks cleaner without the unnecessary trailing `? ` character. Furthermore, looking at the [URI specification of the W3C](https://www.w3.org/Addressing/URL/uri-spec.html), it seems a trailing `?` would even violate the standard, strictly speaking.

Unless there are good reasons to keep the trailing `?`, I propose the simple change of removing the `?` for empty query strings.