### PR TITLE
Removed deprecated class constant Client::Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Solarium library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [6.3.0]
 ### Added
 - Support for Luke queries
 - Solarium\Component\QueryElevation::setExcludeTags()
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update queries use the JSON request format by default
 - Ping queries set omitHeader=false by default
+
+### Removed
+- Removed deprecated class constant Client::Version. Use Client::getVersion() instead.
 
 ### Deprecated
 - Solarium\QueryType\Server\Collections\Result\CreateResult::getStatus(), use getCreateStatus() instead

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,7 +19,7 @@ use Solarium\Core\Client\Client as CoreClient;
 class Client extends CoreClient
 {
     /**
-     * Version number of the Solarium library.
+     * Returns the version string.
      *
      * The version is built up in this format: major.minor.mini
      *
@@ -39,15 +39,6 @@ class Client extends CoreClient
      *
      * @see checkExact()
      * @see checkMinimal()
-     *
-     * @var string
-     *
-     * @deprecated This class constant will be removed in Solarium 6.3.0. Use Client::getVersion() instead.
-     */
-    const VERSION = '6.2.7-deprecated';
-
-    /**
-     * Returns the version string.
      *
      * @return string
      */

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -38,17 +38,6 @@ class ClientTest extends TestCase
         );
     }
 
-//    /**
-//     * @deprecated The class constant will be removed in Solarium 6.3.0.
-//     */
-//    public function testVersionConstant()
-//    {
-//        $this->assertSame(
-//            self::$installedVersion,
-//            Client::VERSION
-//        );
-//    }
-
     public function testCheckExact()
     {
         $this->assertTrue(


### PR DESCRIPTION
Use Client::getVersion() instead.