### PR TITLE
Codecov GitHub Action v1 is deprecated

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -111,7 +111,7 @@ jobs:
                 ls -l PHP*/clover*.xml
 
             - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v1
+              uses: codecov/codecov-action@v3
               with:
                   files: PHP*/clover*.xml
                   flags: unittests


### PR DESCRIPTION
[⚠️ Deprecation of v1](https://github.com/marketplace/actions/codecov#%EF%B8%8F--deprecation-of-v1):

> **As of February 1, 2022, v1 has been fully sunset and no longer functions**

Seems to be why we keep running into these errors.

```
{'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
```