### PR TITLE
Support for Luke queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for Luke queries
+
 ### Fixed
 - JSON serialization of arrays with non-consecutive indices in multivalue fields
 
 ### Changed
 - Update queries use the JSON request format by default
+
 
 ## [6.2.8]
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
+        "halaxa/json-machine": "^1.1",
         "psr/event-dispatcher": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",

--- a/docs/queries/luke-query/luke-query.md
+++ b/docs/queries/luke-query/luke-query.md
@@ -1,0 +1,246 @@
+Luke query
+==========
+
+Luke queries can be used to [access information on the schema data](https://solr.apache.org/guide/luke-request-handler.html).
+
+Building a Luke query
+---------------------
+
+**Available options:**
+
+| Name                   | Type   | Default value                                 | Description                                                                                                                              |
+|------------------------|--------|-----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| show                   | string | null                                          | The data about the index to include in the response. Use one of the `SHOW_*` class constants as value.                                   |
+| id                     | string | null                                          | Get a document using the `uniqueKeyField` specified in the schema.                                                                       |
+| docId                  | int    | null                                          | Get a document using a Lucene documentID.                                                                                                |
+| fields                 | string | null                                          | Fields to get details for. Separate multiple fields with commas. Use `'*'` to include all fields.                                        |
+| numTerms               | int    | null                                          | The number of top terms for each field.                                                                                                  |
+| includeIndexFieldFlags | bool   | null                                          | Whether to return index flags for each field. Fetching index flags can slow down Luke requests.                                          |
+| documentclass          | string | Solarium\\QueryType\\Select\\Result\\Document | Classname for a document in the result. If you set a custom classname make sure the class is readily available (or through autoloading). |
+||
+
+The `show` option determines which information will be queried from the Luke handler.
+The Luke query defines constants for the possible values.
+
+- `$lukeQuery::SHOW_INDEX`: high-level details about the [index](#index)
+- `$lukeQuery::SHOW_ALL`: information about [all fields](#all-fields)
+- `$lukeQuery::SHOW_SCHEMA`: details about the [schema](#schema)
+- `$lukeQuery::SHOW_DOC`: details about a specific [document](#document)
+
+If the `fields` option is provided to get [field details](#field-details), or `id` or `docId`
+to get [document](#document) details, `show` can be omitted.
+
+### Index
+
+Return the high-level details about the index.
+
+There are no additional options for this show style.
+
+This information is included in all Luke results and can be retrieved with `$result->getIndex()`.
+
+```php
+$lukeQuery = $client->createLuke();
+$lukeQuery->setShow($lukeQuery::SHOW_INDEX);
+
+$result = $client->luke($lukeQuery);
+
+$index = $result->getIndex();
+```
+
+### All fields
+
+Return information about all fields.
+
+`includeIndexFieldFlags` can be set to `false` to disable fetching and returning index flags.
+
+This information can be retrieved with `$result->getFields()`.
+
+```php
+$lukeQuery = $client->createLuke();
+$lukeQuery->setShow($lukeQuery::SHOW_ALL);
+
+// omitting index flags for each field can speed up Luke requests
+//$lukeQuery->setIncludeIndexFieldFlags(false);
+
+$result = $client->luke($lukeQuery);
+
+$fields = $result->getFields();
+```
+
+#### Field details
+
+Return detailed information about specified fields. Use with caution especially on large indexes!
+
+`fields` must be set to a field list or `'*'` to enable this. `'*'` fetches the details for all fields.
+
+`numTerms` can be set to the number of top terms to return for each field.
+
+`includeIndexFieldFlags` can be set to `false` to disable fetching and returning index flags.
+
+This information can be retrieved with `$result->getFields()`.
+
+```php
+$lukeQuery = $client->createLuke();
+
+// set the fields you want detailed information for
+$lukeQuery->setFields('text,cat,price_c');
+
+// you can also get detailed information for all fields
+//$lukeQuery->setFields('*');
+
+// omitting index flags for each field can speed up Luke requests
+//$lukeQuery->setIncludeIndexFieldFlags(false);
+
+// set the number of top terms for each field (Solr's default is 10)
+$lukeQuery->setNumTerms(5);
+
+$result = $client->luke($lukeQuery);
+
+$fields = $result->getFields();
+```
+
+### Schema
+
+Return details about the schema.
+
+There are no additional options for this show style.
+
+This information can be retrieved with `$result->getSchema()`.
+
+```php
+$lukeQuery = $client->createLuke();
+$lukeQuery->setShow($lukeQuery::SHOW_SCHEMA);
+
+$result = $client->luke($lukeQuery);
+
+$schema = $result->getSchema();
+```
+
+### Document
+
+Return details about a specific document. This includes the actual document from the index.
+
+`id` can be set to an ID in the `uniqueKeyField` specified in the schema.
+
+`docId` can be set to a Lucene documentID.
+
+`documentclass` can be set to a custom classname for the actual document in the result.
+
+This information can be retrieved with `$result->getDoc()`.
+
+```php
+$lukeQuery = $client->createLuke();
+$lukeQuery->setShow($lukeQuery::SHOW_DOC);
+
+// get a document using the uniqueKeyField specified in the schema
+$lukeQuery->setId('9885A004');
+
+// alternatively, you can use a Lucene documentID
+//$lukeQuery->setDocId(27);
+
+$result = $client->luke($lukeQuery);
+
+$docInfo = $result->getDoc();
+```
+
+Result of a Luke query
+----------------------
+
+### Example usage
+
+A full example is available for each show style.
+
+- [Index](result-of-a-luke-query/index-details.md)
+- [All fields](result-of-a-luke-query/all-fields.md)
+- [Field details](result-of-a-luke-query/field-details.md)
+- [Schema](result-of-a-luke-query/schema.md)
+- [Document](result-of-a-luke-query/document.md)
+
+### Property getters
+
+A Luke result consists of an object or collection of objects with getters for every
+possible property in a response. The getters are named after the corresponding
+properties and follow the camelCase convention of the Solarium codebase.
+
+#### Examples
+
+- `version` → `getVersion()`
+- `numDocs` → `getNumDocs()`
+- `NOTE` → `getNote()`
+
+### Omittable properties
+
+There are properties that will always be present in a response and properties that can
+be omitted. The getter for an omittable property will return `null` if it isn't present
+in the response.
+
+### Boolean properties
+
+Some boolean properties will always be present in a response, while others may be omitted
+if they aren't `true`. Result objects have isser or hasser convenience methods
+— depending on what makes sense grammatically — for all boolean properties. They'll
+always offer a boolean answer to the question "*is this …?*" or "*does this have …?*"
+
+If the distinction between an explicit `false` and an omitted property matters, you can
+use the getter. As for all omittable properties, it will return `null` instead.
+
+#### Examples
+
+- `current` → `isCurrent()` & `getCurrent()`
+- `hasDeletions` → `hasDeletions()` & `getHasDeletions()`
+
+### Flag lists
+
+Fields have properties that are represented by Solr as a string containing a list of
+flags. A separate key of the flags is included in the [info](#generally-helpful-information)
+section of the response. Solarium augments each flag list by turning it into a
+`Solarium\QueryType\Luke\Result\FlagList` object. This object provides the original
+string representation, a traversable list of the flags that are set (incorporating
+the definition from the key), and issers for every flag.
+
+#### Example
+
+```php
+echo $field->getFlags();
+// I-S-UM----OF-----l
+
+foreach ($field->getFlags() as $f => $flag) {
+    echo $f, ': ', $flag;
+}
+// I: Indexed
+// S: Stored
+// U: UnInvertible
+// M: Multivalued
+// O: Omit Norms
+// F: Omit Term Frequencies & Positions
+// l: Sort Missing Last
+
+$field->getFlags()->isIndexed(); // true
+$field->getFlags()->isTokenized(); // false
+$field->getFlags()->isStored(); // true
+$field->getFlags()->isDocValues(); // false
+$field->getFlags()->isUninvertible(); // true
+$field->getFlags()->isMultiValued(); // true
+$field->getFlags()->isTermVectors(); // false
+$field->getFlags()->isTermOffsets(); // false
+$field->getFlags()->isTermPositions(); // false
+$field->getFlags()->isTermPayloads(); // false
+$field->getFlags()->isOmitNorms(); // true
+$field->getFlags()->isOmitTermFreqAndPositions(); // true
+$field->getFlags()->isOmitPositions(); // false
+$field->getFlags()->isStoreOffsetsWithPositions(); // false
+$field->getFlags()->isLazy(); // false
+$field->getFlags()->isBinary(); // false
+$field->getFlags()->isSortMissingFirst(); // false
+$field->getFlags()->isSortMissingLast(); // true
+```
+
+### Generally helpful information
+
+Some generally helpful information is available in the result for every show style
+that includes more than just the high-level index details. This information can be
+retrieved with `$result->getInfo()`.
+
+#### Example usage
+
+A full [Info](result-of-a-luke-query/info.md) example is available.

--- a/docs/queries/luke-query/result-of-a-luke-query/all-fields.md
+++ b/docs/queries/luke-query/result-of-a-luke-query/all-fields.md
@@ -1,0 +1,110 @@
+Result of a Luke query — All fields
+===================================
+
+```php
+$fields = $result->getFields();
+```
+
+Information on all fields, including schema and (if not omitted) field
+[flags](../luke-query.md#flag-lists).
+
+Example usage
+-------------
+
+```php
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a Luke query
+$lukeQuery = $client->createLuke();
+$lukeQuery->setShow($lukeQuery::SHOW_ALL);
+
+// omitting index flags for each field can speed up Luke requests
+//$lukeQuery->setIncludeIndexFieldFlags(false);
+
+$result = $client->luke($lukeQuery);
+
+$index = $result->getIndex();
+$fields = $result->getFields();
+$info = $result->getInfo();
+
+echo '<h1>index</h1>';
+
+echo '<table>';
+echo '<tr><th>numDocs</th><td>' . $index->getNumDocs() . '</td></tr>';
+echo '<tr><th>maxDoc</th><td>' . $index->getMaxDoc() . '</td></tr>';
+echo '<tr><th>deletedDocs</th><td>' . $index->getDeletedDocs() . '</td></tr>';
+echo '<tr><th>indexHeapUsageBytes</th><td>' . ($index->getIndexHeapUsageBytes() ?? '(not supported by this version of Solr)') . '</td></tr>';
+echo '<tr><th>version</th><td>' . $index->getVersion() . '</td></tr>';
+echo '<tr><th>segmentCount</th><td>' . $index->getSegmentCount() . '</td></tr>';
+echo '<tr><th>current</th><td>' . ($index->getCurrent() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>hasDeletions</th><td>' . ($index->getHasDeletions() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>directory</th><td>' . $index->getDirectory() . '</td></tr>';
+echo '<tr><th>segmentsFile</th><td>' . $index->getSegmentsFile() . '</td></tr>';
+echo '<tr><th>segmentsFileSizeInBytes</th><td>' . $index->getSegmentsFileSizeInBytes() . '</td></tr>';
+
+$userData = $index->getUserData();
+echo '<tr><th>userData</th><td>';
+if (null !== $userData->getCommitCommandVer()) {
+    echo 'commitCommandVer: ' . $userData->getCommitCommandVer() . '<br/>';
+}
+if (null !== $userData->getCommitTimeMSec()) {
+    echo 'commitTimeMSec: ' . $userData->getCommitTimeMSec() . '<br/>';
+}
+echo '</td></tr>';
+
+if (null !== $index->getLastModified()) {
+    echo '<tr><th>lastModified</th><td>' . $index->getLastModified()->format(DATE_RFC3339_EXTENDED) . '</td></tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>fields</h1>';
+
+echo '<table>';
+echo '<tr>';
+echo '<th>name</th><th>type</th><th>schema</th>';
+echo '<th>schema⚑<br/>indexed</th><th>schema⚑<br/>tokenized</th><th>schema⚑<br/>stored</th><th>schema⚑<br/>docValues</th>'; // just a few examples, there's a corresponding is*() method for each flag
+echo '<th>dynamicBase</th><th>index</th>';
+echo '<th>index⚑<br/>tokenized</th><th>index⚑<br/>termVectors</th><th>index⚑<br/>omitNorms</th>'; // a few more examples of corresponding is*() methods for flags
+echo '<th>docs</th>';
+echo '</tr>';
+foreach ($fields as $field) {
+    echo '<tr>';
+    echo '<th>' . $field->getName() . '</th><td>' . $field->getType() . '</td><td>' . $field->getSchema() . '</td>';
+    echo '<td>' . ($field->getSchema()->isIndexed() ? '⚐' : '') . '</td><td>' . ($field->getSchema()->isTokenized() ? '⚐' : '') . '</td><td>' . ($field->getSchema()->isStored() ? '⚐' : '') . '</td><td>' . ($field->getSchema()->isDocValues() ? '⚐' : '') . '</td>';
+    echo '<td>' . $field->getDynamicBase() . '</td><td>' . $field->getIndex() . '</td>';
+    // some fields have '(unstored field)' or no index flags at all in the result
+    // and with $lukeQuery->setIncludeIndexFieldFlags(false), index flags are omitted for each field
+    if (is_object($field->getIndex())) {
+        echo '<td>' . ($field->getIndex()->isTokenized() ? '⚐' : '') . '</td><td>' . ($field->getIndex()->isTermVectors() ? '⚐' : '') . '</td><td>' . ($field->getIndex()->isOmitNorms() ? '⚐' : '') . '</td>';
+    } else {
+        echo '<td></td><td></td><td></td>';
+    }
+    echo '<td>' . $field->getDocs() . '</td>';
+    echo '</tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>info</h1>';
+
+echo '<table>';
+echo '<tr><th>key</th><td>';
+foreach ($info->getKey() as $abbreviation => $flag) {
+    echo $abbreviation . ': ' . $flag . '<br/>';
+}
+echo '</td></tr>';
+echo '<tr><th>NOTE</th><td>' . $info->getNote() . '</td></tr>';
+echo '</table>';
+
+htmlFooter();
+
+```

--- a/docs/queries/luke-query/result-of-a-luke-query/document.md
+++ b/docs/queries/luke-query/result-of-a-luke-query/document.md
@@ -1,0 +1,170 @@
+Result of a Luke query — Document
+=================================
+
+```php
+$docInfo = $result->getDoc();
+```
+
+The detailed information on a document contains the documentID and document fields info
+from Lucene, as well as the full document from Solr.
+
+Document info properties
+------------------------
+
+### Lucene documentID
+
+This is the internal documentID set by Lucene. Can be retrieved with
+`$docInfo->getDocId()`.
+
+**Note:** You can't use this to reliably indentify the document. Lucene may change it
+during optimize, merge …
+
+### Document fields info
+
+This provides detailed information on the fields and their values, including
+[flags](../luke-query.md#flag-lists). Can be retrieved with `$docInfo->getLucene()`.
+
+### Solr document
+
+A [read-only document](/documents/#read-only-document). Can be retrieved with
+`$docInfo->getSolr()`.
+
+Caveat with `json_encode()`
+---------------------------
+
+The JSON representation of the document fields info in a Luke response contains
+duplicate keys for multivalue fields. This can't be encoded back to an equivalent JSON
+representation with `json_encode()`. If you do need this JSON representation, you can
+get it from the response body instead.
+
+```php
+// this loses info on multiple values of multivalue fields
+$json = json_encode($result);
+
+// this gets the original JSON from the Solr response
+$json = $result->getResponse()->getBody();
+```
+
+Example usage
+-------------
+
+```php
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a Luke query
+$lukeQuery = $client->createLuke();
+$lukeQuery->setShow($lukeQuery::SHOW_DOC);
+
+// get a document using the uniqueKeyField specified in the schema
+$lukeQuery->setId('9885A004');
+
+// alternatively, you can use a Lucene documentID
+//$lukeQuery->setDocId(27);
+
+$result = $client->luke($lukeQuery);
+
+$index = $result->getIndex();
+$docInfo = $result->getDoc();
+$info = $result->getInfo();
+
+echo '<h1>index</h1>';
+
+echo '<table>';
+echo '<tr><th>numDocs</th><td>' . $index->getNumDocs() . '</td></tr>';
+echo '<tr><th>maxDoc</th><td>' . $index->getMaxDoc() . '</td></tr>';
+echo '<tr><th>deletedDocs</th><td>' . $index->getDeletedDocs() . '</td></tr>';
+echo '<tr><th>indexHeapUsageBytes</th><td>' . ($index->getIndexHeapUsageBytes() ?? '(not supported by this version of Solr)') . '</td></tr>';
+echo '<tr><th>version</th><td>' . $index->getVersion() . '</td></tr>';
+echo '<tr><th>segmentCount</th><td>' . $index->getSegmentCount() . '</td></tr>';
+echo '<tr><th>current</th><td>' . ($index->getCurrent() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>hasDeletions</th><td>' . ($index->getHasDeletions() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>directory</th><td>' . $index->getDirectory() . '</td></tr>';
+echo '<tr><th>segmentsFile</th><td>' . $index->getSegmentsFile() . '</td></tr>';
+echo '<tr><th>segmentsFileSizeInBytes</th><td>' . $index->getSegmentsFileSizeInBytes() . '</td></tr>';
+
+$userData = $index->getUserData();
+echo '<tr><th>userData</th><td>';
+if (null !== $userData->getCommitCommandVer()) {
+    echo 'commitCommandVer: ' . $userData->getCommitCommandVer() . '<br/>';
+}
+if (null !== $userData->getCommitTimeMSec()) {
+    echo 'commitTimeMSec: ' . $userData->getCommitTimeMSec() . '<br/>';
+}
+echo '</td></tr>';
+
+if (null !== $index->getLastModified()) {
+    echo '<tr><th>lastModified</th><td>' . $index->getLastModified()->format(DATE_RFC3339_EXTENDED) . '</td></tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>doc</h1>';
+
+echo '<h2>docId</h2>';
+
+echo '<table>';
+echo '<tr><th>Lucene documentID</th><td>' . $docInfo->getDocId() . '</td></tr>';
+echo '</table>';
+
+echo '<h2>lucene</h2>';
+
+echo '<table>';
+echo '<tr>';
+echo '<th>name</th><th>type</th><th>schema</th>';
+echo '<th>schema⚑<br/>indexed</th><th>schema⚑<br/>tokenized</th><th>schema⚑<br/>stored</th><th>schema⚑<br/>docValues</th>'; // just a few examples, there's a corresponding is*() method for each flag
+echo '<th>flags</th>';
+echo '<th>flags⚑<br/>indexed</th><th>flags⚑<br/>omitNorms</th><th>flags⚑<br/>omitTermFreqAndPositions</th>'; // a few more examples of corresponding is*() methods for flags
+echo '<th>value</th><th>docFreq</th><th>termVector</th>';
+echo '</tr>';
+foreach ($docInfo->getLucene() as $field) {
+    echo '<tr>';
+    echo '<th>' . $field->getName() . '</th><td>' . $field->getType() . '</td><td>' . $field->getSchema() . '</td>';
+    echo '<td>' . ($field->getSchema()->isIndexed() ? '⚐' : '') . '</td><td>' . ($field->getSchema()->isTokenized() ? '⚐' : '') . '</td><td>' . ($field->getSchema()->isStored() ? '⚐' : '') . '</td><td>' . ($field->getSchema()->isDocValues() ? '⚐' : '') . '</td>';
+    echo '<td>' . $field->getFlags() . '</td>';
+    echo '<td>' . ($field->getFlags()->isIndexed() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isOmitNorms() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isOmitTermFreqAndPositions() ? '⚐' : '') . '</td>';
+    echo '<td>' . $field->getValue() . '</td><td>' . $field->getDocFreq() . '</td><td>';
+    if (null !== $termVector = $field->getTermVector()) {
+        foreach ($termVector as $term => $frequency) {
+            echo $term . ': ' . $frequency . '<br/>';
+        }
+    }
+    echo '</td>';
+    echo '</tr>';
+}
+echo '</table>';
+
+echo '<h2>solr</h2>';
+
+echo '<table>';
+foreach ($docInfo->getSolr() as $field => $value) {
+    if (is_array($value)) {
+        $value = implode(', ', $value);
+    }
+
+    echo '<tr><th>' . $field . '</th><td>' . $value . '</td></tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>info</h1>';
+
+echo '<table>';
+echo '<tr><th>key</th><td>';
+foreach ($info->getKey() as $abbreviation => $flag) {
+    echo $abbreviation . ': ' . $flag . '<br/>';
+}
+echo '</td></tr>';
+echo '<tr><th>NOTE</th><td>' . $info->getNote() . '</td></tr>';
+echo '</table>';
+
+htmlFooter();
+
+```

--- a/docs/queries/luke-query/result-of-a-luke-query/field-details.md
+++ b/docs/queries/luke-query/result-of-a-luke-query/field-details.md
@@ -1,0 +1,144 @@
+Result of a Luke query — Field details
+======================================
+
+```php
+$fields = $result->getFields();
+```
+
+Detailed information on specified fields, including schema and (if not omitted)
+field [flags](../luke-query.md#flag-lists), and frequency arrays.
+
+Example usage
+-------------
+
+```php
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+echo '<h2>Note: Use with caution especially on large indexes!</h2>';
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a Luke query
+$lukeQuery = $client->createLuke();
+
+// set the fields you want detailed information for
+$lukeQuery->setFields('text,cat,price_c');
+
+// you can also get detailed information for all fields
+//$lukeQuery->setFields('*');
+
+// omitting index flags for each field can speed up Luke requests
+//$lukeQuery->setIncludeIndexFieldFlags(false);
+
+// set the number of top terms for each field (Solr's default is 10)
+$lukeQuery->setNumTerms(5);
+
+$result = $client->luke($lukeQuery);
+
+$index = $result->getIndex();
+$fields = $result->getFields();
+$info = $result->getInfo();
+
+echo '<h1>index</h1>';
+
+echo '<table>';
+echo '<tr><th>numDocs</th><td>' . $index->getNumDocs() . '</td></tr>';
+echo '<tr><th>maxDoc</th><td>' . $index->getMaxDoc() . '</td></tr>';
+echo '<tr><th>deletedDocs</th><td>' . $index->getDeletedDocs() . '</td></tr>';
+echo '<tr><th>indexHeapUsageBytes</th><td>' . ($index->getIndexHeapUsageBytes() ?? '(not supported by this version of Solr)') . '</td></tr>';
+echo '<tr><th>version</th><td>' . $index->getVersion() . '</td></tr>';
+echo '<tr><th>segmentCount</th><td>' . $index->getSegmentCount() . '</td></tr>';
+echo '<tr><th>current</th><td>' . ($index->getCurrent() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>hasDeletions</th><td>' . ($index->getHasDeletions() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>directory</th><td>' . $index->getDirectory() . '</td></tr>';
+echo '<tr><th>segmentsFile</th><td>' . $index->getSegmentsFile() . '</td></tr>';
+echo '<tr><th>segmentsFileSizeInBytes</th><td>' . $index->getSegmentsFileSizeInBytes() . '</td></tr>';
+
+$userData = $index->getUserData();
+echo '<tr><th>userData</th><td>';
+if (null !== $userData->getCommitCommandVer()) {
+    echo 'commitCommandVer: ' . $userData->getCommitCommandVer() . '<br/>';
+}
+if (null !== $userData->getCommitTimeMSec()) {
+    echo 'commitTimeMSec: ' . $userData->getCommitTimeMSec() . '<br/>';
+}
+echo '</td></tr>';
+
+if (null !== $index->getLastModified()) {
+    echo '<tr><th>lastModified</th><td>' . $index->getLastModified()->format(DATE_RFC3339_EXTENDED) . '</td></tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>fields</h1>';
+
+foreach ($fields as $field) {
+    echo '<h2>' . $field . '</h2>';
+
+    echo '<table>';
+    echo '<tr><th>type</th><td>' . $field->getType() . '</td></tr>';
+    echo '<tr><th>schema</th><td>';
+    foreach ($field->getSchema() as $flag) {
+        echo $flag . '<br/>';
+    }
+    echo '</td></tr>';
+    if (null !== $field->getDynamicBase()) {
+        echo '<tr><th>dynamicBase</th><td>' . $field->getDynamicBase() . '</td></tr>';
+    }
+    // some fields don't have index flags in the result (with $lukeQuery->setIncludeIndexFieldFlags(false), none of the fields have)
+    if (null !== $field->getIndex()) {
+        echo '<tr><th>index</th><td>';
+        // some fields have '(unstored field)' in the result instead of flags
+        if (is_object($field->getIndex())) {
+            foreach ($field->getIndex() as $flag) {
+                echo $flag . '<br/>';
+            }
+        } else {
+            echo $field->getIndex();
+        }
+        echo '</td></tr>';
+    }
+    if (null !== $field->getDocs()) {
+        echo '<tr><th>docs</th><td>' . $field->getDocs() . '</td></tr>';
+    }
+    if (null !== $field->getDistinct()) {
+        echo '<tr><th>distinct</th><td>' . $field->getDistinct() . '</td></tr>';
+    }
+    if (null !== $field->getTopTerms()) {
+        echo '<tr><th>topTerms</th><td>';
+        foreach ($field->getTopTerms() as $term => $frequency) {
+            echo $term . ': ' . $frequency . '<br/>';
+        }
+        echo '</td></tr>';
+    }
+    if (null !== $field->getHistogram()) {
+        echo '<tr><th>histogram</th><td>';
+        foreach ($field->getHistogram() as $bucket => $frequency) {
+            echo $bucket . ': ' . $frequency . '<br/>';
+        }
+        echo '</td></tr>';
+    }
+    echo '</table>';
+}
+
+echo '<hr/>';
+
+echo '<h1>info</h1>';
+
+echo '<table>';
+echo '<tr><th>key</th><td>';
+foreach ($info->getKey() as $abbreviation => $flag) {
+    echo $abbreviation . ': ' . $flag . '<br/>';
+}
+echo '</td></tr>';
+echo '<tr><th>NOTE</th><td>' . $info->getNote() . '</td></tr>';
+echo '</table>';
+
+htmlFooter();
+
+```

--- a/docs/queries/luke-query/result-of-a-luke-query/index-details.md
+++ b/docs/queries/luke-query/result-of-a-luke-query/index-details.md
@@ -1,0 +1,63 @@
+Result of a Luke query — Index
+==============================
+
+```php
+$index = $result->getIndex();
+```
+
+The index details include high-level information about the index. They are also
+available in the results for all other show styles.
+
+Example usage
+-------------
+
+```php
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a Luke query
+$lukeQuery = $client->createLuke();
+$lukeQuery->setShow($lukeQuery::SHOW_INDEX);
+
+$result = $client->luke($lukeQuery);
+
+$index = $result->getIndex();
+
+echo '<h1>index</h1>';
+
+echo '<table>';
+echo '<tr><th>numDocs</th><td>' . $index->getNumDocs() . '</td></tr>';
+echo '<tr><th>maxDoc</th><td>' . $index->getMaxDoc() . '</td></tr>';
+echo '<tr><th>deletedDocs</th><td>' . $index->getDeletedDocs() . '</td></tr>';
+echo '<tr><th>indexHeapUsageBytes</th><td>' . ($index->getIndexHeapUsageBytes() ?? '(not supported by this version of Solr)') . '</td></tr>';
+echo '<tr><th>version</th><td>' . $index->getVersion() . '</td></tr>';
+echo '<tr><th>segmentCount</th><td>' . $index->getSegmentCount() . '</td></tr>';
+echo '<tr><th>current</th><td>' . ($index->getCurrent() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>hasDeletions</th><td>' . ($index->getHasDeletions() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>directory</th><td>' . $index->getDirectory() . '</td></tr>';
+echo '<tr><th>segmentsFile</th><td>' . $index->getSegmentsFile() . '</td></tr>';
+echo '<tr><th>segmentsFileSizeInBytes</th><td>' . $index->getSegmentsFileSizeInBytes() . '</td></tr>';
+
+$userData = $index->getUserData();
+echo '<tr><th>userData</th><td>';
+if (null !== $userData->getCommitCommandVer()) {
+    echo 'commitCommandVer: ' . $userData->getCommitCommandVer() . '<br/>';
+}
+if (null !== $userData->getCommitTimeMSec()) {
+    echo 'commitTimeMSec: ' . $userData->getCommitTimeMSec() . '<br/>';
+}
+echo '</td></tr>';
+
+if (null !== $index->getLastModified()) {
+    echo '<tr><th>lastModified</th><td>' . $index->getLastModified()->format(DATE_RFC3339_EXTENDED) . '</td></tr>';
+}
+echo '</table>';
+
+htmlFooter();
+
+```

--- a/docs/queries/luke-query/result-of-a-luke-query/info.md
+++ b/docs/queries/luke-query/result-of-a-luke-query/info.md
@@ -1,0 +1,44 @@
+Result of a Luke query — Info
+=============================
+
+```php
+$info = $result->getInfo();
+```
+
+Some generally helpful information is available in the result for every show style
+that includes more than just the high-level index details. It contains the key to
+[flag lists](../luke-query.md#flag-lists) and a note.
+
+Example usage
+-------------
+
+```php
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a Luke query
+$lukeQuery = $client->createLuke();
+
+$result = $client->luke($lukeQuery);
+
+$info = $result->getInfo();
+
+echo '<h1>info</h1>';
+
+echo '<table>';
+echo '<tr><th>key</th><td>';
+foreach ($info->getKey() as $abbreviation => $flag) {
+    echo $abbreviation . ': ' . $flag . '<br/>';
+}
+echo '</td></tr>';
+echo '<tr><th>NOTE</th><td>' . $info->getNote() . '</td></tr>';
+echo '</table>';
+
+htmlFooter();
+
+```

--- a/docs/queries/luke-query/result-of-a-luke-query/schema.md
+++ b/docs/queries/luke-query/result-of-a-luke-query/schema.md
@@ -1,0 +1,260 @@
+Result of a Luke query — Schema
+===============================
+
+```php
+$schema = $result->getSchema();
+```
+
+Schema information contains details about:
+
+- fields: `$schema->getFields()`
+- dynamic fields: `$schema->getDynamicFields()`
+- unique key field: `$schema->getUniqueKeyField()`
+- similarity: `$schema->getSimilarity()`
+- types: `$schema->getTypes()`
+
+References to fields and types
+------------------------------
+
+Field information contains the name of the field type, and the names of source fields or
+destination fields if it's included in one or more `copyField` directives. Type information
+contains the names of the fields and the wildcard patterns of the dynamic fields that are
+defined with that type. These field and type names are returned as strings by Solr.
+Solarium augments them by turning them into references to the object that represents the
+field or type in the result, while maintaining the original representation if used in a
+string context.
+
+The stringable approach is also followed for other properties of fields and types, including
+[flag lists](../luke-query.md#flag-lists). This gives a concise way to answer questions
+about your schema.
+
+### Some examples
+
+_What is the type of the `title` field?_
+
+```php
+echo $schema->getField('title')->getType();
+// text_gen_sort
+```
+
+This also works for dynamic fields and the unique key field (if present in your schema).
+
+```php
+echo $schema->getDynamicField('*_i')->getType();
+// pint
+echo $schema->getUniqueKeyField()->getType();
+// string
+```
+
+_Which index analyzer is used by the `text_gen_sort` field type?_
+_And which tokenizer does it use?_
+
+```php
+echo $schema->getType('text_gen_sort')->getIndexAnalyzer();
+// org.apache.solr.analysis.TokenizerChain
+echo $schema->getType('text_gen_sort')->getIndexAnalyzer()->getTokenizer();
+// org.apache.lucene.analysis.standard.StandardTokenizerFactory
+```
+
+If you want to know the tokenizer for a field without needing to know the type, you can
+chain the methods together in a one-liner.
+
+_Which tokenizer is used by the index analyzer for the `title` field?_
+
+```php
+echo $schema->getField('title')->getType()->getIndexAnalyzer()->getTokenizer();
+// org.apache.lucene.analysis.standard.StandardTokenizerFactory
+```
+
+You can get a list of the (dynamic) fields that have a certain type.
+
+_Which fields are of the type `pint`?_
+Or: _Which fields have the same type as the field `popularity`?_
+
+```php
+echo implode(', ', $schema->getType('pint')->getFields());
+// popularity, *_is, *_i
+echo implode(', ', $schema->getField('popularity')->getType()->getFields());
+// popularity, *_is, *_i
+```
+
+In a similar way, copy sources and destinations can be iterated and method chained.
+
+```php
+foreach ($schema->getField('author')->getCopyDests() as $destField) {
+    echo $destField;
+}
+// author_s
+// text
+
+foreach ($schema->getField('author')->getCopyDests() as $destField) {
+    echo $destField->getName(), ': ', $destField->getType();
+}
+// author_s: string
+// text: text_general
+```
+
+Solr class names
+----------------
+
+Some properties of `similarity` and `types` return a string that represents a Solr class
+name. This is the fully-qualified class name (<abbr>FQCN</abbr>) from Java, prefixed with
+the package name that the class originated from. Solarium comes with a utility method that
+returns a compact display version of such a Java FQCN.
+
+### Example
+
+```php
+use Solarium\Support\Utility;
+
+echo Utility::compactSolrClassName('org.apache.solr.schema.TextField');
+// o.a.s.s.TextField
+
+echo Utility::compactSolrClassName('org.apache.solr.search.similarities.SchemaSimilarityFactory$SchemaSimilarity');
+// o.a.s.s.s.SchemaSimilarityFactory$SchemaSimilarity
+```
+
+Example usage
+-------------
+
+```php
+<?php
+
+use Solarium\Support\Utility;
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a Luke query
+$lukeQuery = $client->createLuke();
+$lukeQuery->setShow($lukeQuery::SHOW_SCHEMA);
+
+$result = $client->luke($lukeQuery);
+
+$index = $result->getIndex();
+$schema = $result->getSchema();
+$info = $result->getInfo();
+
+echo '<h1>index</h1>';
+
+echo '<table>';
+echo '<tr><th>numDocs</th><td>' . $index->getNumDocs() . '</td></tr>';
+echo '<tr><th>maxDoc</th><td>' . $index->getMaxDoc() . '</td></tr>';
+echo '<tr><th>deletedDocs</th><td>' . $index->getDeletedDocs() . '</td></tr>';
+echo '<tr><th>indexHeapUsageBytes</th><td>' . ($index->getIndexHeapUsageBytes() ?? '(not supported by this version of Solr)') . '</td></tr>';
+echo '<tr><th>version</th><td>' . $index->getVersion() . '</td></tr>';
+echo '<tr><th>segmentCount</th><td>' . $index->getSegmentCount() . '</td></tr>';
+echo '<tr><th>current</th><td>' . ($index->getCurrent() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>hasDeletions</th><td>' . ($index->getHasDeletions() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>directory</th><td>' . $index->getDirectory() . '</td></tr>';
+echo '<tr><th>segmentsFile</th><td>' . $index->getSegmentsFile() . '</td></tr>';
+echo '<tr><th>segmentsFileSizeInBytes</th><td>' . $index->getSegmentsFileSizeInBytes() . '</td></tr>';
+
+$userData = $index->getUserData();
+echo '<tr><th>userData</th><td>';
+if (null !== $userData->getCommitCommandVer()) {
+    echo 'commitCommandVer: ' . $userData->getCommitCommandVer() . '<br/>';
+}
+if (null !== $userData->getCommitTimeMSec()) {
+    echo 'commitTimeMSec: ' . $userData->getCommitTimeMSec() . '<br/>';
+}
+echo '</td></tr>';
+
+if (null !== $index->getLastModified()) {
+    echo '<tr><th>lastModified</th><td>' . $index->getLastModified()->format(DATE_RFC3339_EXTENDED) . '</td></tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>schema</h1>';
+
+echo '<h2>fields</h2>';
+
+echo '<table>';
+echo '<tr>';
+echo '<th>name</th><th>type</th><th>flags</th>';
+echo '<th>⚑<br/>indexed</th><th>⚑<br/>tokenized</th><th>⚑<br/>stored</th><th>⚑<br/>docValues</th>'; // just a few examples, there's a corresponding is*() method for each flag
+echo '<th>required</th><th>default</th><th>uniqueKey</th><th>positionIncrementGap</th>';
+echo '<th>copyDests</th><th>copySources</th>';
+echo '</tr>';
+foreach ($schema->getFields() as $field) {
+    echo '<tr>';
+    echo '<th>' . $field->getName() . '</th><td>' . $field->getType() . '</td><td>' . $field->getFlags() . '</td>';
+    echo '<td>' . ($field->getFlags()->isIndexed() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isTokenized() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isStored() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isDocValues() ? '⚐' : '') . '</td>';
+    echo '<td>' . ($field->isRequired() ? '✓' : '') . '</td><td>' . $field->getDefault() . '</td><td>' . ($field->isUniqueKey() ? '✓' : '') . '</td><td>' . $field->getPositionIncrementGap() . '</td>';
+    echo '<td>' . implode(', ', $field->getCopyDests()) . '</td><td>' . implode(', ', $field->getCopySources()) . '</td>';
+    echo '</tr>';
+}
+echo '</table>';
+
+echo '<h2>dynamicFields</h2>';
+
+echo '<table>';
+echo '<tr>';
+echo '<th>name</th><th>type</th><th>flags</th>';
+echo '<th>⚑<br/>multiValued</th><th>⚑<br/>omitNorms</th><th>⚑<br/>sortMissingFirst</th><th>⚑<br/>sortMissingLast</th>'; // a few more examples of corresponding is*() methods for flags
+echo '<th>positionIncrementGap</th>';
+echo '<th>copyDests</th><th>copySources</th>';
+echo '</tr>';
+foreach ($schema->getDynamicFields() as $field) {
+    echo '<tr>';
+    echo '<th>' . $field->getName() . '</th><td>' . $field->getType() . '</td><td>' . $field->getFlags() . '</td>';
+    echo '<td>' . ($field->getFlags()->isMultiValued() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isOmitNorms() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isSortMissingFirst() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isSortMissingLast() ? '⚐' : '') . '</td>';
+    echo '<td>' . $field->getPositionIncrementGap() . '</td>';
+    echo '<td>' . implode(', ', $field->getCopyDests()) . '</td><td>' . implode(', ', $field->getCopySources()) . '</td>';
+    echo '</tr>';
+}
+echo '</table>';
+
+echo '<h2>uniqueKeyField</h2>';
+
+if (null !== $uniqueKeyField = $schema->getUniqueKeyField()) {
+    echo $uniqueKeyField;
+} else {
+    echo 'No &lt;uniqueKey&gt; defined in schema.';
+}
+
+echo '<h2>similarity</h2>';
+
+$similarity = $schema->getSimilarity();
+
+echo '<table>';
+echo '<tr><th>className</th><td>' . $similarity->getClassName() . '</td></tr>';
+echo '<tr><th>details</th><td>' . $similarity->getDetails() . '</td></tr>';
+echo '</table>';
+
+echo '<h2>types</h2>';
+
+echo '<table>';
+echo '<tr>';
+echo '<th>name</th><th>fields</th><th>tokenized</th><th>className</th>';
+echo '<th>indexAnalyzer</th><th>queryAnalyzer</th><th>similarity</th>';
+echo '</tr>';
+foreach ($schema->getTypes() as $type) {
+    echo '<tr>';
+    echo '<th>' . $type->getName() . '</th><td>' . implode(', ', $type->getFields()) . '</td><td>' . ($type->isTokenized() ? '✓' : '') . '</td><td>' . Utility::compactSolrClassName($type->getClassName()) . '</td>';
+    echo '<td>' . Utility::compactSolrClassName($type->getIndexAnalyzer()) . '</td><td>' . Utility::compactSolrClassName($type->getQueryAnalyzer()) . '</td><td>' . Utility::compactSolrClassName($type->getSimilarity()) . '</td>';
+    echo '</tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>info</h1>';
+
+echo '<table>';
+echo '<tr><th>key</th><td>';
+foreach ($info->getKey() as $abbreviation => $flag) {
+    echo $abbreviation . ': ' . $flag . '<br/>';
+}
+echo '</td></tr>';
+echo '<tr><th>NOTE</th><td>' . $info->getNote() . '</td></tr>';
+echo '</table>';
+
+htmlFooter();
+
+```

--- a/examples/2.11.1-luke-query-index.php
+++ b/examples/2.11.1-luke-query-index.php
@@ -1,0 +1,47 @@
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a Luke query
+$lukeQuery = $client->createLuke();
+$lukeQuery->setShow($lukeQuery::SHOW_INDEX);
+
+$result = $client->luke($lukeQuery);
+
+$index = $result->getIndex();
+
+echo '<h1>index</h1>';
+
+echo '<table>';
+echo '<tr><th>numDocs</th><td>' . $index->getNumDocs() . '</td></tr>';
+echo '<tr><th>maxDoc</th><td>' . $index->getMaxDoc() . '</td></tr>';
+echo '<tr><th>deletedDocs</th><td>' . $index->getDeletedDocs() . '</td></tr>';
+echo '<tr><th>indexHeapUsageBytes</th><td>' . ($index->getIndexHeapUsageBytes() ?? '(not supported by this version of Solr)') . '</td></tr>';
+echo '<tr><th>version</th><td>' . $index->getVersion() . '</td></tr>';
+echo '<tr><th>segmentCount</th><td>' . $index->getSegmentCount() . '</td></tr>';
+echo '<tr><th>current</th><td>' . ($index->getCurrent() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>hasDeletions</th><td>' . ($index->getHasDeletions() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>directory</th><td>' . $index->getDirectory() . '</td></tr>';
+echo '<tr><th>segmentsFile</th><td>' . $index->getSegmentsFile() . '</td></tr>';
+echo '<tr><th>segmentsFileSizeInBytes</th><td>' . $index->getSegmentsFileSizeInBytes() . '</td></tr>';
+
+$userData = $index->getUserData();
+echo '<tr><th>userData</th><td>';
+if (null !== $userData->getCommitCommandVer()) {
+    echo 'commitCommandVer: ' . $userData->getCommitCommandVer() . '<br/>';
+}
+if (null !== $userData->getCommitTimeMSec()) {
+    echo 'commitTimeMSec: ' . $userData->getCommitTimeMSec() . '<br/>';
+}
+echo '</td></tr>';
+
+if (null !== $index->getLastModified()) {
+    echo '<tr><th>lastModified</th><td>' . $index->getLastModified()->format(DATE_RFC3339_EXTENDED) . '</td></tr>';
+}
+echo '</table>';
+
+htmlFooter();

--- a/examples/2.11.2-luke-query-all-fields.php
+++ b/examples/2.11.2-luke-query-all-fields.php
@@ -1,0 +1,94 @@
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a Luke query
+$lukeQuery = $client->createLuke();
+$lukeQuery->setShow($lukeQuery::SHOW_ALL);
+
+// omitting index flags for each field can speed up Luke requests
+//$lukeQuery->setIncludeIndexFieldFlags(false);
+
+$result = $client->luke($lukeQuery);
+
+$index = $result->getIndex();
+$fields = $result->getFields();
+$info = $result->getInfo();
+
+echo '<h1>index</h1>';
+
+echo '<table>';
+echo '<tr><th>numDocs</th><td>' . $index->getNumDocs() . '</td></tr>';
+echo '<tr><th>maxDoc</th><td>' . $index->getMaxDoc() . '</td></tr>';
+echo '<tr><th>deletedDocs</th><td>' . $index->getDeletedDocs() . '</td></tr>';
+echo '<tr><th>indexHeapUsageBytes</th><td>' . ($index->getIndexHeapUsageBytes() ?? '(not supported by this version of Solr)') . '</td></tr>';
+echo '<tr><th>version</th><td>' . $index->getVersion() . '</td></tr>';
+echo '<tr><th>segmentCount</th><td>' . $index->getSegmentCount() . '</td></tr>';
+echo '<tr><th>current</th><td>' . ($index->getCurrent() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>hasDeletions</th><td>' . ($index->getHasDeletions() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>directory</th><td>' . $index->getDirectory() . '</td></tr>';
+echo '<tr><th>segmentsFile</th><td>' . $index->getSegmentsFile() . '</td></tr>';
+echo '<tr><th>segmentsFileSizeInBytes</th><td>' . $index->getSegmentsFileSizeInBytes() . '</td></tr>';
+
+$userData = $index->getUserData();
+echo '<tr><th>userData</th><td>';
+if (null !== $userData->getCommitCommandVer()) {
+    echo 'commitCommandVer: ' . $userData->getCommitCommandVer() . '<br/>';
+}
+if (null !== $userData->getCommitTimeMSec()) {
+    echo 'commitTimeMSec: ' . $userData->getCommitTimeMSec() . '<br/>';
+}
+echo '</td></tr>';
+
+if (null !== $index->getLastModified()) {
+    echo '<tr><th>lastModified</th><td>' . $index->getLastModified()->format(DATE_RFC3339_EXTENDED) . '</td></tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>fields</h1>';
+
+echo '<table>';
+echo '<tr>';
+echo '<th>name</th><th>type</th><th>schema</th>';
+echo '<th>schema⚑<br/>indexed</th><th>schema⚑<br/>tokenized</th><th>schema⚑<br/>stored</th><th>schema⚑<br/>docValues</th>'; // just a few examples, there's a corresponding is*() method for each flag
+echo '<th>dynamicBase</th><th>index</th>';
+echo '<th>index⚑<br/>tokenized</th><th>index⚑<br/>termVectors</th><th>index⚑<br/>omitNorms</th>'; // a few more examples of corresponding is*() methods for flags
+echo '<th>docs</th>';
+echo '</tr>';
+foreach ($fields as $field) {
+    echo '<tr>';
+    echo '<th>' . $field->getName() . '</th><td>' . $field->getType() . '</td><td>' . $field->getSchema() . '</td>';
+    echo '<td>' . ($field->getSchema()->isIndexed() ? '⚐' : '') . '</td><td>' . ($field->getSchema()->isTokenized() ? '⚐' : '') . '</td><td>' . ($field->getSchema()->isStored() ? '⚐' : '') . '</td><td>' . ($field->getSchema()->isDocValues() ? '⚐' : '') . '</td>';
+    echo '<td>' . $field->getDynamicBase() . '</td><td>' . $field->getIndex() . '</td>';
+    // some fields have '(unstored field)' or no index flags at all in the result
+    // and with $lukeQuery->setIncludeIndexFieldFlags(false), index flags are omitted for each field
+    if (is_object($field->getIndex())) {
+        echo '<td>' . ($field->getIndex()->isTokenized() ? '⚐' : '') . '</td><td>' . ($field->getIndex()->isTermVectors() ? '⚐' : '') . '</td><td>' . ($field->getIndex()->isOmitNorms() ? '⚐' : '') . '</td>';
+    } else {
+        echo '<td></td><td></td><td></td>';
+    }
+    echo '<td>' . $field->getDocs() . '</td>';
+    echo '</tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>info</h1>';
+
+echo '<table>';
+echo '<tr><th>key</th><td>';
+foreach ($info->getKey() as $abbreviation => $flag) {
+    echo $abbreviation . ': ' . $flag . '<br/>';
+}
+echo '</td></tr>';
+echo '<tr><th>NOTE</th><td>' . $info->getNote() . '</td></tr>';
+echo '</table>';
+
+htmlFooter();

--- a/examples/2.11.2.1-luke-query-field-details.php
+++ b/examples/2.11.2.1-luke-query-field-details.php
@@ -1,0 +1,128 @@
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+echo '<h2>Note: Use with caution especially on large indexes!</h2>';
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a Luke query
+$lukeQuery = $client->createLuke();
+
+// set the fields you want detailed information for
+$lukeQuery->setFields('text,cat,price_c');
+
+// you can also get detailed information for all fields
+//$lukeQuery->setFields('*');
+
+// omitting index flags for each field can speed up Luke requests
+//$lukeQuery->setIncludeIndexFieldFlags(false);
+
+// set the number of top terms for each field (Solr's default is 10)
+$lukeQuery->setNumTerms(5);
+
+$result = $client->luke($lukeQuery);
+
+$index = $result->getIndex();
+$fields = $result->getFields();
+$info = $result->getInfo();
+
+echo '<h1>index</h1>';
+
+echo '<table>';
+echo '<tr><th>numDocs</th><td>' . $index->getNumDocs() . '</td></tr>';
+echo '<tr><th>maxDoc</th><td>' . $index->getMaxDoc() . '</td></tr>';
+echo '<tr><th>deletedDocs</th><td>' . $index->getDeletedDocs() . '</td></tr>';
+echo '<tr><th>indexHeapUsageBytes</th><td>' . ($index->getIndexHeapUsageBytes() ?? '(not supported by this version of Solr)') . '</td></tr>';
+echo '<tr><th>version</th><td>' . $index->getVersion() . '</td></tr>';
+echo '<tr><th>segmentCount</th><td>' . $index->getSegmentCount() . '</td></tr>';
+echo '<tr><th>current</th><td>' . ($index->getCurrent() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>hasDeletions</th><td>' . ($index->getHasDeletions() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>directory</th><td>' . $index->getDirectory() . '</td></tr>';
+echo '<tr><th>segmentsFile</th><td>' . $index->getSegmentsFile() . '</td></tr>';
+echo '<tr><th>segmentsFileSizeInBytes</th><td>' . $index->getSegmentsFileSizeInBytes() . '</td></tr>';
+
+$userData = $index->getUserData();
+echo '<tr><th>userData</th><td>';
+if (null !== $userData->getCommitCommandVer()) {
+    echo 'commitCommandVer: ' . $userData->getCommitCommandVer() . '<br/>';
+}
+if (null !== $userData->getCommitTimeMSec()) {
+    echo 'commitTimeMSec: ' . $userData->getCommitTimeMSec() . '<br/>';
+}
+echo '</td></tr>';
+
+if (null !== $index->getLastModified()) {
+    echo '<tr><th>lastModified</th><td>' . $index->getLastModified()->format(DATE_RFC3339_EXTENDED) . '</td></tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>fields</h1>';
+
+foreach ($fields as $field) {
+    echo '<h2>' . $field . '</h2>';
+
+    echo '<table>';
+    echo '<tr><th>type</th><td>' . $field->getType() . '</td></tr>';
+    echo '<tr><th>schema</th><td>';
+    foreach ($field->getSchema() as $flag) {
+        echo $flag . '<br/>';
+    }
+    echo '</td></tr>';
+    if (null !== $field->getDynamicBase()) {
+        echo '<tr><th>dynamicBase</th><td>' . $field->getDynamicBase() . '</td></tr>';
+    }
+    // some fields don't have index flags in the result (with $lukeQuery->setIncludeIndexFieldFlags(false), none of the fields have)
+    if (null !== $field->getIndex()) {
+        echo '<tr><th>index</th><td>';
+        // some fields have '(unstored field)' in the result instead of flags
+        if (is_object($field->getIndex())) {
+            foreach ($field->getIndex() as $flag) {
+                echo $flag . '<br/>';
+            }
+        } else {
+            echo $field->getIndex();
+        }
+        echo '</td></tr>';
+    }
+    if (null !== $field->getDocs()) {
+        echo '<tr><th>docs</th><td>' . $field->getDocs() . '</td></tr>';
+    }
+    if (null !== $field->getDistinct()) {
+        echo '<tr><th>distinct</th><td>' . $field->getDistinct() . '</td></tr>';
+    }
+    if (null !== $field->getTopTerms()) {
+        echo '<tr><th>topTerms</th><td>';
+        foreach ($field->getTopTerms() as $term => $frequency) {
+            echo $term . ': ' . $frequency . '<br/>';
+        }
+        echo '</td></tr>';
+    }
+    if (null !== $field->getHistogram()) {
+        echo '<tr><th>histogram</th><td>';
+        foreach ($field->getHistogram() as $bucket => $frequency) {
+            echo $bucket . ': ' . $frequency . '<br/>';
+        }
+        echo '</td></tr>';
+    }
+    echo '</table>';
+}
+
+echo '<hr/>';
+
+echo '<h1>info</h1>';
+
+echo '<table>';
+echo '<tr><th>key</th><td>';
+foreach ($info->getKey() as $abbreviation => $flag) {
+    echo $abbreviation . ': ' . $flag . '<br/>';
+}
+echo '</td></tr>';
+echo '<tr><th>NOTE</th><td>' . $info->getNote() . '</td></tr>';
+echo '</table>';
+
+htmlFooter();

--- a/examples/2.11.3-luke-query-schema.php
+++ b/examples/2.11.3-luke-query-schema.php
@@ -1,0 +1,138 @@
+<?php
+
+use Solarium\Support\Utility;
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a Luke query
+$lukeQuery = $client->createLuke();
+$lukeQuery->setShow($lukeQuery::SHOW_SCHEMA);
+
+$result = $client->luke($lukeQuery);
+
+$index = $result->getIndex();
+$schema = $result->getSchema();
+$info = $result->getInfo();
+
+echo '<h1>index</h1>';
+
+echo '<table>';
+echo '<tr><th>numDocs</th><td>' . $index->getNumDocs() . '</td></tr>';
+echo '<tr><th>maxDoc</th><td>' . $index->getMaxDoc() . '</td></tr>';
+echo '<tr><th>deletedDocs</th><td>' . $index->getDeletedDocs() . '</td></tr>';
+echo '<tr><th>indexHeapUsageBytes</th><td>' . ($index->getIndexHeapUsageBytes() ?? '(not supported by this version of Solr)') . '</td></tr>';
+echo '<tr><th>version</th><td>' . $index->getVersion() . '</td></tr>';
+echo '<tr><th>segmentCount</th><td>' . $index->getSegmentCount() . '</td></tr>';
+echo '<tr><th>current</th><td>' . ($index->getCurrent() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>hasDeletions</th><td>' . ($index->getHasDeletions() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>directory</th><td>' . $index->getDirectory() . '</td></tr>';
+echo '<tr><th>segmentsFile</th><td>' . $index->getSegmentsFile() . '</td></tr>';
+echo '<tr><th>segmentsFileSizeInBytes</th><td>' . $index->getSegmentsFileSizeInBytes() . '</td></tr>';
+
+$userData = $index->getUserData();
+echo '<tr><th>userData</th><td>';
+if (null !== $userData->getCommitCommandVer()) {
+    echo 'commitCommandVer: ' . $userData->getCommitCommandVer() . '<br/>';
+}
+if (null !== $userData->getCommitTimeMSec()) {
+    echo 'commitTimeMSec: ' . $userData->getCommitTimeMSec() . '<br/>';
+}
+echo '</td></tr>';
+
+if (null !== $index->getLastModified()) {
+    echo '<tr><th>lastModified</th><td>' . $index->getLastModified()->format(DATE_RFC3339_EXTENDED) . '</td></tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>schema</h1>';
+
+echo '<h2>fields</h2>';
+
+echo '<table>';
+echo '<tr>';
+echo '<th>name</th><th>type</th><th>flags</th>';
+echo '<th>⚑<br/>indexed</th><th>⚑<br/>tokenized</th><th>⚑<br/>stored</th><th>⚑<br/>docValues</th>'; // just a few examples, there's a corresponding is*() method for each flag
+echo '<th>required</th><th>default</th><th>uniqueKey</th><th>positionIncrementGap</th>';
+echo '<th>copyDests</th><th>copySources</th>';
+echo '</tr>';
+foreach ($schema->getFields() as $field) {
+    echo '<tr>';
+    echo '<th>' . $field->getName() . '</th><td>' . $field->getType() . '</td><td>' . $field->getFlags() . '</td>';
+    echo '<td>' . ($field->getFlags()->isIndexed() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isTokenized() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isStored() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isDocValues() ? '⚐' : '') . '</td>';
+    echo '<td>' . ($field->isRequired() ? '✓' : '') . '</td><td>' . $field->getDefault() . '</td><td>' . ($field->isUniqueKey() ? '✓' : '') . '</td><td>' . $field->getPositionIncrementGap() . '</td>';
+    echo '<td>' . implode(', ', $field->getCopyDests()) . '</td><td>' . implode(', ', $field->getCopySources()) . '</td>';
+    echo '</tr>';
+}
+echo '</table>';
+
+echo '<h2>dynamicFields</h2>';
+
+echo '<table>';
+echo '<tr>';
+echo '<th>name</th><th>type</th><th>flags</th>';
+echo '<th>⚑<br/>multiValued</th><th>⚑<br/>omitNorms</th><th>⚑<br/>sortMissingFirst</th><th>⚑<br/>sortMissingLast</th>'; // a few more examples of corresponding is*() methods for flags
+echo '<th>positionIncrementGap</th>';
+echo '<th>copyDests</th><th>copySources</th>';
+echo '</tr>';
+foreach ($schema->getDynamicFields() as $field) {
+    echo '<tr>';
+    echo '<th>' . $field->getName() . '</th><td>' . $field->getType() . '</td><td>' . $field->getFlags() . '</td>';
+    echo '<td>' . ($field->getFlags()->isMultiValued() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isOmitNorms() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isSortMissingFirst() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isSortMissingLast() ? '⚐' : '') . '</td>';
+    echo '<td>' . $field->getPositionIncrementGap() . '</td>';
+    echo '<td>' . implode(', ', $field->getCopyDests()) . '</td><td>' . implode(', ', $field->getCopySources()) . '</td>';
+    echo '</tr>';
+}
+echo '</table>';
+
+echo '<h2>uniqueKeyField</h2>';
+
+if (null !== $uniqueKeyField = $schema->getUniqueKeyField()) {
+    echo $uniqueKeyField;
+} else {
+    echo 'No &lt;uniqueKey&gt; defined in schema.';
+}
+
+echo '<h2>similarity</h2>';
+
+$similarity = $schema->getSimilarity();
+
+echo '<table>';
+echo '<tr><th>className</th><td>' . $similarity->getClassName() . '</td></tr>';
+echo '<tr><th>details</th><td>' . $similarity->getDetails() . '</td></tr>';
+echo '</table>';
+
+echo '<h2>types</h2>';
+
+echo '<table>';
+echo '<tr>';
+echo '<th>name</th><th>fields</th><th>tokenized</th><th>className</th>';
+echo '<th>indexAnalyzer</th><th>queryAnalyzer</th><th>similarity</th>';
+echo '</tr>';
+foreach ($schema->getTypes() as $type) {
+    echo '<tr>';
+    echo '<th>' . $type->getName() . '</th><td>' . implode(', ', $type->getFields()) . '</td><td>' . ($type->isTokenized() ? '✓' : '') . '</td><td>' . Utility::compactSolrClassName($type->getClassName()) . '</td>';
+    echo '<td>' . Utility::compactSolrClassName($type->getIndexAnalyzer()) . '</td><td>' . Utility::compactSolrClassName($type->getQueryAnalyzer()) . '</td><td>' . Utility::compactSolrClassName($type->getSimilarity()) . '</td>';
+    echo '</tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>info</h1>';
+
+echo '<table>';
+echo '<tr><th>key</th><td>';
+foreach ($info->getKey() as $abbreviation => $flag) {
+    echo $abbreviation . ': ' . $flag . '<br/>';
+}
+echo '</td></tr>';
+echo '<tr><th>NOTE</th><td>' . $info->getNote() . '</td></tr>';
+echo '</table>';
+
+htmlFooter();

--- a/examples/2.11.4-luke-query-doc.php
+++ b/examples/2.11.4-luke-query-doc.php
@@ -1,0 +1,117 @@
+<?php
+
+require_once(__DIR__.'/init.php');
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a Luke query
+$lukeQuery = $client->createLuke();
+$lukeQuery->setShow($lukeQuery::SHOW_DOC);
+
+// get a document using the uniqueKeyField specified in the schema
+$lukeQuery->setId('9885A004');
+
+// alternatively, you can use a Lucene documentID
+//$lukeQuery->setDocId(27);
+
+$result = $client->luke($lukeQuery);
+
+$index = $result->getIndex();
+$docInfo = $result->getDoc();
+$info = $result->getInfo();
+
+echo '<h1>index</h1>';
+
+echo '<table>';
+echo '<tr><th>numDocs</th><td>' . $index->getNumDocs() . '</td></tr>';
+echo '<tr><th>maxDoc</th><td>' . $index->getMaxDoc() . '</td></tr>';
+echo '<tr><th>deletedDocs</th><td>' . $index->getDeletedDocs() . '</td></tr>';
+echo '<tr><th>indexHeapUsageBytes</th><td>' . ($index->getIndexHeapUsageBytes() ?? '(not supported by this version of Solr)') . '</td></tr>';
+echo '<tr><th>version</th><td>' . $index->getVersion() . '</td></tr>';
+echo '<tr><th>segmentCount</th><td>' . $index->getSegmentCount() . '</td></tr>';
+echo '<tr><th>current</th><td>' . ($index->getCurrent() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>hasDeletions</th><td>' . ($index->getHasDeletions() ? 'true' : 'false') . '</td></tr>';
+echo '<tr><th>directory</th><td>' . $index->getDirectory() . '</td></tr>';
+echo '<tr><th>segmentsFile</th><td>' . $index->getSegmentsFile() . '</td></tr>';
+echo '<tr><th>segmentsFileSizeInBytes</th><td>' . $index->getSegmentsFileSizeInBytes() . '</td></tr>';
+
+$userData = $index->getUserData();
+echo '<tr><th>userData</th><td>';
+if (null !== $userData->getCommitCommandVer()) {
+    echo 'commitCommandVer: ' . $userData->getCommitCommandVer() . '<br/>';
+}
+if (null !== $userData->getCommitTimeMSec()) {
+    echo 'commitTimeMSec: ' . $userData->getCommitTimeMSec() . '<br/>';
+}
+echo '</td></tr>';
+
+if (null !== $index->getLastModified()) {
+    echo '<tr><th>lastModified</th><td>' . $index->getLastModified()->format(DATE_RFC3339_EXTENDED) . '</td></tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>doc</h1>';
+
+echo '<h2>docId</h2>';
+
+echo '<table>';
+echo '<tr><th>Lucene documentID</th><td>' . $docInfo->getDocId() . '</td></tr>';
+echo '</table>';
+
+echo '<h2>lucene</h2>';
+
+echo '<table>';
+echo '<tr>';
+echo '<th>name</th><th>type</th><th>schema</th>';
+echo '<th>schema⚑<br/>indexed</th><th>schema⚑<br/>tokenized</th><th>schema⚑<br/>stored</th><th>schema⚑<br/>docValues</th>'; // just a few examples, there's a corresponding is*() method for each flag
+echo '<th>flags</th>';
+echo '<th>flags⚑<br/>indexed</th><th>flags⚑<br/>omitNorms</th><th>flags⚑<br/>omitTermFreqAndPositions</th>'; // a few more examples of corresponding is*() methods for flags
+echo '<th>value</th><th>docFreq</th><th>termVector</th>';
+echo '</tr>';
+foreach ($docInfo->getLucene() as $field) {
+    echo '<tr>';
+    echo '<th>' . $field->getName() . '</th><td>' . $field->getType() . '</td><td>' . $field->getSchema() . '</td>';
+    echo '<td>' . ($field->getSchema()->isIndexed() ? '⚐' : '') . '</td><td>' . ($field->getSchema()->isTokenized() ? '⚐' : '') . '</td><td>' . ($field->getSchema()->isStored() ? '⚐' : '') . '</td><td>' . ($field->getSchema()->isDocValues() ? '⚐' : '') . '</td>';
+    echo '<td>' . $field->getFlags() . '</td>';
+    echo '<td>' . ($field->getFlags()->isIndexed() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isOmitNorms() ? '⚐' : '') . '</td><td>' . ($field->getFlags()->isOmitTermFreqAndPositions() ? '⚐' : '') . '</td>';
+    echo '<td>' . $field->getValue() . '</td><td>' . $field->getDocFreq() . '</td><td>';
+    if (null !== $termVector = $field->getTermVector()) {
+        foreach ($termVector as $term => $frequency) {
+            echo $term . ': ' . $frequency . '<br/>';
+        }
+    }
+    echo '</td>';
+    echo '</tr>';
+}
+echo '</table>';
+
+echo '<h2>solr</h2>';
+
+echo '<table>';
+foreach ($docInfo->getSolr() as $field => $value) {
+    if (is_array($value)) {
+        $value = implode(', ', $value);
+    }
+
+    echo '<tr><th>' . $field . '</th><td>' . $value . '</td></tr>';
+}
+echo '</table>';
+
+echo '<hr/>';
+
+echo '<h1>info</h1>';
+
+echo '<table>';
+echo '<tr><th>key</th><td>';
+foreach ($info->getKey() as $abbreviation => $flag) {
+    echo $abbreviation . ': ' . $flag . '<br/>';
+}
+echo '</td></tr>';
+echo '<tr><th>NOTE</th><td>' . $info->getNote() . '</td></tr>';
+echo '</table>';
+
+htmlFooter();

--- a/examples/execute_all.php
+++ b/examples/execute_all.php
@@ -179,6 +179,7 @@ try {
         '2.2.5-rollback.php',
         '2.10.2-managedresources-stopwords.php',
         '2.10.3-managedresources-synonyms.php',
+        '2.11.4-luke-query-doc.php',
         '7.1-plugin-loadbalancer.php',
     ];
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -40,7 +40,7 @@
 
             <li>2. Queries</li>
             <ul style="list-style:none;">
-                <li>2.1. Select query</li>
+                <li>2.1 Select query</li>
                 <ul style="list-style:none;">
                     <li><a href="2.1.1-query-params.php">2.1.1 Select query params</a></li>
                     <li><a href="2.1.2-custom-result-document.php">2.1.2 Custom result document</a></li>
@@ -92,7 +92,7 @@
                     <li><a href="2.1.7-query-reuse.php">2.1.7 Query re-use</a></li>
                 </ul>
 
-                <li>2.2. Update query</li>
+                <li>2.2 Update query</li>
                 <ul style="list-style:none;">
                     <li><a href="2.2.1-add-docs.php">2.2.1 Add docs</a></li>
                     <ul style="list-style:none;">
@@ -106,13 +106,13 @@
                     <li><a href="2.2.6-rawxml.php">2.2.6 Issue raw XML update commands</a></li>
                 </ul>
 
-                <li>2.3. MoreLikeThis query</li>
+                <li>2.3 MoreLikeThis query</li>
                 <ul style="list-style:none;">
                     <li><a href="2.3.1-mlt-query.php">2.3.1 MoreLikeThis query</a></li>
                     <li><a href="2.3.2-mlt-stream.php">2.3.2 MoreLikeThis query input as stream</a></li>
                 </ul>
 
-                <li>2.4. Analysis queries</li>
+                <li>2.4 Analysis queries</li>
                 <ul style="list-style:none;">
                     <li><a href="2.4.1-analysis-document.php">2.4.1 Analysis query for a document</a></li>
                     <li><a href="2.4.2-analysis-field.php">2.4.2 Analysis query for a field</a></li>
@@ -124,11 +124,22 @@
                 <li><a href="2.8-realtime-get-query.php">2.8 Realtime get query</a></li>
                 <li><a href="2.9-server-core-admin-status.php">2.9 Core admin query</a></li>
 
-                <li>2.10. Managed resources queries</li>
+                <li>2.10 Managed resources queries</li>
                 <ul style="list-style:none;">
                     <li><a href="2.10.1-managedresources-resources.php">2.10.1 Resources query</a></li>
                     <li><a href="2.10.2-managedresources-stopwords.php">2.10.2 Stopwords query</a></li>
                     <li><a href="2.10.3-managedresources-synonyms.php">2.10.3 Synonyms query</a></li>
+                </ul>
+
+                <li>2.11 Luke query</li>
+                <ul style="list-style:none;">
+                    <li><a href="2.11.1-luke-query-index.php">2.11.1 Index</a></li>
+                    <li><a href="2.11.2-luke-query-all-fields.php">2.11.2 Fields</a></li>
+                    <ul style="list-style:none;">
+                        <li><a href="2.11.2.1-luke-query-field-details.php">2.11.2.1 Field details</a></li>
+                    </ul>
+                    <li><a href="2.11.3-luke-query-schema.php">2.11.3 Schema</a></li>
+                    <li><a href="2.11.4-luke-query-doc.php">2.11.4 Document</a></li>
                 </ul>
             </ul>
 

--- a/src/Core/Client/Client.php
+++ b/src/Core/Client/Client.php
@@ -45,6 +45,8 @@ use Solarium\QueryType\Analysis\Query\Field as AnalysisQueryField;
 use Solarium\QueryType\Extract\Query as ExtractQuery;
 use Solarium\QueryType\Extract\Result as ExtractResult;
 use Solarium\QueryType\Graph\Query as GraphQuery;
+use Solarium\QueryType\Luke\Query as LukeQuery;
+use Solarium\QueryType\Luke\Result\Result as LukeResult;
 use Solarium\QueryType\ManagedResources\Query\Resources as ManagedResourcesQuery;
 use Solarium\QueryType\ManagedResources\Query\Stopwords as ManagedStopwordsQuery;
 use Solarium\QueryType\ManagedResources\Query\Synonyms as ManagedSynonymsQuery;
@@ -155,6 +157,11 @@ class Client extends Configurable implements ClientInterface
     const QUERY_REALTIME_GET = 'get';
 
     /**
+     * Querytype luke.
+     */
+    const QUERY_LUKE = 'luke';
+
+    /**
      * Querytype cores.
      */
     const QUERY_CORE_ADMIN = 'cores';
@@ -219,6 +226,7 @@ class Client extends Configurable implements ClientInterface
         self::QUERY_GRAPH => GraphQuery::class,
         self::QUERY_EXTRACT => ExtractQuery::class,
         self::QUERY_REALTIME_GET => RealtimeGetQuery::class,
+        self::QUERY_LUKE => LukeQuery::class,
         self::QUERY_CORE_ADMIN => CoreAdminQuery::class,
         self::QUERY_COLLECTIONS => CollectionsQuery::class,
         self::QUERY_CONFIGSETS => ConfigsetsQuery::class,
@@ -1034,6 +1042,22 @@ class Client extends Configurable implements ClientInterface
     }
 
     /**
+     * Execute a Luke query.
+     *
+     * This is a convenience method that forwards the query to the
+     * execute method, thus allowing for an easy to use and clean API.
+     *
+     * @param QueryInterface|\Solarium\QueryType\Luke\Query $query
+     * @param Endpoint|string|null                          $endpoint
+     *
+     * @return ResultInterface|\Solarium\QueryType\Luke\Result\Result
+     */
+    public function luke(QueryInterface $query, $endpoint = null): LukeResult
+    {
+        return $this->execute($query, $endpoint);
+    }
+
+    /**
      * Execute a CoreAdmin query.
      *
      * This is a convenience method that forwards the query to the
@@ -1280,6 +1304,18 @@ class Client extends Configurable implements ClientInterface
     public function createRealtimeGet(array $options = null): RealtimeGetQuery
     {
         return $this->createQuery(self::QUERY_REALTIME_GET, $options);
+    }
+
+    /**
+     * Create a Luke query instance.
+     *
+     * @param mixed $options
+     *
+     * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Luke\Query
+     */
+    public function createLuke(array $options = null): LukeQuery
+    {
+        return $this->createQuery(self::QUERY_LUKE, $options);
     }
 
     /**

--- a/src/Core/Client/ClientInterface.php
+++ b/src/Core/Client/ClientInterface.php
@@ -22,6 +22,8 @@ use Solarium\QueryType\Analysis\Query\Field as AnalysisQueryField;
 use Solarium\QueryType\Extract\Query as ExtractQuery;
 use Solarium\QueryType\Extract\Result as ExtractResult;
 use Solarium\QueryType\Graph\Query as GraphQuery;
+use Solarium\QueryType\Luke\Query as LukeQuery;
+use Solarium\QueryType\Luke\Result\Result as LukeResult;
 use Solarium\QueryType\ManagedResources\Query\Resources as ManagedResourcesQuery;
 use Solarium\QueryType\ManagedResources\Query\Stopwords as ManagedStopwordsQuery;
 use Solarium\QueryType\ManagedResources\Query\Synonyms as ManagedSynonymsQuery;
@@ -498,6 +500,19 @@ interface ClientInterface
     public function realtimeGet(QueryInterface $query, $endpoint = null): RealtimeGetResult;
 
     /**
+     * Execute a Luke query.
+     *
+     * @internal this is a convenience method that forwards the query to the
+     *  execute method, thus allowing for an easy to use and clean API
+     *
+     * @param QueryInterface|\Solarium\QueryType\Luke\Query $query
+     * @param Endpoint|string|null                          $endpoint
+     *
+     * @return ResultInterface|\Solarium\QueryType\Luke\Result\Result
+     */
+    public function luke(QueryInterface $query, $endpoint = null): LukeResult;
+
+    /**
      * Execute a CoreAdmin query.
      *
      * @internal this is a convenience method that forwards the query to the
@@ -664,6 +679,15 @@ interface ClientInterface
      * @return \Solarium\QueryType\RealtimeGet\Query
      */
     public function createRealtimeGet(array $options = null): RealtimeGetQuery;
+
+    /**
+     * Create a Luke query instance.
+     *
+     * @param array $options
+     *
+     * @return \Solarium\QueryType\Luke\Query
+     */
+    public function createLuke(array $options = null): LukeQuery;
 
     /**
      * Create a CoreAdmin query instance.

--- a/src/QueryType/Luke/Query.php
+++ b/src/QueryType/Luke/Query.php
@@ -1,0 +1,327 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke;
+
+use Solarium\Core\Client\Client;
+use Solarium\Core\Query\AbstractQuery as BaseQuery;
+use Solarium\Core\Query\RequestBuilderInterface;
+use Solarium\Core\Query\ResponseParserInterface;
+use Solarium\QueryType\Luke\ResponseParser\Doc as DocResponseParser;
+use Solarium\QueryType\Luke\ResponseParser\Index as IndexResponseParser;
+use Solarium\QueryType\Luke\ResponseParser\Fields as FieldsResponseParser;
+use Solarium\QueryType\Luke\ResponseParser\Schema as SchemaResponseParser;
+use Solarium\QueryType\Luke\Result\Result;
+use Solarium\QueryType\Select\Result\Document;
+
+/**
+ * Luke query.
+ *
+ * Luke queries offer programmatic access to the information provided on the
+ * Schema Browser page of the Admin UI.
+ *
+ * {@see https://solr.apache.org/guide/luke-request-handler.html}
+ */
+class Query extends BaseQuery
+{
+    /**
+     * Return details about indexed fields plus the index details.
+     */
+    const SHOW_ALL = 'all';
+
+    /**
+     * Return details about a specific document plus the index details.
+     *
+     * Works in conjuction with a 'docId' or 'id' paramater.
+     */
+    const SHOW_DOC = 'doc';
+
+    /**
+     * Return the high level details about the index.
+     */
+    const SHOW_INDEX = 'index';
+
+    /**
+     * Return details about the schema plus the index details.
+     */
+    const SHOW_SCHEMA = 'schema';
+
+    /**
+     * Default options.
+     *
+     * @var array
+     */
+    protected $options = [
+        'resultclass' => Result::class,
+        'documentclass' => Document::class,
+        'handler' => 'admin/luke',
+        'omitheader' => true,
+    ];
+
+    /**
+     * Get type for this query.
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return Client::QUERY_LUKE;
+    }
+
+    /**
+     * Get a requestbuilder for this query.
+     *
+     * @return RequestBuilder
+     */
+    public function getRequestBuilder(): RequestBuilderInterface
+    {
+        return new RequestBuilder();
+    }
+
+    /**
+     * Get a response parser for this query.
+     *
+     * @return ResponseParserInterface
+     */
+    public function getResponseParser(): ResponseParserInterface
+    {
+        switch ($this->getShow()) {
+            case self::SHOW_SCHEMA:
+                $parser = new SchemaResponseParser();
+                break;
+            case self::SHOW_DOC:
+            case null:
+                if (null !== $this->getId() || null !== $this->getDocId()) {
+                    $parser = new DocResponseParser();
+                    break;
+                }
+                // without 'id' or 'docId', SHOW_DOC or no 'show' at all behaves like SHOW_ALL
+                // no break
+            case self::SHOW_ALL:
+                $parser = new FieldsResponseParser();
+                break;
+            case self::SHOW_INDEX:
+            default:
+                $parser = new IndexResponseParser();
+        }
+
+        return $parser;
+    }
+
+    /**
+     * Set a custom document class.
+     *
+     * This class should implement the document interface.
+     *
+     * @param string $value classname
+     *
+     * @return self Provides fluent interface
+     */
+    public function setDocumentClass(string $value): self
+    {
+        $this->setOption('documentclass', $value);
+
+        return $this;
+    }
+
+    /**
+     * Get the current documentclass option.
+     *
+     * The value is a classname, not an instance.
+     *
+     * @return string|null
+     */
+    public function getDocumentClass(): ?string
+    {
+        return $this->getOption('documentclass');
+    }
+
+    /**
+     * Set the data about the index to include in the response.
+     *
+     * Use one of the SHOW_* constants as value.
+     *
+     * {@see SHOW_ALL} returns all fields plus the index details. This is also the
+     * default behaviour if no 'show' and no 'id' or 'docId' is set.
+     *
+     * {@see SHOW_INDEX} only returns high level details about the index. This data
+     * is also included in all of the other responses.
+     *
+     * {@see SHOW_SCHEMA} returns details about the schema plus the index details.
+     *
+     * {@see SHOW_DOC} returns details about a specific document plus the index details.
+     * It works in conjunction with {@see setId()} or {@see setDocId()}. This is
+     * also the default behaviour if 'show' isn't set and an 'id' or 'docId' is set.
+     *
+     * @param string $show
+     *
+     * @return self Provides fluent interface
+     */
+    public function setShow(string $show): self
+    {
+        $this->setOption('show', $show);
+
+        return $this;
+    }
+
+    /**
+     * Get the data about the index to include in the response.
+     *
+     * @return string|null
+     */
+    public function getShow(): ?string
+    {
+        return $this->getOption('show');
+    }
+
+    /**
+     * Set the id of a document to get using the uniqueKey field specified in schema.xml.
+     *
+     * @see setDocId() To set a Lucene documentID instead.
+     *
+     * @param mixed $id
+     *
+     * @return self Provides fluent interface
+     */
+    public function setId($id): self
+    {
+        $this->setOption('id', $id);
+
+        return $this;
+    }
+
+    /**
+     * Get the id of the document to get.
+     *
+     * @return mixed|null
+     */
+    public function getId()
+    {
+        return $this->getOption('id');
+    }
+
+    /**
+     * Set the Lucene documentID of a document to get.
+     *
+     * @see setId() To set the uniqueKey id of a document instead.
+     *
+     * @param int $docId
+     *
+     * @return self Provides fluent interface
+     */
+    public function setDocId(int $docId): self
+    {
+        $this->setOption('docId', $docId);
+
+        return $this;
+    }
+
+    /**
+     * Get the Lucene documentID of the document to get.
+     *
+     * @return int|null
+     */
+    public function getDocId(): ?int
+    {
+        return $this->getOption('docId');
+    }
+
+    /**
+     * Limit the returned values to a set of fields.
+     *
+     * Separate multiple fields with commas if you use string input.
+     *
+     * @param string|array $fields
+     *
+     * @return self Provides fluent interface
+     */
+    public function setFields($fields): self
+    {
+        if (\is_string($fields)) {
+            $fields = explode(',', $fields);
+            $fields = array_map('trim', $fields);
+        }
+
+        $this->setOption('fields', $fields);
+
+        return $this;
+    }
+
+    /**
+     * Get the set of fields to limit the returned values to.
+     *
+     * @return array
+     */
+    public function getFields(): array
+    {
+        return $this->getOption('fields') ?? [];
+    }
+
+    /**
+     * Set the number of top terms for each field.
+     *
+     * @param int $numTerms
+     *
+     * @return self Provides fluent interface
+     */
+    public function setNumTerms(int $numTerms): self
+    {
+        $this->setOption('numTerms', $numTerms);
+
+        return $this;
+    }
+
+    /**
+     * Get the number of top terms for each field.
+     *
+     * @return int|null
+     */
+    public function getNumTerms(): ?int
+    {
+        return $this->getOption('numTerms');
+    }
+
+    /**
+     * Set whether index-flags for each field should be returned.
+     *
+     * @param bool $includeIndexFieldFlags
+     *
+     * @return self
+     */
+    public function setIncludeIndexFieldFlags(bool $includeIndexFieldFlags): self
+    {
+        $this->setOption('includeIndexFieldFlags', $includeIndexFieldFlags);
+
+        return $this;
+    }
+
+    /**
+     * Get whether index-flags for each field should be returned.
+     *
+     * @return bool|null
+     */
+    public function getIncludeIndexFieldFlags(): ?bool
+    {
+        return $this->getOption('includeIndexFieldFlags');
+    }
+
+    /**
+     * Initialize options.
+     */
+    protected function init()
+    {
+        foreach ($this->options as $name => $value) {
+            switch ($name) {
+                case 'fields':
+                    $this->setFields($value);
+                    break;
+            }
+        }
+    }
+}

--- a/src/QueryType/Luke/RequestBuilder.php
+++ b/src/QueryType/Luke/RequestBuilder.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke;
+
+use Solarium\Core\Client\Request;
+use Solarium\Core\Query\AbstractQuery;
+use Solarium\Core\Query\AbstractRequestBuilder;
+use Solarium\Core\Query\QueryInterface;
+
+/**
+ * Build a Luke request.
+ */
+class RequestBuilder extends AbstractRequestBuilder
+{
+    /**
+     * Build request for a Luke query.
+     *
+     * @param QueryInterface|Query $query
+     *
+     * @return Request
+     */
+    public function build(AbstractQuery $query): Request
+    {
+        $request = parent::build($query);
+
+        // add luke params to request
+        $fields = $query->getFields();
+
+        $request->addParam('show', $query->getShow());
+        $request->addParam('id', $query->getId());
+        $request->addParam('docId', $query->getDocId());
+        $request->addParam('fl', 0 === \count($fields) ? null : implode(',', $fields));
+        $request->addParam('numTerms', $query->getNumTerms());
+        $request->addParam('includeIndexFieldFlags', $query->getIncludeIndexFieldFlags());
+
+        return $request;
+    }
+}

--- a/src/QueryType/Luke/ResponseParser/Doc.php
+++ b/src/QueryType/Luke/ResponseParser/Doc.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\ResponseParser;
+
+use JsonMachine\Items as JsonMachineItems;
+use JsonMachine\JsonDecoder\ExtJsonDecoder;
+use Solarium\Core\Query\DocumentInterface;
+use Solarium\Core\Query\Result\ResultInterface;
+use Solarium\Exception\RuntimeException;
+use Solarium\QueryType\Luke\Result\Doc\DocFieldInfo;
+use Solarium\QueryType\Luke\Result\Doc\DocInfo;
+use Solarium\QueryType\Luke\Result\FlagList;
+use Solarium\QueryType\Luke\Result\Result;
+
+/**
+ * Parse Luke doc response data.
+ */
+class Doc extends Index
+{
+    use InfoTrait;
+
+    /**
+     * @var ResultInterface
+     */
+    protected $result;
+
+    /**
+     * Get result data for the response.
+     *
+     * @param Result $result
+     *
+     * @return array
+     */
+    public function parse(ResultInterface $result): array
+    {
+        $this->result = $result;
+
+        $data = parent::parse($result);
+
+        // 'lucene' can contain the same key multiple times for multiValued fields.
+        // A SimpleOrderedMap in Solr, it isn't represented as a flat array in JSON
+        // and unlike a NamedList its output format can't be controlled with json.nl.
+        // We can't rely on json_decode() if we don't want data loss for these fields.
+        $data['doc']['lucene'] = JsonMachineItems::fromString(
+            $result->getResponse()->getBody(),
+            [
+                // like json_decode('...', true), ExtJsonDecoder(true) returns arrays instead of objects
+                'decoder' => new ExtJsonDecoder(true),
+                'pointer' => '/doc/lucene',
+            ]
+        );
+
+        // parse 'info' first so 'doc' can use it for flag lookups
+        $data['infoResult'] = $this->parseInfo($data['info']);
+        $data['docResult'] = $this->parseDoc($data['doc']);
+
+        return $data;
+    }
+
+    /**
+     * @param array $docData
+     *
+     * @return DocInfo
+     */
+    protected function parseDoc(array $docData): DocInfo
+    {
+        $docInfo = new DocInfo($docData['docId']);
+
+        $docInfo->setLucene($this->parseLucene($docData['lucene']));
+        $docInfo->setSolr($this->parseSolr($docData['solr']));
+
+        return $docInfo;
+    }
+
+    /**
+     * @param JsonMachineItems $luceneData
+     *
+     * @return DocFieldInfo[]
+     */
+    protected function parseLucene(JsonMachineItems $luceneData): array
+    {
+        $lucene = [];
+
+        foreach ($luceneData as $name => $details) {
+            $fieldInfo = new DocFieldInfo($name);
+
+            $fieldInfo->setType($details['type']);
+            $fieldInfo->setSchema(new FlagList($details['schema'], $this->key));
+            $fieldInfo->setFlags(new FlagList($details['flags'], $this->key));
+            $fieldInfo->setValue($details['value']);
+            $fieldInfo->setInternal($details['internal']);
+            $fieldInfo->setBinary($details['binary'] ?? null);
+            $fieldInfo->setDocFreq($details['docFreq'] ?? null);
+            $fieldInfo->setTermVector($details['termVector'] ?? null);
+
+            $lucene[] = $fieldInfo;
+        }
+
+        return $lucene;
+    }
+
+    /**
+     * @param array $solrData
+     *
+     * @throws RuntimeException
+     *
+     * @return DocumentInterface
+     */
+    protected function parseSolr(array $solrData): DocumentInterface
+    {
+        $documentClass = $this->result->getQuery()->getDocumentClass();
+        $classes = class_implements($documentClass);
+        if (!\in_array(DocumentInterface::class, $classes, true)) {
+            throw new RuntimeException('The result document class must implement a document interface');
+        }
+
+        return new $documentClass($solrData);
+    }
+}

--- a/src/QueryType/Luke/ResponseParser/Fields.php
+++ b/src/QueryType/Luke/ResponseParser/Fields.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\ResponseParser;
+
+use Solarium\Core\Query\Result\ResultInterface;
+use Solarium\QueryType\Luke\Result\Fields\FieldInfo;
+use Solarium\QueryType\Luke\Result\FlagList;
+use Solarium\QueryType\Luke\Result\Result;
+
+/**
+ * Parse Luke fields response data.
+ */
+class Fields extends Index
+{
+    use InfoTrait;
+
+    /**
+     * Get result data for the response.
+     *
+     * @param Result $result
+     *
+     * @return array
+     */
+    public function parse(ResultInterface $result): array
+    {
+        $data = parent::parse($result);
+
+        // parse 'info' first so 'fields' can use it for flag lookups
+        $data['infoResult'] = $this->parseInfo($data['info']);
+        $data['fieldsResult'] = $this->parseFields($data['fields']);
+
+        return $data;
+    }
+
+    /**
+     * @param array $fieldsData
+     *
+     * @return FieldInfo[]
+     */
+    protected function parseFields(array $fieldsData): array
+    {
+        $fields = [];
+
+        foreach ($fieldsData as $name => $info) {
+            $field = new FieldInfo($name);
+
+            $field->setType($info['type']);
+            $field->setSchema(new FlagList($info['schema'], $this->key));
+            $field->setDynamicBase($info['dynamicBase'] ?? null);
+
+            // index isn't set if field isn't indexed or if includeIndexFieldFlags=false was set on the query
+            if (isset($info['index'])) {
+                $index = $info['index'];
+
+                // the response can have '(unstored field)' in lieu of an actual flags string
+                if ('(unstored field)' !== $index) {
+                    $index = new FlagList($index, $this->key);
+                }
+
+                $field->setIndex($index);
+            }
+
+            $field->setDocs($info['docs'] ?? null);
+            $field->setDistinct($info['distinct'] ?? null);
+
+            if (isset($info['topTerms'])) {
+                $field->setTopTerms($this->convertToKeyValueArray($info['topTerms']));
+            }
+
+            if (isset($info['histogram'])) {
+                $field->setHistogram($this->convertToKeyValueArray($info['histogram']));
+            }
+
+            $fields[$name] = $field;
+        }
+
+        return $fields;
+    }
+}

--- a/src/QueryType/Luke/ResponseParser/Index.php
+++ b/src/QueryType/Luke/ResponseParser/Index.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\ResponseParser;
+
+use Solarium\Core\Query\AbstractResponseParser;
+use Solarium\Core\Query\ResponseParserInterface;
+use Solarium\Core\Query\Result\ResultInterface;
+use Solarium\QueryType\Luke\Result\Index\Index as IndexResult;
+use Solarium\QueryType\Luke\Result\Index\UserData;
+use Solarium\QueryType\Luke\Result\Result;
+
+/**
+ * Parse Luke index response data.
+ */
+class Index extends AbstractResponseParser implements ResponseParserInterface
+{
+    /**
+     * Get result data for the response.
+     *
+     * @param Result $result
+     *
+     * @return array
+     */
+    public function parse(ResultInterface $result): array
+    {
+        $data = $result->getData();
+
+        $data['indexResult'] = $this->parseIndex($data['index']);
+        $data['schemaResult'] = null;
+        $data['docResult'] = null;
+        $data['fieldsResult'] = null;
+        $data['infoResult'] = null;
+
+        $data = $this->addHeaderInfo($data, $data);
+
+        return $data;
+    }
+
+    /**
+     * @param array $indexData
+     *
+     * @return IndexResult
+     */
+    protected function parseIndex(array $indexData): IndexResult
+    {
+        $index = new IndexResult();
+
+        $index->setNumDocs($indexData['numDocs']);
+        $index->setMaxDoc($indexData['maxDoc']);
+        $index->setDeletedDocs($indexData['deletedDocs']);
+        // indexHeapUsageBytes was removed in SOLR-15341 for Solr 9
+        $index->setIndexHeapUsageBytes($indexData['indexHeapUsageBytes'] ?? null);
+        $index->setVersion($indexData['version']);
+        $index->setSegmentCount($indexData['segmentCount']);
+        $index->setCurrent($indexData['current']);
+        $index->setHasDeletions($indexData['hasDeletions']);
+        $index->setDirectory($indexData['directory']);
+        $index->setSegmentsFile($indexData['segmentsFile']);
+        $index->setSegmentsFileSizeInBytes($indexData['segmentsFileSizeInBytes']);
+
+        // userData is empty if there haven't been any commits yet
+        $userData = new UserData();
+        $userData->setCommitCommandVer($indexData['userData']['commitCommandVer'] ?? null);
+        $userData->setCommitTimeMSec($indexData['userData']['commitTimeMSec'] ?? null);
+        $index->setUserData($userData);
+
+        // lastModified is calculated from commitTimeMSec (in Solr) and will be empty too before the first commit
+        $lastModified = isset($indexData['lastModified']) ? new \DateTime($indexData['lastModified']) : null;
+        $index->setLastModified($lastModified);
+
+        return $index;
+    }
+}

--- a/src/QueryType/Luke/ResponseParser/InfoTrait.php
+++ b/src/QueryType/Luke/ResponseParser/InfoTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\ResponseParser;
+
+use Solarium\QueryType\Luke\Result\Info\Info as InfoResult;
+
+/**
+ * Parse Luke info response data and use the result to parse flags from other response data.
+ */
+trait InfoTrait
+{
+    /**
+     * A key to what each character in the field flags means.
+     *
+     * @var array
+     */
+    protected $key;
+
+    /**
+     * @param array $infoData
+     *
+     * @return InfoResult
+     */
+    protected function parseInfo(array $infoData): InfoResult
+    {
+        $info = new InfoResult();
+
+        $info->setKey($infoData['key']);
+        $info->setNote($infoData['NOTE']);
+
+        // for lookups when parsing flags
+        $this->key = $info->getKey();
+
+        return $info;
+    }
+}

--- a/src/QueryType/Luke/ResponseParser/Schema.php
+++ b/src/QueryType/Luke/ResponseParser/Schema.php
@@ -1,0 +1,326 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\ResponseParser;
+
+use Solarium\Core\Query\Result\ResultInterface;
+use Solarium\Exception\RuntimeException;
+use Solarium\QueryType\Luke\Result\FlagList;
+use Solarium\QueryType\Luke\Result\Result;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicBasedField;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicField;
+use Solarium\QueryType\Luke\Result\Schema\Field\Field;
+use Solarium\QueryType\Luke\Result\Schema\Field\WildcardField;
+use Solarium\QueryType\Luke\Result\Schema\Schema as SchemaResult;
+use Solarium\QueryType\Luke\Result\Schema\Similarity;
+use Solarium\QueryType\Luke\Result\Schema\Type\AbstractAnalyzer;
+use Solarium\QueryType\Luke\Result\Schema\Type\CharFilter;
+use Solarium\QueryType\Luke\Result\Schema\Type\Filter;
+use Solarium\QueryType\Luke\Result\Schema\Type\IndexAnalyzer;
+use Solarium\QueryType\Luke\Result\Schema\Type\QueryAnalyzer;
+use Solarium\QueryType\Luke\Result\Schema\Type\Tokenizer;
+use Solarium\QueryType\Luke\Result\Schema\Type\Type;
+use Solarium\Support\Utility;
+
+/**
+ * Parse Luke schema response data.
+ */
+class Schema extends Index
+{
+    use InfoTrait;
+
+    /**
+     * Get result data for the response.
+     *
+     * @param Result $result
+     *
+     * @return array
+     */
+    public function parse(ResultInterface $result): array
+    {
+        $data = parent::parse($result);
+
+        // parse 'info' first so 'schema' can use it for flag lookups
+        $data['infoResult'] = $this->parseInfo($data['info']);
+        $data['schemaResult'] = $this->parseSchema($data['schema']);
+
+        return $data;
+    }
+
+    /**
+     * @param array $schemaData
+     *
+     * @return SchemaResult
+     */
+    protected function parseSchema(array $schemaData): SchemaResult
+    {
+        $schema = new SchemaResult();
+
+        $fields = $this->parseFields($schemaData['fields']);
+        $dynamicFields = $this->parseFields($schemaData['dynamicFields'], true);
+        $uniqueKeyField = $schemaData['uniqueKeyField'];
+
+        $similarity = new Similarity();
+        $similarity->setClassName($schemaData['similarity']['className']);
+        $similarity->setDetails($schemaData['similarity']['details']);
+
+        $types = $this->parseTypes($schemaData['types']);
+
+        // linking it all together
+
+        // link type first because it's necessary for DynamicField::createField()
+        $this->linkFieldType($fields, $schemaData['fields'], $types);
+        $this->linkFieldType($dynamicFields, $schemaData['dynamicFields'], $types);
+        $this->linkTypeFields($types, $schemaData['types'], $fields, $dynamicFields);
+
+        // store copyField sources that aren't in $fields or $dynamicFields
+        $dynamicBasedFields = [];
+        $wildcardFields = [];
+
+        $this->linkFields($fields, $schemaData['fields'], $fields, $dynamicFields, $dynamicBasedFields, $wildcardFields);
+        $this->linkFields($dynamicFields, $schemaData['dynamicFields'], $fields, $dynamicFields, $dynamicBasedFields, $wildcardFields);
+
+        $schema->setFields($fields);
+        $schema->setDynamicFields($dynamicFields);
+
+        // a schema isn't required to have a <uniqueKey> field
+        if (null !== $uniqueKeyField) {
+            $schema->setUniqueKeyField($fields[$uniqueKeyField]);
+        }
+
+        $schema->setSimilarity($similarity);
+        $schema->setTypes($types);
+
+        return $schema;
+    }
+
+    /**
+     * @param array $fieldData
+     * @param bool  $dynamic
+     *
+     * @return Field[]|DynamicField[]
+     */
+    protected function parseFields(array $fieldData, bool $dynamic = false): array
+    {
+        $fieldClass = $dynamic ? DynamicField::class : Field::class;
+        $fields = [];
+
+        foreach ($fieldData as $name => $details) {
+            $field = new $fieldClass($name);
+
+            $field->setFlags(new FlagList($details['flags'], $this->key));
+            $field->setRequired($details['required'] ?? null);
+            $field->setDefault($details['default'] ?? null);
+            $field->setUniqueKey($details['uniqueKey'] ?? null);
+            $field->setPositionIncrementGap($details['positionIncrementGap'] ?? null);
+
+            $fields[$name] = $field;
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @param array $typeData
+     *
+     * @return Type[]
+     */
+    protected function parseTypes(array $typeData): array
+    {
+        $types = [];
+
+        foreach ($typeData as $name => $details) {
+            $type = new Type($name);
+
+            $indexAnalyzer = $this->parseAnalyzer($details['indexAnalyzer'], IndexAnalyzer::class);
+            $queryAnalyzer = $this->parseAnalyzer($details['queryAnalyzer'], QueryAnalyzer::class);
+
+            // similarity is empty for types that don't have a specific similarity
+            $similarity = new Similarity();
+            $similarity->setClassName($details['similarity']['className'] ?? null);
+            $similarity->setDetails($details['similarity']['details'] ?? null);
+
+            $type->setTokenized($details['tokenized']);
+            $type->setClassName($details['className']);
+            $type->setIndexAnalyzer($indexAnalyzer);
+            $type->setQueryAnalyzer($queryAnalyzer);
+            $type->setSimilarity($similarity);
+
+            $types[$name] = $type;
+        }
+
+        return $types;
+    }
+
+    /**
+     * @param array  $analyzerData
+     * @param string $analyzerClass
+     *
+     * @return IndexAnalyzer|QueryAnalyzer
+     */
+    protected function parseAnalyzer(array $analyzerData, string $analyzerClass): AbstractAnalyzer
+    {
+        $analyzer = new $analyzerClass($analyzerData['className']);
+
+        if (isset($analyzerData['charFilters'])) {
+            $charFilters = $this->parseFilters($analyzerData['charFilters'], CharFilter::class);
+
+            $analyzer->setCharFilters($charFilters);
+        }
+
+        if (isset($analyzerData['tokenizer'])) {
+            $tokenizer = new Tokenizer($analyzerData['tokenizer']['className']);
+            $tokenizer->setArgs($analyzerData['tokenizer']['args']);
+
+            $analyzer->setTokenizer($tokenizer);
+        }
+
+        if (isset($analyzerData['filters'])) {
+            $filters = $this->parseFilters($analyzerData['filters'], Filter::class);
+
+            $analyzer->setFilters($filters);
+        }
+
+        return $analyzer;
+    }
+
+    /**
+     * @param array  $filterData
+     * @param string $filterClass
+     *
+     * @return CharFilter[]|Filter[]
+     */
+    protected function parseFilters(array $filterData, string $filterClass): array
+    {
+        $filters = [];
+
+        foreach ($filterData as $name => $details) {
+            $filter = new $filterClass($name);
+            $filter->setArgs($details['args']);
+            $filter->setClassName($details['className']);
+
+            $filters[$name] = $filter;
+        }
+
+        return $filters;
+    }
+
+    /**
+     * Link fields with their {@see Type}.
+     *
+     * @param Field[]|DynamicField[] $fields
+     * @param array                  $fieldData
+     * @param Type[]                 $types
+     */
+    protected function linkFieldType(array &$fields, array &$fieldData, array &$types): void
+    {
+        foreach ($fields as $name => $field) {
+            $field->setType($types[$fieldData[$name]['type']]);
+        }
+    }
+
+    /**
+     * Link fields with their copy destinations and sources.
+     *
+     * @param Field[]|DynamicField[] $fieldsToLink
+     * @param array                  $fieldData
+     * @param Field[]                $fields
+     * @param DynamicField[]         $dynamicFields
+     * @param DynamicBasedField[]    $dynamicBasedFields
+     * @param WildcardField[]        $wildcardFields
+     */
+    protected function linkFields(array &$fieldsToLink, array &$fieldData, array &$fields, array &$dynamicFields, array &$dynamicBasedFields, array &$wildcardFields): void
+    {
+        foreach ($fieldsToLink as $name => $field) {
+            foreach ($fieldData[$name]['copyDests'] as $copyDest) {
+                if (Utility::isWildcardPattern($copyDest)) {
+                    $field->addCopyDest($dynamicFields[$copyDest]);
+                } elseif (isset($fields[$copyDest])) {
+                    $field->addCopyDest($fields[$copyDest]);
+                } else {
+                    if (!isset($dynamicBasedFields[$copyDest])) {
+                        $dynamicBasedField = $dynamicFields[$this->findDynamicField($copyDest, array_keys($dynamicFields))]->createField($copyDest);
+                        $dynamicBasedFields[$copyDest] = $dynamicBasedField;
+                    }
+                    $dynamicBasedFields[$copyDest]->addCopySource($fieldsToLink[$name]);
+                    $field->addCopyDest($dynamicBasedFields[$copyDest]);
+                }
+            }
+
+            foreach ($fieldData[$name]['copySources'] as $copySource) {
+                if (Utility::isWildcardPattern($copySource)) {
+                    if (isset($dynamicFields[$copySource])) {
+                        $field->addCopySource($dynamicFields[$copySource]);
+                    } else {
+                        if (!isset($wildcardFields[$copySource])) {
+                            $wildcardField = new WildcardField($copySource);
+                            $wildcardFields[$copySource] = $wildcardField;
+                        }
+                        $wildcardFields[$copySource]->addCopyDest($fieldsToLink[$name]);
+                        $field->addCopySource($wildcardFields[$copySource]);
+                    }
+                } elseif (isset($fields[$copySource])) {
+                    $field->addCopySource($fields[$copySource]);
+                } else {
+                    if (!isset($dynamicBasedFields[$copySource])) {
+                        $dynamicBasedField = $dynamicFields[$this->findDynamicField($copySource, array_keys($dynamicFields))]->createField($copySource);
+                        $dynamicBasedFields[$copySource] = $dynamicBasedField;
+                    }
+                    $dynamicBasedFields[$copySource]->addCopyDest($fieldsToLink[$name]);
+                    $field->addCopySource($dynamicBasedFields[$copySource]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Link types with their associated fields and dynamic fields.
+     *
+     * @param Type[]         $types
+     * @param array          $typeData
+     * @param Field[]        $fields
+     * @param DynamicField[] $dynamicFields
+     */
+    protected function linkTypeFields(array &$types, array &$typeData, array &$fields, array &$dynamicFields): void
+    {
+        foreach ($types as $typeName => $type) {
+            // if a type has no associated fields, Solr returns null rather than an empty array
+            if (null !== $typeData[$typeName]['fields']) {
+                foreach ($typeData[$typeName]['fields'] as $fieldName) {
+                    if (Utility::isWildcardPattern($fieldName)) {
+                        $type->addField($dynamicFields[$fieldName]);
+                    } else {
+                        $type->addField($fields[$fieldName]);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Find the dynamic field in a list that matches the field name.
+     *
+     * @param string   $fieldName
+     * @param string[] $dynamicFields
+     *
+     * @throws RuntimeException
+     *
+     * @return string
+     */
+    protected function findDynamicField(string $fieldName, array $dynamicFields): string
+    {
+        foreach ($dynamicFields as $dynamicField) {
+            if (Utility::fieldMatchesWildcard($dynamicField, $fieldName)) {
+                return $dynamicField;
+            }
+        }
+
+        throw new RuntimeException(sprintf('Field name %s doesn\'t match a dynamicField name.', $fieldName));
+    }
+}

--- a/src/QueryType/Luke/Result/Doc/DocFieldInfo.php
+++ b/src/QueryType/Luke/Result/Doc/DocFieldInfo.php
@@ -1,0 +1,266 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Doc;
+
+use Solarium\QueryType\Luke\Result\FlagList;
+
+/**
+ * Document field information.
+ */
+class DocFieldInfo
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string|null
+     */
+    protected $type;
+
+    /**
+     * @var FlagList
+     */
+    protected $schema;
+
+    /**
+     * @var FlagList
+     */
+    protected $flags;
+
+    /**
+     * @var string|null
+     */
+    protected $value = null;
+
+    /**
+     * @var string
+     */
+    protected $internal;
+
+    /**
+     * @var string|null
+     */
+    protected $binary;
+
+    /**
+     * @var int|null
+     */
+    protected $docFreq;
+
+    /**
+     * @var array|null
+     */
+    protected $termVector;
+
+    /**
+     * Constructor.
+     *
+     * @param string $name
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Returns field name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Returns field type.
+     *
+     * @return string|null
+     */
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string|null $type
+     *
+     * @return self
+     */
+    public function setType(?string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * Returns schema flags.
+     *
+     * @return FlagList
+     */
+    public function getSchema(): FlagList
+    {
+        return $this->schema;
+    }
+
+    /**
+     * @param FlagList $schema
+     *
+     * @return self
+     */
+    public function setSchema(FlagList $schema): self
+    {
+        $this->schema = $schema;
+
+        return $this;
+    }
+
+    /**
+     * Returns index flags.
+     *
+     * @return FlagList
+     */
+    public function getFlags(): FlagList
+    {
+        return $this->flags;
+    }
+
+    /**
+     * @param FlagList $flags
+     *
+     * @return self
+     */
+    public function setFlags($flags): self
+    {
+        $this->flags = $flags;
+
+        return $this;
+    }
+
+    /**
+     * Returns the external (human readable) value.
+     *
+     * @return string|null
+     */
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string|null $value
+     *
+     * @return self
+     */
+    public function setValue(?string $value): self
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Returns the stored value.
+     *
+     * @return string
+     */
+    public function getInternal(): string
+    {
+        return $this->internal;
+    }
+
+    /**
+     * @param string $internal
+     *
+     * @return self
+     */
+    public function setInternal(string $internal): self
+    {
+        $this->internal = $internal;
+
+        return $this;
+    }
+
+    /**
+     * Returns the binary value.
+     *
+     * @return string|null
+     */
+    public function getBinary(): ?string
+    {
+        return $this->binary;
+    }
+
+    /**
+     * @param string|null $binary
+     *
+     * @return self
+     */
+    public function setBinary(?string $binary): self
+    {
+        $this->binary = $binary;
+
+        return $this;
+    }
+
+    /**
+     * Returns the number of documents that contain the term in the field.
+     *
+     * This can be 0 for non-indexed fields or null because it isn't calculated for point fields.
+     *
+     * @return int|null
+     */
+    public function getDocFreq(): ?int
+    {
+        return $this->docFreq;
+    }
+
+    /**
+     * @param int|null $docFreq
+     *
+     * @return self
+     */
+    public function setDocFreq(?int $docFreq): self
+    {
+        $this->docFreq = $docFreq;
+
+        return $this;
+    }
+
+    /**
+     * Returns the term vector.
+     *
+     * @return array|null
+     */
+    public function getTermVector(): ?array
+    {
+        return $this->termVector;
+    }
+
+    /**
+     * @param array|null $termVector
+     *
+     * @return self
+     */
+    public function setTermVector(?array $termVector): self
+    {
+        $this->termVector = $termVector;
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->name.': '.$this->value;
+    }
+}

--- a/src/QueryType/Luke/Result/Doc/DocInfo.php
+++ b/src/QueryType/Luke/Result/Doc/DocInfo.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Doc;
+
+use Solarium\Core\Query\DocumentInterface;
+
+/**
+ * Retrieved doc information.
+ */
+class DocInfo
+{
+    /**
+     * @var int
+     */
+    protected $docId;
+
+    /**
+     * @var DocFieldInfo[]
+     */
+    protected $lucene;
+
+    /**
+     * @var DocumentInterface
+     */
+    protected $solr;
+
+    /**
+     * Constructor.
+     *
+     * @param int $docId Lucene documentID
+     */
+    public function __construct(int $docId)
+    {
+        $this->docId = $docId;
+    }
+
+    /**
+     * Returns the Lucene documentID.
+     *
+     * @return int
+     */
+    public function getDocId(): int
+    {
+        return $this->docId;
+    }
+
+    /**
+     * Returns the document fields information.
+     *
+     * @return DocFieldInfo[]
+     */
+    public function getLucene(): array
+    {
+        return $this->lucene;
+    }
+
+    /**
+     * @param DocFieldInfo[] $lucene
+     *
+     * @return self
+     */
+    public function setLucene(array $lucene): self
+    {
+        $this->lucene = $lucene;
+
+        return $this;
+    }
+
+    /**
+     * Returns the Solr document.
+     *
+     * @return DocumentInterface
+     */
+    public function getSolr(): DocumentInterface
+    {
+        return $this->solr;
+    }
+
+    /**
+     * @param DocumentInterface $solr
+     *
+     * @return self
+     */
+    public function setSolr(DocumentInterface $solr): self
+    {
+        $this->solr = $solr;
+
+        return $this;
+    }
+}

--- a/src/QueryType/Luke/Result/Fields/FieldInfo.php
+++ b/src/QueryType/Luke/Result/Fields/FieldInfo.php
@@ -1,0 +1,264 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Fields;
+
+use Solarium\QueryType\Luke\Result\FlagList;
+
+/**
+ * Retrieved field information.
+ */
+class FieldInfo
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string|null
+     */
+    protected $type;
+
+    /**
+     * @var FlagList
+     */
+    protected $schema;
+
+    /**
+     * @var string|null
+     */
+    protected $dynamicBase = null;
+
+    /**
+     * @var FlagList|string|null
+     */
+    protected $index = null;
+
+    /**
+     * @var int|null
+     */
+    protected $docs = null;
+
+    /**
+     * @var int|null
+     */
+    protected $distinct = null;
+
+    /**
+     * @var array|null
+     */
+    protected $topTerms = null;
+
+    /**
+     * @var array|null
+     */
+    protected $histogram = null;
+
+    /**
+     * Constructor.
+     *
+     * @param string $name
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Returns field name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Returns field type.
+     *
+     * @return string|null
+     */
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string|null $type
+     *
+     * @return self
+     */
+    public function setType(?string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * Returns schema flags.
+     *
+     * @return FlagList
+     */
+    public function getSchema(): FlagList
+    {
+        return $this->schema;
+    }
+
+    /**
+     * @param FlagList $schema
+     *
+     * @return self
+     */
+    public function setSchema(FlagList $schema): self
+    {
+        $this->schema = $schema;
+
+        return $this;
+    }
+
+    /**
+     * Returns the name of the dynamic field this field is based on.
+     *
+     * @return string|null
+     */
+    public function getDynamicBase(): ?string
+    {
+        return $this->dynamicBase;
+    }
+
+    /**
+     * @param string|null $dynamicBase
+     *
+     * @return self
+     */
+    public function setDynamicBase(?string $dynamicBase): self
+    {
+        $this->dynamicBase = $dynamicBase;
+
+        return $this;
+    }
+
+    /**
+     * Returns index flags.
+     *
+     * @return FlagList|string|null
+     */
+    public function getIndex()
+    {
+        return $this->index;
+    }
+
+    /**
+     * @param FlagList|string|null $index
+     *
+     * @return self
+     */
+    public function setIndex($index): self
+    {
+        $this->index = $index;
+
+        return $this;
+    }
+
+    /**
+     * Returns number of documents.
+     *
+     * @return int|null
+     */
+    public function getDocs(): ?int
+    {
+        return $this->docs;
+    }
+
+    /**
+     * @param int|null $docs
+     *
+     * @return self
+     */
+    public function setDocs(?int $docs): self
+    {
+        $this->docs = $docs;
+
+        return $this;
+    }
+
+    /**
+     * Returns number of distinct terms.
+     *
+     * @return int|null
+     */
+    public function getDistinct(): ?int
+    {
+        return $this->distinct;
+    }
+
+    /**
+     * @param int|null $distinct
+     *
+     * @return self
+     */
+    public function setDistinct(?int $distinct): self
+    {
+        $this->distinct = $distinct;
+
+        return $this;
+    }
+
+    /**
+     * Returns the list of top terms and their document frequencies.
+     *
+     * @return array|null
+     */
+    public function getTopTerms(): ?array
+    {
+        return $this->topTerms;
+    }
+
+    /**
+     * @param array|null $topTerms
+     *
+     * @return self
+     */
+    public function setTopTerms(?array $topTerms): self
+    {
+        $this->topTerms = $topTerms;
+
+        return $this;
+    }
+
+    /**
+     * Returns the term histogram.
+     *
+     * @return array|null
+     */
+    public function getHistogram(): ?array
+    {
+        return $this->histogram;
+    }
+
+    /**
+     * @param array|null $histogram
+     *
+     * @return self
+     */
+    public function setHistogram(?array $histogram): self
+    {
+        $this->histogram = $histogram;
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/QueryType/Luke/Result/Flag.php
+++ b/src/QueryType/Luke/Result/Flag.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result;
+
+/**
+ * Immutable field flag.
+ */
+class Flag
+{
+    /**
+     * @var string
+     */
+    protected $abbreviation;
+
+    /**
+     * @var string
+     */
+    protected $display;
+
+    /**
+     * Constructor.
+     *
+     * @param string $abbreviation
+     * @param string $display
+     */
+    public function __construct(string $abbreviation, string $display)
+    {
+        $this->abbreviation = $abbreviation;
+        $this->display = $display;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAbbreviation(): string
+    {
+        return $this->abbreviation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplay(): string
+    {
+        return $this->display;
+    }
+
+    public function __toString(): string
+    {
+        return $this->display;
+    }
+}

--- a/src/QueryType/Luke/Result/FlagList.php
+++ b/src/QueryType/Luke/Result/FlagList.php
@@ -1,0 +1,331 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result;
+
+/**
+ * Immutable {@see Flag} list.
+ */
+class FlagList implements \ArrayAccess, \Countable, \Iterator
+{
+    /**
+     * @var string
+     */
+    protected $flags;
+
+    /**
+     * @var Flag[]
+     */
+    protected $list = [];
+
+    /**
+     * @var string[]
+     */
+    protected $lookup = [];
+
+    /**
+     * Iterator position.
+     *
+     * @var int
+     */
+    protected $position = 0;
+
+    /**
+     * Iterator length.
+     *
+     * @var int
+     */
+    protected $length;
+
+    /**
+     * Constructor.
+     *
+     * @param string $flags The flags string that was returned by Solr
+     * @param array  $key   The info key that was returned by Solr
+     */
+    public function __construct(string $flags, array $key)
+    {
+        $this->flags = $flags;
+        $index = 0;
+
+        foreach (str_split($flags) as $flag) {
+            if ('-' !== $flag) {
+                $this->list[$index] = new Flag($flag, $key[$flag]);
+                $this->lookup[$index] = $flag;
+                ++$index;
+            }
+        }
+
+        $this->length = $index;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isIndexed(): ?bool
+    {
+        return \in_array('I', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTokenized(): bool
+    {
+        return \in_array('T', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isStored(): bool
+    {
+        return \in_array('S', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDocValues(): bool
+    {
+        return \in_array('D', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isUninvertible(): bool
+    {
+        return \in_array('U', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isMultiValued(): bool
+    {
+        return \in_array('M', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTermVectors(): bool
+    {
+        return \in_array('V', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTermOffsets(): bool
+    {
+        return \in_array('o', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTermPositions(): bool
+    {
+        return \in_array('p', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTermPayloads(): bool
+    {
+        return \in_array('y', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isOmitNorms(): bool
+    {
+        return \in_array('O', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isOmitTermFreqAndPositions(): bool
+    {
+        return \in_array('F', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isOmitPositions(): bool
+    {
+        return \in_array('P', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isStoreOffsetsWithPositions(): bool
+    {
+        return \in_array('H', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLazy(): bool
+    {
+        return \in_array('L', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isBinary(): bool
+    {
+        return \in_array('B', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSortMissingFirst(): bool
+    {
+        return \in_array('f', $this->lookup);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSortMissingLast(): bool
+    {
+        return \in_array('l', $this->lookup);
+    }
+
+    /**
+     * Countable implementation.
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return $this->length;
+    }
+
+    /**
+     * Iterator implementation.
+     *
+     * @return Flag
+     */
+    public function current(): Flag
+    {
+        return $this->list[$this->position];
+    }
+
+    /**
+     * Iterator implementation.
+     *
+     * @return string
+     */
+    public function key(): string
+    {
+        return $this->lookup[$this->position];
+    }
+
+    /**
+     * Iterator implementation.
+     *
+     * @return void
+     */
+    public function next(): void
+    {
+        ++$this->position;
+    }
+
+    /**
+     * Iterator implementation.
+     *
+     * @return void
+     */
+    public function rewind(): void
+    {
+        $this->position = 0;
+    }
+
+    /**
+     * Iterator implementation.
+     *
+     * @return bool
+     */
+    public function valid(): bool
+    {
+        return $this->position < $this->length;
+    }
+
+    /**
+     * ArrayAccess implementation.
+     *
+     * @param mixed $offset
+     *
+     * @return bool
+     */
+    public function offsetExists($offset): bool
+    {
+        return \in_array($offset, $this->lookup);
+    }
+
+    #[\ReturnTypeWillChange]
+    /**
+     * ArrayAccess implementation.
+     *
+     * @param mixed $offset
+     *
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        $value = null;
+
+        if (false !== $index = array_search($offset, $this->lookup)) {
+            $value = $this->list[$index];
+        }
+
+        return $value;
+    }
+
+    /**
+     * ArrayAccess implementation.
+     *
+     * @param mixed $offset
+     * @param mixed $value
+     */
+    public function offsetSet($offset, $value): void
+    {
+        // Details are immutable.
+    }
+
+    /**
+     * ArrayAccess implementation.
+     *
+     * @param mixed $offset
+     */
+    public function offsetUnset($offset): void
+    {
+        // Details are immutable.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        return $this->flags;
+    }
+}

--- a/src/QueryType/Luke/Result/Index/Index.php
+++ b/src/QueryType/Luke/Result/Index/Index.php
@@ -1,0 +1,357 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Index;
+
+/**
+ * Retrieved index information.
+ */
+class Index
+{
+    /**
+     * @var int
+     */
+    protected $numDocs;
+
+    /**
+     * @var int
+     */
+    protected $maxDoc;
+
+    /**
+     * @var int
+     */
+    protected $deletedDocs;
+
+    /**
+     * @var int|null
+     */
+    protected $indexHeapUsageBytes;
+
+    /**
+     * @var int
+     */
+    protected $version;
+
+    /**
+     * @var int
+     */
+    protected $segmentCount;
+
+    /**
+     * @var bool
+     */
+    protected $current;
+
+    /**
+     * @var bool
+     */
+    protected $hasDeletions;
+
+    /**
+     * @var string
+     */
+    protected $directory;
+
+    /**
+     * @var string
+     */
+    protected $segmentsFile;
+
+    /**
+     * @var int
+     */
+    protected $segmentsFileSizeInBytes;
+
+    /**
+     * @var UserData
+     */
+    protected $userData;
+
+    /**
+     * @var \DateTime|null
+     */
+    protected $lastModified;
+
+    /**
+     * @return int
+     */
+    public function getNumDocs(): int
+    {
+        return $this->numDocs;
+    }
+
+    /**
+     * @param int $numDocs
+     *
+     * @return self
+     */
+    public function setNumDocs(int $numDocs): self
+    {
+        $this->numDocs = $numDocs;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxDoc(): int
+    {
+        return $this->maxDoc;
+    }
+
+    /**
+     * @param int $maxDoc
+     *
+     * @return self
+     */
+    public function setMaxDoc(int $maxDoc): self
+    {
+        $this->maxDoc = $maxDoc;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDeletedDocs(): int
+    {
+        return $this->deletedDocs;
+    }
+
+    /**
+     * @param int $deletedDocs
+     *
+     * @return self
+     */
+    public function setDeletedDocs(int $deletedDocs): self
+    {
+        $this->deletedDocs = $deletedDocs;
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getIndexHeapUsageBytes(): ?int
+    {
+        return $this->indexHeapUsageBytes;
+    }
+
+    /**
+     * @param int|null $indexHeapUsageBytes
+     *
+     * @return self
+     */
+    public function setIndexHeapUsageBytes(?int $indexHeapUsageBytes): self
+    {
+        $this->indexHeapUsageBytes = $indexHeapUsageBytes;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+
+    /**
+     * @param int $version
+     *
+     * @return self
+     */
+    public function setVersion(int $version): self
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSegmentCount(): int
+    {
+        return $this->segmentCount;
+    }
+
+    /**
+     * @param int $segmentCount
+     *
+     * @return self
+     */
+    public function setSegmentCount(int $segmentCount): self
+    {
+        $this->segmentCount = $segmentCount;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCurrent(): bool
+    {
+        return $this->current;
+    }
+
+    /**
+     * @param bool $current
+     *
+     * @return self
+     */
+    public function setCurrent(bool $current): self
+    {
+        $this->current = $current;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCurrent(): bool
+    {
+        return $this->current;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHasDeletions(): bool
+    {
+        return $this->hasDeletions;
+    }
+
+    /**
+     * @param bool $hasDeletions
+     *
+     * @return self
+     */
+    public function setHasDeletions(bool $hasDeletions): self
+    {
+        $this->hasDeletions = $hasDeletions;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasDeletions(): bool
+    {
+        return $this->hasDeletions;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDirectory(): string
+    {
+        return $this->directory;
+    }
+
+    /**
+     * @param string $directory
+     *
+     * @return self
+     */
+    public function setDirectory(string $directory): self
+    {
+        $this->directory = $directory;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSegmentsFile(): string
+    {
+        return $this->segmentsFile;
+    }
+
+    /**
+     * @param string $segmentsFile
+     *
+     * @return self
+     */
+    public function setSegmentsFile(string $segmentsFile): self
+    {
+        $this->segmentsFile = $segmentsFile;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSegmentsFileSizeInBytes(): int
+    {
+        return $this->segmentsFileSizeInBytes;
+    }
+
+    /**
+     * @param int $segmentsFileSizeInBytes
+     *
+     * @return self
+     */
+    public function setSegmentsFileSizeInBytes(int $segmentsFileSizeInBytes): self
+    {
+        $this->segmentsFileSizeInBytes = $segmentsFileSizeInBytes;
+
+        return $this;
+    }
+
+    /**
+     * @return UserData
+     */
+    public function getUserData(): UserData
+    {
+        return $this->userData;
+    }
+
+    /**
+     * @param UserData $userData
+     *
+     * @return self
+     */
+    public function setUserData(UserData $userData): self
+    {
+        $this->userData = $userData;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime|null
+     */
+    public function getLastModified(): ?\DateTime
+    {
+        return $this->lastModified;
+    }
+
+    /**
+     * @param \DateTime|null $lastModified
+     *
+     * @return $this
+     */
+    public function setLastModified(?\DateTime $lastModified): self
+    {
+        $this->lastModified = $lastModified;
+
+        return $this;
+    }
+}

--- a/src/QueryType/Luke/Result/Index/UserData.php
+++ b/src/QueryType/Luke/Result/Index/UserData.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Index;
+
+/**
+ * User data.
+ *
+ * Contains information on the latest commit.
+ */
+class UserData
+{
+    /**
+     * @var string|null
+     */
+    protected $commitCommandVer = null;
+
+    /**
+     * @var string|null
+     */
+    protected $commitTimeMSec = null;
+
+    /**
+     * @return string|null
+     */
+    public function getCommitCommandVer(): ?string
+    {
+        return $this->commitCommandVer;
+    }
+
+    /**
+     * @param string|null $commitCommandVer
+     *
+     * @return self
+     */
+    public function setCommitCommandVer(?string $commitCommandVer): self
+    {
+        $this->commitCommandVer = $commitCommandVer;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCommitTimeMSec(): ?string
+    {
+        return $this->commitTimeMSec;
+    }
+
+    /**
+     * @param string|null $commitTimeMSec
+     *
+     * @return self
+     */
+    public function setCommitTimeMSec(?string $commitTimeMSec): self
+    {
+        $this->commitTimeMSec = $commitTimeMSec;
+
+        return $this;
+    }
+}

--- a/src/QueryType/Luke/Result/Info/Info.php
+++ b/src/QueryType/Luke/Result/Info/Info.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Info;
+
+/**
+ * Retrieved info information.
+ */
+class Info
+{
+    /**
+     * @var array
+     */
+    protected $key;
+
+    /**
+     * @var string
+     */
+    protected $note;
+
+    /**
+     * @return array
+     */
+    public function getKey(): array
+    {
+        return $this->key;
+    }
+
+    /**
+     * @param array $key
+     *
+     * @return self
+     */
+    public function setKey(array $key): self
+    {
+        $this->key = $key;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNote(): string
+    {
+        return $this->note;
+    }
+
+    /**
+     * @param string $note
+     *
+     * @return self
+     */
+    public function setNote(string $note): self
+    {
+        $this->note = $note;
+
+        return $this;
+    }
+}

--- a/src/QueryType/Luke/Result/Result.php
+++ b/src/QueryType/Luke/Result/Result.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result;
+
+use Solarium\Core\Query\Result\QueryType as BaseResult;
+use Solarium\QueryType\Luke\Result\Doc\DocInfo;
+use Solarium\QueryType\Luke\Result\Fields\FieldInfo;
+use Solarium\QueryType\Luke\Result\Index\Index;
+use Solarium\QueryType\Luke\Result\Info\Info;
+use Solarium\QueryType\Luke\Result\Schema\Schema;
+
+/**
+ * Luke query result.
+ */
+class Result extends BaseResult
+{
+    /**
+     * @var Index
+     */
+    protected $indexResult;
+
+    /**
+     * @var Schema|null
+     */
+    protected $schemaResult;
+
+    /**
+     * @var DocInfo|null;
+     */
+    protected $docResult;
+
+    /**
+     * @var FieldInfo[]|null;
+     */
+    protected $fieldsResult;
+
+    /**
+     * @var Info|null
+     */
+    protected $infoResult;
+
+    /**
+     * @return Index
+     */
+    public function getIndex(): Index
+    {
+        $this->parseResponse();
+
+        return $this->indexResult;
+    }
+
+    /**
+     * @return Schema|null
+     */
+    public function getSchema(): ?Schema
+    {
+        $this->parseResponse();
+
+        return $this->schemaResult;
+    }
+
+    /**
+     * @return DocInfo|null
+     */
+    public function getDoc(): ?DocInfo
+    {
+        $this->parseResponse();
+
+        return $this->docResult;
+    }
+
+    /**
+     * @return FieldInfo[]|null
+     */
+    public function getFields(): ?array
+    {
+        $this->parseResponse();
+
+        return $this->fieldsResult;
+    }
+
+    /**
+     * @return Info|null
+     */
+    public function getInfo(): ?Info
+    {
+        $this->parseResponse();
+
+        return $this->infoResult;
+    }
+}

--- a/src/QueryType/Luke/Result/Schema/Field/AbstractField.php
+++ b/src/QueryType/Luke/Result/Schema/Field/AbstractField.php
@@ -1,0 +1,266 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Field;
+
+use Solarium\QueryType\Luke\Result\FlagList;
+use Solarium\QueryType\Luke\Result\Schema\Type\Type;
+
+/**
+ * Field base class.
+ */
+abstract class AbstractField implements FieldInterface
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var Type
+     */
+    protected $type;
+
+    /**
+     * @var FlagList
+     */
+    protected $flags;
+
+    /**
+     * @var bool|null
+     */
+    protected $required = null;
+
+    /**
+     * @var string|null
+     */
+    protected $default = null;
+
+    /**
+     * @var bool|null
+     */
+    protected $uniqueKey = null;
+
+    /**
+     * @var int|null
+     */
+    protected $positionIncrementGap = null;
+
+    /**
+     * @var CopyFieldDestInterface[]
+     */
+    protected $copyDests = [];
+
+    /**
+     * @var CopyFieldSourceInterface[]
+     */
+    protected $copySources = [];
+
+    /**
+     * Constructor.
+     *
+     * @param string $name
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return Type
+     */
+    public function &getType(): Type
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param Type $type
+     *
+     * @return self
+     */
+    public function setType(Type &$type): self
+    {
+        $this->type = &$type;
+
+        return $this;
+    }
+
+    /**
+     * @return FlagList
+     */
+    public function getFlags(): FlagList
+    {
+        return $this->flags;
+    }
+
+    /**
+     * @param FlagList $flags
+     *
+     * @return self
+     */
+    public function setFlags(FlagList $flags): self
+    {
+        $this->flags = $flags;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getRequired(): ?bool
+    {
+        return $this->required;
+    }
+
+    /**
+     * @param bool|null $required
+     *
+     * @return self
+     */
+    public function setRequired(?bool $required): self
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRequired(): bool
+    {
+        return true === $this->required;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDefault(): ?string
+    {
+        return $this->default;
+    }
+
+    /**
+     * @param string|null $default
+     *
+     * @return self
+     */
+    public function setDefault(?string $default): self
+    {
+        $this->default = $default;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getUniqueKey(): ?bool
+    {
+        return $this->uniqueKey;
+    }
+
+    /**
+     * @param bool|null $uniqueKey
+     *
+     * @return self
+     */
+    public function setUniqueKey(?bool $uniqueKey): self
+    {
+        $this->uniqueKey = $uniqueKey;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isUniqueKey(): bool
+    {
+        return true === $this->uniqueKey;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPositionIncrementGap(): ?int
+    {
+        return $this->positionIncrementGap;
+    }
+
+    /**
+     * @param int|null $positionIncrementGap
+     *
+     * @return self
+     */
+    public function setPositionIncrementGap(?int $positionIncrementGap): self
+    {
+        $this->positionIncrementGap = $positionIncrementGap;
+
+        return $this;
+    }
+
+    /**
+     * @return CopyFieldDestInterface[]
+     */
+    public function getCopyDests(): array
+    {
+        return $this->copyDests;
+    }
+
+    /**
+     * @param CopyFieldDestInterface $copyDest
+     *
+     * @return self
+     */
+    public function addCopyDest(CopyFieldDestInterface &$copyDest): self
+    {
+        $this->copyDests[] = &$copyDest;
+
+        return $this;
+    }
+
+    /**
+     * @return CopyFieldSourceInterface[]
+     */
+    public function getCopySources(): array
+    {
+        return $this->copySources;
+    }
+
+    /**
+     * @param CopyFieldSourceInterface $copySource
+     *
+     * @return self
+     */
+    public function addCopySource(CopyFieldSourceInterface &$copySource): self
+    {
+        $this->copySources[] = &$copySource;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/QueryType/Luke/Result/Schema/Field/CopyFieldDestInterface.php
+++ b/src/QueryType/Luke/Result/Schema/Field/CopyFieldDestInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Field;
+
+/**
+ * Marker interface for copy destination fields.
+ *
+ * @see https://solr.apache.org/guide/copying-fields.html
+ */
+interface CopyFieldDestInterface
+{
+}

--- a/src/QueryType/Luke/Result/Schema/Field/CopyFieldSourceInterface.php
+++ b/src/QueryType/Luke/Result/Schema/Field/CopyFieldSourceInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Field;
+
+/**
+ * Marker interface for copy source fields.
+ *
+ * @see https://solr.apache.org/guide/copying-fields.html
+ */
+interface CopyFieldSourceInterface
+{
+}

--- a/src/QueryType/Luke/Result/Schema/Field/DynamicBasedField.php
+++ b/src/QueryType/Luke/Result/Schema/Field/DynamicBasedField.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Field;
+
+/**
+ * Field created from a dynamic field definition.
+ *
+ * Used for fields that are a copy source or destination, and aren't
+ * explicitly defined in the schema.
+ */
+class DynamicBasedField extends AbstractField implements CopyFieldDestInterface, CopyFieldSourceInterface
+{
+    /**
+     * @var DynamicField
+     */
+    protected $dynamicBase;
+
+    /**
+     * @return DynamicField
+     */
+    public function &getDynamicBase(): DynamicField
+    {
+        return $this->dynamicBase;
+    }
+
+    /**
+     * @param DynamicField $dynamicBase
+     *
+     * @return self
+     */
+    public function setDynamicBase(DynamicField &$dynamicBase): self
+    {
+        $this->dynamicBase = &$dynamicBase;
+
+        return $this;
+    }
+}

--- a/src/QueryType/Luke/Result/Schema/Field/DynamicField.php
+++ b/src/QueryType/Luke/Result/Schema/Field/DynamicField.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Field;
+
+/**
+ * Retrieved dynamic field definition.
+ *
+ * @see https://solr.apache.org/guide/dynamic-fields.html
+ */
+class DynamicField extends AbstractField implements CopyFieldDestInterface, CopyFieldSourceInterface, SchemaFieldInterface
+{
+    /**
+     * Create a {@see DynamicBasedField} from this dynamic field definition.
+     *
+     * @param string $name
+     *
+     * @return DynamicBasedField
+     */
+    public function createField(string $name): DynamicBasedField
+    {
+        $field = new DynamicBasedField($name);
+
+        $field->setType($this->getType());
+        $field->setFlags($this->getFlags());
+        $field->setPositionIncrementGap($this->getPositionIncrementGap());
+        $field->setDynamicBase($this);
+
+        return $field;
+    }
+}

--- a/src/QueryType/Luke/Result/Schema/Field/Field.php
+++ b/src/QueryType/Luke/Result/Schema/Field/Field.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Field;
+
+/**
+ * Retrieved field definition.
+ */
+class Field extends AbstractField implements CopyFieldDestInterface, CopyFieldSourceInterface, SchemaFieldInterface
+{
+}

--- a/src/QueryType/Luke/Result/Schema/Field/FieldInterface.php
+++ b/src/QueryType/Luke/Result/Schema/Field/FieldInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Field;
+
+/**
+ * Field interface.
+ */
+interface FieldInterface
+{
+    /**
+     * Constructor.
+     *
+     * @param string $name
+     */
+    public function __construct(string $name);
+
+    /**
+     * @return string
+     */
+    public function getName(): string;
+
+    public function __toString(): string;
+}

--- a/src/QueryType/Luke/Result/Schema/Field/SchemaFieldInterface.php
+++ b/src/QueryType/Luke/Result/Schema/Field/SchemaFieldInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Field;
+
+/**
+ * Marker interface for fields that are directly defined in the schema.
+ */
+interface SchemaFieldInterface
+{
+}

--- a/src/QueryType/Luke/Result/Schema/Field/WildcardField.php
+++ b/src/QueryType/Luke/Result/Schema/Field/WildcardField.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Field;
+
+/**
+ * Wildcard field used as a copy source.
+ *
+ * This is used when a copyField source isn't an explicit field and doesn't match a dynamicField.
+ *
+ * @internal a copyField destination can only be an explicit field or match a dynamicField
+ *
+ * @see https://solr.apache.org/guide/copying-fields.html
+ */
+class WildcardField implements CopyFieldSourceInterface, FieldInterface
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var CopyFieldDestInterface[]
+     */
+    protected $copyDests = [];
+
+    /**
+     * Constructor.
+     *
+     * @param string $name
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return CopyFieldDestInterface[]
+     */
+    public function getCopyDests(): array
+    {
+        return $this->copyDests;
+    }
+
+    /**
+     * @param CopyFieldDestInterface $copyDest
+     *
+     * @return self
+     */
+    public function addCopyDest(CopyFieldDestInterface &$copyDest): self
+    {
+        $this->copyDests[] = &$copyDest;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/QueryType/Luke/Result/Schema/Schema.php
+++ b/src/QueryType/Luke/Result/Schema/Schema.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema;
+
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicField;
+use Solarium\QueryType\Luke\Result\Schema\Field\Field;
+use Solarium\QueryType\Luke\Result\Schema\Type\Type;
+
+/**
+ * Retrieved schema information.
+ */
+class Schema
+{
+    /**
+     * @var Field[]
+     */
+    protected $fields;
+
+    /**
+     * @var DynamicField[]
+     */
+    protected $dynamicFields;
+
+    /**
+     * @var Field|null
+     */
+    protected $uniqueKeyField = null;
+
+    /**
+     * @var Similarity
+     */
+    protected $similarity;
+
+    /**
+     * @var Type[]
+     */
+    protected $types;
+
+    /**
+     * @return Field[]
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return Field|null
+     */
+    public function getField(string $name): ?Field
+    {
+        return $this->fields[$name] ?? null;
+    }
+
+    /**
+     * @param Field[] $fields
+     *
+     * @return self
+     */
+    public function setFields(array $fields): self
+    {
+        $this->fields = $fields;
+
+        return $this;
+    }
+
+    /**
+     * @return DynamicField[]
+     */
+    public function getDynamicFields(): array
+    {
+        return $this->dynamicFields;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return DynamicField|null
+     */
+    public function getDynamicField(string $name): ?DynamicField
+    {
+        return $this->dynamicFields[$name] ?? null;
+    }
+
+    /**
+     * @param DynamicField[] $dynamicFields
+     *
+     * @return self
+     */
+    public function setDynamicFields(array $dynamicFields): self
+    {
+        $this->dynamicFields = $dynamicFields;
+
+        return $this;
+    }
+
+    /**
+     * @return Field|null
+     */
+    public function &getUniqueKeyField(): ?Field
+    {
+        return $this->uniqueKeyField;
+    }
+
+    /**
+     * @param Field $uniqueKeyField
+     *
+     * @return self
+     */
+    public function setUniqueKeyField(Field &$uniqueKeyField): self
+    {
+        $this->uniqueKeyField = &$uniqueKeyField;
+
+        return $this;
+    }
+
+    /**
+     * @return Similarity
+     */
+    public function getSimilarity(): Similarity
+    {
+        return $this->similarity;
+    }
+
+    /**
+     * @param Similarity $similarity
+     *
+     * @return self
+     */
+    public function setSimilarity(Similarity $similarity): self
+    {
+        $this->similarity = $similarity;
+
+        return $this;
+    }
+
+    /**
+     * @return Type[]
+     */
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return Type|null
+     */
+    public function getType(string $name): ?Type
+    {
+        return $this->types[$name] ?? null;
+    }
+
+    /**
+     * @param Type[] $types
+     *
+     * @return self
+     */
+    public function setTypes(array $types): self
+    {
+        $this->types = $types;
+
+        return $this;
+    }
+}

--- a/src/QueryType/Luke/Result/Schema/Similarity.php
+++ b/src/QueryType/Luke/Result/Schema/Similarity.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema;
+
+/**
+ * Similarity.
+ */
+class Similarity
+{
+    /**
+     * @var string|null
+     */
+    protected $className = null;
+
+    /**
+     * @var string|null
+     */
+    protected $details = null;
+
+    /**
+     * @return string|null
+     */
+    public function getClassName(): ?string
+    {
+        return $this->className;
+    }
+
+    /**
+     * @param string|null $className
+     *
+     * @return self
+     */
+    public function setClassName(?string $className): self
+    {
+        $this->className = $className;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDetails(): ?string
+    {
+        return $this->details;
+    }
+
+    /**
+     * @param string|null $details
+     *
+     * @return self
+     */
+    public function setDetails(?string $details): self
+    {
+        $this->details = $details;
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->className ?? '';
+    }
+}

--- a/src/QueryType/Luke/Result/Schema/Type/AbstractAnalyzer.php
+++ b/src/QueryType/Luke/Result/Schema/Type/AbstractAnalyzer.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Type;
+
+/**
+ * Analyzer base class.
+ */
+abstract class AbstractAnalyzer
+{
+    /**
+     * @var string
+     */
+    protected $className;
+
+    /**
+     * @var CharFilter[]
+     */
+    protected $charFilters = [];
+
+    /**
+     * @var Tokenizer|null
+     */
+    protected $tokenizer = null;
+
+    /**
+     * @var Filter[]
+     */
+    protected $filters = [];
+
+    /**
+     * Constructor.
+     *
+     * @param string $className
+     */
+    public function __construct(string $className)
+    {
+        $this->className = $className;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassName(): string
+    {
+        return $this->className;
+    }
+
+    /**
+     * @return CharFilter[]
+     */
+    public function getCharFilters(): array
+    {
+        return $this->charFilters;
+    }
+
+    /**
+     * @param CharFilter[] $charFilters
+     *
+     * @return self
+     */
+    public function setCharFilters(array $charFilters): self
+    {
+        $this->charFilters = $charFilters;
+
+        return $this;
+    }
+
+    /**
+     * @return Tokenizer|null
+     */
+    public function getTokenizer(): ?Tokenizer
+    {
+        return $this->tokenizer;
+    }
+
+    /**
+     * @param Tokenizer $tokenizer
+     *
+     * @return self
+     */
+    public function setTokenizer(Tokenizer $tokenizer): self
+    {
+        $this->tokenizer = $tokenizer;
+
+        return $this;
+    }
+
+    /**
+     * @return Filter[]
+     */
+    public function getFilters(): array
+    {
+        return $this->filters;
+    }
+
+    /**
+     * @param Filter[] $filters
+     *
+     * @return self
+     */
+    public function setFilters(array $filters): self
+    {
+        $this->filters = $filters;
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->className;
+    }
+}

--- a/src/QueryType/Luke/Result/Schema/Type/AbstractFilter.php
+++ b/src/QueryType/Luke/Result/Schema/Type/AbstractFilter.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Type;
+
+/**
+ * Filter base class.
+ */
+abstract class AbstractFilter
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var array
+     */
+    protected $args;
+
+    /**
+     * @var string
+     */
+    protected $className;
+
+    /**
+     * Constructor.
+     *
+     * @param string $name
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return array
+     */
+    public function getArgs(): array
+    {
+        return $this->args;
+    }
+
+    /**
+     * @param array $args
+     *
+     * @return self
+     */
+    public function setArgs(array $args): self
+    {
+        $this->args = $args;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassName(): string
+    {
+        return $this->className;
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return self
+     */
+    public function setClassName(string $className): self
+    {
+        $this->className = $className;
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/QueryType/Luke/Result/Schema/Type/CharFilter.php
+++ b/src/QueryType/Luke/Result/Schema/Type/CharFilter.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Type;
+
+/**
+ * Character filter.
+ */
+class CharFilter extends AbstractFilter
+{
+}

--- a/src/QueryType/Luke/Result/Schema/Type/Filter.php
+++ b/src/QueryType/Luke/Result/Schema/Type/Filter.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Type;
+
+/**
+ * Token filter.
+ */
+class Filter extends AbstractFilter
+{
+}

--- a/src/QueryType/Luke/Result/Schema/Type/IndexAnalyzer.php
+++ b/src/QueryType/Luke/Result/Schema/Type/IndexAnalyzer.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Type;
+
+/**
+ * Index time analyzer.
+ */
+class IndexAnalyzer extends AbstractAnalyzer
+{
+}

--- a/src/QueryType/Luke/Result/Schema/Type/QueryAnalyzer.php
+++ b/src/QueryType/Luke/Result/Schema/Type/QueryAnalyzer.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Type;
+
+/**
+ * Query time analyzer.
+ */
+class QueryAnalyzer extends AbstractAnalyzer
+{
+}

--- a/src/QueryType/Luke/Result/Schema/Type/Tokenizer.php
+++ b/src/QueryType/Luke/Result/Schema/Type/Tokenizer.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Type;
+
+/**
+ * Tokenizer.
+ */
+class Tokenizer
+{
+    /**
+     * @var string
+     */
+    protected $className;
+
+    /**
+     * @var array
+     */
+    protected $args;
+
+    /**
+     * Constructor.
+     *
+     * @param string $className
+     */
+    public function __construct(string $className)
+    {
+        $this->className = $className;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassName(): string
+    {
+        return $this->className;
+    }
+
+    /**
+     * @return array
+     */
+    public function getArgs(): array
+    {
+        return $this->args;
+    }
+
+    /**
+     * @param array $args
+     *
+     * @return self
+     */
+    public function setArgs(array $args): self
+    {
+        $this->args = $args;
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->className;
+    }
+}

--- a/src/QueryType/Luke/Result/Schema/Type/Type.php
+++ b/src/QueryType/Luke/Result/Schema/Type/Type.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Luke\Result\Schema\Type;
+
+use Solarium\QueryType\Luke\Result\Schema\Field\SchemaFieldInterface;
+use Solarium\QueryType\Luke\Result\Schema\Similarity;
+
+/**
+ * Retrieved field type definition.
+ */
+class Type
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var SchemaFieldInterface[]
+     */
+    protected $fields = [];
+
+    /**
+     * @var bool
+     */
+    protected $tokenized;
+
+    /**
+     * @var string
+     */
+    protected $className;
+
+    /**
+     * @var IndexAnalyzer
+     */
+    protected $indexAnalyzer;
+
+    /**
+     * @var QueryAnalyzer
+     */
+    protected $queryAnalyzer;
+
+    /**
+     * @var Similarity
+     */
+    protected $similarity;
+
+    /**
+     * Constructor.
+     *
+     * @param string $name
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return SchemaFieldInterface[]
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @param SchemaFieldInterface $field
+     *
+     * @return self
+     */
+    public function addField(SchemaFieldInterface &$field): self
+    {
+        $this->fields[] = &$field;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getTokenized(): bool
+    {
+        return $this->tokenized;
+    }
+
+    /**
+     * @param bool $tokenized
+     *
+     * @return self
+     */
+    public function setTokenized(bool $tokenized): self
+    {
+        $this->tokenized = $tokenized;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTokenized(): bool
+    {
+        return $this->tokenized;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassName(): string
+    {
+        return $this->className;
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return self
+     */
+    public function setClassName(string $className): self
+    {
+        $this->className = $className;
+
+        return $this;
+    }
+
+    /**
+     * @return IndexAnalyzer
+     */
+    public function getIndexAnalyzer(): IndexAnalyzer
+    {
+        return $this->indexAnalyzer;
+    }
+
+    /**
+     * @param IndexAnalyzer $indexAnalyzer
+     *
+     * @return self
+     */
+    public function setIndexAnalyzer(IndexAnalyzer $indexAnalyzer): self
+    {
+        $this->indexAnalyzer = $indexAnalyzer;
+
+        return $this;
+    }
+
+    /**
+     * @return QueryAnalyzer
+     */
+    public function getQueryAnalyzer(): QueryAnalyzer
+    {
+        return $this->queryAnalyzer;
+    }
+
+    /**
+     * @param QueryAnalyzer $queryAnalyzer
+     *
+     * @return self
+     */
+    public function setQueryAnalyzer(QueryAnalyzer $queryAnalyzer): self
+    {
+        $this->queryAnalyzer = $queryAnalyzer;
+
+        return $this;
+    }
+
+    /**
+     * @return Similarity
+     */
+    public function getSimilarity(): Similarity
+    {
+        return $this->similarity;
+    }
+
+    /**
+     * @param Similarity $similarity
+     *
+     * @return self
+     */
+    public function setSimilarity(Similarity $similarity): self
+    {
+        $this->similarity = $similarity;
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Support/Utility.php
+++ b/src/Support/Utility.php
@@ -9,6 +9,8 @@
 
 namespace Solarium\Support;
 
+use Solarium\Exception\UnexpectedValueException;
+
 /**
  * Utility.
  */
@@ -61,5 +63,73 @@ class Utility
     public static function isPointValue(string $value): bool
     {
         return (bool) preg_match('/^-?\d+(?:\.\d+)?[, ]-?\d+(?:\.\d+)?$/', $value);
+    }
+
+    /**
+     * Check whether a field name is a wildcard pattern.
+     *
+     * Wildcards are used in {@see https://solr.apache.org/guide/dynamic-fields.html dynamicField}
+     * and {@see https://solr.apache.org/guide/copying-fields.html copyField} definitions.
+     *
+     * @param string $fieldName
+     *
+     * @return bool
+     */
+    public static function isWildcardPattern(string $fieldName): bool
+    {
+        return 1 === substr_count($fieldName, '*') && preg_match('/^\*|\*$/', $fieldName);
+    }
+
+    /**
+     * Check whether a field name matches a wildcard pattern.
+     *
+     * Wildcards are used in {@see https://solr.apache.org/guide/dynamic-fields.html dynamicField}
+     * and {@see https://solr.apache.org/guide/copying-fields.html copyField} definitions.
+     *
+     * @param string $wildcardPattern
+     * @param string $fieldName
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return bool
+     */
+    public static function fieldMatchesWildcard(string $wildcardPattern, string $fieldName): bool
+    {
+        if (!self::isWildcardPattern($wildcardPattern)) {
+            throw new UnexpectedValueException('Wildcard pattern must have a "*" only at the start or the end.');
+        }
+
+        $match = false;
+
+        if ('*' === $wildcardPattern) {
+            $match = true;
+        } elseif (0 === strpos($wildcardPattern, '*')) {
+            $match = substr($wildcardPattern, 1) === substr($fieldName, 1 - \strlen($wildcardPattern));
+        } else {
+            $match = 0 === strpos($fieldName, substr($wildcardPattern, 0, -1));
+        }
+
+        return $match;
+    }
+
+    /**
+     * Returns a compact display version of the (Java) FQCN of a Solr component.
+     *
+     * The package hierachy is abbreviated to one-letter prefixes. This compact
+     * representation is purely informative. Different package hierarchies can
+     * have overlapping abbreviations.
+     *
+     * Example: 'org.apache.solr.schema.TextField'
+     *  becomes 'o.a.s.s.TextField'
+     * Example: 'org.apache.solr.search.similarities.SchemaSimilarityFactory$SchemaSimilarity'
+     *  becomes 'o.a.s.s.s.SchemaSimilarityFactory$SchemaSimilarity'
+     *
+     * @param string $className
+     *
+     * @return string
+     */
+    public static function compactSolrClassName(string $className): string
+    {
+        return preg_replace('/(?<=[a-z1-9])[a-z1-9]+(?=\.)/i', '', $className);
     }
 }

--- a/tests/Core/Client/ClientTest.php
+++ b/tests/Core/Client/ClientTest.php
@@ -29,6 +29,7 @@ use Solarium\Plugin\Loadbalancer\Loadbalancer;
 use Solarium\QueryType\Analysis\Query\Field as AnalysisQueryField;
 use Solarium\QueryType\Extract\Query as ExtractQuery;
 use Solarium\QueryType\Graph\Query as GraphQuery;
+use Solarium\QueryType\Luke\Query as LukeQuery;
 use Solarium\QueryType\ManagedResources\Query\Resources as ManagedResourcesQuery;
 use Solarium\QueryType\ManagedResources\Query\Stopwords as ManagedStopwordsQuery;
 use Solarium\QueryType\ManagedResources\Query\Synonyms as ManagedSynonymsQuery;
@@ -1116,6 +1117,22 @@ class ClientTest extends TestCase
             ->willReturn(new \Solarium\QueryType\RealtimeGet\Result($query, new Response('dummyresponse', ['HTTP 1.0 200 OK'])));
 
         $observer->realtimeGet($query);
+    }
+
+    public function testLuke()
+    {
+        $query = new LukeQuery();
+
+        $observer = $this->getMockBuilder(Client::class)
+            ->onlyMethods(['execute'])
+            ->setConstructorArgs([new MyAdapter(), new EventDispatcher()])
+            ->getMock();
+        $observer->expects($this->once())
+                 ->method('execute')
+                 ->with($this->equalTo($query))
+            ->willReturn(new \Solarium\QueryType\Luke\Result\Result($query, new Response('dummyresponse', ['HTTP 1.0 200 OK'])));
+
+        $observer->luke($query);
     }
 
     public function testCoreAdmin()

--- a/tests/QueryType/Luke/QueryTest.php
+++ b/tests/QueryType/Luke/QueryTest.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Client;
+use Solarium\QueryType\Luke\Query;
+use Solarium\QueryType\Luke\RequestBuilder;
+use Solarium\QueryType\Luke\ResponseParser\Doc as DocResponseParser;
+use Solarium\QueryType\Luke\ResponseParser\Index as IndexResponseParser;
+use Solarium\QueryType\Luke\ResponseParser\Fields as FieldsResponseParser;
+use Solarium\QueryType\Luke\ResponseParser\Schema as SchemaResponseParser;
+
+class QueryTest extends TestCase
+{
+    /**
+     * @var Query
+     */
+    protected $query;
+
+    public function setUp(): void
+    {
+        $this->query = new Query();
+    }
+
+    public function testConfigMode()
+    {
+        $options = [
+            'handler' => 'my/handler',
+            'resultclass' => 'MyResult',
+            'documentclass' => 'MyDocument',
+            'omitheader' => false,
+            'show' => Query::SHOW_INDEX,
+            'id' => 'abc',
+            'docId' => 123,
+            'fields' => ['field1', 'field2'],
+            'numTerms' => 5,
+            'includeIndexFieldFlags' => true,
+        ];
+        $this->query->setOptions($options);
+
+        $this->assertSame(
+            $options['handler'],
+            $this->query->getHandler()
+        );
+
+        $this->assertSame(
+            $options['resultclass'],
+            $this->query->getResultClass()
+        );
+
+        $this->assertSame(
+            $options['documentclass'],
+            $this->query->getDocumentClass()
+        );
+
+        $this->assertFalse(
+            $this->query->getOmitHeader()
+        );
+
+        $this->assertSame(
+            $options['show'],
+            $this->query->getShow()
+        );
+
+        $this->assertSame(
+            $options['id'],
+            $this->query->getId()
+        );
+
+        $this->assertSame(
+            $options['docId'],
+            $this->query->getDocId()
+        );
+
+        $this->assertSame(
+            $options['fields'],
+            $this->query->getFields()
+        );
+
+        $this->assertSame(
+            $options['numTerms'],
+            $this->query->getNumTerms()
+        );
+
+        $this->assertTrue(
+            $this->query->getIncludeIndexFieldFlags()
+        );
+    }
+
+    public function testConfigModeFieldsAsString()
+    {
+        $this->query->setOptions(['fields' => 'field3,field4, field5']);
+        $this->assertSame(
+            ['field3', 'field4', 'field5'],
+            $this->query->getFields()
+        );
+    }
+
+    public function testGetType()
+    {
+        $this->assertSame(Client::QUERY_LUKE, $this->query->getType());
+    }
+
+    public function testGetRequestBuilder()
+    {
+        $this->assertInstanceOf(RequestBuilder::class, $this->query->getRequestBuilder());
+    }
+
+    /**
+     * Without parameters, the behaviour is the same as SHOW_ALL.
+     */
+    public function testGetResponseParserWithoutShowWithoutFieldsOrIdOrDocId()
+    {
+        $this->assertInstanceOf(FieldsResponseParser::class, $this->query->getResponseParser());
+    }
+
+    /**
+     * With only 'fl', the same parsing as for SHOW_ALL can be used.
+     */
+    public function testGetResponseParserWithoutShowWithFields()
+    {
+        $this->query->setFields('field1,field2');
+        $this->assertInstanceOf(FieldsResponseParser::class, $this->query->getResponseParser());
+    }
+
+    /**
+     * With only an 'id', the behaviour is the same as SHOW_DOC with 'id'.
+     */
+    public function testGetResponseParserWithoutShowWithId()
+    {
+        $this->query->setId('abc');
+        $this->assertInstanceOf(DocResponseParser::class, $this->query->getResponseParser());
+    }
+
+    /**
+     * With only a 'docId', the behaviour is the same as SHOW_DOC with 'docId'.
+     */
+    public function testGetResponseParserWithoutShowWithDocId()
+    {
+        $this->query->setDocId(123);
+        $this->assertInstanceOf(DocResponseParser::class, $this->query->getResponseParser());
+    }
+
+    public function testGetResponseParserWithShowAll()
+    {
+        $this->query->setShow(Query::SHOW_ALL);
+        $this->assertInstanceOf(FieldsResponseParser::class, $this->query->getResponseParser());
+    }
+
+    public function testGetResponseParserWithShowAllWithFields()
+    {
+        $this->query->setShow(Query::SHOW_ALL);
+        $this->query->setFields('field1,field2');
+        $this->assertInstanceOf(FieldsResponseParser::class, $this->query->getResponseParser());
+    }
+
+    /**
+     * SHOW_DOC without 'id' or 'docId' behaves like SHOW_ALL.
+     */
+    public function testGetResponseParserWithShowDocWithoutIdOrDocId()
+    {
+        $this->query->setShow(Query::SHOW_DOC);
+        $this->assertInstanceOf(FieldsResponseParser::class, $this->query->getResponseParser());
+    }
+
+    /**
+     * SHOW_DOC without 'id' or 'docId', but with 'fl', behaves like 'fl' without 'show'.
+     */
+    public function testGetResponseParserWithShowDocWithOnlyFields()
+    {
+        $this->query->setShow(Query::SHOW_DOC);
+        $this->query->setFields('field1,field2');
+        $this->assertInstanceOf(FieldsResponseParser::class, $this->query->getResponseParser());
+    }
+
+    public function testGetResponseParserWithShowDocWithId()
+    {
+        $this->query->setShow(Query::SHOW_DOC);
+        $this->query->setId('abc');
+        $this->assertInstanceOf(DocResponseParser::class, $this->query->getResponseParser());
+    }
+
+    /**
+     * 'fl' is ignored if SHOW_DOC has an 'id'.
+     */
+    public function testGetResponseParserWithShowDocWithIdAndFields()
+    {
+        $this->query->setShow(Query::SHOW_DOC);
+        $this->query->setId('abc');
+        $this->query->setFields('field1,field2');
+        $this->assertInstanceOf(DocResponseParser::class, $this->query->getResponseParser());
+    }
+
+    public function testGetResponseParserWithShowDocWithDocId()
+    {
+        $this->query->setShow(Query::SHOW_DOC);
+        $this->query->setDocId(123);
+        $this->assertInstanceOf(DocResponseParser::class, $this->query->getResponseParser());
+    }
+
+    /**
+     * 'fl' is ignored if SHOW_DOC has a 'docId'.
+     */
+    public function testGetResponseParserWithShowDocWithDocIdAndFields()
+    {
+        $this->query->setShow(Query::SHOW_DOC);
+        $this->query->setDocId(123);
+        $this->query->setFields('field1,field2');
+        $this->assertInstanceOf(DocResponseParser::class, $this->query->getResponseParser());
+    }
+
+    public function testGetResponseParserWithShowIndex()
+    {
+        $this->query->setShow(Query::SHOW_INDEX);
+        $this->assertInstanceOf(IndexResponseParser::class, $this->query->getResponseParser());
+    }
+
+    public function testGetResponseParserWithShowSchema()
+    {
+        $this->query->setShow(Query::SHOW_SCHEMA);
+        $this->assertInstanceOf(SchemaResponseParser::class, $this->query->getResponseParser());
+    }
+
+    /**
+     * Fallback to SHOW_INDEX behaviour for unknown show style.
+     */
+    public function testGetResponseParserWithUnknownShow()
+    {
+        $this->query->setShow('unknown');
+        $this->assertInstanceOf(IndexResponseParser::class, $this->query->getResponseParser());
+    }
+
+    public function testSetAndGetDocumentClass()
+    {
+        $this->query->setDocumentClass('MyDocument');
+        $this->assertSame('MyDocument', $this->query->getDocumentClass());
+    }
+
+    public function testSetAndGetShow()
+    {
+        $this->query->setShow(Query::SHOW_SCHEMA);
+        $this->assertSame(Query::SHOW_SCHEMA, $this->query->getShow());
+    }
+
+    public function testSetAndGetId()
+    {
+        $this->query->setId('abc');
+        $this->assertSame('abc', $this->query->getId());
+    }
+
+    public function testSetAndGetDocId()
+    {
+        $this->query->setDocId(123);
+        $this->assertSame(123, $this->query->getDocId());
+    }
+
+    public function testSetAndGetFieldsAsArray()
+    {
+        $this->query->setFields(['field1', 'field2']);
+        $this->assertSame(['field1', 'field2'], $this->query->getFields());
+    }
+
+    public function testSetAndGetFieldsAsString()
+    {
+        $this->query->setFields('field1,field2, field3');
+        $this->assertSame(['field1', 'field2', 'field3'], $this->query->getFields());
+    }
+
+    public function testGetUnsetFields()
+    {
+        $this->assertSame([], $this->query->getFields());
+    }
+
+    public function testSetAndGetNumTerms()
+    {
+        $this->query->setNumTerms(15);
+        $this->assertSame(15, $this->query->getNumTerms());
+    }
+
+    public function testSetAndGetIncludeIndexFieldFlags()
+    {
+        $this->query->setIncludeIndexFieldFlags(false);
+        $this->assertFalse($this->query->getIncludeIndexFieldFlags());
+    }
+}

--- a/tests/QueryType/Luke/RequestBuilderTest.php
+++ b/tests/QueryType/Luke/RequestBuilderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Request;
+use Solarium\QueryType\Luke\Query;
+use Solarium\QueryType\Luke\RequestBuilder;
+
+class RequestBuilderTest extends TestCase
+{
+    /**
+     * @var Query
+     */
+    protected $query;
+
+    /**
+     * @var RequestBuilder
+     */
+    protected $builder;
+
+    public function setUp(): void
+    {
+        $this->query = new Query();
+        $this->builder = new RequestBuilder();
+    }
+
+    public function testBuildParams()
+    {
+        $this->query->setShow(Query::SHOW_DOC);
+        $this->query->setId('abc');
+        $this->query->setDocId(123);
+        $this->query->setFields(['id', 'name']);
+        $this->query->setNumTerms(15);
+        $this->query->setIncludeIndexFieldFlags(false);
+
+        $request = $this->builder->build($this->query);
+
+        $this->assertEquals(
+            [
+                'show' => 'doc',
+                'id' => 'abc',
+                'docId' => 123,
+                'fl' => 'id,name',
+                'numTerms' => 15,
+                'includeIndexFieldFlags' => 'false',
+                'wt' => 'json',
+                'omitHeader' => 'true',
+                'json.nl' => 'flat',
+            ],
+            $request->getParams()
+        );
+
+        $this->assertSame(Request::METHOD_GET, $request->getMethod());
+    }
+
+    public function testEmptyBuildParams()
+    {
+        $request = $this->builder->build($this->query);
+
+        $this->assertEquals(
+            [
+                'wt' => 'json',
+                'omitHeader' => 'true',
+                'json.nl' => 'flat',
+            ],
+            $request->getParams()
+        );
+
+        $this->assertSame(Request::METHOD_GET, $request->getMethod());
+    }
+}

--- a/tests/QueryType/Luke/ResponseParser/DocDataTrait.php
+++ b/tests/QueryType/Luke/ResponseParser/DocDataTrait.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\ResponseParser;
+
+/**
+ * Default doc data used in Doc test.
+ */
+trait DocDataTrait
+{
+    /**
+     * Returns a raw JSON string as it would be output by Solr.
+     *
+     * The $.doc.lucene node of a Luke response contains duplicate keys for
+     * multiValued fields. We can't fully represent these in the array returned
+     * by {@see getDocData()}.
+     *
+     * @return string
+     */
+    public function getRawDocData(): string
+    {
+        /*
+         * Representation of binary data is tentative. We can't base our
+         * example on actual response data because of SOLR-16293.
+         */
+        return <<<'JSON'
+            {
+                "docId": 1701,
+                "lucene": {
+                    "id": {
+                        "type": "string",
+                        "schema": "I-S-U-----OF-----l",
+                        "flags": "ITS-------OF------",
+                        "value": "NCC-1701",
+                        "internal": "NCC-1701",
+                        "docFreq": 1
+                    },
+                    "name": {
+                        "type": "text_general",
+                        "schema": "ITS-U-------------",
+                        "flags": "ITS---------------",
+                        "value": "Enterprise document",
+                        "internal": "Enterprise document",
+                        "docFreq": 0,
+                        "termVector": {
+                            "enterprise": 2,
+                            "document": 1
+                        }
+                    },
+                    "cat": {
+                        "type": "string",
+                        "schema": "I-S-UM----OF-----l",
+                        "flags": "ITS-------OF------",
+                        "value": "Constitution",
+                        "internal": "Constitution",
+                        "docFreq": 12
+                    },
+                    "cat": {
+                        "type": "string",
+                        "schema": "I-S-UM----OF-----l",
+                        "flags": "ITS-------OF------",
+                        "value": "Galaxy",
+                        "internal": "Galaxy",
+                        "docFreq": 6
+                    },
+                    "price": {
+                        "type": "pfloat",
+                        "schema": "I-SDU-----OF------",
+                        "flags": "-TS---------------",
+                        "value": "92.0",
+                        "internal": "92.0"
+                    },
+                    "flagship": {
+                        "type": "boolean",
+                        "schema": "I-S-U-----OF-----l",
+                        "flags": "ITS-------OF------",
+                        "value": "true",
+                        "internal": "T",
+                        "docFreq": 1
+                    },
+                    "insignia": {
+                        "type": "binary",
+                        "schema": "I-S-U------F------",
+                        "flags": "I-S-------OF------",
+                        "value": "PS9cPQ==",
+                        "internal": "PS9cPQ==",
+                        "binary": "PS9cPQ=="
+                    }
+                },
+                "solr": {
+                    "id": "NCC-1701",
+                    "name": "Enterprise document",
+                    "cat": [
+                        "Constitution",
+                        "Galaxy"
+                    ],
+                    "price": 3.59,
+                    "flagship": true,
+                    "insignia": "PS9cPQ=="
+                }
+            }
+        JSON;
+    }
+
+    public function getDocData(): array
+    {
+        return json_decode($this->getRawDocData(), true);
+    }
+}

--- a/tests/QueryType/Luke/ResponseParser/DocTest.php
+++ b/tests/QueryType/Luke/ResponseParser/DocTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\ResponseParser;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Response;
+use Solarium\Core\Query\DocumentInterface;
+use Solarium\Exception\RuntimeException;
+use Solarium\QueryType\Luke\Query;
+use Solarium\QueryType\Luke\ResponseParser\Doc as ResponseParser;
+use Solarium\QueryType\Luke\Result\Doc\DocFieldInfo;
+use Solarium\QueryType\Luke\Result\Doc\DocInfo;
+use Solarium\QueryType\Luke\Result\Index\Index;
+use Solarium\QueryType\Luke\Result\Info\Info;
+use Solarium\QueryType\Luke\Result\Result;
+
+class DocTest extends TestCase
+{
+    use DocDataTrait;
+    use IndexDataTrait;
+    use InfoDataTrait;
+
+    /**
+     * @var Result|MockObject
+     */
+    protected $resultStub;
+
+    public function setUp(): void
+    {
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'doc' => $this->getDocData(),
+            'info' => $this->getInfoData(),
+        ];
+
+        // the doc parser accesses the response body directly
+        $rawData = sprintf(<<<'JSON'
+                {
+                    "responseHeader": {
+                        "status": 0,
+                        "QTime": 3
+                    },
+                    "index": %s,
+                    "doc": %s,
+                    "info": %s
+                }
+            JSON,
+            json_encode($data['index']),
+            $this->getRawDocData(),
+            json_encode($data['info']),
+        );
+
+        $responseStub = $this->createMock(Response::class);
+        $responseStub->expects($this->any())
+            ->method('getBody')
+            ->willReturn($rawData);
+
+        $this->resultStub = $this->createMock(Result::class);
+        $this->resultStub->expects($this->any())
+            ->method('getResponse')
+            ->willReturn($responseStub);
+        $this->resultStub->expects($this->any())
+            ->method('getData')
+            ->willReturn($data);
+    }
+
+    public function testParse(): DocInfo
+    {
+        $query = new Query();
+        $query->setShow(Query::SHOW_DOC);
+        $query->setDocId(1701);
+
+        $this->resultStub->expects($this->any())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $parser = new ResponseParser();
+        $result = $parser->parse($this->resultStub);
+
+        $this->assertInstanceOf(Index::class, $result['indexResult']);
+        $this->assertNull($result['schemaResult']);
+        $this->assertInstanceOf(DocInfo::class, $result['docResult']);
+        $this->assertNull($result['fieldsResult']);
+        $this->assertInstanceOf(Info::class, $result['infoResult']);
+
+        return $result['docResult'];
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testDocId(DocInfo $doc)
+    {
+        $this->assertSame(1701, $doc->getDocId());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testLucene(DocInfo $doc)
+    {
+        $lucene = $doc->getLucene();
+
+        // 5 single value fields + 1 multiValued with 2 values
+        $this->assertCount(7, $lucene);
+        $this->assertContainsOnlyInstancesOf(DocFieldInfo::class, $lucene);
+
+        // single value field
+        $this->assertSame('id', $lucene[0]->getName());
+        $this->assertSame('string', $lucene[0]->getType());
+        $this->assertSame('I-S-U-----OF-----l', (string) ($schema = $lucene[0]->getSchema()));
+        $this->assertSame('ITS-------OF------', (string) ($flags = $lucene[0]->getFlags()));
+        $this->assertSame('NCC-1701', $lucene[0]->getValue());
+        $this->assertSame('NCC-1701', $lucene[0]->getInternal());
+        $this->assertSame(1, $lucene[0]->getDocFreq());
+        $this->assertNull($lucene[0]->getBinary());
+        $this->assertNull($lucene[0]->getTermVector());
+
+        // flags are covered exhaustively in SchemaTest::testFieldFlags()
+        $this->assertFalse($schema->isTokenized());
+        $this->assertTrue($schema->isSortMissingLast());
+        $this->assertTrue($flags->isTokenized());
+        $this->assertFalse($flags->isSortMissingLast());
+
+        // 'value' is different from 'internal' for some field types
+        $this->assertSame('true', $lucene[5]->getValue());
+        $this->assertSame('T', $lucene[5]->getInternal());
+
+        // 'binary' is returned for binary fields
+        $this->assertSame('PS9cPQ==', $lucene[6]->getBinary());
+
+        // some field types don't return 'docFreq'
+        $this->assertNull($lucene[4]->getDocFreq());
+
+        // 'termVector' is returned if Solr maintains full term vectors for a field
+        $this->assertSame(
+            [
+                'enterprise' => 2,
+                'document' => 1,
+            ],
+            $lucene[1]->getTermVector()
+        );
+
+        // multiValued field
+        $this->assertSame('cat', $lucene[2]->getName());
+        $this->assertSame('string', $lucene[2]->getType());
+        $this->assertSame('Constitution', $lucene[2]->getValue());
+        $this->assertSame('Constitution', $lucene[2]->getInternal());
+        $this->assertSame(12, $lucene[2]->getDocFreq());
+        $this->assertSame('cat', $lucene[3]->getName());
+        $this->assertSame('string', $lucene[3]->getType());
+        $this->assertSame('Galaxy', $lucene[3]->getValue());
+        $this->assertSame('Galaxy', $lucene[3]->getInternal());
+        $this->assertSame(6, $lucene[3]->getDocFreq());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testSolr(DocInfo $doc)
+    {
+        $solr = $doc->getSolr();
+
+        $this->assertInstanceOf(DocumentInterface::class, $solr);
+
+        $this->assertSame(
+            [
+                'id' => 'NCC-1701',
+                'name' => 'Enterprise document',
+                'cat' => [
+                    'Constitution',
+                    'Galaxy',
+                ],
+                'price' => 3.59,
+                'flagship' => true,
+                'insignia' => 'PS9cPQ==',
+            ],
+            $solr->getFields()
+        );
+    }
+
+    public function testParseWithInvalidDocumentClass()
+    {
+        $query = new Query();
+        $query->setDocumentClass(\stdClass::class);
+        $query->setShow(Query::SHOW_DOC);
+        $query->setDocId(1701);
+
+        $this->resultStub->expects($this->any())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $parser = new ResponseParser();
+
+        $this->expectException(RuntimeException::class);
+        $parser->parse($this->resultStub);
+    }
+}

--- a/tests/QueryType/Luke/ResponseParser/FieldsDataTrait.php
+++ b/tests/QueryType/Luke/ResponseParser/FieldsDataTrait.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\ResponseParser;
+
+/**
+ * Default fields data used in Fields test.
+ */
+trait FieldsDataTrait
+{
+    public function getFieldsData(): array
+    {
+        return [
+            'field' => [
+                'type' => 'type_a',
+                'schema' => 'I-S-U-----OF-----l',
+                'index' => 'ITS-------OF------',
+                'docs' => 25,
+                'distinct' => 70,
+                'topTerms' => [
+                    'a',
+                    18,
+                    'b',
+                    7,
+                ],
+                'histogram' => [
+                    '1',
+                    0,
+                    '2',
+                    1,
+                    '4',
+                    2,
+                ],
+            ],
+            'field_unstored' => [
+                'type' => 'type_b',
+                'schema' => 'I---U-----OF-----l',
+                'index' => '(unstored field)',
+                'docs' => 20,
+                'distinct' => 16,
+                'topTerms' => [
+                    'c',
+                    12,
+                    'a',
+                    8,
+                ],
+                'histogram' => [
+                    '1',
+                    4,
+                    '2',
+                    1,
+                ],
+            ],
+            'field_unindexed' => [
+                'type' => 'type_c',
+                'schema' => '---D--------------',
+            ],
+            'dynamic_field' => [
+                'type' => 'type_a',
+                'schema' => 'I-S-U-----OF-----l',
+                'dynamicBase' => '*_field',
+            ],
+        ];
+    }
+}

--- a/tests/QueryType/Luke/ResponseParser/FieldsTest.php
+++ b/tests/QueryType/Luke/ResponseParser/FieldsTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\ResponseParser;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Query;
+use Solarium\QueryType\Luke\ResponseParser\Fields as ResponseParser;
+use Solarium\QueryType\Luke\Result\Fields\FieldInfo;
+use Solarium\QueryType\Luke\Result\Index\Index;
+use Solarium\QueryType\Luke\Result\Info\Info;
+use Solarium\QueryType\Luke\Result\Result;
+
+class FieldsTest extends TestCase
+{
+    use FieldsDataTrait;
+    use IndexDataTrait;
+    use InfoDataTrait;
+
+    public function testParse(): array
+    {
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'fields' => $this->getFieldsData(),
+            'info' => $this->getInfoData(),
+        ];
+
+        $query = new Query();
+        $query->setShow(Query::SHOW_ALL);
+        $query->setFields('*');
+
+        $resultStub = $this->createMock(Result::class);
+        $resultStub->expects($this->any())
+            ->method('getQuery')
+            ->willReturn($query);
+        $resultStub->expects($this->any())
+            ->method('getData')
+            ->willReturn($data);
+
+        $parser = new ResponseParser();
+        $result = $parser->parse($resultStub);
+
+        $this->assertInstanceOf(Index::class, $result['indexResult']);
+        $this->assertNull($result['schemaResult']);
+        $this->assertNull($result['docResult']);
+        $this->assertContainsOnlyInstancesOf(FieldInfo::class, $result['fieldsResult']);
+        $this->assertInstanceOf(Info::class, $result['infoResult']);
+
+        return $result['fieldsResult'];
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testName(array $fields)
+    {
+        $this->assertSame('field', $fields['field']->getName());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testType(array $fields)
+    {
+        $this->assertSame('type_a', $fields['field']->getType());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testSchema(array $fields)
+    {
+        $schema = $fields['field']->getSchema();
+
+        $this->assertSame('I-S-U-----OF-----l', (string) $schema);
+
+        // flags are covered exhaustively in SchemaTest::testFieldFlags()
+        $this->assertTrue($schema->isIndexed());
+        $this->assertFalse($schema->isTokenized());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testDynamicBase(array $fields)
+    {
+        $this->assertNull($fields['field']->getDynamicBase());
+        $this->assertSame('*_field', $fields['dynamic_field']->getDynamicBase());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testIndex(array $fields)
+    {
+        $index = $fields['field']->getIndex();
+
+        $this->assertSame('ITS-------OF------', (string) $index);
+
+        // flags are covered exhaustively in SchemaTest::testFieldFlags()
+        $this->assertTrue($index->isTokenized());
+        $this->assertFalse($index->isUninvertible());
+
+        $this->assertSame('(unstored field)', $fields['field_unstored']->getIndex());
+
+        $this->assertNull($fields['field_unindexed']->getIndex());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testDocs(array $fields)
+    {
+        $this->assertSame(25, $fields['field']->getDocs());
+        $this->assertNull($fields['field_unindexed']->getDocs());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testDistinct(array $fields)
+    {
+        $this->assertSame(70, $fields['field']->getDistinct());
+        $this->assertNull($fields['field_unindexed']->getDistinct());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testTopTerms(array $fields)
+    {
+        $this->assertSame([
+            'a' => 18,
+            'b' => 7,
+        ], $fields['field']->getTopTerms());
+        $this->assertNull($fields['field_unindexed']->getTopTerms());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testHistogram(array $fields)
+    {
+        $this->assertSame([
+            '1' => 0,
+            '2' => 1,
+            '4' => 2,
+        ], $fields['field']->getHistogram());
+        $this->assertNull($fields['field_unindexed']->getHistogram());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testToString(array $fields)
+    {
+        $this->assertSame('field', (string) $fields['field']);
+    }
+}

--- a/tests/QueryType/Luke/ResponseParser/IndexDataTrait.php
+++ b/tests/QueryType/Luke/ResponseParser/IndexDataTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\ResponseParser;
+
+/**
+ * Default index data used in all ResponseParser tests.
+ */
+trait IndexDataTrait
+{
+    public function getIndexData(): array
+    {
+        return [
+            'numDocs' => 15,
+            'maxDoc' => 20,
+            'deletedDocs' => 5,
+            'indexHeapUsageBytes' => 2000,
+            'version' => 6,
+            'segmentCount' => 1,
+            'current' => false,
+            'hasDeletions' => true,
+            'directory' => 'directory info',
+            'segmentsFile' => 'segments_3',
+            'segmentsFileSizeInBytes' => 200,
+            'userData' => [
+                'commitCommandVer' => '123456789123456789',
+                'commitTimeMSec' => '123456789',
+            ],
+            'lastModified' => '2022-01-01T20:00:15.789Z',
+        ];
+    }
+}

--- a/tests/QueryType/Luke/ResponseParser/IndexTest.php
+++ b/tests/QueryType/Luke/ResponseParser/IndexTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\ResponseParser;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Query;
+use Solarium\QueryType\Luke\ResponseParser\Index as ResponseParser;
+use Solarium\QueryType\Luke\Result\Index\Index;
+use Solarium\QueryType\Luke\Result\Result;
+
+class IndexTest extends TestCase
+{
+    use IndexDataTrait;
+
+    public function testParse(): Index
+    {
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+        ];
+
+        $query = new Query();
+        $query->setShow(Query::SHOW_INDEX);
+
+        $resultStub = $this->createMock(Result::class);
+        $resultStub->expects($this->any())
+            ->method('getQuery')
+            ->willReturn($query);
+        $resultStub->expects($this->any())
+            ->method('getData')
+            ->willReturn($data);
+
+        $parser = new ResponseParser();
+        $result = $parser->parse($resultStub);
+
+        $this->assertInstanceOf(Index::class, $result['indexResult']);
+        $this->assertNull($result['schemaResult']);
+        $this->assertNull($result['docResult']);
+        $this->assertNull($result['fieldsResult']);
+        $this->assertNull($result['infoResult']);
+
+        return $result['indexResult'];
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testIndex(Index $index)
+    {
+        $this->assertSame(15, $index->getNumDocs());
+        $this->assertSame(20, $index->getMaxDoc());
+        $this->assertSame(5, $index->getDeletedDocs());
+        $this->assertSame(2000, $index->getIndexHeapUsageBytes());
+        $this->assertSame(6, $index->getVersion());
+        $this->assertSame(1, $index->getSegmentCount());
+        $this->assertFalse($index->getCurrent());
+        $this->assertTrue($index->hasDeletions());
+        $this->assertSame('directory info', $index->getDirectory());
+        $this->assertSame('segments_3', $index->getSegmentsFile());
+        $this->assertSame(200, $index->getSegmentsFileSizeInBytes());
+        $this->assertSame('123456789123456789', $index->getUserData()->getCommitCommandVer());
+        $this->assertSame('123456789', $index->getUserData()->getCommitTimeMSec());
+        $this->assertEquals(new \DateTime('2022-01-01T20:00:15.789Z'), $index->getLastModified());
+    }
+
+    /**
+     * indexHeapUsageBytes was removed in SOLR-15341 for Solr 9.
+     */
+    public function testParseWithoutIndexHeapUsageBytes()
+    {
+        $indexData = $this->getIndexData();
+        unset($indexData['indexHeapUsageBytes']);
+
+        $data = [
+            'index' => $indexData,
+            'responseHeader' => [
+                'status' => 1,
+                'QTime' => 13,
+            ],
+        ];
+
+        $query = new Query();
+        $query->setShow(Query::SHOW_INDEX);
+
+        $resultStub = $this->createMock(Result::class);
+        $resultStub->expects($this->any())
+            ->method('getData')
+            ->willReturn($data);
+        $resultStub->expects($this->any())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $parser = new ResponseParser();
+        $result = $parser->parse($resultStub);
+
+        $this->assertNull($result['indexResult']->getIndexHeapUsageBytes());
+    }
+
+    /**
+     * userData is empty if there haven't been any commits yet.
+     * lastModified is calculated from commitTimeMSec (in Solr) and will be empty too.
+     */
+    public function testParseWithoutUserData()
+    {
+        $indexData = $this->getIndexData();
+        $indexData['userData'] = [];
+        unset($indexData['lastModified']);
+
+        $data = [
+            'index' => $indexData,
+            'responseHeader' => [
+                'status' => 1,
+                'QTime' => 13,
+            ],
+        ];
+
+        $query = new Query();
+        $query->setShow(Query::SHOW_INDEX);
+
+        $resultStub = $this->createMock(Result::class);
+        $resultStub->expects($this->any())
+            ->method('getData')
+            ->willReturn($data);
+        $resultStub->expects($this->any())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $parser = new ResponseParser();
+        $result = $parser->parse($resultStub);
+
+        $this->assertNull($result['indexResult']->getUserData()->getCommitCommandVer());
+        $this->assertNull($result['indexResult']->getUserData()->getCommitTimeMSec());
+        $this->assertNull($result['indexResult']->getLastModified());
+    }
+}

--- a/tests/QueryType/Luke/ResponseParser/InfoDataTrait.php
+++ b/tests/QueryType/Luke/ResponseParser/InfoDataTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\ResponseParser;
+
+/**
+ * Default info data used in multiple ResponseParser tests.
+ */
+trait InfoDataTrait
+{
+    public function getInfoData(): array
+    {
+        // all the actual flag abbrevations are needed for parsing 'schema', 'doc', or 'fields'
+        return [
+            'key' => [
+                'I' => 'Flag I',
+                'T' => 'Flag T',
+                'S' => 'Flag S',
+                'D' => 'Flag D',
+                'U' => 'Flag U',
+                'M' => 'Flag M',
+                'V' => 'Flag V',
+                'o' => 'Flag o',
+                'p' => 'Flag p',
+                'y' => 'Flag y',
+                'O' => 'Flag O',
+                'F' => 'Flag F',
+                'P' => 'Flag P',
+                'H' => 'Flag H',
+                'L' => 'Flag L',
+                'B' => 'Flag B',
+                'f' => 'Flag f',
+                'l' => 'Flag l',
+            ],
+            'NOTE' => 'This is a note.',
+        ];
+    }
+}

--- a/tests/QueryType/Luke/ResponseParser/InfoTest.php
+++ b/tests/QueryType/Luke/ResponseParser/InfoTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\ResponseParser;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Query;
+use Solarium\QueryType\Luke\ResponseParser\Fields as ResponseParser;
+use Solarium\QueryType\Luke\Result\Info\Info;
+use Solarium\QueryType\Luke\Result\Result;
+
+class InfoTest extends TestCase
+{
+    use FieldsDataTrait;
+    use IndexDataTrait;
+    use InfoDataTrait;
+
+    public function testParse(): Info
+    {
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'fields' => $this->getFieldsData(),
+            'info' => $this->getInfoData(),
+        ];
+
+        $query = new Query();
+
+        $resultStub = $this->createMock(Result::class);
+        $resultStub->expects($this->any())
+            ->method('getQuery')
+            ->willReturn($query);
+        $resultStub->expects($this->any())
+            ->method('getData')
+            ->willReturn($data);
+
+        $parser = new ResponseParser();
+        $result = $parser->parse($resultStub);
+
+        $this->assertInstanceOf(Info::class, $result['infoResult']);
+
+        return $result['infoResult'];
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testInfo(Info $info)
+    {
+        $infoData = $this->getInfoData();
+
+        $this->assertSame($infoData['key'], $info->getKey());
+        $this->assertSame($infoData['NOTE'], $info->getNote());
+    }
+}

--- a/tests/QueryType/Luke/ResponseParser/SchemaDataTrait.php
+++ b/tests/QueryType/Luke/ResponseParser/SchemaDataTrait.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\ResponseParser;
+
+/**
+ * Default schema data used in Schema test.
+ */
+trait SchemaDataTrait
+{
+    public function getSchemaData(): array
+    {
+        return [
+            'fields' => [
+                'flags_a' => [
+                    'type' => 'type_untokenized',
+                    'flags' => 'I-S-U-V-p-O-P-L-f-',
+                    'copyDests' => [],
+                    'copySources' => [],
+                ],
+                'flags_b' => [
+                    'type' => 'type_tokenized',
+                    'flags' => '-T-D-M-o-y-F-H-B-l',
+                    'copyDests' => [],
+                    'copySources' => [],
+                ],
+                'required' => [
+                    'type' => 'type_untokenized',
+                    'flags' => 'I-SDU-------------',
+                    'required' => true,
+                    'copyDests' => [],
+                    'copySources' => [],
+                ],
+                'default' => [
+                    'type' => 'type_untokenized',
+                    'flags' => 'I-SDU-------------',
+                    'default' => '0.0',
+                    'copyDests' => [],
+                    'copySources' => [],
+                ],
+                'uniquekey' => [
+                    'type' => 'type_untokenized',
+                    'flags' => 'I-SDU-------------',
+                    'uniqueKey' => true,
+                    'copyDests' => [],
+                    'copySources' => [],
+                ],
+                'pos_inc_gap' => [
+                    'type' => 'type_tokenized',
+                    'flags' => 'ITSDU-------------',
+                    'positionIncrementGap' => 100,
+                    'copyDests' => [],
+                    'copySources' => [],
+                ],
+                'copy_from' => [
+                    'type' => 'type_untokenized',
+                    'flags' => 'ITSDU-------------',
+                    'copyDests' => [
+                        'copy_to',
+                        'dynamic_copy_to',
+                    ],
+                    'copySources' => [],
+                ],
+                'copy_to' => [
+                    'type' => 'type_untokenized',
+                    'flags' => 'ITSDU-------------',
+                    'copyDests' => [],
+                    'copySources' => [
+                        'copy_from',
+                        'dynamic_copy_from',
+                        '*_copy_from',
+                        '*_wildcard',
+                    ],
+                ],
+            ],
+            'dynamicFields' => [
+                '*_pos_inc_gap' => [
+                    'type' => 'type_tokenized',
+                    'flags' => 'ITSDU-------------',
+                    'positionIncrementGap' => 200,
+                    'copyDests' => [],
+                    'copySources' => [],
+                ],
+                '*_copy_from' => [
+                    'type' => 'type_untokenized',
+                    'flags' => 'I-SDU-------------',
+                    'copyDests' => [
+                        'copy_to',
+                        'dynamic_copy_to',
+                        '*_copy_to',
+                    ],
+                    'copySources' => [],
+                ],
+                '*_copy_to' => [
+                    'type' => 'type_untokenized',
+                    'flags' => 'I-SDU-------------',
+                    'copyDests' => [],
+                    'copySources' => [
+                        '*_copy_from',
+                        '*_wildcard',
+                    ],
+                ],
+            ],
+            'uniqueKeyField' => 'uniquekey',
+            'similarity' => [
+                'className' => 'org.example.SchemaSimilarityFactory$SchemaSimilarity',
+                'details' => 'Similarity details.',
+            ],
+            'types' => [
+                'type_untokenized' => [
+                    'fields' => [
+                        'flags_a',
+                        'required',
+                        'default',
+                        'uniquekey',
+                        'copy_from',
+                        'copy_to',
+                        '*_copy_from',
+                        '*_copy_to',
+                    ],
+                    'tokenized' => false,
+                    'className' => 'org.example.TestField',
+                    'indexAnalyzer' => [
+                        'className' => 'org.example.TestFieldType$DefaultAnalyzer',
+                    ],
+                    'queryAnalyzer' => [
+                        'className' => 'org.example.TestFieldType$DefaultAnalyzer',
+                    ],
+                    'similarity' => [],
+                ],
+                'type_tokenized' => [
+                    'fields' => [
+                        'flags_b',
+                        'pos_inc_gap',
+                        '*_pos_inc_gap',
+                    ],
+                    'tokenized' => true,
+                    'className' => 'org.example.TokenizedField',
+                    'indexAnalyzer' => [
+                        'className' => 'org.example.TokenizerChain',
+                        'charFilters' => [
+                            'FirstCharFilterFactory' => [
+                                'args' => [
+                                    'class' => 'solr.FirstCharFilterFactory',
+                                    'luceneMatchVersion' => '1.2.3',
+                                ],
+                                'className' => 'org.example.FirstCharFilterFactory',
+                            ],
+                            'NextCharFilterFactory' => [
+                                'args' => [
+                                    'class' => 'solr.NextCharFilterFactory',
+                                    'luceneMatchVersion' => '1.2.3',
+                                ],
+                                'className' => 'org.example.NextCharFilterFactory',
+                            ],
+                        ],
+                        'tokenizer' => [
+                            'className' => 'org.example.TestTokenizerFactory',
+                            'args' => [
+                                'class' => 'solr.TestTokenizerFactory',
+                                'luceneMatchVersion' => '1.2.3',
+                            ],
+                        ],
+                        'filters' => [
+                            'FirstFilterFactory' => [
+                                'args' => [
+                                    'class' => 'solr.FirstFilterFactory',
+                                    'luceneMatchVersion' => '1.2.3',
+                                ],
+                                'className' => 'org.example.FirstFilterFactory',
+                            ],
+                            'NextFilterFactory' => [
+                                'args' => [
+                                    'class' => 'solr.NextFilterFactory',
+                                    'luceneMatchVersion' => '1.2.3',
+                                ],
+                                'className' => 'org.example.NextFilterFactory',
+                            ],
+                        ],
+                    ],
+                    'queryAnalyzer' => [
+                        'className' => 'org.example.TokenizerChain',
+                        'charFilters' => [
+                            'FirstCharFilterFactory' => [
+                                'args' => [
+                                    'class' => 'solr.FirstCharFilterFactory',
+                                    'luceneMatchVersion' => '1.2.3',
+                                ],
+                                'className' => 'org.example.FirstCharFilterFactory',
+                            ],
+                            'NextCharFilterFactory' => [
+                                'args' => [
+                                    'class' => 'solr.NextCharFilterFactory',
+                                    'luceneMatchVersion' => '1.2.3',
+                                ],
+                                'className' => 'org.example.NextCharFilterFactory',
+                            ],
+                        ],
+                        'tokenizer' => [
+                            'className' => 'org.example.TestTokenizerFactory',
+                            'args' => [
+                                'class' => 'solr.TestTokenizerFactory',
+                                'luceneMatchVersion' => '1.2.3',
+                            ],
+                        ],
+                        'filters' => [
+                            'FirstFilterFactory' => [
+                                'args' => [
+                                    'class' => 'solr.FirstFilterFactory',
+                                    'luceneMatchVersion' => '1.2.3',
+                                ],
+                                'className' => 'org.example.FirstFilterFactory',
+                            ],
+                            'NextFilterFactory' => [
+                                'args' => [
+                                    'class' => 'solr.NextFilterFactory',
+                                    'luceneMatchVersion' => '1.2.3',
+                                ],
+                                'className' => 'org.example.NextFilterFactory',
+                            ],
+                        ],
+                    ],
+                    'similarity' => [],
+                ],
+                'type_similarity' => [
+                    'fields' => null,
+                    'tokenized' => true,
+                    'className' => 'org.example.SimilarityField',
+                    'indexAnalyzer' => [
+                        'className' => 'org.example.TestAnalyzedField$TestAnalyzedAnalyzer',
+                    ],
+                    'queryAnalyzer' => [
+                        'className' => 'org.example.TokenizerChain',
+                        'tokenizer' => [
+                            'className' => 'org.example.TestTokenizerFactory',
+                            'args' => [
+                                'class' => 'solr.TestTokenizerFactory',
+                                'luceneMatchVersion' => '1.2.3',
+                            ],
+                        ],
+                    ],
+                    'similarity' => [
+                        'className' => 'org.example.TestSimilarity',
+                        'details' => 'Type similarity details.',
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/QueryType/Luke/ResponseParser/SchemaTest.php
+++ b/tests/QueryType/Luke/ResponseParser/SchemaTest.php
@@ -1,0 +1,565 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\ResponseParser;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Exception\RuntimeException;
+use Solarium\QueryType\Luke\Query;
+use Solarium\QueryType\Luke\ResponseParser\Schema as ResponseParser;
+use Solarium\QueryType\Luke\Result\Index\Index;
+use Solarium\QueryType\Luke\Result\Info\Info;
+use Solarium\QueryType\Luke\Result\Result;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicBasedField;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicField;
+use Solarium\QueryType\Luke\Result\Schema\Field\Field;
+use Solarium\QueryType\Luke\Result\Schema\Field\WildcardField;
+use Solarium\QueryType\Luke\Result\Schema\Schema;
+use Solarium\QueryType\Luke\Result\Schema\Type\IndexAnalyzer;
+use Solarium\QueryType\Luke\Result\Schema\Type\QueryAnalyzer;
+
+class SchemaTest extends TestCase
+{
+    use IndexDataTrait;
+    use InfoDataTrait;
+    use SchemaDataTrait;
+
+    public function testParse(): Schema
+    {
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'schema' => $this->getSchemaData(),
+            'info' => $this->getInfoData(),
+        ];
+
+        $query = new Query();
+        $query->setShow(Query::SHOW_SCHEMA);
+
+        $resultStub = $this->createMock(Result::class);
+        $resultStub->expects($this->any())
+            ->method('getQuery')
+            ->willReturn($query);
+        $resultStub->expects($this->any())
+            ->method('getData')
+            ->willReturn($data);
+
+        $parser = new ResponseParser();
+        $result = $parser->parse($resultStub);
+
+        $this->assertInstanceOf(Index::class, $result['indexResult']);
+        $this->assertInstanceOf(Schema::class, $result['schemaResult']);
+        $this->assertNull($result['docResult']);
+        $this->assertNull($result['fieldsResult']);
+        $this->assertInstanceOf(Info::class, $result['infoResult']);
+
+        return $result['schemaResult'];
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testFields(Schema $schema)
+    {
+        $fields = $schema->getFields();
+
+        $this->assertCount(8, $fields);
+
+        $this->assertSame('flags_a', $fields['flags_a']->getName());
+
+        $this->assertSame('type_untokenized', (string) $fields['flags_a']->getType());
+
+        $this->assertSame('I-SDU-------------', (string) $fields['uniquekey']->getFlags());
+
+        $this->assertNull($fields['flags_a']->getRequired());
+        $this->assertFalse($fields['flags_a']->isRequired());
+        $this->assertTrue($fields['required']->getRequired());
+        $this->assertTrue($fields['required']->isRequired());
+
+        $this->assertNull($fields['flags_a']->getDefault());
+        $this->assertSame('0.0', $fields['default']->getDefault());
+
+        $this->assertNull($fields['flags_a']->getUniqueKey());
+        $this->assertFalse($fields['flags_a']->isUniqueKey());
+        $this->assertTrue($fields['uniquekey']->getUniqueKey());
+        $this->assertTrue($fields['uniquekey']->isUniqueKey());
+
+        $this->assertNull($fields['flags_a']->getPositionIncrementGap());
+        $this->assertSame(100, $fields['pos_inc_gap']->getPositionIncrementGap());
+
+        $this->assertSame([], $fields['copy_to']->getCopyDests());
+        $this->assertSame('copy_to,dynamic_copy_to', implode(',', $fields['copy_from']->getCopyDests()));
+
+        $this->assertSame([], $fields['copy_from']->getCopySources());
+        $this->assertSame('copy_from,dynamic_copy_from,*_copy_from,*_wildcard', implode(',', $fields['copy_to']->getCopySources()));
+
+        $this->assertSame('flags_a', (string) $fields['flags_a']);
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testFieldFlags(Schema $schema)
+    {
+        $flags = $schema->getField('flags_a')->getFlags();
+
+        $this->assertSame('I-S-U-V-p-O-P-L-f-', (string) $flags);
+
+        $this->assertTrue($flags->isIndexed());
+        $this->assertFalse($flags->isTokenized());
+        $this->assertTrue($flags->isStored());
+        $this->assertFalse($flags->isDocValues());
+        $this->assertTrue($flags->isUninvertible());
+        $this->assertFalse($flags->isMultiValued());
+        $this->assertTrue($flags->isTermVectors());
+        $this->assertFalse($flags->isTermOffsets());
+        $this->assertTrue($flags->isTermPositions());
+        $this->assertFalse($flags->isTermPayloads());
+        $this->assertTrue($flags->isOmitNorms());
+        $this->assertFalse($flags->isOmitTermFreqAndPositions());
+        $this->assertTrue($flags->isOmitPositions());
+        $this->assertFalse($flags->isStoreOffsetsWithPositions());
+        $this->assertTrue($flags->isLazy());
+        $this->assertFalse($flags->isBinary());
+        $this->assertTrue($flags->isSortMissingFirst());
+        $this->assertFalse($flags->isSortMissingLast());
+
+        $flags = $schema->getField('flags_b')->getFlags();
+
+        $this->assertSame('-T-D-M-o-y-F-H-B-l', (string) $flags);
+
+        $this->assertFalse($flags->isIndexed());
+        $this->assertTrue($flags->isTokenized());
+        $this->assertFalse($flags->isStored());
+        $this->assertTrue($flags->isDocValues());
+        $this->assertFalse($flags->isUninvertible());
+        $this->assertTrue($flags->isMultiValued());
+        $this->assertFalse($flags->isTermVectors());
+        $this->assertTrue($flags->isTermOffsets());
+        $this->assertFalse($flags->isTermPositions());
+        $this->assertTrue($flags->isTermPayloads());
+        $this->assertFalse($flags->isOmitNorms());
+        $this->assertTrue($flags->isOmitTermFreqAndPositions());
+        $this->assertFalse($flags->isOmitPositions());
+        $this->assertTrue($flags->isStoreOffsetsWithPositions());
+        $this->assertFalse($flags->isLazy());
+        $this->assertTrue($flags->isBinary());
+        $this->assertFalse($flags->isSortMissingFirst());
+        $this->assertTrue($flags->isSortMissingLast());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testFieldCopyDests(Schema $schema)
+    {
+        $copyDests = $schema->getField('copy_from')->getCopyDests();
+
+        $this->assertInstanceOf(Field::class, $copyDests[0]);
+        $this->assertInstanceOf(DynamicBasedField::class, $copyDests[1]);
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testFieldCopySources(Schema $schema)
+    {
+        $copySources = $schema->getField('copy_to')->getCopySources();
+
+        $this->assertInstanceOf(Field::class, $copySources[0]);
+        $this->assertInstanceOf(DynamicBasedField::class, $copySources[1]);
+        $this->assertInstanceOf(DynamicField::class, $copySources[2]);
+        $this->assertInstanceOf(WildcardField::class, $copySources[3]);
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testDynamicFields(Schema $schema)
+    {
+        $dynamicFields = $schema->getDynamicFields();
+
+        $this->assertCount(3, $dynamicFields);
+
+        $this->assertSame('*_pos_inc_gap', $dynamicFields['*_pos_inc_gap']->getName());
+
+        $this->assertSame('type_tokenized', (string) $dynamicFields['*_pos_inc_gap']->getType());
+
+        $this->assertSame('ITSDU-------------', (string) $dynamicFields['*_pos_inc_gap']->getFlags());
+
+        $this->assertNull($dynamicFields['*_pos_inc_gap']->getRequired());
+        $this->assertFalse($dynamicFields['*_pos_inc_gap']->isRequired());
+
+        $this->assertNull($dynamicFields['*_pos_inc_gap']->getDefault());
+
+        $this->assertNull($dynamicFields['*_pos_inc_gap']->getUniqueKey());
+        $this->assertFalse($dynamicFields['*_pos_inc_gap']->isUniqueKey());
+
+        $this->assertNull($dynamicFields['*_copy_to']->getPositionIncrementGap());
+        $this->assertSame(200, $dynamicFields['*_pos_inc_gap']->getPositionIncrementGap());
+
+        $this->assertSame([], $dynamicFields['*_copy_to']->getCopyDests());
+        $this->assertSame('copy_to,dynamic_copy_to,*_copy_to', implode(',', $dynamicFields['*_copy_from']->getCopyDests()));
+
+        $this->assertSame([], $dynamicFields['*_copy_from']->getCopySources());
+        $this->assertSame('*_copy_from,*_wildcard', implode(',', $dynamicFields['*_copy_to']->getCopySources()));
+
+        $this->assertSame('*_pos_inc_gap', (string) $dynamicFields['*_pos_inc_gap']);
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testDynamicFieldFlags(Schema $schema)
+    {
+        // flags are covered exhaustively in testFieldFlags()
+        $this->assertTrue($schema->getDynamicField('*_pos_inc_gap')->getFlags()->isTokenized());
+        $this->assertFalse($schema->getDynamicField('*_copy_to')->getFlags()->isTokenized());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testDynamicFieldCopyDests(Schema $schema)
+    {
+        $copyDests = $schema->getDynamicField('*_copy_from')->getCopyDests();
+
+        $this->assertInstanceOf(Field::class, $copyDests[0]);
+        $this->assertInstanceOf(DynamicBasedField::class, $copyDests[1]);
+        $this->assertInstanceOf(DynamicField::class, $copyDests[2]);
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testDynamicFieldCopySources(Schema $schema)
+    {
+        $copySources = $schema->getDynamicField('*_copy_to')->getCopySources();
+
+        $this->assertInstanceOf(DynamicField::class, $copySources[0]);
+        $this->assertInstanceOf(WildcardField::class, $copySources[1]);
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testUniqueKeyField(Schema $schema)
+    {
+        $this->assertSame('uniquekey', (string) $schema->getUniqueKeyField());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testSimilarity(Schema $schema)
+    {
+        $similarity = $schema->getSimilarity();
+
+        $this->assertSame('org.example.SchemaSimilarityFactory$SchemaSimilarity', $similarity->getClassName());
+        $this->assertSame('Similarity details.', $similarity->getDetails());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testTypes(Schema $schema)
+    {
+        $types = $schema->getTypes();
+
+        $this->assertCount(3, $types);
+
+        $this->assertSame('type_tokenized', $types['type_tokenized']->getName());
+
+        $this->assertSame([], $types['type_similarity']->getFields());
+        $this->assertSame('flags_b,pos_inc_gap,*_pos_inc_gap', implode(',', $types['type_tokenized']->getFields()));
+
+        $this->assertFalse($types['type_untokenized']->isTokenized());
+        $this->assertTrue($types['type_tokenized']->isTokenized());
+
+        $this->assertSame('org.example.TestField', $types['type_untokenized']->getClassName());
+
+        $this->assertSame('org.example.TestFieldType$DefaultAnalyzer', (string) $types['type_untokenized']->getIndexAnalyzer());
+
+        $this->assertSame('org.example.TokenizerChain', (string) $types['type_tokenized']->getQueryAnalyzer());
+
+        $this->assertSame('', (string) $types['type_tokenized']->getSimilarity());
+        $this->assertSame('org.example.TestSimilarity', (string) $types['type_similarity']->getSimilarity());
+
+        $this->assertSame('type_tokenized', (string) $types['type_tokenized']);
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testIndexAnalyzer(Schema $schema): IndexAnalyzer
+    {
+        $indexAnalyzer = $schema->getType('type_untokenized')->getIndexAnalyzer();
+
+        $this->assertSame('org.example.TestFieldType$DefaultAnalyzer', $indexAnalyzer->getClassName());
+        $this->assertSame([], $indexAnalyzer->getCharFilters());
+        $this->assertNull($indexAnalyzer->getTokenizer());
+        $this->assertSame([], $indexAnalyzer->getFilters());
+
+        $indexAnalyzer = $schema->getType('type_tokenized')->getIndexAnalyzer();
+
+        $this->assertSame('org.example.TokenizerChain', $indexAnalyzer->getClassName());
+        $this->assertSame('FirstCharFilterFactory,NextCharFilterFactory', implode(',', $indexAnalyzer->getCharFilters()));
+        $this->assertSame('org.example.TestTokenizerFactory', (string) $indexAnalyzer->getTokenizer());
+        $this->assertSame('FirstFilterFactory,NextFilterFactory', implode(',', $indexAnalyzer->getFilters()));
+
+        return $indexAnalyzer;
+    }
+
+    /**
+     * @depends testIndexAnalyzer
+     */
+    public function testIndexAnalyzerCharFilters(IndexAnalyzer $indexAnalyzer)
+    {
+        $charFilter = $indexAnalyzer->getCharFilters()['FirstCharFilterFactory'];
+
+        $this->assertSame(
+            [
+                'class' => 'solr.FirstCharFilterFactory',
+                'luceneMatchVersion' => '1.2.3',
+            ],
+            $charFilter->getArgs()
+        );
+        $this->assertSame('org.example.FirstCharFilterFactory', $charFilter->getClassName());
+    }
+
+    /**
+     * @depends testIndexAnalyzer
+     */
+    public function testIndexAnalyzerTokenizer(IndexAnalyzer $indexAnalyzer)
+    {
+        $tokenizer = $indexAnalyzer->getTokenizer();
+
+        $this->assertSame('org.example.TestTokenizerFactory', $tokenizer->getClassName());
+        $this->assertSame(
+            [
+                'class' => 'solr.TestTokenizerFactory',
+                'luceneMatchVersion' => '1.2.3',
+            ],
+            $tokenizer->getArgs()
+        );
+    }
+
+    /**
+     * @depends testIndexAnalyzer
+     */
+    public function testIndexAnalyzerFilters(IndexAnalyzer $indexAnalyzer)
+    {
+        $filter = $indexAnalyzer->getFilters()['FirstFilterFactory'];
+
+        $this->assertSame(
+            [
+                'class' => 'solr.FirstFilterFactory',
+                'luceneMatchVersion' => '1.2.3',
+            ],
+            $filter->getArgs()
+        );
+        $this->assertSame('org.example.FirstFilterFactory', $filter->getClassName());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testQueryAnalyzer(Schema $schema): QueryAnalyzer
+    {
+        $queryAnalyzer = $schema->getType('type_untokenized')->getQueryAnalyzer();
+
+        $this->assertSame('org.example.TestFieldType$DefaultAnalyzer', $queryAnalyzer->getClassName());
+        $this->assertSame([], $queryAnalyzer->getCharFilters());
+        $this->assertNull($queryAnalyzer->getTokenizer());
+        $this->assertSame([], $queryAnalyzer->getFilters());
+
+        $queryAnalyzer = $schema->getType('type_tokenized')->getQueryAnalyzer();
+
+        $this->assertSame('org.example.TokenizerChain', $queryAnalyzer->getClassName());
+        $this->assertSame('FirstCharFilterFactory,NextCharFilterFactory', implode(',', $queryAnalyzer->getCharFilters()));
+        $this->assertSame('org.example.TestTokenizerFactory', (string) $queryAnalyzer->getTokenizer());
+        $this->assertSame('FirstFilterFactory,NextFilterFactory', implode(',', $queryAnalyzer->getFilters()));
+
+        return $queryAnalyzer;
+    }
+
+    /**
+     * @depends testQueryAnalyzer
+     */
+    public function testQueryAnalyzerCharFilters(QueryAnalyzer $queryAnalyzer)
+    {
+        $charFilter = $queryAnalyzer->getCharFilters()['FirstCharFilterFactory'];
+
+        $this->assertSame(
+            [
+                'class' => 'solr.FirstCharFilterFactory',
+                'luceneMatchVersion' => '1.2.3',
+            ],
+            $charFilter->getArgs()
+        );
+        $this->assertSame('org.example.FirstCharFilterFactory', $charFilter->getClassName());
+    }
+
+    /**
+     * @depends testQueryAnalyzer
+     */
+    public function testQueryAnalyzerTokenizer(QueryAnalyzer $queryAnalyzer)
+    {
+        $tokenizer = $queryAnalyzer->getTokenizer();
+
+        $this->assertSame('org.example.TestTokenizerFactory', $tokenizer->getClassName());
+        $this->assertSame(
+            [
+                'class' => 'solr.TestTokenizerFactory',
+                'luceneMatchVersion' => '1.2.3',
+            ],
+            $tokenizer->getArgs()
+        );
+    }
+
+    /**
+     * @depends testQueryAnalyzer
+     */
+    public function testQueryAnalyzerFilters(QueryAnalyzer $queryAnalyzer)
+    {
+        $filter = $queryAnalyzer->getFilters()['FirstFilterFactory'];
+
+        $this->assertSame(
+            [
+                'class' => 'solr.FirstFilterFactory',
+                'luceneMatchVersion' => '1.2.3',
+            ],
+            $filter->getArgs()
+        );
+        $this->assertSame('org.example.FirstFilterFactory', $filter->getClassName());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testTypeSimilarity(Schema $schema)
+    {
+        $similarity = $schema->getType('type_untokenized')->getSimilarity();
+
+        $this->assertNull($similarity->getClassName());
+        $this->assertNull($similarity->getDetails());
+
+        $similarity = $schema->getType('type_similarity')->getSimilarity();
+
+        $this->assertSame('org.example.TestSimilarity', $similarity->getClassName());
+        $this->assertSame('Type similarity details.', $similarity->getDetails());
+    }
+
+    /**
+     * @depends testParse
+     */
+    public function testReferences(Schema $schema)
+    {
+        $this->assertSame($schema->getType('type_untokenized'), $schema->getField('flags_a')->getType());
+
+        $this->assertSame($schema->getField('copy_to'), $schema->getField('copy_from')->getCopyDests()[0]);
+        $this->assertSame($schema->getDynamicField('*_copy_to'), $schema->getField('copy_from')->getCopyDests()[1]->getDynamicBase());
+
+        $this->assertSame($schema->getField('copy_from'), $schema->getField('copy_to')->getCopySources()[0]);
+        $this->assertSame($schema->getDynamicField('*_copy_from'), $schema->getField('copy_to')->getCopySources()[1]->getDynamicBase());
+        $this->assertSame($schema->getDynamicField('*_copy_from'), $schema->getField('copy_to')->getCopySources()[2]);
+
+        $this->assertSame($schema->getType('type_tokenized'), $schema->getDynamicField('*_pos_inc_gap')->getType());
+
+        $this->assertSame($schema->getField('copy_to'), $schema->getDynamicField('*_copy_from')->getCopyDests()[0]);
+        $this->assertSame($schema->getDynamicField('*_copy_to'), $schema->getDynamicField('*_copy_from')->getCopyDests()[1]->getDynamicBase());
+        $this->assertSame($schema->getDynamicField('*_copy_to'), $schema->getDynamicField('*_copy_from')->getCopyDests()[2]);
+
+        $this->assertSame($schema->getDynamicField('*_copy_from'), $schema->getDynamicField('*_copy_to')->getCopySources()[0]);
+
+        // dynamic based fields and wildcards don't have a direct definition to reference in the schema, but multiple occurrences still reference a single instance
+        $this->assertSame($schema->getField('copy_from')->getCopyDests()[1], $schema->getDynamicField('*_copy_from')->getCopyDests()[1]);
+        $this->assertSame($schema->getField('copy_to')->getCopySources()[3], $schema->getDynamicField('*_copy_to')->getCopySources()[1]);
+
+        $this->assertSame($schema->getField('uniquekey'), $schema->getUniqueKeyField());
+
+        $this->assertSame($schema->getField('flags_b'), $schema->getType('type_tokenized')->getFields()[0]);
+        $this->assertSame($schema->getDynamicField('*_pos_inc_gap'), $schema->getType('type_tokenized')->getFields()[2]);
+    }
+
+    /**
+     * A schema isn't required to have a uniqueKey field.
+     */
+    public function testParseSchemaWithoutUniqueKey()
+    {
+        $schemaData = $this->getSchemaData();
+        $schemaData['uniqueKeyField'] = null;
+        unset($schemaData['fields']['uniquekey']['uniqueKey']);
+
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'schema' => $schemaData,
+            'info' => $this->getInfoData(),
+        ];
+
+        $query = new Query();
+        $query->setShow(Query::SHOW_SCHEMA);
+
+        $resultStub = $this->createMock(Result::class);
+        $resultStub->expects($this->any())
+            ->method('getData')
+            ->willReturn($data);
+        $resultStub->expects($this->any())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $parser = new ResponseParser();
+        $result = $parser->parse($resultStub);
+
+        $this->assertNull($result['schemaResult']->getUniqueKeyField());
+    }
+
+    /**
+     * Test a copyField dest or source that isn't a wildcard pattern and doesn't match an explicit field or dynamicField.
+     *
+     * This will never happen with real data because Solr refuses to load a schema with such a copyField definition, stating:
+     *  'undefined_field' is not a glob and doesn't match any explicit field or dynamicField.
+     *
+     * We still need a code path covering this eventuality to satisfy the static analysis rules.
+     *
+     * @testWith ["copy_from", "copyDests"]
+     *           ["copy_to", "copySources"]
+     */
+    public function testParseUndefinedCopyField(string $fieldName, string $destOrSource)
+    {
+        $schemaData = $this->getSchemaData();
+        $schemaData['fields'][$fieldName][$destOrSource][] = 'undefined_field';
+
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'schema' => $schemaData,
+            'info' => $this->getInfoData(),
+        ];
+
+        $query = new Query();
+        $query->setShow(Query::SHOW_SCHEMA);
+
+        $resultStub = $this->createMock(Result::class);
+        $resultStub->expects($this->any())
+            ->method('getData')
+            ->willReturn($data);
+        $resultStub->expects($this->any())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Field name undefined_field doesn\'t match a dynamicField name.');
+        $parser = new ResponseParser();
+        $parser->parse($resultStub);
+    }
+}

--- a/tests/QueryType/Luke/Result/Doc/DocFieldInfoTest.php
+++ b/tests/QueryType/Luke/Result/Doc/DocFieldInfoTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Doc;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Doc\DocFieldInfo;
+use Solarium\QueryType\Luke\Result\FlagList;
+
+class DocFieldInfoTest extends TestCase
+{
+    /**
+     * @var DocFieldInfo
+     */
+    protected $docFieldInfo;
+
+    public function setUp(): void
+    {
+        $this->docFieldInfo = new DocFieldInfo('fieldA');
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('fieldA', $this->docFieldInfo->getName());
+    }
+
+    public function testSetAndGetType()
+    {
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setType('my_type'));
+        $this->assertSame('my_type', $this->docFieldInfo->getType());
+
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setType(null));
+        $this->assertNull($this->docFieldInfo->getType());
+    }
+
+    public function testSetAndGetSchema()
+    {
+        $schema = new FlagList('-', []);
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setSchema($schema));
+        $this->assertSame($schema, $this->docFieldInfo->getSchema());
+    }
+
+    public function testSetAndGetFlags()
+    {
+        $flags = new FlagList('-', []);
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setFlags($flags));
+        $this->assertSame($flags, $this->docFieldInfo->getFlags());
+    }
+
+    public function testSetAndGetValue()
+    {
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setValue('external value'));
+        $this->assertSame('external value', $this->docFieldInfo->getValue());
+
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setValue(null));
+        $this->assertNull($this->docFieldInfo->getValue());
+    }
+
+    public function testSetAndGetInternal()
+    {
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setInternal('internal value'));
+        $this->assertSame('internal value', $this->docFieldInfo->getInternal());
+    }
+
+    public function testSetAndGetBinary()
+    {
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setBinary('binary value'));
+        $this->assertSame('binary value', $this->docFieldInfo->getBinary());
+
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setBinary(null));
+        $this->assertNull($this->docFieldInfo->getBinary());
+    }
+
+    public function testSetAndGetDocFreq()
+    {
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setDocFreq(5));
+        $this->assertSame(5, $this->docFieldInfo->getDocFreq());
+
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setDocFreq(null));
+        $this->assertNull($this->docFieldInfo->getDocFreq());
+    }
+
+    public function testSetAndGetTermVector()
+    {
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setTermVector([]));
+        $this->assertSame([], $this->docFieldInfo->getTermVector());
+
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setTermVector(null));
+        $this->assertNull($this->docFieldInfo->getTermVector());
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('fieldA: ', (string) $this->docFieldInfo);
+
+        $this->docFieldInfo->setValue('string representation of the value');
+        $this->assertSame('fieldA: string representation of the value', (string) $this->docFieldInfo);
+    }
+}

--- a/tests/QueryType/Luke/Result/Doc/DocInfoTest.php
+++ b/tests/QueryType/Luke/Result/Doc/DocInfoTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Doc;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Doc\DocFieldInfo;
+use Solarium\QueryType\Luke\Result\Doc\DocInfo;
+use Solarium\QueryType\Select\Result\Document;
+
+class DocInfoTest extends TestCase
+{
+    /**
+     * @var DocInfo
+     */
+    protected $docInfo;
+
+    public function setUp(): void
+    {
+        $this->docInfo = new DocInfo(42);
+    }
+
+    public function testGetDocId()
+    {
+        $this->assertSame(42, $this->docInfo->getDocId());
+    }
+
+    public function testSetAndGetLucene()
+    {
+        $docFieldInfo = new DocFieldInfo('field');
+        $this->assertSame($this->docInfo, $this->docInfo->setLucene([$docFieldInfo]));
+        $this->assertSame([$docFieldInfo], $this->docInfo->getLucene());
+    }
+
+    public function testSetAndGetSolr()
+    {
+        $document = new Document([]);
+        $this->assertSame($this->docInfo, $this->docInfo->setSolr($document));
+        $this->assertSame($document, $this->docInfo->getSolr());
+    }
+}

--- a/tests/QueryType/Luke/Result/Fields/FieldInfoTest.php
+++ b/tests/QueryType/Luke/Result/Fields/FieldInfoTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Fields;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Fields\FieldInfo;
+use Solarium\QueryType\Luke\Result\FlagList;
+
+class FieldInfoTest extends TestCase
+{
+    /**
+     * @var FieldInfo
+     */
+    protected $fieldInfo;
+
+    public function setUp(): void
+    {
+        $this->fieldInfo = new FieldInfo('fieldA');
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('fieldA', $this->fieldInfo->getName());
+    }
+
+    public function testSetAndGetType()
+    {
+        $this->assertSame($this->fieldInfo, $this->fieldInfo->setType('my_type'));
+        $this->assertSame('my_type', $this->fieldInfo->getType());
+    }
+
+    public function testSetAndGetSchema()
+    {
+        $schema = new FlagList('-', []);
+        $this->assertSame($this->fieldInfo, $this->fieldInfo->setSchema($schema));
+        $this->assertSame($schema, $this->fieldInfo->getSchema());
+    }
+
+    public function testSetAndGetDynamicBase()
+    {
+        $this->assertSame($this->fieldInfo, $this->fieldInfo->setDynamicBase('field_*'));
+        $this->assertSame('field_*', $this->fieldInfo->getDynamicBase());
+
+        $this->assertSame($this->fieldInfo, $this->fieldInfo->setDynamicBase(null));
+        $this->assertNull($this->fieldInfo->getDynamicBase());
+    }
+
+    public function testSetAndGetIndex()
+    {
+        $index = new FlagList('-', []);
+        $this->assertSame($this->fieldInfo, $this->fieldInfo->setIndex($index));
+        $this->assertSame($index, $this->fieldInfo->getIndex());
+
+        $this->assertSame($this->fieldInfo, $this->fieldInfo->setIndex('(unstored field)'));
+        $this->assertSame('(unstored field)', $this->fieldInfo->getIndex());
+
+        $this->assertSame($this->fieldInfo, $this->fieldInfo->setIndex(null));
+        $this->assertNull($this->fieldInfo->getIndex());
+    }
+
+    public function testSetAndGetDocs()
+    {
+        $this->assertSame($this->fieldInfo, $this->fieldInfo->setDocs(42));
+        $this->assertSame(42, $this->fieldInfo->getDocs());
+
+        $this->assertSame($this->fieldInfo, $this->fieldInfo->setDocs(null));
+        $this->assertNull($this->fieldInfo->getDocs());
+    }
+
+    public function testSetAndGetDistinct()
+    {
+        $this->assertSame($this->fieldInfo, $this->fieldInfo->setDistinct(24));
+        $this->assertSame(24, $this->fieldInfo->getDistinct());
+
+        $this->assertSame($this->fieldInfo, $this->fieldInfo->setDistinct(null));
+        $this->assertNull($this->fieldInfo->getDistinct());
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('fieldA', (string) $this->fieldInfo);
+    }
+}

--- a/tests/QueryType/Luke/Result/FlagListTest.php
+++ b/tests/QueryType/Luke/Result/FlagListTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Flag;
+use Solarium\QueryType\Luke\Result\FlagList;
+
+class FlagListTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    protected $flags;
+
+    /**
+     * @var FlagList
+     */
+    protected $flagList;
+
+    public function setUp(): void
+    {
+        $this->flags = [
+            'A' => new Flag('A', 'A Flag'),
+            'O' => new Flag('O', 'Other Flag'),
+        ];
+        $this->flagList = new FlagList('AO-', [
+            'A' => 'A Flag',
+            'O' => 'Other Flag',
+            'U' => 'Unused Flag',
+        ]);
+    }
+
+    public function testIsIndexed()
+    {
+        $flags = new FlagList('I', ['I' => new Flag('I', '...')]);
+        $this->assertTrue($flags->isIndexed());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isIndexed());
+    }
+
+    public function testIsTokenized()
+    {
+        $flags = new FlagList('T', ['T' => new Flag('T', '...')]);
+        $this->assertTrue($flags->isTokenized());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isTokenized());
+    }
+
+    public function testIsStored()
+    {
+        $flags = new FlagList('S', ['S' => new Flag('S', '...')]);
+        $this->assertTrue($flags->isStored());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isStored());
+    }
+
+    public function testIsDocValues()
+    {
+        $flags = new FlagList('D', ['D' => new Flag('D', '...')]);
+        $this->assertTrue($flags->isDocValues());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isDocValues());
+    }
+
+    public function testIsUninvertible()
+    {
+        $flags = new FlagList('U', ['U' => new Flag('U', '...')]);
+        $this->assertTrue($flags->isUninvertible());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isUninvertible());
+    }
+
+    public function testIsMultiValued()
+    {
+        $flags = new FlagList('M', ['M' => new Flag('M', '...')]);
+        $this->assertTrue($flags->isMultiValued());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isMultiValued());
+    }
+
+    public function testIsTermVectors()
+    {
+        $flags = new FlagList('V', ['V' => new Flag('V', '...')]);
+        $this->assertTrue($flags->isTermVectors());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isTermVectors());
+    }
+
+    public function testIsTermOffsets()
+    {
+        $flags = new FlagList('o', ['o' => new Flag('o', '...')]);
+        $this->assertTrue($flags->isTermOffsets());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isTermOffsets());
+    }
+
+    public function testIsTermPositions()
+    {
+        $flags = new FlagList('p', ['p' => new Flag('p', '...')]);
+        $this->assertTrue($flags->isTermPositions());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isTermPositions());
+    }
+
+    public function testIsTermPayloads()
+    {
+        $flags = new FlagList('y', ['y' => new Flag('y', '...')]);
+        $this->assertTrue($flags->isTermPayloads());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isTermPayloads());
+    }
+
+    public function testIsOmitNorms()
+    {
+        $flags = new FlagList('O', ['O' => new Flag('O', '...')]);
+        $this->assertTrue($flags->isOmitNorms());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isOmitNorms());
+    }
+
+    public function testIsOmitTermFreqAndPositions()
+    {
+        $flags = new FlagList('F', ['F' => new Flag('F', '...')]);
+        $this->assertTrue($flags->isOmitTermFreqAndPositions());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isOmitTermFreqAndPositions());
+    }
+
+    public function testIsOmitPositions()
+    {
+        $flags = new FlagList('P', ['P' => new Flag('P', '...')]);
+        $this->assertTrue($flags->isOmitPositions());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isOmitPositions());
+    }
+
+    public function testIsStoreOffsetsWithPositions()
+    {
+        $flags = new FlagList('H', ['H' => new Flag('H', '...')]);
+        $this->assertTrue($flags->isStoreOffsetsWithPositions());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isStoreOffsetsWithPositions());
+    }
+
+    public function testIsLazy()
+    {
+        $flags = new FlagList('L', ['L' => new Flag('L', '...')]);
+        $this->assertTrue($flags->isLazy());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isLazy());
+    }
+
+    public function testIsBinary()
+    {
+        $flags = new FlagList('B', ['B' => new Flag('B', '...')]);
+        $this->assertTrue($flags->isBinary());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isBinary());
+    }
+
+    public function testIsSortMissingFirst()
+    {
+        $flags = new FlagList('f', ['f' => new Flag('f', '...')]);
+        $this->assertTrue($flags->isSortMissingFirst());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isSortMissingFirst());
+    }
+
+    public function testIsSortMissingLast()
+    {
+        $flags = new FlagList('l', ['l' => new Flag('l', '...')]);
+        $this->assertTrue($flags->isSortMissingLast());
+
+        $flags = new FlagList('-', []);
+        $this->assertFalse($flags->isSortMissingLast());
+    }
+
+    public function testCountable()
+    {
+        $this->assertCount(2, $this->flagList);
+    }
+
+    public function testIterator()
+    {
+        $expected = [
+            0 => ['A', new Flag('A', 'A Flag')],
+            1 => ['O', new Flag('O', 'Other Flag')],
+        ];
+        $index = 0;
+
+        foreach ($this->flagList as $abbrevation => $flag) {
+            $this->assertSame($expected[$index][0], $abbrevation);
+            $this->assertEquals($expected[$index][1], $flag);
+            ++$index;
+        }
+    }
+
+    public function testArrayAccess()
+    {
+        $this->assertArrayHasKey('O', $this->flagList);
+        $this->assertArrayNotHasKey('U', $this->flagList);
+        $this->assertEquals(new Flag('O', 'Other Flag'), $this->flagList['O']);
+        $this->assertNull($this->flagList['U']);
+    }
+
+    public function testArrayAccessImmutable()
+    {
+        $this->flagList['N'] = new Flag('N', 'New Flag');
+        $this->assertArrayNotHasKey('N', $this->flagList);
+        unset($this->flagList['A']);
+        $this->assertArrayHasKey('A', $this->flagList);
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('AO-', (string) $this->flagList);
+    }
+}

--- a/tests/QueryType/Luke/Result/FlagTest.php
+++ b/tests/QueryType/Luke/Result/FlagTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Flag;
+
+class FlagTest extends TestCase
+{
+    /**
+     * @var Flag
+     */
+    protected $flag;
+
+    public function setUp(): void
+    {
+        $this->flag = new Flag('A', 'A Flag');
+    }
+
+    public function testGetAbbreviation()
+    {
+        $this->assertSame('A', $this->flag->getAbbreviation());
+    }
+
+    public function testGetDisplay()
+    {
+        $this->assertSame('A Flag', $this->flag->getDisplay());
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('A Flag', (string) $this->flag);
+    }
+}

--- a/tests/QueryType/Luke/Result/Index/IndexTest.php
+++ b/tests/QueryType/Luke/Result/Index/IndexTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Index;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Index\Index;
+use Solarium\QueryType\Luke\Result\Index\UserData;
+
+class IndexTest extends TestCase
+{
+    /**
+     * @var Index
+     */
+    protected $index;
+
+    public function setUp(): void
+    {
+        $this->index = new Index();
+    }
+
+    public function testSetAndGetNumDocs()
+    {
+        $this->assertSame($this->index, $this->index->setNumDocs(20));
+        $this->assertSame(20, $this->index->getNumDocs());
+    }
+
+    public function testSetAndGetMaxDoc()
+    {
+        $this->assertSame($this->index, $this->index->setMaxDoc(30));
+        $this->assertSame(30, $this->index->getMaxDoc());
+    }
+
+    public function testSetAndGetDeletedDocs()
+    {
+        $this->assertSame($this->index, $this->index->setDeletedDocs(10));
+        $this->assertSame(10, $this->index->getDeletedDocs());
+    }
+
+    public function testSetAndGetIndexHeapUsageBytes()
+    {
+        $this->assertSame($this->index, $this->index->setIndexHeapUsageBytes(5000));
+        $this->assertSame(5000, $this->index->getIndexHeapUsageBytes());
+
+        $this->assertSame($this->index, $this->index->setIndexHeapUsageBytes(null));
+        $this->assertNull($this->index->getIndexHeapUsageBytes());
+    }
+
+    public function testSetAndGetVersion()
+    {
+        $this->assertSame($this->index, $this->index->setVersion(5));
+        $this->assertSame(5, $this->index->getVersion());
+    }
+
+    public function testSetAndGetSegmentCount()
+    {
+        $this->assertSame($this->index, $this->index->setSegmentCount(1));
+        $this->assertSame(1, $this->index->getSegmentCount());
+    }
+
+    public function testSetAndGetAndIsCurrent()
+    {
+        $this->assertSame($this->index, $this->index->setCurrent(true));
+        $this->assertTrue($this->index->getCurrent());
+        $this->assertTrue($this->index->isCurrent());
+    }
+
+    public function testSetAndGetAndHasDeletions()
+    {
+        $this->assertSame($this->index, $this->index->setHasDeletions(false));
+        $this->assertFalse($this->index->getHasDeletions());
+        $this->assertFalse($this->index->hasDeletions());
+    }
+
+    public function testSetAndGetDirectory()
+    {
+        $this->assertSame($this->index, $this->index->setDirectory('directory info'));
+        $this->assertSame('directory info', $this->index->getDirectory());
+    }
+
+    public function testSetAndGetSegmentsFile()
+    {
+        $this->assertSame($this->index, $this->index->setSegmentsFile('segments_2'));
+        $this->assertSame('segments_2', $this->index->getSegmentsFile());
+    }
+
+    public function testSetAndGetSegmentsFileSizeInBytes()
+    {
+        $this->assertSame($this->index, $this->index->setSegmentsFileSizeInBytes(200));
+        $this->assertSame(200, $this->index->getSegmentsFileSizeInBytes());
+    }
+
+    public function testSetAndGetUserData()
+    {
+        $userData = new UserData();
+        $this->assertSame($this->index, $this->index->setUserData($userData));
+        $this->assertSame($userData, $this->index->getUserData());
+    }
+
+    public function testSetAndGetLastModified()
+    {
+        $lastModified = new \DateTime();
+        $this->assertSame($this->index, $this->index->setLastModified($lastModified));
+        $this->assertSame($lastModified, $this->index->getLastModified());
+
+        $this->assertSame($this->index, $this->index->setLastModified(null));
+        $this->assertNull($this->index->getLastModified());
+    }
+}

--- a/tests/QueryType/Luke/Result/Index/UserDataTest.php
+++ b/tests/QueryType/Luke/Result/Index/UserDataTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Index;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Index\UserData;
+
+class UserDataTest extends TestCase
+{
+    /**
+     * @var UserData
+     */
+    protected $userData;
+
+    public function setUp(): void
+    {
+        $this->userData = new UserData();
+    }
+
+    public function testSetAndGetCommitCommandVer()
+    {
+        $this->assertSame($this->userData, $this->userData->setCommitCommandVer('123456789123456789'));
+        $this->assertSame('123456789123456789', $this->userData->getCommitCommandVer());
+
+        $this->assertSame($this->userData, $this->userData->setCommitCommandVer(null));
+        $this->assertNull($this->userData->getCommitCommandVer());
+    }
+
+    public function testSetAndGetCommitTimeMSec()
+    {
+        $this->assertSame($this->userData, $this->userData->setCommitTimeMSec('123456789'));
+        $this->assertSame('123456789', $this->userData->getCommitTimeMSec());
+
+        $this->assertSame($this->userData, $this->userData->setCommitTimeMSec(null));
+        $this->assertNull($this->userData->getCommitTimeMSec());
+    }
+}

--- a/tests/QueryType/Luke/Result/Info/InfoTest.php
+++ b/tests/QueryType/Luke/Result/Info/InfoTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Info;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Info\Info;
+
+class InfoTest extends TestCase
+{
+    /**
+     * @var Info
+     */
+    protected $info;
+
+    public function setUp(): void
+    {
+        $this->info = new Info();
+    }
+
+    public function testSetAndGetKey()
+    {
+        $key = [
+            'A' => 'A Flag',
+            'O' => 'Other Flag',
+        ];
+        $this->assertSame($this->info, $this->info->setKey($key));
+        $this->assertSame($key, $this->info->getKey());
+    }
+
+    public function testSetAndGetNote()
+    {
+        $this->assertSame($this->info, $this->info->setNote('This is a note.'));
+        $this->assertSame('This is a note.', $this->info->getNote());
+    }
+}

--- a/tests/QueryType/Luke/Result/ResultTest.php
+++ b/tests/QueryType/Luke/Result/ResultTest.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Response;
+use Solarium\QueryType\Luke\Query;
+use Solarium\QueryType\Luke\Result\Doc\DocInfo;
+use Solarium\QueryType\Luke\Result\Fields\FieldInfo;
+use Solarium\QueryType\Luke\Result\Index\Index;
+use Solarium\QueryType\Luke\Result\Info\Info;
+use Solarium\QueryType\Luke\Result\Result;
+use Solarium\QueryType\Luke\Result\Schema\Schema;
+use Solarium\Tests\QueryType\Luke\ResponseParser\DocDataTrait;
+use Solarium\Tests\QueryType\Luke\ResponseParser\FieldsDataTrait;
+use Solarium\Tests\QueryType\Luke\ResponseParser\IndexDataTrait;
+use Solarium\Tests\QueryType\Luke\ResponseParser\InfoDataTrait;
+use Solarium\Tests\QueryType\Luke\ResponseParser\SchemaDataTrait;
+
+class ResultTest extends TestCase
+{
+    use DocDataTrait;
+    use FieldsDataTrait;
+    use IndexDataTrait;
+    use InfoDataTrait;
+    use SchemaDataTrait;
+
+    public function testWithShowAll()
+    {
+        $query = new Query();
+        $query->setShow(Query::SHOW_ALL);
+
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'fields' => $this->getFieldsData(),
+            'info' => $this->getInfoData(),
+        ];
+
+        $response = new Response(json_encode($data), ['HTTP 1.1 200 OK']);
+        $result = new Result($query, $response);
+
+        $this->assertInstanceOf(Index::class, $result->getIndex());
+        $this->assertNull($result->getSchema());
+        $this->assertNull($result->getDoc());
+        $this->assertContainsOnlyInstancesOf(FieldInfo::class, $result->getFields());
+        $this->assertInstanceOf(Info::class, $result->getInfo());
+    }
+
+    public function testWithShowIndex()
+    {
+        $query = new Query();
+        $query->setShow(Query::SHOW_INDEX);
+
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+        ];
+
+        $response = new Response(json_encode($data), ['HTTP 1.1 200 OK']);
+        $result = new Result($query, $response);
+
+        $this->assertInstanceOf(Index::class, $result->getIndex());
+        $this->assertNull($result->getSchema());
+        $this->assertNull($result->getDoc());
+        $this->assertNull($result->getFields());
+        $this->assertNull($result->getInfo());
+    }
+
+    public function testWithShowSchema()
+    {
+        $query = new Query();
+        $query->setShow(Query::SHOW_SCHEMA);
+
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'schema' => $this->getSchemaData(),
+            'info' => $this->getInfoData(),
+        ];
+
+        $response = new Response(json_encode($data), ['HTTP 1.1 200 OK']);
+        $result = new Result($query, $response);
+
+        $this->assertInstanceOf(Index::class, $result->getIndex());
+        $this->assertInstanceOf(Schema::class, $result->getSchema());
+        $this->assertNull($result->getDoc());
+        $this->assertNull($result->getFields());
+        $this->assertInstanceOf(Info::class, $result->getInfo());
+    }
+
+    public function testWithShowDocWithoutIdOrDocId()
+    {
+        $query = new Query();
+        $query->setShow(Query::SHOW_DOC);
+
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'fields' => $this->getFieldsData(),
+            'info' => $this->getInfoData(),
+        ];
+
+        $response = new Response(json_encode($data), ['HTTP 1.1 200 OK']);
+        $result = new Result($query, $response);
+
+        $this->assertInstanceOf(Index::class, $result->getIndex());
+        $this->assertNull($result->getSchema());
+        $this->assertNull($result->getDoc());
+        $this->assertContainsOnlyInstancesOf(FieldInfo::class, $result->getFields());
+        $this->assertInstanceOf(Info::class, $result->getInfo());
+    }
+
+    public function testWithShowDocWithId()
+    {
+        $query = new Query();
+        $query->setShow(Query::SHOW_DOC);
+        $query->setId('NCC-1701');
+
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'doc' => $this->getDocData(),
+            'info' => $this->getInfoData(),
+        ];
+
+        $response = new Response(json_encode($data), ['HTTP 1.1 200 OK']);
+        $result = new Result($query, $response);
+
+        $this->assertInstanceOf(Index::class, $result->getIndex());
+        $this->assertNull($result->getSchema());
+        $this->assertInstanceOf(DocInfo::class, $result->getDoc());
+        $this->assertNull($result->getFields());
+        $this->assertInstanceOf(Info::class, $result->getInfo());
+    }
+
+    public function testWithShowDocWithDocId()
+    {
+        $query = new Query();
+        $query->setShow(Query::SHOW_DOC);
+        $query->setDocId(1701);
+
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'doc' => $this->getDocData(),
+            'info' => $this->getInfoData(),
+        ];
+
+        $response = new Response(json_encode($data), ['HTTP 1.1 200 OK']);
+        $result = new Result($query, $response);
+
+        $this->assertInstanceOf(Index::class, $result->getIndex());
+        $this->assertNull($result->getSchema());
+        $this->assertInstanceOf(DocInfo::class, $result->getDoc());
+        $this->assertNull($result->getFields());
+        $this->assertInstanceOf(Info::class, $result->getInfo());
+    }
+
+    public function testWithoutShowWithoutIdOrDocId()
+    {
+        $query = new Query();
+
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'fields' => $this->getFieldsData(),
+            'info' => $this->getInfoData(),
+        ];
+
+        $response = new Response(json_encode($data), ['HTTP 1.1 200 OK']);
+        $result = new Result($query, $response);
+
+        $this->assertInstanceOf(Index::class, $result->getIndex());
+        $this->assertNull($result->getSchema());
+        $this->assertNull($result->getDoc());
+        $this->assertContainsOnlyInstancesOf(FieldInfo::class, $result->getFields());
+        $this->assertInstanceOf(Info::class, $result->getInfo());
+    }
+
+    public function testWithoutShowDocWithId()
+    {
+        $query = new Query();
+        $query->setId('NCC-1701');
+
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'doc' => $this->getDocData(),
+            'info' => $this->getInfoData(),
+        ];
+
+        $response = new Response(json_encode($data), ['HTTP 1.1 200 OK']);
+        $result = new Result($query, $response);
+
+        $this->assertInstanceOf(Index::class, $result->getIndex());
+        $this->assertNull($result->getSchema());
+        $this->assertInstanceOf(DocInfo::class, $result->getDoc());
+        $this->assertNull($result->getFields());
+        $this->assertInstanceOf(Info::class, $result->getInfo());
+    }
+
+    public function testWithoutShowDocWithDocId()
+    {
+        $query = new Query();
+        $query->setDocId(1701);
+
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'doc' => $this->getDocData(),
+            'info' => $this->getInfoData(),
+        ];
+
+        $response = new Response(json_encode($data), ['HTTP 1.1 200 OK']);
+        $result = new Result($query, $response);
+
+        $this->assertInstanceOf(Index::class, $result->getIndex());
+        $this->assertNull($result->getSchema());
+        $this->assertInstanceOf(DocInfo::class, $result->getDoc());
+        $this->assertNull($result->getFields());
+        $this->assertInstanceOf(Info::class, $result->getInfo());
+    }
+
+    public function testWithUnknownShow()
+    {
+        $query = new Query();
+        $query->setShow('unknown');
+
+        $data = [
+            'responseHeader' => [
+                'status' => 0,
+                'QTime' => 3,
+            ],
+            'index' => $this->getIndexData(),
+            'unknown' => [
+                'hypothetical response data',
+                'for a new "show" parameter',
+                'that we don\'t support yet',
+            ],
+        ];
+
+        $response = new Response(json_encode($data), ['HTTP 1.1 200 OK']);
+        $result = new Result($query, $response);
+
+        $this->assertInstanceOf(Index::class, $result->getIndex());
+        $this->assertNull($result->getSchema());
+        $this->assertNull($result->getDoc());
+        $this->assertNull($result->getFields());
+        $this->assertNull($result->getInfo());
+    }
+}

--- a/tests/QueryType/Luke/Result/Schema/Field/AbstractFieldTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Field/AbstractFieldTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema\Field;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\FlagList;
+use Solarium\QueryType\Luke\Result\Schema\Field\AbstractField;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicBasedField;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicField;
+use Solarium\QueryType\Luke\Result\Schema\Field\Field;
+use Solarium\QueryType\Luke\Result\Schema\Field\WildcardField;
+use Solarium\QueryType\Luke\Result\Schema\Type\Type;
+
+abstract class AbstractFieldTest extends TestCase
+{
+    /**
+     * @var AbstractField
+     */
+    protected $field;
+
+    abstract public function testGetName();
+
+    public function testSetAndGetType()
+    {
+        $type = new Type('my_type');
+        $this->assertSame($this->field, $this->field->setType($type));
+        $this->assertSame($type, $this->field->getType());
+    }
+
+    public function testSetAndGetFlags()
+    {
+        $flags = new FlagList('-', []);
+        $this->assertSame($this->field, $this->field->setFlags($flags));
+        $this->assertSame($flags, $this->field->getFlags());
+    }
+
+    public function testSetAndGetAndIsRequired()
+    {
+        $this->assertSame($this->field, $this->field->setRequired(true));
+        $this->assertTrue($this->field->getRequired());
+        $this->assertTrue($this->field->isRequired());
+
+        $this->assertSame($this->field, $this->field->setRequired(false));
+        $this->assertFalse($this->field->getRequired());
+        $this->assertFalse($this->field->isRequired());
+
+        $this->assertSame($this->field, $this->field->setRequired(null));
+        $this->assertNull($this->field->getRequired());
+        $this->assertFalse($this->field->isRequired());
+    }
+
+    public function testSetAndGetDefault()
+    {
+        $this->assertSame($this->field, $this->field->setDefault('0.0'));
+        $this->assertSame('0.0', $this->field->getDefault());
+
+        $this->assertSame($this->field, $this->field->setDefault(null));
+        $this->assertNull($this->field->getDefault());
+    }
+
+    public function testSetAndGetAndIsUniqueKey()
+    {
+        $this->assertSame($this->field, $this->field->setUniqueKey(true));
+        $this->assertTrue($this->field->getUniqueKey());
+        $this->assertTrue($this->field->isUniqueKey());
+
+        $this->assertSame($this->field, $this->field->setUniqueKey(false));
+        $this->assertFalse($this->field->getUniqueKey());
+        $this->assertFalse($this->field->isUniqueKey());
+
+        $this->assertSame($this->field, $this->field->setUniqueKey(null));
+        $this->assertNull($this->field->getUniqueKey());
+        $this->assertFalse($this->field->isUniqueKey());
+    }
+
+    public function testSetAndGetPositionIncrementGap()
+    {
+        $this->assertSame($this->field, $this->field->setPositionIncrementGap(42));
+        $this->assertSame(42, $this->field->getPositionIncrementGap());
+
+        $this->assertSame($this->field, $this->field->setPositionIncrementGap(null));
+        $this->assertNull($this->field->getPositionIncrementGap());
+    }
+
+    public function testAddAndGetCopyDests()
+    {
+        $copyDests = [
+            $field = new Field('field_a'),
+            $dynamicField = new DynamicField('*_b'),
+            $dynamicBasedField = new DynamicBasedField('field_b'),
+        ];
+        $this->assertSame($this->field, $this->field->addCopyDest($field));
+        $this->assertSame($this->field, $this->field->addCopyDest($dynamicField));
+        $this->assertSame($this->field, $this->field->addCopyDest($dynamicBasedField));
+        $this->assertSame($copyDests, $this->field->getCopyDests());
+    }
+
+    public function testAddAndGetCopySources()
+    {
+        $copyDests = [
+            $field = new Field('field_a'),
+            $dynamicField = new DynamicField('*_b'),
+            $dynamicBasedField = new DynamicBasedField('field_b'),
+            $wildcard = new WildcardField('field_*'),
+        ];
+        $this->assertSame($this->field, $this->field->addCopySource($field));
+        $this->assertSame($this->field, $this->field->addCopySource($dynamicField));
+        $this->assertSame($this->field, $this->field->addCopySource($dynamicBasedField));
+        $this->assertSame($this->field, $this->field->addCopySource($wildcard));
+        $this->assertSame($copyDests, $this->field->getCopySources());
+    }
+
+    abstract public function testToString();
+}

--- a/tests/QueryType/Luke/Result/Schema/Field/DynamicBasedFieldTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Field/DynamicBasedFieldTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema\Field;
+
+use Solarium\QueryType\Luke\Result\Schema\Field\CopyFieldDestInterface;
+use Solarium\QueryType\Luke\Result\Schema\Field\CopyFieldSourceInterface;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicBasedField;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicField;
+use Solarium\QueryType\Luke\Result\Schema\Field\SchemaFieldInterface;
+
+class DynamicBasedFieldTest extends AbstractFieldTest
+{
+    /**
+     * @var DynamicBasedField
+     */
+    protected $field;
+
+    public function setUp(): void
+    {
+        $this->field = new DynamicBasedField('fieldA');
+    }
+
+    public function testCopyFieldDest()
+    {
+        $this->assertInstanceOf(CopyFieldDestInterface::class, $this->field);
+    }
+
+    public function testCopyFieldSource()
+    {
+        $this->assertInstanceOf(CopyFieldSourceInterface::class, $this->field);
+    }
+
+    public function testNotSchemaField()
+    {
+        $this->assertNotInstanceOf(SchemaFieldInterface::class, $this->field);
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('fieldA', $this->field->getName());
+    }
+
+    public function testSetAndGetDynamicBase()
+    {
+        $dynamicBase = new DynamicField('*_a');
+        $this->assertSame($this->field, $this->field->setDynamicBase($dynamicBase));
+        $this->assertSame($dynamicBase, $this->field->getDynamicBase());
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('fieldA', (string) $this->field);
+    }
+}

--- a/tests/QueryType/Luke/Result/Schema/Field/DynamicFieldTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Field/DynamicFieldTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema\Field;
+
+use Solarium\QueryType\Luke\Result\FlagList;
+use Solarium\QueryType\Luke\Result\Schema\Field\CopyFieldDestInterface;
+use Solarium\QueryType\Luke\Result\Schema\Field\CopyFieldSourceInterface;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicBasedField;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicField;
+use Solarium\QueryType\Luke\Result\Schema\Field\SchemaFieldInterface;
+use Solarium\QueryType\Luke\Result\Schema\Type\Type;
+
+class DynamicFieldTest extends AbstractFieldTest
+{
+    /**
+     * @var DynamicField
+     */
+    protected $field;
+
+    public function setUp(): void
+    {
+        $this->field = new DynamicField('field_*');
+    }
+
+    public function testCopyFieldDest()
+    {
+        $this->assertInstanceOf(CopyFieldDestInterface::class, $this->field);
+    }
+
+    public function testCopyFieldSource()
+    {
+        $this->assertInstanceOf(CopyFieldSourceInterface::class, $this->field);
+    }
+
+    public function testSchemaField()
+    {
+        $this->assertInstanceOf(SchemaFieldInterface::class, $this->field);
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('field_*', $this->field->getName());
+    }
+
+    public function testCreateField()
+    {
+        $type = new Type('type_a');
+        $flags = new FlagList('A-', ['A' => 'A Flag']);
+
+        $this->field->setType($type);
+        $this->field->setFlags($flags);
+        $this->field->setPositionIncrementGap(1000);
+
+        $newField = $this->field->createField('newField');
+
+        $this->assertInstanceOf(DynamicBasedField::class, $newField);
+        $this->assertSame('newField', $newField->getName());
+        $this->assertSame($type, $newField->getType());
+        $this->assertSame($flags, $newField->getFlags());
+        $this->assertSame(1000, $newField->getPositionIncrementGap());
+        $this->assertSame($this->field, $newField->getDynamicBase());
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('field_*', (string) $this->field);
+    }
+}

--- a/tests/QueryType/Luke/Result/Schema/Field/FieldTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Field/FieldTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema\Field;
+
+use Solarium\QueryType\Luke\Result\Schema\Field\CopyFieldDestInterface;
+use Solarium\QueryType\Luke\Result\Schema\Field\CopyFieldSourceInterface;
+use Solarium\QueryType\Luke\Result\Schema\Field\Field;
+use Solarium\QueryType\Luke\Result\Schema\Field\SchemaFieldInterface;
+
+class FieldTest extends AbstractFieldTest
+{
+    /**
+     * @var Field
+     */
+    protected $field;
+
+    public function setUp(): void
+    {
+        $this->field = new Field('fieldA');
+    }
+
+    public function testCopyFieldDest()
+    {
+        $this->assertInstanceOf(CopyFieldDestInterface::class, $this->field);
+    }
+
+    public function testCopyFieldSource()
+    {
+        $this->assertInstanceOf(CopyFieldSourceInterface::class, $this->field);
+    }
+
+    public function testSchemaField()
+    {
+        $this->assertInstanceOf(SchemaFieldInterface::class, $this->field);
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('fieldA', $this->field->getName());
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('fieldA', (string) $this->field);
+    }
+}

--- a/tests/QueryType/Luke/Result/Schema/Field/WildcardTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Field/WildcardTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema\Field;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Schema\Field\CopyFieldDestInterface;
+use Solarium\QueryType\Luke\Result\Schema\Field\CopyFieldSourceInterface;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicBasedField;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicField;
+use Solarium\QueryType\Luke\Result\Schema\Field\Field;
+use Solarium\QueryType\Luke\Result\Schema\Field\SchemaFieldInterface;
+use Solarium\QueryType\Luke\Result\Schema\Field\WildcardField;
+
+class WildcardTest extends TestCase
+{
+    /**
+     * @var WildcardField
+     */
+    protected $field;
+
+    public function setUp(): void
+    {
+        $this->field = new WildcardField('field_*');
+    }
+
+    public function testNotCopyFieldDest()
+    {
+        $this->assertNotInstanceOf(CopyFieldDestInterface::class, $this->field);
+    }
+
+    public function testCopyFieldSource()
+    {
+        $this->assertInstanceOf(CopyFieldSourceInterface::class, $this->field);
+    }
+
+    public function testNotSchemaField()
+    {
+        $this->assertNotInstanceOf(SchemaFieldInterface::class, $this->field);
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('field_*', $this->field->getName());
+    }
+
+    public function testAddAndGetCopyDests()
+    {
+        $copyDests = [
+            $field = new Field('field_a'),
+            $dynamicField = new DynamicField('*_b'),
+            $dynamicBasedField = new DynamicBasedField('field_b'),
+        ];
+        $this->assertSame($this->field, $this->field->addCopyDest($field));
+        $this->assertSame($this->field, $this->field->addCopyDest($dynamicField));
+        $this->assertSame($this->field, $this->field->addCopyDest($dynamicBasedField));
+        $this->assertSame($copyDests, $this->field->getCopyDests());
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('field_*', (string) $this->field);
+    }
+}

--- a/tests/QueryType/Luke/Result/Schema/SchemaTest.php
+++ b/tests/QueryType/Luke/Result/Schema/SchemaTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicField;
+use Solarium\QueryType\Luke\Result\Schema\Field\Field;
+use Solarium\QueryType\Luke\Result\Schema\Schema;
+use Solarium\QueryType\Luke\Result\Schema\Similarity;
+use Solarium\QueryType\Luke\Result\Schema\Type\Type;
+
+class SchemaTest extends TestCase
+{
+    /**
+     * @var Schema
+     */
+    protected $schema;
+
+    public function setUp(): void
+    {
+        $this->schema = new Schema();
+    }
+
+    public function testSetAndGetFields()
+    {
+        $fields = [
+            'field1' => new Field('field1'),
+            'field2' => new Field('field2'),
+        ];
+        $this->assertSame($this->schema, $this->schema->setFields($fields));
+        $this->assertSame($fields, $this->schema->getFields());
+    }
+
+    public function testGetField()
+    {
+        $field = new Field('field3');
+        $this->schema->setFields(['field3' => $field]);
+        $this->assertSame($field, $this->schema->getField('field3'));
+        $this->assertNull($this->schema->getField('field4'));
+    }
+
+    public function testSetAndGetDynamicFields()
+    {
+        $dynamicFields = [
+            'dynamicfield1' => new DynamicField('dynamicfield1'),
+            'dynamicfield2' => new DynamicField('dynamicfield2'),
+        ];
+        $this->assertSame($this->schema, $this->schema->setDynamicFields($dynamicFields));
+        $this->assertSame($dynamicFields, $this->schema->getDynamicFields());
+    }
+
+    public function testGetDynamicField()
+    {
+        $dynamicField = new DynamicField('dynamicfield3');
+        $this->schema->setDynamicFields(['dynamicfield3' => $dynamicField]);
+        $this->assertSame($dynamicField, $this->schema->getDynamicField('dynamicfield3'));
+        $this->assertNull($this->schema->getDynamicField('dynamicfield4'));
+    }
+
+    public function testSetAndGetUniqueKeyField()
+    {
+        $this->assertNull($this->schema->getUniqueKeyField());
+
+        $uniqueKeyField = new Field('id');
+        $this->assertSame($this->schema, $this->schema->setUniqueKeyField($uniqueKeyField));
+        $this->assertSame($uniqueKeyField, $this->schema->getUniqueKeyField());
+    }
+
+    public function testSetAndGetSimilarity()
+    {
+        $similarity = new Similarity();
+        $this->assertSame($this->schema, $this->schema->setSimilarity($similarity));
+        $this->assertSame($similarity, $this->schema->getSimilarity());
+    }
+
+    public function testSetAndGetTypes()
+    {
+        $types = [
+            'type_a' => new Type('type_a'),
+            'type_b' => new Type('type_b'),
+        ];
+        $this->assertSame($this->schema, $this->schema->setTypes($types));
+        $this->assertSame($types, $this->schema->getTypes());
+    }
+
+    public function testGetType()
+    {
+        $type = new Type('type_c');
+        $this->schema->setTypes(['type_c' => $type]);
+        $this->assertSame($type, $this->schema->getType('type_c'));
+        $this->assertNull($this->schema->getType('type_d'));
+    }
+}

--- a/tests/QueryType/Luke/Result/Schema/SimilarityTest.php
+++ b/tests/QueryType/Luke/Result/Schema/SimilarityTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Schema\Similarity;
+
+class SimilarityTest extends TestCase
+{
+    /**
+     * @var Similarity
+     */
+    protected $similarity;
+
+    public function setUp(): void
+    {
+        $this->similarity = new Similarity();
+    }
+
+    public function testSetAndGetClassName()
+    {
+        $this->assertSame($this->similarity, $this->similarity->setClassName('org.example.SimilarityClass'));
+        $this->assertSame('org.example.SimilarityClass', $this->similarity->getClassName());
+
+        $this->assertSame($this->similarity, $this->similarity->setClassName(null));
+        $this->assertNull($this->similarity->getClassName());
+    }
+
+    public function testSetAndGetDetails()
+    {
+        $this->assertSame($this->similarity, $this->similarity->setDetails('similarity details'));
+        $this->assertSame('similarity details', $this->similarity->getDetails());
+
+        $this->assertSame($this->similarity, $this->similarity->setDetails(null));
+        $this->assertNull($this->similarity->getDetails());
+    }
+
+    public function testToString()
+    {
+        $this->similarity->setClassName('org.example.SimilarityClass');
+        $this->assertSame('org.example.SimilarityClass', (string) $this->similarity);
+
+        $this->similarity->setClassName(null);
+        $this->assertSame('', (string) $this->similarity);
+    }
+}

--- a/tests/QueryType/Luke/Result/Schema/Type/AbstractAnalyzerTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/AbstractAnalyzerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema\Type;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Schema\Type\AbstractAnalyzer;
+use Solarium\QueryType\Luke\Result\Schema\Type\CharFilter;
+use Solarium\QueryType\Luke\Result\Schema\Type\Filter;
+use Solarium\QueryType\Luke\Result\Schema\Type\Tokenizer;
+
+abstract class AbstractAnalyzerTest extends TestCase
+{
+    /**
+     * @var AbstractAnalyzer
+     */
+    protected $analyzer;
+
+    abstract public function testGetClassName();
+
+    public function testSetAndGetCharFilters()
+    {
+        $charFilters = [
+            'FirstCharFilterFactory' => new CharFilter('FirstCharFilterFactory'),
+            'NextCharFilterFactory' => new CharFilter('NextCharFilterFactory'),
+        ];
+        $this->assertSame($this->analyzer, $this->analyzer->setCharFilters($charFilters));
+        $this->assertSame($charFilters, $this->analyzer->getCharFilters());
+    }
+
+    public function testSetAndGetTokenizer()
+    {
+        $tokenizer = new Tokenizer('org.example.tokenizerFactory');
+        $this->assertSame($this->analyzer, $this->analyzer->setTokenizer($tokenizer));
+        $this->assertSame($tokenizer, $this->analyzer->getTokenizer());
+    }
+
+    public function testSetAndGetFilters()
+    {
+        $filters = [
+            'FirstFilterFactory' => new Filter('FirstFilterFactory'),
+            'NextFilterFactory' => new Filter('NextFilterFactory'),
+        ];
+        $this->assertSame($this->analyzer, $this->analyzer->setFilters($filters));
+        $this->assertSame($filters, $this->analyzer->getFilters());
+    }
+
+    abstract public function testToString();
+}

--- a/tests/QueryType/Luke/Result/Schema/Type/AbstractFilterTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/AbstractFilterTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema\Type;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Schema\Type\AbstractFilter;
+
+abstract class AbstractFilterTest extends TestCase
+{
+    /**
+     * @var AbstractFilter
+     */
+    protected $filter;
+
+    abstract public function testGetName();
+
+    public function testSetAndGetArgs()
+    {
+        $args = [
+            'class' => 'solr.FilterFactory',
+            'luceneMatchVersion' => '1.2.3',
+        ];
+        $this->assertSame($this->filter, $this->filter->setArgs($args));
+        $this->assertSame($args, $this->filter->getArgs());
+    }
+
+    public function testSetAndGetClassName()
+    {
+        $this->assertSame($this->filter, $this->filter->setClassName('org.example.FilterFactory'));
+        $this->assertSame('org.example.FilterFactory', $this->filter->getClassName());
+    }
+
+    abstract public function testToString();
+}

--- a/tests/QueryType/Luke/Result/Schema/Type/CharFilterTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/CharFilterTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema\Type;
+
+use Solarium\QueryType\Luke\Result\Schema\Type\CharFilter;
+
+class CharFilterTest extends AbstractFilterTest
+{
+    /**
+     * @var CharFilter
+     */
+    protected $filter;
+
+    public function setUp(): void
+    {
+        $this->filter = new CharFilter('CharFilter');
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('CharFilter', $this->filter->getName());
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('CharFilter', (string) $this->filter);
+    }
+}

--- a/tests/QueryType/Luke/Result/Schema/Type/FilterTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/FilterTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema\Type;
+
+use Solarium\QueryType\Luke\Result\Schema\Type\Filter;
+
+class FilterTest extends AbstractFilterTest
+{
+    /**
+     * @var Filter
+     */
+    protected $filter;
+
+    public function setUp(): void
+    {
+        $this->filter = new Filter('Filter');
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('Filter', $this->filter->getName());
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('Filter', (string) $this->filter);
+    }
+}

--- a/tests/QueryType/Luke/Result/Schema/Type/IndexAnalyzerTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/IndexAnalyzerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema\Type;
+
+use Solarium\QueryType\Luke\Result\Schema\Type\IndexAnalyzer;
+
+class IndexAnalyzerTest extends AbstractAnalyzerTest
+{
+    /**
+     * @var IndexAnalyzer
+     */
+    protected $analyzer;
+
+    public function setUp(): void
+    {
+        $this->analyzer = new IndexAnalyzer('org.example.IndexAnalyzerClass');
+    }
+
+    public function testGetClassName()
+    {
+        $this->assertSame('org.example.IndexAnalyzerClass', $this->analyzer->getClassName());
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('org.example.IndexAnalyzerClass', (string) $this->analyzer);
+    }
+}

--- a/tests/QueryType/Luke/Result/Schema/Type/QueryAnalyzerTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/QueryAnalyzerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema\Type;
+
+use Solarium\QueryType\Luke\Result\Schema\Type\QueryAnalyzer;
+
+class QueryAnalyzerTest extends AbstractAnalyzerTest
+{
+    /**
+     * @var QueryAnalyzer
+     */
+    protected $analyzer;
+
+    public function setUp(): void
+    {
+        $this->analyzer = new QueryAnalyzer('org.example.QueryAnalyzerClass');
+    }
+
+    public function testGetClassName()
+    {
+        $this->assertSame('org.example.QueryAnalyzerClass', $this->analyzer->getClassName());
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('org.example.QueryAnalyzerClass', (string) $this->analyzer);
+    }
+}

--- a/tests/QueryType/Luke/Result/Schema/Type/TokenizerTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/TokenizerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Schema\Type\Tokenizer;
+
+class TokenizerTest extends TestCase
+{
+    /**
+     * @var Tokenizer
+     */
+    protected $tokenizer;
+
+    public function setUp(): void
+    {
+        $this->tokenizer = new Tokenizer('org.example.TokenizerFactory');
+    }
+
+    public function testGetClassName()
+    {
+        $this->assertSame('org.example.TokenizerFactory', $this->tokenizer->getClassName());
+    }
+
+    public function testSetAndGetArgs()
+    {
+        $args = [
+            'class' => 'TokenizerFactory',
+            'luceneMatchVersion' => '1.2.3',
+        ];
+        $this->assertSame($this->tokenizer, $this->tokenizer->setArgs($args));
+        $this->assertSame($args, $this->tokenizer->getArgs());
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('org.example.TokenizerFactory', (string) $this->tokenizer);
+    }
+}

--- a/tests/QueryType/Luke/Result/Schema/Type/TypeTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/TypeTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Luke\Result\Schema\Type;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Luke\Result\Schema\Field\DynamicField;
+use Solarium\QueryType\Luke\Result\Schema\Field\Field;
+use Solarium\QueryType\Luke\Result\Schema\Similarity;
+use Solarium\QueryType\Luke\Result\Schema\Type\IndexAnalyzer;
+use Solarium\QueryType\Luke\Result\Schema\Type\QueryAnalyzer;
+use Solarium\QueryType\Luke\Result\Schema\Type\Type;
+
+class TypeTest extends TestCase
+{
+    /**
+     * @var Type
+     */
+    protected $type;
+
+    public function setUp(): void
+    {
+        $this->type = new Type('my_type');
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('my_type', $this->type->getName());
+    }
+
+    public function testAddAndGetFields()
+    {
+        $copyDests = [
+            $field = new Field('field_a'),
+            $dynamicField = new DynamicField('*_b'),
+        ];
+        $this->assertSame($this->type, $this->type->addField($field));
+        $this->assertSame($this->type, $this->type->addField($dynamicField));
+        $this->assertSame($copyDests, $this->type->getFields());
+    }
+
+    /**
+     * If a type has no associated fields, Solr returns null rather than an empty array.
+     * We normalise this to an empty array to avoid TypeErrors with array functions.
+     */
+    public function testGetNoFields()
+    {
+        $this->assertSame([], $this->type->getFields());
+    }
+
+    public function testSetAndGetAndIsTokenized()
+    {
+        $this->assertSame($this->type, $this->type->setTokenized(true));
+        $this->assertTrue($this->type->getTokenized());
+        $this->assertTrue($this->type->isTokenized());
+    }
+
+    public function testSetAndGetClassName()
+    {
+        $this->assertSame($this->type, $this->type->setClassName('org.example.MyClass'));
+        $this->assertSame('org.example.MyClass', $this->type->getClassName());
+    }
+
+    public function testSetAndGetIndexAnalyzer()
+    {
+        $indexAnalyzer = new IndexAnalyzer('org.example.IndexAnalyzerClass');
+        $this->assertSame($this->type, $this->type->setIndexAnalyzer($indexAnalyzer));
+        $this->assertSame($indexAnalyzer, $this->type->getIndexAnalyzer());
+    }
+
+    public function testSetAndGetQueryAnalyzer()
+    {
+        $queryAnalyzer = new QueryAnalyzer('org.example.QueryAnalyzerClass');
+        $this->assertSame($this->type, $this->type->setQueryAnalyzer($queryAnalyzer));
+        $this->assertSame($queryAnalyzer, $this->type->getQueryAnalyzer());
+    }
+
+    public function testSetAndGetSimilarity()
+    {
+        $similarity = new Similarity();
+        $this->assertSame($this->type, $this->type->setSimilarity($similarity));
+        $this->assertSame($similarity, $this->type->getSimilarity());
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('my_type', (string) $this->type);
+    }
+}


### PR DESCRIPTION
Closes #363.

This didn't look like too much work, short page in the [ref guide](https://solr.apache.org/guide/solr/latest/indexing-guide/luke-request-handler.html) with just a handful of parameters. Turns out it takes 4½ result parsers to interpret the result!

The most important change in this PR is the inclusion of a new dependency: [`halaxa/json-machine`](https://github.com/halaxa/json-machine). It doesn't introduce any further dependencies of its own, except optionally `ext-json` which we already require anyway. This library allows parsing the part of the result that is a `SimpleOrderedMap` in Solr's Java code. The JSON representation of that data structure can contain duplicate keys and `json_decode()` can't handle it without data loss. There are other places where that data structure is used (e.g. MoreLikeThisComponent), this seems a good way to deal with it.

I've provided extensive examples of the different results you can get for the different combinations of parameters. The logic behind how I named getters/issers/hassers is included in the documentation. Also went into more detail in the documentation on how flag lists and parts of the schema result can be used as the string value from Solr or as objects for an augmented user experience.

The unit tests provide full coverage of every aspect of the code. The integration tests verify the expected result type for the different combinations of parameters.