### PR TITLE
Solr 9.1 → 9.2 for integration tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,12 +51,12 @@ jobs:
                 ref: branch_8_11
                 path: lucene-solr
 
-            - name: Checkout solr 9.1
+            - name: Checkout solr 9.2
               if: matrix.solr == 9
               uses: actions/checkout@v2
               with:
                 repository: apache/solr
-                ref: branch_9_1
+                ref: branch_9_2
                 path: lucene-solr
 
             - name: Start Solr ${{ matrix.solr }} in ${{ matrix.mode }} mode

--- a/src/QueryType/Luke/Result/Doc/DocFieldInfo.php
+++ b/src/QueryType/Luke/Result/Doc/DocFieldInfo.php
@@ -42,7 +42,7 @@ class DocFieldInfo
     protected $value = null;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $internal;
 
@@ -172,19 +172,19 @@ class DocFieldInfo
     /**
      * Returns the stored value.
      *
-     * @return string
+     * @return string|null
      */
-    public function getInternal(): string
+    public function getInternal(): ?string
     {
         return $this->internal;
     }
 
     /**
-     * @param string $internal
+     * @param string|null $internal
      *
      * @return self
      */
-    public function setInternal(string $internal): self
+    public function setInternal(?string $internal): self
     {
         $this->internal = $internal;
 

--- a/tests/QueryType/Luke/ResponseParser/DocDataTrait.php
+++ b/tests/QueryType/Luke/ResponseParser/DocDataTrait.php
@@ -18,10 +18,6 @@ trait DocDataTrait
      */
     public function getRawDocData(): string
     {
-        /*
-         * Representation of binary data is tentative. We can't base our
-         * example on actual response data because of SOLR-16293.
-         */
         return <<<'JSON'
             {
                 "docId": 1701,
@@ -80,10 +76,11 @@ trait DocDataTrait
                     "insignia": {
                         "type": "binary",
                         "schema": "I-S-U------F------",
-                        "flags": "I-S-------OF------",
+                        "flags": "-TS------------B--",
                         "value": "PS9cPQ==",
-                        "internal": "PS9cPQ==",
-                        "binary": "PS9cPQ=="
+                        "internal": null,
+                        "binary": "PS9cPQ==",
+                        "docFreq": 0
                     }
                 },
                 "solr": {

--- a/tests/QueryType/Luke/ResponseParser/DocTest.php
+++ b/tests/QueryType/Luke/ResponseParser/DocTest.php
@@ -131,8 +131,11 @@ class DocTest extends TestCase
         $this->assertSame('true', $lucene[5]->getValue());
         $this->assertSame('T', $lucene[5]->getInternal());
 
-        // 'binary' is returned for binary fields
+        // 'value' and 'binary' are returned for binary fields, but 'internal' is null
+        $this->assertTrue($lucene[6]->getFlags()->isBinary());
+        $this->assertSame('PS9cPQ==', $lucene[6]->getValue());
         $this->assertSame('PS9cPQ==', $lucene[6]->getBinary());
+        $this->assertNull($lucene[6]->getInternal());
 
         // some field types don't return 'docFreq'
         $this->assertNull($lucene[4]->getDocFreq());

--- a/tests/QueryType/Luke/Result/Doc/DocFieldInfoTest.php
+++ b/tests/QueryType/Luke/Result/Doc/DocFieldInfoTest.php
@@ -59,6 +59,9 @@ class DocFieldInfoTest extends TestCase
     {
         $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setInternal('internal value'));
         $this->assertSame('internal value', $this->docFieldInfo->getInternal());
+
+        $this->assertSame($this->docFieldInfo, $this->docFieldInfo->setInternal(null));
+        $this->assertNull($this->docFieldInfo->getInternal());
     }
 
     public function testSetAndGetBinary()

--- a/tests/QueryType/ManagedResources/Query/Command/ExistsTest.php
+++ b/tests/QueryType/ManagedResources/Query/Command/ExistsTest.php
@@ -59,7 +59,8 @@ class ExistsTest extends TestCase
      * SOLR-16274
      * ==========
      *
-     * Affected: Solr 8.11.2
+     * Affected: Solr 8.11.2, Solr 9.0 – 9.1
+     * Fixed: Solr 8.11.3, Solr 9.2
      *
      * A HEAD request for an existing stopword list, synonym map, or term against affected
      * Solr versions returns "500 Server Error" instead of "200 OK".


### PR DESCRIPTION
And a fix for Luke document queries that return binary fields now that that functionality has been fixed in Solr.