### PR TITLE
Mark passwords as #[\SensitiveParameter]

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
               with:
                 php-version: ${{ matrix.php }}
                 extensions: dom, curl, libxml, mbstring, zip, iconv, json, simplexml
-                ini-values: memory_limit=256M, post_max_size=256M
+                ini-values: memory_limit=256M, post_max_size=256M, zend.exception_ignore_args=Off
                 coverage: pcov
 
             - name: Checkout solarium

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Solarium\QueryType\Extract\Query::setFile() now supports file pointer resources
 - Solarium\QueryType\Extract\Result::getFile() and getFileMetadata() to access the retrieved data for `extractOnly=true`
 
+### Changed
+- Solarium\Core\Client\Endpoint::setAuthentication() marks $password as #[\SensitiveParameter] (PHP 8 >= 8.2.0)
+- Solarium\Core\Client\Endpoint::setAuthorizationToken() marks $token as #[\SensitiveParameter] (PHP 8 >= 8.2.0)
+- Solarium\Core\Client\Request::setAuthentication() marks $password as #[\SensitiveParameter] (PHP 8 >= 8.2.0)
+
 
 ## [6.3.0]
 ### Added

--- a/src/Core/Client/Endpoint.php
+++ b/src/Core/Client/Endpoint.php
@@ -358,8 +358,11 @@ class Endpoint extends Configurable
      *
      * @return self Provides fluent interface
      */
-    public function setAuthentication(string $username, string $password): self
-    {
+    public function setAuthentication(
+        string $username,
+        #[\SensitiveParameter]
+        string $password
+    ): self {
         $this->setOption('username', $username);
         $this->setOption('password', $password);
 
@@ -389,8 +392,11 @@ class Endpoint extends Configurable
      *
      * @return self Provides fluent interface
      */
-    public function setAuthorizationToken(string $tokenname, string $token): self
-    {
+    public function setAuthorizationToken(
+        string $tokenname,
+        #[\SensitiveParameter]
+        string $token
+    ): self {
         $this->setOption('tokenname', $tokenname);
         $this->setOption('token', $token);
 

--- a/src/Core/Client/Request.php
+++ b/src/Core/Client/Request.php
@@ -453,8 +453,11 @@ class Request extends Configurable implements RequestParamsInterface
      *
      * @return self Provides fluent interface
      */
-    public function setAuthentication(string $username, string $password): self
-    {
+    public function setAuthentication(
+        string $username,
+        #[\SensitiveParameter]
+        string $password
+    ): self {
         $this->setOption('username', $username);
         $this->setOption('password', $password);
 

--- a/tests/Core/Client/EndpointTest.php
+++ b/tests/Core/Client/EndpointTest.php
@@ -264,6 +264,26 @@ class EndpointTest extends TestCase
         );
     }
 
+    public function testSetAuthenticationSensitiveParameter()
+    {
+        // #[\SensitiveParameter] was introduced in PHP 8.2
+        if (!class_exists('\SensitiveParameter')) {
+            $this->expectNotToPerformAssertions();
+
+            return;
+        }
+
+        try {
+            // trigger a \TypeError with the $user argument
+            $this->endpoint->setAuthentication(null, 'S0M3p455');
+        } catch (\TypeError $e) {
+            $trace = $e->getTrace();
+
+            // \SensitiveParameterValue::class trips phpstan in PHP versions that don't support it
+            $this->assertInstanceOf('\SensitiveParameterValue', $trace[0]['args'][1]);
+        }
+    }
+
     public function testGetAndSetAuthorizationToken()
     {
         $tokenname = 'Token';
@@ -278,6 +298,26 @@ class EndpointTest extends TestCase
             ],
             $this->endpoint->getAuthorizationToken()
         );
+    }
+
+    public function testSetAuthorizationTokenSensitiveParameter()
+    {
+        // #[\SensitiveParameter] was introduced in PHP 8.2
+        if (!class_exists('\SensitiveParameter')) {
+            $this->expectNotToPerformAssertions();
+
+            return;
+        }
+
+        try {
+            // trigger a \TypeError with the $tokenname argument
+            $this->endpoint->setAuthorizationToken(null, '1234567890ABCDEFG');
+        } catch (\TypeError $e) {
+            $trace = $e->getTrace();
+
+            // \SensitiveParameterValue::class trips phpstan in PHP versions that don't support it
+            $this->assertInstanceOf('\SensitiveParameterValue', $trace[0]['args'][1]);
+        }
     }
 
     public function testIsAndSetLeader()

--- a/tests/Core/Client/RequestTest.php
+++ b/tests/Core/Client/RequestTest.php
@@ -543,6 +543,26 @@ EOF;
         );
     }
 
+    public function testSetAuthenticationSensitiveParameter()
+    {
+        // #[\SensitiveParameter] was introduced in PHP 8.2
+        if (!class_exists('\SensitiveParameter')) {
+            $this->expectNotToPerformAssertions();
+
+            return;
+        }
+
+        try {
+            // trigger a \TypeError with the $user argument
+            $this->request->setAuthentication(null, 'S0M3p455');
+        } catch (\TypeError $e) {
+            $trace = $e->getTrace();
+
+            // \SensitiveParameterValue::class trips phpstan in PHP versions that don't support it
+            $this->assertInstanceOf('\SensitiveParameterValue', $trace[0]['args'][1]);
+        }
+    }
+
     public function testSetAndGetIsServerRequest()
     {
         $this->request->setIsServerRequest();


### PR DESCRIPTION
PHP 8.2 lets you [redact sensitive parameters](https://www.php.net/manual/en/class.sensitiveparameter) in a stack trace.