### PR TITLE
Loadbalancer failover on HTTP status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the Solarium library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Loadbalancer plugin can failover on an optional list of HTTP status codes
+
+
 ## [6.3.0]
 ### Added
 - Support for Luke queries

--- a/examples/7.1-plugin-loadbalancer.php
+++ b/examples/7.1-plugin-loadbalancer.php
@@ -22,6 +22,11 @@ $loadbalancer->addEndpoint($endpoint1, 100);
 $loadbalancer->addEndpoint($endpoint2, 100);
 $loadbalancer->addEndpoint($endpoint3, 1);
 
+// you can optionally enable failover mode for unresponsive endpoints, and additionally HTTP status codes of your choosing
+$loadbalancer->setFailoverEnabled(true);
+$loadbalancer->setFailoverMaxRetries(3);
+$loadbalancer->addFailoverStatusCode(504);
+
 // create a basic query to execute
 $query = $client->createSelect();
 

--- a/src/Plugin/Loadbalancer/Event/Events.php
+++ b/src/Plugin/Loadbalancer/Event/Events.php
@@ -26,6 +26,16 @@ class Events
     public const ENDPOINT_FAILURE = EndpointFailure::class;
 
     /**
+     * This event is called after an HTTP response status code is encountered
+     * that is in the list of failover error codes.
+     *
+     * Gets the endpoint and the response as params
+     *
+     * @var string
+     */
+    public const STATUS_CODE_FAILURE = StatusCodeFailure::class;
+
+    /**
      * Not instantiable.
      */
     private function __construct()

--- a/src/Plugin/Loadbalancer/Event/StatusCodeFailure.php
+++ b/src/Plugin/Loadbalancer/Event/StatusCodeFailure.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Solarium package.
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+namespace Solarium\Plugin\Loadbalancer\Event;
+
+use Solarium\Core\Client\Endpoint;
+use Solarium\Core\Client\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * StatusCodeFailure event, see {@see Events} for details.
+ */
+class StatusCodeFailure extends Event
+{
+    /**
+     * @var Endpoint
+     */
+    protected $endpoint;
+
+    /**
+     * @var Response
+     */
+    protected $response;
+
+    /**
+     * Constructor.
+     *
+     * @param Endpoint $endpoint
+     * @param Response $response
+     */
+    public function __construct(Endpoint $endpoint, Response $response)
+    {
+        $this->endpoint = $endpoint;
+        $this->response = $response;
+    }
+
+    /**
+     * @return Endpoint
+     */
+    public function getEndpoint(): Endpoint
+    {
+        return $this->endpoint;
+    }
+
+    /**
+     * @return Response
+     */
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
+}

--- a/tests/Plugin/Loadbalancer/Event/StatusCodeFailureTest.php
+++ b/tests/Plugin/Loadbalancer/Event/StatusCodeFailureTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Solarium\Tests\Plugin\Loadbalancer\Event;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Response;
+use Solarium\Plugin\Loadbalancer\Event\StatusCodeFailure;
+use Solarium\Tests\Integration\TestClientFactory;
+
+class StatusCodeFailureTest extends TestCase
+{
+    public function testConstructorAndGetters()
+    {
+        $client = TestClientFactory::createWithCurlAdapter();
+        $endpoint = $client->getEndpoint();
+        $response = new Response('test response');
+
+        $event = new StatusCodeFailure($endpoint, $response);
+
+        $this->assertSame($endpoint, $event->getEndpoint());
+        $this->assertSame($response, $event->getResponse());
+    }
+}

--- a/tests/Plugin/Loadbalancer/LoadbalancerTest.php
+++ b/tests/Plugin/Loadbalancer/LoadbalancerTest.php
@@ -16,6 +16,9 @@ use Solarium\Exception\HttpException;
 use Solarium\Exception\InvalidArgumentException;
 use Solarium\Exception\OutOfBoundsException;
 use Solarium\Exception\RuntimeException;
+use Solarium\Plugin\Loadbalancer\Event\EndpointFailure as EndpointFailureEvent;
+use Solarium\Plugin\Loadbalancer\Event\Events as LoadbalancerEvents;
+use Solarium\Plugin\Loadbalancer\Event\StatusCodeFailure as StatusCodeFailureEvent;
 use Solarium\Plugin\Loadbalancer\Loadbalancer;
 use Solarium\QueryType\Select\Query\Query as SelectQuery;
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;
@@ -52,7 +55,7 @@ class LoadbalancerTest extends TestCase
         $adapter = $this->createMock(AdapterInterface::class);
         $adapter->expects($this->any())
             ->method('execute')
-            ->willReturn(new Response('dummyresult'));
+            ->willReturn(new Response('dummyresult', ['HTTP/1.1 200 OK']));
         $this->client->setAdapter($adapter);
         $this->plugin->initPlugin($this->client, []);
     }
@@ -60,6 +63,9 @@ class LoadbalancerTest extends TestCase
     public function testConfigMode()
     {
         $options = [
+            'failoverenabled' => true,
+            'failovermaxretries' => 5,
+            'failoverstatuscodes' => '402, 403',
             'endpoint' => [
                 'server1' => 10,
                 'server2' => 5,
@@ -68,6 +74,10 @@ class LoadbalancerTest extends TestCase
         ];
 
         $this->plugin->setOptions($options);
+
+        $this->assertTrue($this->plugin->getFailoverEnabled());
+        $this->assertSame(5, $this->plugin->getFailoverMaxRetries());
+        $this->assertSame([402, 403], $this->plugin->getFailoverStatusCodes());
 
         $this->assertSame(
             ['server1' => 10, 'server2' => 5],
@@ -123,6 +133,11 @@ class LoadbalancerTest extends TestCase
         );
     }
 
+    public function testDefaultFailoverEnabled()
+    {
+        $this->assertFalse($this->plugin->getFailoverEnabled());
+    }
+
     public function testSetAndGetFailoverEnabled()
     {
         $this->plugin->setFailoverEnabled(true);
@@ -133,6 +148,47 @@ class LoadbalancerTest extends TestCase
     {
         $this->plugin->setFailoverMaxRetries(16);
         $this->assertSame(16, $this->plugin->getFailoverMaxRetries());
+    }
+
+    public function testDefaultFailoverStatusCodes()
+    {
+        $this->assertSame([], $this->plugin->getFailoverStatusCodes());
+    }
+
+    public function testAddFailoverStatusCode()
+    {
+        $this->plugin->addFailoverStatusCode(400);
+        $this->plugin->addFailoverStatusCode(401);
+        $this->assertSame([400, 401], $this->plugin->getFailoverStatusCodes());
+    }
+
+    public function testAddFailoverStatusCodes()
+    {
+        $this->plugin->addFailoverStatusCodes([400, 401]);
+        $this->plugin->addFailoverStatusCodes('500, 501');
+        $this->assertSame([400, 401, 500, 501], $this->plugin->getFailoverStatusCodes());
+    }
+
+    public function testClearFailoverStatusCodes()
+    {
+        $this->plugin->addFailoverStatusCode(400);
+        $this->plugin->clearFailoverStatusCodes();
+        $this->assertSame([], $this->plugin->getFailoverStatusCodes());
+    }
+
+    public function testRemoveFailoverStatusCode()
+    {
+        $this->plugin->addFailoverStatusCodes([400, 401]);
+        $this->plugin->removeFailoverStatusCode(400);
+        $this->assertSame([401], $this->plugin->getFailoverStatusCodes());
+    }
+
+    public function testSetFailoverStatusCodes()
+    {
+        $this->plugin->setFailoverStatusCodes([400, 401]);
+        $this->assertSame([400, 401], $this->plugin->getFailoverStatusCodes());
+        $this->plugin->setFailoverStatusCodes('500, 501');
+        $this->assertSame([500, 501], $this->plugin->getFailoverStatusCodes());
     }
 
     public function testAddEndpoint()
@@ -433,10 +489,10 @@ class LoadbalancerTest extends TestCase
         );
     }
 
-    public function testFailover()
+    public function testFailoverOnEndpointFailure()
     {
         $this->plugin = new TestLoadbalancer(); // special loadbalancer that returns endpoints in fixed order
-        $this->client->setAdapter(new TestAdapterForFailover()); // set special mock that fails once
+        $this->client->setAdapter(new TestAdapterForFailover(true)); // set special mock that fails once with an HTTP exception
         $this->plugin->initPlugin($this->client, []);
 
         $request = new Request();
@@ -447,6 +503,16 @@ class LoadbalancerTest extends TestCase
         $this->plugin->setEndpoints($endpoints);
         $this->plugin->setFailoverEnabled(true);
 
+        $endpointFailureListenerCalled = 0;
+        $this->client->getEventDispatcher()->addListener(
+            LoadbalancerEvents::ENDPOINT_FAILURE,
+            function (EndpointFailureEvent $event) use (&$endpointFailureListenerCalled) {
+                ++$endpointFailureListenerCalled;
+                $this->assertSame('server1', $event->getEndpoint()->getKey());
+                $this->assertSame('failover exception', $event->getException()->getStatusMessage());
+            }
+        );
+
         $query = new SelectQuery();
         $event = new PreCreateRequestEvent($query);
         $this->plugin->preCreateRequest($event);
@@ -454,10 +520,44 @@ class LoadbalancerTest extends TestCase
         $event = new PreExecuteRequestEvent($request, new Endpoint());
         $this->plugin->preExecuteRequest($event);
 
-        $this->assertSame(
-            'server2',
-            $this->plugin->getLastEndpoint()
+        $this->assertSame(1, $endpointFailureListenerCalled);
+        $this->assertSame('server2', $this->plugin->getLastEndpoint());
+    }
+
+    public function testFailoverOnStatusCodeFailure()
+    {
+        $this->plugin = new TestLoadbalancer(); // special loadbalancer that returns endpoints in fixed order
+        $this->client->setAdapter(new TestAdapterForFailover(false)); // set special mock that fails once with an HTTP status error
+        $this->plugin->initPlugin($this->client, []);
+
+        $request = new Request();
+        $endpoints = [
+           'server1' => 1,
+           'server2' => 1,
+        ];
+        $this->plugin->setEndpoints($endpoints);
+        $this->plugin->setFailoverEnabled(true);
+        $this->plugin->addFailoverStatusCode(504);
+
+        $statusCodeFailureListenerCalled = 0;
+        $this->client->getEventDispatcher()->addListener(
+            LoadbalancerEvents::STATUS_CODE_FAILURE,
+            function (StatusCodeFailureEvent $event) use (&$statusCodeFailureListenerCalled) {
+                ++$statusCodeFailureListenerCalled;
+                $this->assertSame('server1', $event->getEndpoint()->getKey());
+                $this->assertSame(504, $event->getResponse()->getStatusCode());
+            }
         );
+
+        $query = new SelectQuery();
+        $event = new PreCreateRequestEvent($query);
+        $this->plugin->preCreateRequest($event);
+
+        $event = new PreExecuteRequestEvent($request, new Endpoint());
+        $this->plugin->preExecuteRequest($event);
+
+        $this->assertSame(1, $statusCodeFailureListenerCalled);
+        $this->assertSame('server2', $this->plugin->getLastEndpoint());
     }
 
     public function testFailoverMaxRetries()
@@ -511,22 +611,41 @@ class TestLoadbalancer extends Loadbalancer
 
 class TestAdapterForFailover extends HttpAdapter
 {
+    protected $endpointFailure;
+
     protected $counter = 0;
 
     protected $failCount = 1;
 
-    public function setFailCount($count)
+    /**
+     * Constructor.
+     *
+     * @param bool $endpointFailure Fail with an endpoint failure (true) or an HTTP status error (false)?
+     */
+    public function __construct(bool $endpointFailure = true)
+    {
+        $this->endpointFailure = $endpointFailure;
+    }
+
+    public function setFailCount(int $count): self
     {
         $this->failCount = $count;
+
+        return $this;
     }
 
     public function execute(Request $request, Endpoint $endpoint): Response
     {
         ++$this->counter;
+
         if ($this->counter <= $this->failCount) {
-            throw new HttpException('failover exception');
+            if ($this->endpointFailure) {
+                throw new HttpException('failover exception');
+            } else {
+                return new Response('dummyvalue', ['HTTP/1.1 504 Gateway Timeout']);
+            }
         }
 
-        return new Response('dummyvalue');
+        return new Response('dummyvalue', ['HTTP/1.1 200 OK']);
     }
 }


### PR DESCRIPTION
Closes #298.

I don't think we can come up with an indisputable default list for status codes. So I left it empty and it's up to the user to add all desired status codes.