### PR TITLE
Fix PHP 8.2 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - JSON serialization of arrays with non-consecutive indices in multivalue fields
+- PHP 8.2 deprecations
 
 ### Changed
 - Update queries use the JSON request format by default
+
+### Deprecated
+- Solarium\QueryType\Server\Collections\Result\CreateResult::getStatus(), use getCreateStatus() instead
+- Solarium\QueryType\Server\Collections\Result\DeleteResult::getStatus(), use getDeleteStatus() instead
+- Solarium\QueryType\Server\Collections\Result\ReloadResult::getStatus(), use getReloadStatus() instead
 
 
 ## [6.2.8]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for Luke queries
 - Solarium\Component\QueryElevation::setExcludeTags()
+- Solarium\Core\Query\Result\QueryType::getStatus() and getQueryTime(), inherited by all Solarium\QueryType Results
+- Solarium\QueryType\CoreAdmin\Result\Result::getInitFailureResults()
+- Solarium\QueryType\Ping\Result::getPingStatus() and getZkConnected()
 
 ### Fixed
 - JSON serialization of arrays with non-consecutive indices in multivalue fields
@@ -15,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update queries use the JSON request format by default
+- Ping queries set omitHeader=false by default
 
 ### Deprecated
 - Solarium\QueryType\Server\Collections\Result\CreateResult::getStatus(), use getCreateStatus() instead

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -399,6 +399,25 @@ htmlFooter();
 
 For all options (like boosting) see the docs.
 
+### Status and query time
+
+As shown in the update query examples above, you can get the status and query time from a query result.
+The normal Solr status code for succes is `0`.
+The query time is the execution time in milliseconds as reported by Solr and doesn't include network transfer times.
+
+This is possible for every query type if a response header is returned from Solr alongside the result. Solarium
+requests this header by default for [Ping](queries/ping-query.md) and [Update](queries/update-query/update-query.md)
+queries, you have to set it explicitly on the query if you want this returned for other query types.
+
+```php
+$query = $client->createSelect();
+$query->setOmitHeader(false);
+
+$result = $client->select($query);
+echo 'Query status: ' . $result->getStatus();
+echo 'Query time: ' . $result->getQueryTime();
+```
+
 
 Example code
 ------------

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,10 +72,10 @@ $ping = $client->createPing();
 // execute the ping query
 try {
     $result = $client->ping($ping);
-    echo 'Ping query successful';
-    echo '<br/><pre>';
-    var_dump($result->getData());
-    echo '</pre>';
+
+    echo 'Ping query successful<br/><br/>';
+    echo 'Ping status: ' . $result->getPingStatus() . '<br/>';
+    echo 'Query time: ' . $result->getQueryTime() . ' ms';
 } catch (Exception $e) {
     echo 'Ping query failed';
 }

--- a/docs/queries/ping-query.md
+++ b/docs/queries/ping-query.md
@@ -7,13 +7,14 @@ The search executed by a ping is configured with the Request Parameters API. For
 Creating a ping query
 ---------------------
 
-You create a ping query using the createPing method of your client instance. This is a very simple query with only one option, the handler.
+You create a ping query using the createPing method of your client instance. This is a very simple query with only a few options.
 
 **Available options:**
 
-| Name    | Type   | Default value | Description                                    |
-|---------|--------|---------------|------------------------------------------------|
-| handler | string | admin/ping    | Path to the ping handler as configured in Solr |
+| Name       | Type   | Default value | Description                                               |
+|------------|--------|---------------|-----------------------------------------------------------|
+| handler    | string | admin/ping    | Path to the ping handler as configured in Solr            |
+| omitheader | bool   | false         | If `true`, query time will not be available in the result |
 ||
 
 Executing a ping query
@@ -24,7 +25,9 @@ Use the `ping` method of the client to execute the query object. See the example
 Result of a ping query
 ----------------------
 
-The result of a ping query is just as simple as the ping query itself: it either works or not. There is no useful result data. In case of error an exception will be thrown.
+The result of a ping query is just as simple as the ping query itself: it either works or not. In case of error an exception will be thrown.
+
+If you don't omit the response header, it can tell how long the query took. For distributed requests, it can also tell if the node that processed the request was connected with ZooKeeper.
 
 Example
 -------
@@ -47,10 +50,15 @@ $ping = $client->createPing();
 // execute the ping query
 try {
     $result = $client->ping($ping);
-    echo 'Ping query successful';
-    echo '<br/><pre>';
-    var_dump($result->getData());
-    echo '</pre>';
+
+    echo 'Ping query successful<br/><br/>';
+    echo 'Ping status: ' . $result->getPingStatus() . '<br/>';
+    echo 'Query time: ' . $result->getQueryTime() . ' ms<br/>';
+
+    // only relevant for distributed requests
+    if (null !== $zkConnected = $result->getZkConnected()) {
+        echo 'ZooKeeper connected: ' . ($zkConnected ? 'yes' : 'no');
+    }
 } catch (Exception $e) {
     echo 'Ping query failed';
 }

--- a/docs/queries/update-query/the-result-of-an-update-query.md
+++ b/docs/queries/update-query/the-result-of-an-update-query.md
@@ -3,6 +3,4 @@ The result of an update has two result values (both reported by Solr in the resp
 -   status: Solr status code. This is not the HTTP status code! The normal value for success is 0.
 -   querytime: Solr index query time. This doesn't include things like the HTTP responsetime.
 
-By default 'omitHeader' is enabled so these results are missing. If you need the status and/or querytime you can call setOmitHeader(false) on your update query before execution.
-
 In case of an error an exception will be thrown.

--- a/examples/1.1-check-solarium-and-ping.php
+++ b/examples/1.1-check-solarium-and-ping.php
@@ -15,10 +15,15 @@ $ping = $client->createPing();
 // execute the ping query
 try {
     $result = $client->ping($ping);
-    echo 'Ping query successful';
-    echo '<br/><pre>';
-    var_dump($result->getData());
-    echo '</pre>';
+
+    echo 'Ping query successful<br/><br/>';
+    echo 'Ping status: ' . $result->getPingStatus() . '<br/>';
+    echo 'Query time: ' . $result->getQueryTime() . ' ms<br/>';
+
+    // only relevant for distributed requests
+    if (null !== $zkConnected = $result->getZkConnected()) {
+        echo 'ZooKeeper connected: ' . ($zkConnected ? 'yes' : 'no');
+    }
 } catch (Exception $e) {
     echo 'Ping query failed';
 }

--- a/examples/2.9-server-core-admin-status.php
+++ b/examples/2.9-server-core-admin-status.php
@@ -15,10 +15,15 @@ $coreAdminQuery->setAction($statusAction);
 
 $response = $client->coreAdmin($coreAdminQuery);
 $statusResults = $response->getStatusResults();
+$initFailures = $response->getInitFailureResults();
 
 echo '<b>CoreAdmin status action execution:</b><br/>';
 foreach($statusResults as $statusResult) {
-    echo 'Uptime of the core ( ' .$statusResult->getCoreName(). ' ): ' . $statusResult->getUptime();
+    echo 'Uptime of the core ( ' .$statusResult->getCoreName(). ' ): ' . $statusResult->getUptime() . '<br/>';
+}
+
+foreach($initFailures as $initFailure) {
+    echo 'Init failure ( '. $initFailure->getCoreName() .' ): ' . $initFailure->getException() . '<br/>';
 }
 
 htmlFooter();

--- a/src/Core/Query/AbstractResponseParser.php
+++ b/src/Core/Query/AbstractResponseParser.php
@@ -51,30 +51,6 @@ abstract class AbstractResponseParser
     }
 
     /**
-     * Parses header data (if available) and adds it to result data.
-     *
-     * @param array $data
-     * @param array $result
-     *
-     * @return array
-     */
-    public function addHeaderInfo(array $data, array $result): array
-    {
-        $status = null;
-        $queryTime = null;
-
-        if (isset($data['responseHeader'])) {
-            $status = $data['responseHeader']['status'];
-            $queryTime = $data['responseHeader']['QTime'];
-        }
-
-        $result['status'] = $status;
-        $result['queryTime'] = $queryTime;
-
-        return $result;
-    }
-
-    /**
      * Parses HTTP status code and adds boolean wasSuccessful to result data.
      * Parses HTTP status message and adds string statusMessage to result data.
      *

--- a/src/Core/Query/Result/QueryType.php
+++ b/src/Core/Query/Result/QueryType.php
@@ -81,6 +81,11 @@ class QueryType extends Result
 
             $this->mapData($responseParser->parse($this));
 
+            // don't override if ResponseParser already parsed this
+            if (null === $this->responseHeader) {
+                $this->responseHeader = $this->data['responseHeader'] ?? null;
+            }
+
             $this->parsed = true;
         }
     }

--- a/src/Core/Query/Result/QueryType.php
+++ b/src/Core/Query/Result/QueryType.php
@@ -25,9 +25,49 @@ class QueryType extends Result
     protected $parsed = false;
 
     /**
+     * Response header returned by Solr.
+     *
+     * @var array
+     */
+    protected $responseHeader;
+
+    /**
+     * Get Solr status code.
+     *
+     * This is not the HTTP status code! The normal value for success is 0.
+     *
+     * {@internal No return typehint until deprecated inheriting
+     *            methods that are not covariant are removed from
+     *            Solarium\QueryType\Server\Collections\Result classes.}
+     *
+     * @return int|null
+     */
+    public function getStatus()
+    {
+        $this->parseResponse();
+
+        return $this->responseHeader['status'] ?? null;
+    }
+
+    /**
+     * Get Solr query time.
+     *
+     * This doesn't include things like the HTTP responsetime. Purely the Solr
+     * query execution time.
+     *
+     * @return int|null
+     */
+    public function getQueryTime(): ?int
+    {
+        $this->parseResponse();
+
+        return $this->responseHeader['QTime'] ?? null;
+    }
+
+    /**
      * Parse response into result objects.
      *
-     * Only runs once
+     * Only runs once.
      *
      * @throws UnexpectedValueException
      */

--- a/src/QueryType/Analysis/ResponseParser/Field.php
+++ b/src/QueryType/Analysis/ResponseParser/Field.php
@@ -39,7 +39,7 @@ class Field extends ResponseParserAbstract implements ResponseParserInterface
             $items = $this->parseAnalysis($result, $data['analysis']);
         }
 
-        return $this->addHeaderInfo($data, ['items' => $items]);
+        return ['items' => $items];
     }
 
     /**

--- a/src/QueryType/Analysis/Result/Document.php
+++ b/src/QueryType/Analysis/Result/Document.php
@@ -24,52 +24,6 @@ class Document extends BaseResult implements \IteratorAggregate, \Countable
     protected $items;
 
     /**
-     * Status code returned by Solr.
-     *
-     * @var int
-     */
-    protected $status;
-
-    /**
-     * Solr index queryTime.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @var int
-     */
-    protected $queryTime;
-
-    /**
-     * Get Solr status code.
-     *
-     * This is not the HTTP status code! The normal value for success is 0.
-     *
-     * @return int
-     */
-    public function getStatus(): int
-    {
-        $this->parseResponse();
-
-        return $this->status;
-    }
-
-    /**
-     * Get Solr query time.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @return int
-     */
-    public function getQueryTime(): int
-    {
-        $this->parseResponse();
-
-        return $this->queryTime;
-    }
-
-    /**
      * Get all documents.
      *
      * @return ResultList[]

--- a/src/QueryType/Analysis/Result/Field.php
+++ b/src/QueryType/Analysis/Result/Field.php
@@ -24,52 +24,6 @@ class Field extends BaseResult implements \IteratorAggregate, \Countable
     protected $items;
 
     /**
-     * Status code returned by Solr.
-     *
-     * @var int
-     */
-    protected $status;
-
-    /**
-     * Solr index queryTime.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @var int
-     */
-    protected $queryTime;
-
-    /**
-     * Get Solr status code.
-     *
-     * This is not the HTTP status code! The normal value for success is 0.
-     *
-     * @return int
-     */
-    public function getStatus(): int
-    {
-        $this->parseResponse();
-
-        return $this->status;
-    }
-
-    /**
-     * Get Solr query time.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @return int
-     */
-    public function getQueryTime(): int
-    {
-        $this->parseResponse();
-
-        return $this->queryTime;
-    }
-
-    /**
      * Get all lists.
      *
      * @return array

--- a/src/QueryType/Luke/ResponseParser/Index.php
+++ b/src/QueryType/Luke/ResponseParser/Index.php
@@ -38,8 +38,6 @@ class Index extends AbstractResponseParser implements ResponseParserInterface
         $data['fieldsResult'] = null;
         $data['infoResult'] = null;
 
-        $data = $this->addHeaderInfo($data, $data);
-
         return $data;
     }
 

--- a/src/QueryType/Luke/Result/Result.php
+++ b/src/QueryType/Luke/Result/Result.php
@@ -22,6 +22,31 @@ use Solarium\QueryType\Luke\Result\Schema\Schema;
 class Result extends BaseResult
 {
     /**
+     * @var array
+     */
+    protected $index;
+
+    /**
+     * @var array
+     */
+    protected $schema;
+
+    /**
+     * @var array
+     */
+    protected $doc;
+
+    /**
+     * @var array
+     */
+    protected $fields;
+
+    /**
+     * @var array
+     */
+    protected $info;
+
+    /**
      * @var Index
      */
     protected $indexResult;

--- a/src/QueryType/ManagedResources/ResponseParser/Command.php
+++ b/src/QueryType/ManagedResources/ResponseParser/Command.php
@@ -29,7 +29,6 @@ class Command extends ResponseParserAbstract implements ResponseParserInterface
     {
         $data = $result->getData();
         $parsed = $this->parseStatus([], $result);
-        $parsed = $this->addHeaderInfo($data, $parsed);
 
         return $parsed;
     }

--- a/src/QueryType/ManagedResources/ResponseParser/Resources.php
+++ b/src/QueryType/ManagedResources/ResponseParser/Resources.php
@@ -38,6 +38,6 @@ class Resources extends ResponseParserAbstract implements ResponseParserInterfac
             }
         }
 
-        return $this->addHeaderInfo($data, ['items' => $items]);
+        return ['items' => $items];
     }
 }

--- a/src/QueryType/ManagedResources/ResponseParser/Stopword.php
+++ b/src/QueryType/ManagedResources/ResponseParser/Stopword.php
@@ -44,8 +44,6 @@ class Stopword extends ResponseParserAbstract implements ResponseParserInterface
             $parsed['items'] = $items;
         }
 
-        $parsed = $this->addHeaderInfo($data, $parsed);
-
         return $parsed;
     }
 }

--- a/src/QueryType/ManagedResources/ResponseParser/Stopwords.php
+++ b/src/QueryType/ManagedResources/ResponseParser/Stopwords.php
@@ -52,8 +52,6 @@ class Stopwords extends ResponseParserAbstract implements ResponseParserInterfac
             }
         }
 
-        $parsed = $this->addHeaderInfo($data, $parsed);
-
         return $parsed;
     }
 }

--- a/src/QueryType/ManagedResources/ResponseParser/Synonym.php
+++ b/src/QueryType/ManagedResources/ResponseParser/Synonym.php
@@ -47,8 +47,6 @@ class Synonym extends ResponseParserAbstract implements ResponseParserInterface
             $parsed['items'] = $items;
         }
 
-        $parsed = $this->addHeaderInfo($data, $parsed);
-
         return $parsed;
     }
 }

--- a/src/QueryType/ManagedResources/ResponseParser/Synonyms.php
+++ b/src/QueryType/ManagedResources/ResponseParser/Synonyms.php
@@ -65,8 +65,6 @@ class Synonyms extends ResponseParserAbstract implements ResponseParserInterface
             }
         }
 
-        $parsed = $this->addHeaderInfo($data, $parsed);
-
         return $parsed;
     }
 }

--- a/src/QueryType/Ping/Query.php
+++ b/src/QueryType/Ping/Query.php
@@ -31,7 +31,7 @@ class Query extends BaseQuery
     protected $options = [
         'resultclass' => Result::class,
         'handler' => 'admin/ping',
-        'omitheader' => true,
+        'omitheader' => false,
     ];
 
     /**
@@ -55,12 +55,12 @@ class Query extends BaseQuery
     }
 
     /**
-     * The ping query has no response parser so we return a null value.
+     * Get a responseparser for this query.
      *
-     * @return \Solarium\Core\Query\ResponseParserInterface|null
+     * @return ResponseParser
      */
     public function getResponseParser(): ?ResponseParserInterface
     {
-        return null;
+        return new ResponseParser();
     }
 }

--- a/src/QueryType/Ping/ResponseParser.php
+++ b/src/QueryType/Ping/ResponseParser.php
@@ -7,16 +7,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Solarium\QueryType\Update;
+namespace Solarium\QueryType\Ping;
 
-use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
+use Solarium\Core\Query\AbstractResponseParser;
 use Solarium\Core\Query\ResponseParserInterface;
 use Solarium\Core\Query\Result\ResultInterface;
 
 /**
- * Parse update response data.
+ * Parse ping response data.
  */
-class ResponseParser extends ResponseParserAbstract implements ResponseParserInterface
+class ResponseParser extends AbstractResponseParser implements ResponseParserInterface
 {
     /**
      * Parse response data.

--- a/src/QueryType/Ping/Result.php
+++ b/src/QueryType/Ping/Result.php
@@ -9,26 +9,41 @@
 
 namespace Solarium\QueryType\Ping;
 
-use Solarium\Core\Query\Result\Result as BaseResult;
+use Solarium\Core\Query\Result\QueryType as BaseResult;
 
 /**
  * Ping query result.
- *
- * A ping query has no useful result so only a dummy status var is available.
- * If you don't get an exception for a ping query it was successful.
  */
 class Result extends BaseResult
 {
     /**
-     * Get Solr status code.
-     *
-     * Since no status is returned for a ping, a default of 0 is used.
-     * If you don't get an exception for a ping query it was successful.
-     *
-     * @return int
+     * @var string
      */
-    public function getStatus(): int
+    protected $status;
+
+    /**
+     * Return the ping status.
+     *
+     * This is different from the Solr status code you get with {@link getStatus()}.
+     *
+     * @return string
+     */
+    public function getPingStatus(): string
     {
-        return 0;
+        $this->parseResponse();
+
+        return $this->status;
+    }
+
+    /**
+     * Return whether the node was connected with ZooKeeper for a distributed request.
+     *
+     * @return bool|null
+     */
+    public function getZkConnected(): ?bool
+    {
+        $this->parseResponse();
+
+        return $this->responseHeader['zkConnected'] ?? null;
     }
 }

--- a/src/QueryType/Select/ResponseParser.php
+++ b/src/QueryType/Select/ResponseParser.php
@@ -62,15 +62,12 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
             }
         }
 
-        return $this->addHeaderInfo(
-            $data,
-            [
-                'numfound' => $data['response']['numFound'] ?? null,
-                'maxscore' => $data['response']['maxScore'] ?? null,
-                'documents' => $documents,
-                'components' => $components,
-                'nextcursormark' => $data['nextCursorMark'] ?? null,
-            ]
-        );
+        return [
+            'numfound' => $data['response']['numFound'] ?? null,
+            'maxscore' => $data['response']['maxScore'] ?? null,
+            'documents' => $documents,
+            'components' => $components,
+            'nextcursormark' => $data['nextCursorMark'] ?? null,
+        ];
     }
 }

--- a/src/QueryType/Select/Result/Result.php
+++ b/src/QueryType/Select/Result/Result.php
@@ -84,52 +84,6 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     protected $components;
 
     /**
-     * Status code returned by Solr.
-     *
-     * @var int
-     */
-    protected $status;
-
-    /**
-     * Solr index queryTime.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @var int
-     */
-    protected $queryTime;
-
-    /**
-     * Get Solr status code.
-     *
-     * This is not the HTTP status code! The normal value for success is 0.
-     *
-     * @return int
-     */
-    public function getStatus(): int
-    {
-        $this->parseResponse();
-
-        return $this->status;
-    }
-
-    /**
-     * Get Solr query time.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @return int
-     */
-    public function getQueryTime(): int
-    {
-        $this->parseResponse();
-
-        return $this->queryTime;
-    }
-
-    /**
      * get Solr numFound.
      *
      * Returns the total number of documents found by Solr (this is NOT the

--- a/src/QueryType/Server/Api/ResponseParser.php
+++ b/src/QueryType/Server/Api/ResponseParser.php
@@ -30,7 +30,6 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
     {
         $data = $result->getData();
         $data = $this->parseStatus($data, $result);
-        $data = $this->addHeaderInfo($data, $data);
 
         return $data;
     }

--- a/src/QueryType/Server/Collections/ResponseParser/ClusterStatus.php
+++ b/src/QueryType/Server/Collections/ResponseParser/ClusterStatus.php
@@ -29,8 +29,6 @@ class ClusterStatus extends ResponseParser
     {
         $data = $result->getData();
 
-        $data = $this->addHeaderInfo($data, $data);
-
         return $data;
     }
 }

--- a/src/QueryType/Server/Collections/Result/CreateResult.php
+++ b/src/QueryType/Server/Collections/Result/CreateResult.php
@@ -19,9 +19,25 @@ class CreateResult extends AbstractResult
     /**
      * Returns the status of the request and the new core names.
      *
+     * {@internal Deprecated in Solarium 7. Shouldn't override generic method
+     *            {@link \Solarium\Core\Query\Result\QueryType::getStatus()}
+     *            that returns the status code from the response header.}
+     *
      * @return array status of the request and the new core names
+     *
+     * @deprecated Will be removed in Solarium 8. Use {@link getCreateStatus()} instead.
      */
     public function getStatus(): array
+    {
+        return $this->getCreateStatus();
+    }
+
+    /**
+     * Returns the status of the request and the new core names.
+     *
+     * @return array status of the request and the new core names
+     */
+    public function getCreateStatus(): array
     {
         $this->parseResponse();
 

--- a/src/QueryType/Server/Collections/Result/DeleteResult.php
+++ b/src/QueryType/Server/Collections/Result/DeleteResult.php
@@ -19,9 +19,25 @@ class DeleteResult extends AbstractResult
     /**
      * Returns status of the request and the cores that were deleted.
      *
+     * {@internal Deprecated in Solarium 7. Shouldn't override generic method
+     *            {@link \Solarium\Core\Query\Result\QueryType::getStatus()}
+     *            that returns the status code from the response header.}
+     *
      * @return array status of the request and the cores that were deleted
+     *
+     * @deprecated Will be removed in Solarium 8. Use {@link getDeleteStatus()} instead.
      */
     public function getStatus(): array
+    {
+        return $this->getDeleteStatus();
+    }
+
+    /**
+     * Returns status of the request and the cores that were deleted.
+     *
+     * @return array status of the request and the cores that were deleted
+     */
+    public function getDeleteStatus(): array
     {
         $this->parseResponse();
 

--- a/src/QueryType/Server/Collections/Result/ReloadResult.php
+++ b/src/QueryType/Server/Collections/Result/ReloadResult.php
@@ -19,9 +19,25 @@ class ReloadResult extends AbstractResult
     /**
      * Returns status of the request and the cores that were reloaded when the reload was successful.
      *
+     * {@internal Deprecated in Solarium 7. Shouldn't override generic method
+     *            {@link \Solarium\Core\Query\Result\QueryType::getStatus()}
+     *            that returns the status code from the response header.}
+     *
      * @return array status of the request and the cores that were reloaded when the reload was successful
+     *
+     * @deprecated Will be removed in Solarium 8. Use {@link getReloadStatus()} instead.
      */
     public function getStatus(): array
+    {
+        return $this->getReloadStatus();
+    }
+
+    /**
+     * Returns status of the request and the cores that were reloaded when the reload was successful.
+     *
+     * @return array status of the request and the cores that were reloaded when the reload was successful
+     */
+    public function getReloadStatus(): array
     {
         $this->parseResponse();
 

--- a/src/QueryType/Server/CoreAdmin/ResponseParser.php
+++ b/src/QueryType/Server/CoreAdmin/ResponseParser.php
@@ -14,6 +14,7 @@ use Solarium\Core\Query\ResponseParserInterface;
 use Solarium\Core\Query\Result\ResultInterface;
 use Solarium\QueryType\Server\CoreAdmin\Query\Action\CoreActionInterface;
 use Solarium\QueryType\Server\CoreAdmin\Query\Query;
+use Solarium\QueryType\Server\CoreAdmin\Result\InitFailureResult;
 use Solarium\QueryType\Server\CoreAdmin\Result\Result;
 use Solarium\QueryType\Server\CoreAdmin\Result\StatusResult;
 
@@ -34,8 +35,54 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
     public function parse(ResultInterface $result): array
     {
         $data = $result->getData();
+        $data = $this->parseInitFailures($data, $result);
         $data = $this->parseStatus($data, $result);
-        $data = $this->addHeaderInfo($data, $data);
+
+        return $data;
+    }
+
+    /**
+     * @param array                  $data
+     * @param Result|ResultInterface $result
+     *
+     * @throws \Exception
+     *
+     * @return array
+     */
+    protected function parseInitFailures(array $data, ResultInterface $result): array
+    {
+        /** @var Query $query */
+        $query = $result->getQuery();
+        /** @var CoreActionInterface $action */
+        $action = $query->getAction();
+        $type = $action->getType();
+
+        if (Query::ACTION_STATUS !== $type) {
+            return $data;
+        }
+
+        if (!\is_array($data['initFailures'])) {
+            return $data;
+        }
+
+        $initFailureResults = [];
+        $initFailureResult = null;
+
+        foreach ($data['initFailures'] as $coreName => $exception) {
+            $initFailure = new InitFailureResult();
+            $initFailure->setCoreName($coreName);
+            $initFailure->setException($exception);
+
+            $initFailureResults[] = $initFailure;
+
+            // when a core name was set in the action and we have a response we remember it to set a single initFailureResult
+            if ($coreName === $action->getCore()) {
+                $initFailureResult = $initFailure;
+            }
+        }
+
+        $data['initFailureResults'] = $initFailureResults;
+        $data['initFailureResult'] = $initFailureResult;
 
         return $data;
     }

--- a/src/QueryType/Server/CoreAdmin/ResponseParser.php
+++ b/src/QueryType/Server/CoreAdmin/ResponseParser.php
@@ -66,7 +66,6 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         }
 
         $initFailureResults = [];
-        $initFailureResult = null;
 
         foreach ($data['initFailures'] as $coreName => $exception) {
             $initFailure = new InitFailureResult();
@@ -74,15 +73,9 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
             $initFailure->setException($exception);
 
             $initFailureResults[] = $initFailure;
-
-            // when a core name was set in the action and we have a response we remember it to set a single initFailureResult
-            if ($coreName === $action->getCore()) {
-                $initFailureResult = $initFailure;
-            }
         }
 
         $data['initFailureResults'] = $initFailureResults;
-        $data['initFailureResult'] = $initFailureResult;
 
         return $data;
     }

--- a/src/QueryType/Server/CoreAdmin/Result/InitFailureResult.php
+++ b/src/QueryType/Server/CoreAdmin/Result/InitFailureResult.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\QueryType\Server\CoreAdmin\Result;
+
+/**
+ * Retrieved init failure.
+ */
+class InitFailureResult
+{
+    /**
+     * @var string
+     */
+    protected $coreName;
+
+    /**
+     * @var string
+     */
+    protected $exception;
+
+    /**
+     * @return string
+     */
+    public function getCoreName(): string
+    {
+        return $this->coreName;
+    }
+
+    /**
+     * @param string $coreName
+     *
+     * @return self
+     */
+    public function setCoreName(string $coreName): self
+    {
+        $this->coreName = $coreName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getException(): string
+    {
+        return $this->exception;
+    }
+
+    /**
+     * @param string $exception
+     *
+     * @return self
+     */
+    public function setException(string $exception): self
+    {
+        $this->exception = $exception;
+
+        return $this;
+    }
+}

--- a/src/QueryType/Server/CoreAdmin/Result/Result.php
+++ b/src/QueryType/Server/CoreAdmin/Result/Result.php
@@ -34,13 +34,6 @@ class Result extends BaseResult
     protected $initFailureResults;
 
     /**
-     * InitFailureResult when the status only for one core as requested.
-     *
-     * @var InitFailureResult
-     */
-    protected $initFailureResult;
-
-    /**
      * StatusResult collection when multiple statuses have been requested.
      *
      * @var StatusResult[]|null
@@ -89,7 +82,7 @@ class Result extends BaseResult
     }
 
     /**
-     * Returns the init failure result objects for all core statuses.
+     * Returns the init failure result objects.
      *
      * @throws \Solarium\Exception\UnexpectedValueException
      *
@@ -100,20 +93,6 @@ class Result extends BaseResult
         $this->parseResponse();
 
         return $this->initFailureResults;
-    }
-
-    /**
-     * Retrieves the init failure of the core, only available when the query was filtered to a core in the status action.
-     *
-     * @throws \Solarium\Exception\UnexpectedValueException
-     *
-     * @return InitFailureResult|null
-     */
-    public function getInitFailureResult(): ?InitFailureResult
-    {
-        $this->parseResponse();
-
-        return $this->initFailureResult;
     }
 
     /**

--- a/src/QueryType/Server/CoreAdmin/Result/Result.php
+++ b/src/QueryType/Server/CoreAdmin/Result/Result.php
@@ -17,6 +17,30 @@ use Solarium\Core\Query\Result\QueryType as BaseResult;
 class Result extends BaseResult
 {
     /**
+     * @var array
+     */
+    protected $status;
+
+    /**
+     * @var array
+     */
+    protected $initFailures;
+
+    /**
+     * InitFailureResult collection.
+     *
+     * @var InitFailureResult[]
+     */
+    protected $initFailureResults;
+
+    /**
+     * InitFailureResult when the status only for one core as requested.
+     *
+     * @var InitFailureResult
+     */
+    protected $initFailureResult;
+
+    /**
      * StatusResult collection when multiple statuses have been requested.
      *
      * @var StatusResult[]|null
@@ -65,6 +89,34 @@ class Result extends BaseResult
     }
 
     /**
+     * Returns the init failure result objects for all core statuses.
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
+     * @return InitFailureResult[]|null
+     */
+    public function getInitFailureResults(): ?array
+    {
+        $this->parseResponse();
+
+        return $this->initFailureResults;
+    }
+
+    /**
+     * Retrieves the init failure of the core, only available when the query was filtered to a core in the status action.
+     *
+     * @throws \Solarium\Exception\UnexpectedValueException
+     *
+     * @return InitFailureResult|null
+     */
+    public function getInitFailureResult(): ?InitFailureResult
+    {
+        $this->parseResponse();
+
+        return $this->initFailureResult;
+    }
+
+    /**
      * Returns the status result objects for all requested core statuses.
      *
      * @throws \Solarium\Exception\UnexpectedValueException
@@ -79,7 +131,7 @@ class Result extends BaseResult
     }
 
     /**
-     * Retrieves the status of the core, only available when the core was filtered to a core in the status action.
+     * Retrieves the status of the core, only available when the query was filtered to a core in the status action.
      *
      * @throws \Solarium\Exception\UnexpectedValueException
      *

--- a/src/QueryType/Server/Query/ResponseParser.php
+++ b/src/QueryType/Server/Query/ResponseParser.php
@@ -30,7 +30,6 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
     {
         $data = $result->getData();
         $data = $this->parseStatus($data, $result);
-        $data = $this->addHeaderInfo($data, $data);
 
         return $data;
     }

--- a/src/QueryType/Spellcheck/ResponseParser.php
+++ b/src/QueryType/Spellcheck/ResponseParser.php
@@ -62,14 +62,11 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
             }
         }
 
-        return $this->addHeaderInfo(
-            $data,
-            [
-                'results' => $suggestions,
-                'all' => $allSuggestions,
-                'collation' => $collation,
-            ]
-        );
+        return [
+            'results' => $suggestions,
+            'all' => $allSuggestions,
+            'collation' => $collation,
+        ];
     }
 
     /**

--- a/src/QueryType/Spellcheck/Result/Result.php
+++ b/src/QueryType/Spellcheck/Result/Result.php
@@ -17,23 +17,6 @@ use Solarium\Core\Query\Result\QueryType as BaseResult;
 class Result extends BaseResult implements \IteratorAggregate, \Countable
 {
     /**
-     * Status code returned by Solr.
-     *
-     * @var int
-     */
-    protected $status;
-
-    /**
-     * Solr index queryTime.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @var int
-     */
-    protected $queryTime;
-
-    /**
      * Suggester results.
      *
      * @var array
@@ -55,39 +38,6 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      * @var string
      */
     protected $collation;
-
-    /**
-     * Get Solr status code.
-     *
-     * This is not the HTTP status code! The normal value for success is 0.
-     *
-     * @throws \Solarium\Exception\UnexpectedValueException
-     *
-     * @return int
-     */
-    public function getStatus(): int
-    {
-        $this->parseResponse();
-
-        return $this->status;
-    }
-
-    /**
-     * Get Solr query time.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @throws \Solarium\Exception\UnexpectedValueException
-     *
-     * @return int
-     */
-    public function getQueryTime(): int
-    {
-        $this->parseResponse();
-
-        return $this->queryTime;
-    }
 
     /**
      * Get all results.

--- a/src/QueryType/Stream/ResponseParser.php
+++ b/src/QueryType/Stream/ResponseParser.php
@@ -76,12 +76,9 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
             throw $e;
         }
 
-        return $this->addHeaderInfo(
-            $data,
-            [
-                'numfound' => \count($documents),
-                'documents' => $documents,
-            ]
-        );
+        return [
+            'numfound' => \count($documents),
+            'documents' => $documents,
+        ];
     }
 }

--- a/src/QueryType/Stream/Result.php
+++ b/src/QueryType/Stream/Result.php
@@ -34,56 +34,6 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
     protected $documents;
 
     /**
-     * Status code returned by Solr.
-     *
-     * @var int
-     */
-    protected $status;
-
-    /**
-     * Solr index queryTime.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @var int
-     */
-    protected $queryTime;
-
-    /**
-     * Get Solr status code.
-     *
-     * This is not the HTTP status code! The normal value for success is 0.
-     *
-     * @throws \Solarium\Exception\UnexpectedValueException
-     *
-     * @return int
-     */
-    public function getStatus(): int
-    {
-        $this->parseResponse();
-
-        return $this->status;
-    }
-
-    /**
-     * Get Solr query time.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @throws \Solarium\Exception\UnexpectedValueException
-     *
-     * @return int
-     */
-    public function getQueryTime(): int
-    {
-        $this->parseResponse();
-
-        return $this->queryTime;
-    }
-
-    /**
      * get Solr numFound.
      *
      * Returns the total number of documents found by Solr (this is NOT the

--- a/src/QueryType/Suggester/ResponseParser.php
+++ b/src/QueryType/Suggester/ResponseParser.php
@@ -48,13 +48,10 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
             }
         }
 
-        return $this->addHeaderInfo(
-            $data,
-            [
-                'results' => $dictionaries,
-                'all' => $allSuggestions,
-            ]
-        );
+        return [
+            'results' => $dictionaries,
+            'all' => $allSuggestions,
+        ];
     }
 
     /**

--- a/src/QueryType/Suggester/Result/Result.php
+++ b/src/QueryType/Suggester/Result/Result.php
@@ -17,23 +17,6 @@ use Solarium\Core\Query\Result\QueryType as BaseResult;
 class Result extends BaseResult implements \IteratorAggregate, \Countable
 {
     /**
-     * Status code returned by Solr.
-     *
-     * @var int
-     */
-    protected $status;
-
-    /**
-     * Solr index queryTime.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @var int
-     */
-    protected $queryTime;
-
-    /**
      * Suggester results.
      *
      * @var array
@@ -46,39 +29,6 @@ class Result extends BaseResult implements \IteratorAggregate, \Countable
      * @var array
      */
     protected $all;
-
-    /**
-     * Get Solr status code.
-     *
-     * This is not the HTTP status code! The normal value for success is 0.
-     *
-     * @throws \Solarium\Exception\UnexpectedValueException
-     *
-     * @return int
-     */
-    public function getStatus(): int
-    {
-        $this->parseResponse();
-
-        return $this->status;
-    }
-
-    /**
-     * Get Solr query time.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @throws \Solarium\Exception\UnexpectedValueException
-     *
-     * @return int
-     */
-    public function getQueryTime(): int
-    {
-        $this->parseResponse();
-
-        return $this->queryTime;
-    }
 
     /**
      * Get all results.

--- a/src/QueryType/Terms/ResponseParser.php
+++ b/src/QueryType/Terms/ResponseParser.php
@@ -50,6 +50,6 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
             }
         }
 
-        return $this->addHeaderInfo($data, ['results' => $termResults]);
+        return ['results' => $termResults];
     }
 }

--- a/src/QueryType/Terms/Result.php
+++ b/src/QueryType/Terms/Result.php
@@ -17,61 +17,11 @@ use Solarium\Core\Query\Result\QueryType as BaseResult;
 class Result extends BaseResult implements \IteratorAggregate, \Countable
 {
     /**
-     * Status code returned by Solr.
-     *
-     * @var int
-     */
-    protected $status;
-
-    /**
-     * Solr index queryTime.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @var int
-     */
-    protected $queryTime;
-
-    /**
      * Term results.
      *
      * @var array
      */
     protected $results;
-
-    /**
-     * Get Solr status code.
-     *
-     * This is not the HTTP status code! The normal value for success is 0.
-     *
-     * @throws \Solarium\Exception\UnexpectedValueException
-     *
-     * @return int
-     */
-    public function getStatus(): int
-    {
-        $this->parseResponse();
-
-        return $this->status;
-    }
-
-    /**
-     * Get Solr query time.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @throws \Solarium\Exception\UnexpectedValueException
-     *
-     * @return int
-     */
-    public function getQueryTime(): int
-    {
-        $this->parseResponse();
-
-        return $this->queryTime;
-    }
 
     /**
      * Get all term results.

--- a/src/QueryType/Update/Result.php
+++ b/src/QueryType/Update/Result.php
@@ -15,60 +15,11 @@ use Solarium\Core\Query\Result\QueryType as BaseResult;
  * Update result.
  *
  * An update query only returns a query time and status. Both are accessible
- * using the methods provided by {@link Solarium\Result\Query}.
+ * using the methods provided by {@link Solarium\Core\Query\Result\QueryType}.
  *
  * For now this class only exists to distinguish the different result
  * types. It might get some extra behaviour in the future.
  */
 class Result extends BaseResult
 {
-    /**
-     * Status code returned by Solr.
-     *
-     * @var int
-     */
-    protected $status;
-
-    /**
-     * Solr index queryTime.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @var int
-     */
-    protected $queryTime;
-
-    /**
-     * Get Solr status code.
-     *
-     * This is not the HTTP status code! The normal value for success is 0.
-     *
-     * @throws \Solarium\Exception\UnexpectedValueException
-     *
-     * @return int
-     */
-    public function getStatus(): int
-    {
-        $this->parseResponse();
-
-        return $this->status;
-    }
-
-    /**
-     * Get Solr query time.
-     *
-     * This doesn't include things like the HTTP responsetime. Purely the Solr
-     * query execution time.
-     *
-     * @throws \Solarium\Exception\UnexpectedValueException
-     *
-     * @return int
-     */
-    public function getQueryTime(): int
-    {
-        $this->parseResponse();
-
-        return $this->queryTime;
-    }
 }

--- a/tests/Core/Query/ResponseParserTest.php
+++ b/tests/Core/Query/ResponseParserTest.php
@@ -68,37 +68,6 @@ class ResponseParserTest extends TestCase
             $this->parser->parse($result)
         );
     }
-
-    public function testAddHeaderInfo()
-    {
-        $data = [
-            'responseHeader' => [
-                'status' => 0,
-                'QTime' => 5,
-            ],
-        ];
-        $result = ['key' => 'value'];
-        $expected = [
-            'key' => 'value',
-            'status' => 0,
-            'queryTime' => 5,
-        ];
-
-        $this->assertSame($expected, $this->parser->addHeaderInfo($data, $result));
-    }
-
-    public function testAddHeaderInfoEmpty()
-    {
-        $data = [];
-        $result = ['key' => 'value'];
-        $expected = [
-            'key' => 'value',
-            'status' => null,
-            'queryTime' => null,
-        ];
-
-        $this->assertSame($expected, $this->parser->addHeaderInfo($data, $result));
-    }
 }
 
 class TestQueryForResponseParser extends AbstractQuery implements Status4xxNoExceptionInterface

--- a/tests/Core/Query/Result/QueryTypeTest.php
+++ b/tests/Core/Query/Result/QueryTypeTest.php
@@ -24,6 +24,16 @@ class QueryTypeTest extends TestCase
         $this->result = new TestStubResult($query, $response);
     }
 
+    public function testGetStatus()
+    {
+        $this->assertSame(1, $this->result->getStatus());
+    }
+
+    public function testGetQueryTime()
+    {
+        $this->assertSame(12, $this->result->getQueryTime());
+    }
+
     public function testParseResponse()
     {
         $query = new TestStubQuery();
@@ -74,6 +84,8 @@ class TestStubQuery extends SelectQuery
 class TestStubResult extends QueryTypeResult
 {
     public $parseCount = 0;
+
+    protected $dummyvar;
 
     public function parse()
     {

--- a/tests/Core/Query/Result/QueryTypeTest.php
+++ b/tests/Core/Query/Result/QueryTypeTest.php
@@ -49,6 +49,16 @@ class QueryTypeTest extends TestCase
         $this->assertNull($this->result->parse());
     }
 
+    public function testParseResponseResponseHeaderFallback()
+    {
+        $query = new SelectQuery();
+        $response = new Response('{"responseHeader":{"status":1,"QTime":12}}', ['HTTP 1.1 200 OK']);
+        $result = new TestNonDataMappingStubResult($query, $response);
+
+        $this->assertSame(1, $result->getStatus());
+        $this->assertSame(12, $result->getQueryTime());
+    }
+
     public function testParseLazyLoading()
     {
         $this->assertSame(0, $this->result->parseCount);
@@ -101,5 +111,12 @@ class TestStubResult extends QueryTypeResult
     public function getVar($name)
     {
         return $this->$name;
+    }
+}
+
+class TestNonDataMappingStubResult extends QueryTypeResult
+{
+    protected function mapData(array $mapData)
+    {
     }
 }

--- a/tests/Integration/AbstractTechproductsTest.php
+++ b/tests/Integration/AbstractTechproductsTest.php
@@ -212,14 +212,18 @@ abstract class AbstractTechproductsTest extends TestCase
         ];
     }
 
-    /**
-     * The ping test succeeds if no exception is thrown.
-     */
     public function testPing()
     {
         $ping = self::$client->createPing();
         $result = self::$client->ping($ping);
         $this->assertSame(0, $result->getStatus());
+        $this->assertSame('OK', $result->getPingStatus());
+
+        if ($this instanceof AbstractCloudTest) {
+            $this->assertTrue($result->getZkConnected());
+        } else {
+            $this->assertNull($result->getZkConnected());
+        }
     }
 
     public function testSelect(): SelectResult

--- a/tests/Plugin/MinimumScoreFilter/ResultTest.php
+++ b/tests/Plugin/MinimumScoreFilter/ResultTest.php
@@ -81,8 +81,7 @@ class FilterResultDummy extends Result
         $this->maxscore = $maxscore;
         $this->documents = $docs;
         $this->components = $components;
-        $this->queryTime = $queryTime;
-        $this->status = $status;
+        $this->responseHeader = ['status' => $status, 'QTime' => $queryTime];
 
         $this->query = new Query();
         $this->query->setFilterRatio(0.2)->setFilterMode($mode);

--- a/tests/Plugin/PrefetchIteratorTest.php
+++ b/tests/Plugin/PrefetchIteratorTest.php
@@ -748,8 +748,7 @@ class SelectResultDummy extends Result
         $this->numfound = $numfound;
         $this->documents = $docs;
         $this->components = $components;
-        $this->queryTime = $queryTime;
-        $this->status = $status;
+        $this->responseHeader = ['status' => $status, 'QTime' => $queryTime];
     }
 
     public function setNumFound(int $numfound): self

--- a/tests/QueryType/Analysis/ResponseParser/FieldTest.php
+++ b/tests/QueryType/Analysis/ResponseParser/FieldTest.php
@@ -89,8 +89,6 @@ class FieldTest extends TestCase
 
         $this->assertEquals(
             [
-                'status' => 1,
-                'queryTime' => 5,
                 'items' => [],
             ],
             $result

--- a/tests/QueryType/Analysis/Result/DocumentTest.php
+++ b/tests/QueryType/Analysis/Result/DocumentTest.php
@@ -84,7 +84,6 @@ class DocumentDummy extends Document
     public function __construct($status, $queryTime, $items)
     {
         $this->items = $items;
-        $this->queryTime = $queryTime;
-        $this->status = $status;
+        $this->responseHeader = ['status' => $status, 'QTime' => $queryTime];
     }
 }

--- a/tests/QueryType/Analysis/Result/FieldTest.php
+++ b/tests/QueryType/Analysis/Result/FieldTest.php
@@ -64,7 +64,6 @@ class FieldDummy extends Field
     public function __construct($status, $queryTime, $items)
     {
         $this->items = $items;
-        $this->queryTime = $queryTime;
-        $this->status = $status;
+        $this->responseHeader = ['status' => $status, 'QTime' => $queryTime];
     }
 }

--- a/tests/QueryType/Extract/ResultTest.php
+++ b/tests/QueryType/Extract/ResultTest.php
@@ -19,7 +19,6 @@ class ExtractResultDummy extends ExtractResult
 
     public function __construct()
     {
-        $this->status = 1;
-        $this->queryTime = 12;
+        $this->responseHeader = ['status' => 1, 'QTime' => 12];
     }
 }

--- a/tests/QueryType/Luke/Result/ResultTest.php
+++ b/tests/QueryType/Luke/Result/ResultTest.php
@@ -268,7 +268,7 @@ class ResultTest extends TestCase
         ];
 
         $response = new Response(json_encode($data), ['HTTP 1.1 200 OK']);
-        $result = new Result($query, $response);
+        $result = new DummyResult($query, $response);
 
         $this->assertInstanceOf(Index::class, $result->getIndex());
         $this->assertNull($result->getSchema());
@@ -276,4 +276,16 @@ class ResultTest extends TestCase
         $this->assertNull($result->getFields());
         $this->assertNull($result->getInfo());
     }
+}
+
+/**
+ * Get around deprecation for creation of dynamic property
+ * with {@link ResultTest::testWithUnknownShow()}.
+ */
+class DummyResult extends Result
+{
+    /**
+     * @var array
+     */
+    protected $unknown;
 }

--- a/tests/QueryType/Ping/QueryTest.php
+++ b/tests/QueryType/Ping/QueryTest.php
@@ -4,6 +4,8 @@ namespace Solarium\Tests\QueryType\Ping;
 
 use PHPUnit\Framework\TestCase;
 use Solarium\Core\Client\Client;
+use Solarium\QueryType\Ping\RequestBuilder;
+use Solarium\QueryType\Ping\ResponseParser;
 use Solarium\QueryType\Ping\Query;
 
 class QueryTest extends TestCase
@@ -20,14 +22,14 @@ class QueryTest extends TestCase
         $this->assertSame(Client::QUERY_PING, $this->query->getType());
     }
 
-    public function testGetResponseParser()
-    {
-        $this->assertNull($this->query->getResponseParser());
-    }
-
     public function testGetRequestBuilder()
     {
-        $this->assertInstanceOf('Solarium\QueryType\Ping\RequestBuilder', $this->query->getRequestBuilder());
+        $this->assertInstanceOf(RequestBuilder::class, $this->query->getRequestBuilder());
+    }
+
+    public function testGetResponseParser()
+    {
+        $this->assertInstanceOf(ResponseParser::class, $this->query->getResponseParser());
     }
 
     public function testConfigMode()

--- a/tests/QueryType/Ping/RequestBuilderTest.php
+++ b/tests/QueryType/Ping/RequestBuilderTest.php
@@ -15,7 +15,7 @@ class RequestBuilderTest extends TestCase
         $request = $builder->build(new Query());
 
         $this->assertSame(
-            'admin/ping?omitHeader=true&wt=json&json.nl=flat',
+            'admin/ping?omitHeader=false&wt=json&json.nl=flat',
             $request->getUri()
         );
 

--- a/tests/QueryType/Ping/ResponseParserTest.php
+++ b/tests/QueryType/Ping/ResponseParserTest.php
@@ -1,24 +1,24 @@
 <?php
 
-namespace Solarium\Tests\QueryType\Update;
+namespace Solarium\Tests\QueryType\Ping;
 
 use PHPUnit\Framework\TestCase;
 use Solarium\Core\Client\Response;
-use Solarium\QueryType\Update\Query\Query;
-use Solarium\QueryType\Update\ResponseParser;
-use Solarium\QueryType\Update\Result;
+use Solarium\QueryType\Ping\Query;
+use Solarium\QueryType\Ping\ResponseParser;
+use Solarium\QueryType\Ping\Result;
 
 class ResponseParserTest extends TestCase
 {
     public function testParse()
     {
-        $data = '{}';
+        $data = '{"status":"OK"}';
 
         $response = new Response($data, ['HTTP 1.1 200 OK']);
         $result = new Result(new Query(), $response);
         $parser = new ResponseParser();
         $parsed = $parser->parse($result);
 
-        $this->assertSame([], $parsed);
+        $this->assertSame('OK', $parsed['status']);
     }
 }

--- a/tests/QueryType/Ping/ResultTest.php
+++ b/tests/QueryType/Ping/ResultTest.php
@@ -3,23 +3,59 @@
 namespace Solarium\Tests\QueryType\Ping;
 
 use PHPUnit\Framework\TestCase;
-use Solarium\Core\Client\Response;
-use Solarium\QueryType\Ping\Query;
 use Solarium\QueryType\Ping\Result;
-use Solarium\Tests\Integration\TestClientFactory;
 
 class ResultTest extends TestCase
 {
+    /**
+     * @var Result
+     */
+    protected $result;
+
+    public function setUp(): void
+    {
+        $this->result = new PingDummy();
+    }
+
+    public function testGetPingStatus()
+    {
+        $this->assertSame(
+            'OK',
+            $this->result->getPingStatus()
+        );
+    }
+
+    public function testGetZkConnected()
+    {
+        $this->assertTrue(
+            $this->result->getZkConnected()
+        );
+    }
+
     public function testGetStatus()
     {
-        $client = TestClientFactory::createWithCurlAdapter();
-        $query = new Query();
-        $response = new Response('{"responseHeader":{"status":1,"QTime":12}}', ['HTTP 1.1 200 OK']);
-
-        $ping = new Result($query, $response);
         $this->assertSame(
-            0,
-            $ping->getStatus()
+            1,
+            $this->result->getStatus()
         );
+    }
+
+    public function testGetQueryTime()
+    {
+        $this->assertSame(
+            12,
+            $this->result->getQueryTime()
+        );
+    }
+}
+
+class PingDummy extends Result
+{
+    protected $parsed = true;
+
+    public function __construct()
+    {
+        $this->status = 'OK';
+        $this->responseHeader = ['zkConnected' => true, 'status' => 1, 'QTime' => 12];
     }
 }

--- a/tests/QueryType/RealtimeGet/ResultTest.php
+++ b/tests/QueryType/RealtimeGet/ResultTest.php
@@ -18,6 +18,16 @@ class ResultTest extends TestCase
         $this->result = new ResultDummy([$this->doc]);
     }
 
+    public function testGetStatus()
+    {
+        $this->assertSame(1, $this->result->getStatus());
+    }
+
+    public function testGetQueryTime()
+    {
+        $this->assertSame(12, $this->result->getQueryTime());
+    }
+
     public function testGetDocument()
     {
         $this->assertSame($this->doc, $this->result->getDocument());
@@ -31,5 +41,6 @@ class ResultDummy extends Result
     public function __construct($docs)
     {
         $this->documents = $docs;
+        $this->responseHeader = ['status' => 1, 'QTime' => 12];
     }
 }

--- a/tests/QueryType/Select/ResponseParserTest.php
+++ b/tests/QueryType/Select/ResponseParserTest.php
@@ -43,8 +43,6 @@ class ResponseParserTest extends TestCase
         $parser = new ResponseParser();
         $result = $parser->parse($resultStub);
 
-        $this->assertSame(1, $result['status']);
-        $this->assertSame(13, $result['queryTime']);
         $this->assertSame(503, $result['numfound']);
         $this->assertSame(1.23, $result['maxscore']);
 
@@ -90,8 +88,6 @@ class ResponseParserTest extends TestCase
         $parser = new ResponseParser();
         $result = $parser->parse($resultStub);
 
-        $this->assertSame(1, $result['status']);
-        $this->assertSame(13, $result['queryTime']);
         $this->assertSame(503, $result['numfound']);
         $this->assertNull($result['maxscore']);
 
@@ -169,8 +165,6 @@ class ResponseParserTest extends TestCase
         $parser = new ResponseParser();
         $result = $parser->parse($resultStub);
 
-        $this->assertSame(1, $result['status']);
-        $this->assertSame(13, $result['queryTime']);
         $this->assertNull($result['numfound']);
     }
 }

--- a/tests/QueryType/Select/Result/AbstractResultTest.php
+++ b/tests/QueryType/Select/Result/AbstractResultTest.php
@@ -222,7 +222,6 @@ class SelectDummy extends Result
         $this->maxscore = $maxscore;
         $this->documents = $docs;
         $this->components = $components;
-        $this->queryTime = $queryTime;
-        $this->status = $status;
+        $this->responseHeader = ['status' => $status, 'QTime' => $queryTime];
     }
 }

--- a/tests/QueryType/Spellcheck/Result/ResultTest.php
+++ b/tests/QueryType/Spellcheck/Result/ResultTest.php
@@ -105,7 +105,6 @@ class SpellcheckDummy extends Result
         $this->results = $results;
         $this->all = $all;
         $this->collation = $collation;
-        $this->status = 1;
-        $this->queryTime = 12;
+        $this->responseHeader = ['status' => 1, 'QTime' => 12];
     }
 }

--- a/tests/QueryType/Suggester/Result/ResultTest.php
+++ b/tests/QueryType/Suggester/Result/ResultTest.php
@@ -105,7 +105,6 @@ class SuggesterDummy extends Result
     {
         $this->results = $results;
         $this->all = $all;
-        $this->status = 1;
-        $this->queryTime = 12;
+        $this->responseHeader = ['status' => 1, 'QTime' => 12];
     }
 }

--- a/tests/QueryType/Terms/ResultTest.php
+++ b/tests/QueryType/Terms/ResultTest.php
@@ -93,7 +93,6 @@ class TermsDummy extends Result
     public function __construct($results)
     {
         $this->results = $results;
-        $this->status = 1;
-        $this->queryTime = 12;
+        $this->responseHeader = ['status' => 1, 'QTime' => 12];
     }
 }

--- a/tests/QueryType/Update/ResultTest.php
+++ b/tests/QueryType/Update/ResultTest.php
@@ -18,7 +18,6 @@ class UpdateDummy extends UpdateResult
 
     public function __construct()
     {
-        $this->status = 1;
-        $this->queryTime = 12;
+        $this->responseHeader = ['status' => 1, 'QTime' => 12];
     }
 }


### PR DESCRIPTION
Fixes #1063.

Any key that can be present in Solr's response data must be declared as a property of the result class it gets parsed into to avoid 'creation of dynamic property' deprecations.

I've moved the handling of the `responseHeader`'s `status` and `QTime` to the parent `QueryType` result to make it consistent across all QueryTypes and not something individual response parsers have to bother with. Renamed three `getStatus()` methods with a name clash in the Collections results, with a deprecation so it doesn't break BC.

@mkalkbrenner The Collections and CoreAdmin results don't have any unit test coverage so I didn't include any for my additions either. Can we overlook the <100% patch coverage for once? 😉