### PR TITLE
New parameter elevate.excludeTags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support for Luke queries
+- Solarium\Component\QueryElevation::setExcludeTags()
 
 ### Fixed
 - JSON serialization of arrays with non-consecutive indices in multivalue fields

--- a/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-elevation-component.md
@@ -13,6 +13,7 @@ Options
 | markExcludes               | boolean | null          | You can include documents that the elevation configuration would normally exclude by using true. The [excluded] transformer is added to each document. |
 | elevateIds                 | string  | null          | Comma separated list of documents to elevate. This overrides the elevations _and_ exclusions that are configured for the query in the elevation file.  |
 | excludeIds                 | string  | null          | Comma separated list of documents to exclude. This overrides the elevations _and_ exclusions that are configured for the query in the elevation file.  |
+| excludeTags                | string  | null          | Comma separated list of filter query tags to exclude. This excludes filter queries from being applied to elevated documents.                           |
 ||
 
 Example

--- a/src/Component/QueryElevation.php
+++ b/src/Component/QueryElevation.php
@@ -332,6 +332,35 @@ class QueryElevation extends AbstractComponent
     }
 
     /**
+     * Set tags of filter queries to exclude for elevated documents.
+     *
+     * @param string|array $tags can be an array or string with comma separated tags
+     *
+     * @return self Provides fluent interface
+     */
+    public function setExcludeTags($tags): self
+    {
+        if (\is_string($tags)) {
+            $tags = explode(',', $tags);
+            $tags = array_map('trim', $tags);
+        }
+
+        $this->setOption('excludeTags', $tags);
+
+        return $this;
+    }
+
+    /**
+     * Get tags of filter queries to exclude for elevated documents.
+     *
+     * @return array|null
+     */
+    public function getExcludeTags(): ?array
+    {
+        return $this->getOption('excludeTags');
+    }
+
+    /**
      * Initialize options.
      *
      * {@internal Options that influence transformers need additional setup work.
@@ -353,6 +382,9 @@ class QueryElevation extends AbstractComponent
                     break;
                 case 'excludeIds':
                     $this->setExcludeIds($value);
+                    break;
+                case 'excludeTags':
+                    $this->setExcludeTags($value);
                     break;
             }
         }

--- a/src/Component/RequestBuilder/QueryElevation.php
+++ b/src/Component/RequestBuilder/QueryElevation.php
@@ -46,6 +46,9 @@ class QueryElevation implements ComponentRequestBuilderInterface
         $request->addParam('elevateIds', null === ($ids = $component->getElevateIds()) ? null : implode(',', $ids));
         $request->addParam('excludeIds', null === ($ids = $component->getExcludeIds()) ? null : implode(',', $ids));
 
+        // add tags of filter queries to exclude for elevated documents
+        $request->addParam('elevate.excludeTags', null === ($tags = $component->getExcludeTags()) ? null : implode(',', $tags));
+
         return $request;
     }
 }

--- a/tests/Component/QueryElevationTest.php
+++ b/tests/Component/QueryElevationTest.php
@@ -29,6 +29,7 @@ class QueryElevationTest extends TestCase
             'markExcludes' => false,
             'elevateIds' => 'doc1,doc2',
             'excludeIds' => 'doc3,doc4',
+            'excludeTags' => 'tagA,tagB',
         ];
 
         $this->queryelevation->setOptions($options);
@@ -41,6 +42,7 @@ class QueryElevationTest extends TestCase
         $this->assertFalse($this->queryelevation->getMarkExcludes());
         $this->assertSame(['doc1', 'doc2'], $this->queryelevation->getElevateIds());
         $this->assertSame(['doc3', 'doc4'], $this->queryelevation->getExcludeIds());
+        $this->assertSame(['tagA', 'tagB'], $this->queryelevation->getExcludeTags());
     }
 
     public function testGetType()
@@ -174,5 +176,19 @@ class QueryElevationTest extends TestCase
     {
         $this->queryelevation->setExcludeIds('doc3, doc4');
         $this->assertSame(['doc3', 'doc4'], $this->queryelevation->getExcludeIds());
+    }
+
+    public function testSetAndGetExcludeTags()
+    {
+        $tags = ['tagA', 'tagB'];
+
+        $this->queryelevation->setExcludeTags($tags);
+        $this->assertSame($tags, $this->queryelevation->getExcludeTags());
+    }
+
+    public function testSetExcludeTagsAsStringWithTrim()
+    {
+        $this->queryelevation->setExcludeTags('tagA, tagB');
+        $this->assertSame(['tagA', 'tagB'], $this->queryelevation->getExcludeTags());
     }
 }

--- a/tests/Component/RequestBuilder/QueryElevationTest.php
+++ b/tests/Component/RequestBuilder/QueryElevationTest.php
@@ -22,6 +22,7 @@ class QueryElevationTest extends TestCase
         $component->setMarkExcludes(true);
         $component->setElevateIds(['doc1', 'doc2']);
         $component->setExcludeIds(['doc3', 'doc4']);
+        $component->setExcludeTags(['tagA', 'tagB']);
 
         $request = $builder->buildComponent($component, $request);
 
@@ -35,6 +36,7 @@ class QueryElevationTest extends TestCase
                 'markExcludes' => 'true',
                 'elevateIds' => 'doc1,doc2',
                 'excludeIds' => 'doc3,doc4',
+                'elevate.excludeTags' => 'tagA,tagB',
             ],
             $request->getParams()
         );


### PR DESCRIPTION
Was added in [SOLR-16496](https://issues.apache.org/jira/browse/SOLR-16496) / [PR #1154](https://github.com/apache/solr/pull/1154) for Solr 9.2.0.

https://solr.apache.org/guide/solr/latest/query-guide/query-elevation-component.html#the-fq-parameter-with-elevation