### PR TITLE
Fix deprecations for abstract test classes in PHPUnit 9.6

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
     colors="true"

--- a/tests/Component/Highlighting/AbstractHighlightingTestCase.php
+++ b/tests/Component/Highlighting/AbstractHighlightingTestCase.php
@@ -5,7 +5,7 @@ namespace Solarium\Tests\Component\Highlighting;
 use PHPUnit\Framework\TestCase;
 use Solarium\Component\Highlighting\HighlightingInterface;
 
-abstract class AbstractHighlightingTest extends TestCase
+abstract class AbstractHighlightingTestCase extends TestCase
 {
     /**
      * @var HighlightingInterface

--- a/tests/Component/Highlighting/FieldTest.php
+++ b/tests/Component/Highlighting/FieldTest.php
@@ -4,7 +4,7 @@ namespace Solarium\Tests\Component\Highlighting;
 
 use Solarium\Component\Highlighting\Field;
 
-class FieldTest extends AbstractHighlightingTest
+class FieldTest extends AbstractHighlightingTestCase
 {
     /**
      * @var Field

--- a/tests/Component/Highlighting/HighlightingTest.php
+++ b/tests/Component/Highlighting/HighlightingTest.php
@@ -7,7 +7,7 @@ use Solarium\Component\Highlighting\Highlighting;
 use Solarium\Exception\InvalidArgumentException;
 use Solarium\QueryType\Select\Query\Query;
 
-class HighlightingTest extends AbstractHighlightingTest
+class HighlightingTest extends AbstractHighlightingTestCase
 {
     /**
      * @var Highlighting

--- a/tests/Integration/AbstractCloudTestCase.php
+++ b/tests/Integration/AbstractCloudTestCase.php
@@ -7,7 +7,7 @@ use Solarium\Core\Client\State\ClusterState;
 /**
  * Abstract base class.
  */
-abstract class AbstractCloudTest extends AbstractTechproductsTest
+abstract class AbstractCloudTestCase extends AbstractTechproductsTestCase
 {
     protected static function createTechproducts(): void
     {

--- a/tests/Integration/AbstractServerTestCase.php
+++ b/tests/Integration/AbstractServerTestCase.php
@@ -4,7 +4,7 @@ namespace Solarium\Tests\Integration;
 
 use Solarium\Exception\HttpException;
 
-abstract class AbstractServerTest extends AbstractTechproductsTest
+abstract class AbstractServerTestCase extends AbstractTechproductsTestCase
 {
     protected static function createTechproducts(): void
     {

--- a/tests/Integration/AbstractTechproductsTestCase.php
+++ b/tests/Integration/AbstractTechproductsTestCase.php
@@ -59,7 +59,7 @@ use Solarium\Support\Utility;
 use Solarium\Tests\Integration\Plugin\EventTimer;
 use Symfony\Contracts\EventDispatcher\Event;
 
-abstract class AbstractTechproductsTest extends TestCase
+abstract class AbstractTechproductsTestCase extends TestCase
 {
     /**
      * @var ClientInterface
@@ -219,7 +219,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertSame(0, $result->getStatus());
         $this->assertSame('OK', $result->getPingStatus());
 
-        if ($this instanceof AbstractCloudTest) {
+        if ($this instanceof AbstractCloudTestCase) {
             $this->assertTrue($result->getZkConnected());
         } else {
             $this->assertNull($result->getZkConnected());
@@ -960,7 +960,7 @@ abstract class AbstractTechproductsTest extends TestCase
         // Solr 7 doesn't support mlt.interestingTerms for MoreLikeThisComponent
         // Solr 8 & Solr 9: "To use this parameter with the search component, the query cannot be distributed."
         // https://solr.apache.org/guide/morelikethis.html#common-handler-and-component-parameters
-        if (8 <= self::$solrVersion && $this instanceof AbstractServerTest) {
+        if (8 <= self::$solrVersion && $this instanceof AbstractServerTestCase) {
             // with 'details', interesting terms are an associative array of terms and their boost values
             $interestingTerms = $mlt->getInterestingTerm($document->id);
             $this->assertSame('cat:search', key($interestingTerms));
@@ -1224,7 +1224,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $terms->setFields('name');
 
         // Setting distrib to true in a non cloud setup causes exceptions.
-        if ($this instanceof AbstractCloudTest) {
+        if ($this instanceof AbstractCloudTestCase) {
             $terms->setDistrib(true);
         }
 
@@ -1250,7 +1250,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $select = self::$client->createQuery('test');
 
         // Setting distrib to true in a non cloud setup causes exceptions.
-        if ($this instanceof AbstractCloudTest) {
+        if ($this instanceof AbstractCloudTestCase) {
             $select->setDistrib(true);
         }
 
@@ -1391,7 +1391,7 @@ abstract class AbstractTechproductsTest extends TestCase
         $this->assertSame(0, $response->getStatus());
 
         // rollback is currently not supported in SolrCloud mode (SOLR-4895)
-        if ($this instanceof AbstractServerTest) {
+        if ($this instanceof AbstractServerTestCase) {
             // add, rollback, commit
             $update = self::$client->createUpdate();
             $update->setRequestFormat($requestFormat);
@@ -1635,7 +1635,7 @@ abstract class AbstractTechproductsTest extends TestCase
         ], $result->getIterator()->current()->getFields());
 
         // add-distinct with multiple values can add duplicates in Solr 7 cloud mode (SOLR-14550)
-        if (7 === self::$solrVersion && $this instanceof AbstractCloudTest) {
+        if (7 === self::$solrVersion && $this instanceof AbstractCloudTestCase) {
             // we still have to emulate a successful atomic update for the remainder of this test to pass
             $doc = $update->createDocument();
             $doc->setKey('id', 'solarium-test');

--- a/tests/Integration/Proxy/AbstractProxyTestCase.php
+++ b/tests/Integration/Proxy/AbstractProxyTestCase.php
@@ -11,7 +11,7 @@ use Solarium\Core\Client\Request;
  *
  * @group integration
  */
-abstract class AbstractProxyTest extends TestCase
+abstract class AbstractProxyTestCase extends TestCase
 {
     /**
      * @var ClientInterface

--- a/tests/Integration/Proxy/CurlTest.php
+++ b/tests/Integration/Proxy/CurlTest.php
@@ -11,7 +11,7 @@ use Solarium\Tests\Integration\TestClientFactory;
  *
  * @group integration
  */
-class CurlTest extends AbstractProxyTest
+class CurlTest extends AbstractProxyTestCase
 {
     protected static function createClient(): void
     {

--- a/tests/Integration/Proxy/HttpTest.php
+++ b/tests/Integration/Proxy/HttpTest.php
@@ -9,7 +9,7 @@ use Solarium\Tests\Integration\TestClientFactory;
  *
  * @group integration
  */
-class HttpTest extends AbstractProxyTest
+class HttpTest extends AbstractProxyTestCase
 {
     protected static function createClient(): void
     {

--- a/tests/Integration/SolrCloud/CurlTest.php
+++ b/tests/Integration/SolrCloud/CurlTest.php
@@ -3,13 +3,13 @@
 namespace Solarium\Tests\Integration\SolrCloud;
 
 use Solarium\Core\Client\Adapter\Curl;
-use Solarium\Tests\Integration\AbstractCloudTest;
+use Solarium\Tests\Integration\AbstractCloudTestCase;
 
 /**
  * @group integration
  * @group skip_for_solr_server
  */
-class CurlTest extends AbstractCloudTest
+class CurlTest extends AbstractCloudTestCase
 {
     public function setUp(): void
     {

--- a/tests/Integration/SolrCloud/HttpTest.php
+++ b/tests/Integration/SolrCloud/HttpTest.php
@@ -3,13 +3,13 @@
 namespace Solarium\Tests\Integration\SolrCloud;
 
 use Solarium\Core\Client\Adapter\Http;
-use Solarium\Tests\Integration\AbstractCloudTest;
+use Solarium\Tests\Integration\AbstractCloudTestCase;
 
 /**
  * @group integration
  * @group skip_for_solr_server
  */
-class HttpTest extends AbstractCloudTest
+class HttpTest extends AbstractCloudTestCase
 {
     public function setUp(): void
     {

--- a/tests/Integration/SolrCloud/Psr18Test.php
+++ b/tests/Integration/SolrCloud/Psr18Test.php
@@ -2,12 +2,12 @@
 
 namespace Solarium\Tests\Integration\SolrCloud;
 
-use Solarium\Tests\Integration\AbstractCloudTest;
+use Solarium\Tests\Integration\AbstractCloudTestCase;
 
 /**
  * @group integration
  * @group skip_for_solr_server
  */
-class Psr18Test extends AbstractCloudTest
+class Psr18Test extends AbstractCloudTestCase
 {
 }

--- a/tests/Integration/SolrServer/CurlTest.php
+++ b/tests/Integration/SolrServer/CurlTest.php
@@ -3,13 +3,13 @@
 namespace Solarium\Tests\Integration\SolrServer;
 
 use Solarium\Core\Client\Adapter\Curl;
-use Solarium\Tests\Integration\AbstractServerTest;
+use Solarium\Tests\Integration\AbstractServerTestCase;
 
 /**
  * @group integration
  * @group skip_for_solr_cloud
  */
-class CurlTest extends AbstractServerTest
+class CurlTest extends AbstractServerTestCase
 {
     public function setUp(): void
     {

--- a/tests/Integration/SolrServer/HttpTest.php
+++ b/tests/Integration/SolrServer/HttpTest.php
@@ -3,13 +3,13 @@
 namespace Solarium\Tests\Integration\SolrServer;
 
 use Solarium\Core\Client\Adapter\Http;
-use Solarium\Tests\Integration\AbstractServerTest;
+use Solarium\Tests\Integration\AbstractServerTestCase;
 
 /**
  * @group integration
  * @group skip_for_solr_cloud
  */
-class HttpTest extends AbstractServerTest
+class HttpTest extends AbstractServerTestCase
 {
     public function setUp(): void
     {

--- a/tests/Integration/SolrServer/Psr18Test.php
+++ b/tests/Integration/SolrServer/Psr18Test.php
@@ -2,12 +2,12 @@
 
 namespace Solarium\Tests\Integration\SolrServer;
 
-use Solarium\Tests\Integration\AbstractServerTest;
+use Solarium\Tests\Integration\AbstractServerTestCase;
 
 /**
  * @group integration
  * @group skip_for_solr_cloud
  */
-class Psr18Test extends AbstractServerTest
+class Psr18Test extends AbstractServerTestCase
 {
 }

--- a/tests/Plugin/MinimumScoreFilter/DocumentTest.php
+++ b/tests/Plugin/MinimumScoreFilter/DocumentTest.php
@@ -4,9 +4,9 @@ namespace Solarium\Tests\Plugin\MinimumScoreFilter;
 
 use Solarium\Plugin\MinimumScoreFilter\Document as FilterDocument;
 use Solarium\QueryType\Select\Result\Document;
-use Solarium\Tests\QueryType\Select\Result\AbstractDocumentTest;
+use Solarium\Tests\QueryType\Select\Result\AbstractDocumentTestCase;
 
-class DocumentTest extends AbstractDocumentTest
+class DocumentTest extends AbstractDocumentTestCase
 {
     public function setUp(): void
     {

--- a/tests/Plugin/MinimumScoreFilter/QueryTest.php
+++ b/tests/Plugin/MinimumScoreFilter/QueryTest.php
@@ -6,9 +6,9 @@ use Solarium\Component\Grouping;
 use Solarium\Plugin\MinimumScoreFilter\Query;
 use Solarium\Plugin\MinimumScoreFilter\QueryGroupResult;
 use Solarium\Plugin\MinimumScoreFilter\ValueGroupResult;
-use Solarium\Tests\QueryType\Select\Query\AbstractQueryTest;
+use Solarium\Tests\QueryType\Select\Query\AbstractQueryTestCase;
 
-class QueryTest extends AbstractQueryTest
+class QueryTest extends AbstractQueryTestCase
 {
     public function setUp(): void
     {

--- a/tests/Plugin/MinimumScoreFilter/ResultTest.php
+++ b/tests/Plugin/MinimumScoreFilter/ResultTest.php
@@ -6,9 +6,9 @@ use Solarium\Exception\OutOfBoundsException;
 use Solarium\Plugin\MinimumScoreFilter\Query;
 use Solarium\Plugin\MinimumScoreFilter\Result;
 use Solarium\QueryType\Select\Result\Document;
-use Solarium\Tests\QueryType\Select\Result\AbstractResultTest;
+use Solarium\Tests\QueryType\Select\Result\AbstractResultTestCase;
 
-class ResultTest extends AbstractResultTest
+class ResultTest extends AbstractResultTestCase
 {
     public function setUp(): void
     {

--- a/tests/QueryType/Extract/ResultTest.php
+++ b/tests/QueryType/Extract/ResultTest.php
@@ -4,9 +4,9 @@ namespace Solarium\Tests\QueryType\Extract;
 
 use Solarium\QueryType\Extract\Query as ExtractQuery;
 use Solarium\QueryType\Extract\Result as ExtractResult;
-use Solarium\Tests\QueryType\Update\AbstractResultTest;
+use Solarium\Tests\QueryType\Update\AbstractResultTestCase;
 
-class ResultTest extends AbstractResultTest
+class ResultTest extends AbstractResultTestCase
 {
     public function setUp(): void
     {

--- a/tests/QueryType/Luke/Result/Schema/Field/AbstractFieldTestCase.php
+++ b/tests/QueryType/Luke/Result/Schema/Field/AbstractFieldTestCase.php
@@ -11,7 +11,7 @@ use Solarium\QueryType\Luke\Result\Schema\Field\Field;
 use Solarium\QueryType\Luke\Result\Schema\Field\WildcardField;
 use Solarium\QueryType\Luke\Result\Schema\Type\Type;
 
-abstract class AbstractFieldTest extends TestCase
+abstract class AbstractFieldTestCase extends TestCase
 {
     /**
      * @var AbstractField

--- a/tests/QueryType/Luke/Result/Schema/Field/DynamicBasedFieldTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Field/DynamicBasedFieldTest.php
@@ -8,7 +8,7 @@ use Solarium\QueryType\Luke\Result\Schema\Field\DynamicBasedField;
 use Solarium\QueryType\Luke\Result\Schema\Field\DynamicField;
 use Solarium\QueryType\Luke\Result\Schema\Field\SchemaFieldInterface;
 
-class DynamicBasedFieldTest extends AbstractFieldTest
+class DynamicBasedFieldTest extends AbstractFieldTestCase
 {
     /**
      * @var DynamicBasedField

--- a/tests/QueryType/Luke/Result/Schema/Field/DynamicFieldTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Field/DynamicFieldTest.php
@@ -10,7 +10,7 @@ use Solarium\QueryType\Luke\Result\Schema\Field\DynamicField;
 use Solarium\QueryType\Luke\Result\Schema\Field\SchemaFieldInterface;
 use Solarium\QueryType\Luke\Result\Schema\Type\Type;
 
-class DynamicFieldTest extends AbstractFieldTest
+class DynamicFieldTest extends AbstractFieldTestCase
 {
     /**
      * @var DynamicField

--- a/tests/QueryType/Luke/Result/Schema/Field/FieldTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Field/FieldTest.php
@@ -7,7 +7,7 @@ use Solarium\QueryType\Luke\Result\Schema\Field\CopyFieldSourceInterface;
 use Solarium\QueryType\Luke\Result\Schema\Field\Field;
 use Solarium\QueryType\Luke\Result\Schema\Field\SchemaFieldInterface;
 
-class FieldTest extends AbstractFieldTest
+class FieldTest extends AbstractFieldTestCase
 {
     /**
      * @var Field

--- a/tests/QueryType/Luke/Result/Schema/Type/AbstractAnalyzerTestCase.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/AbstractAnalyzerTestCase.php
@@ -8,7 +8,7 @@ use Solarium\QueryType\Luke\Result\Schema\Type\CharFilter;
 use Solarium\QueryType\Luke\Result\Schema\Type\Filter;
 use Solarium\QueryType\Luke\Result\Schema\Type\Tokenizer;
 
-abstract class AbstractAnalyzerTest extends TestCase
+abstract class AbstractAnalyzerTestCase extends TestCase
 {
     /**
      * @var AbstractAnalyzer

--- a/tests/QueryType/Luke/Result/Schema/Type/AbstractFilterTestCase.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/AbstractFilterTestCase.php
@@ -5,7 +5,7 @@ namespace Solarium\Tests\QueryType\Luke\Result\Schema\Type;
 use PHPUnit\Framework\TestCase;
 use Solarium\QueryType\Luke\Result\Schema\Type\AbstractFilter;
 
-abstract class AbstractFilterTest extends TestCase
+abstract class AbstractFilterTestCase extends TestCase
 {
     /**
      * @var AbstractFilter

--- a/tests/QueryType/Luke/Result/Schema/Type/CharFilterTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/CharFilterTest.php
@@ -4,7 +4,7 @@ namespace Solarium\Tests\QueryType\Luke\Result\Schema\Type;
 
 use Solarium\QueryType\Luke\Result\Schema\Type\CharFilter;
 
-class CharFilterTest extends AbstractFilterTest
+class CharFilterTest extends AbstractFilterTestCase
 {
     /**
      * @var CharFilter

--- a/tests/QueryType/Luke/Result/Schema/Type/FilterTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/FilterTest.php
@@ -4,7 +4,7 @@ namespace Solarium\Tests\QueryType\Luke\Result\Schema\Type;
 
 use Solarium\QueryType\Luke\Result\Schema\Type\Filter;
 
-class FilterTest extends AbstractFilterTest
+class FilterTest extends AbstractFilterTestCase
 {
     /**
      * @var Filter

--- a/tests/QueryType/Luke/Result/Schema/Type/IndexAnalyzerTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/IndexAnalyzerTest.php
@@ -4,7 +4,7 @@ namespace Solarium\Tests\QueryType\Luke\Result\Schema\Type;
 
 use Solarium\QueryType\Luke\Result\Schema\Type\IndexAnalyzer;
 
-class IndexAnalyzerTest extends AbstractAnalyzerTest
+class IndexAnalyzerTest extends AbstractAnalyzerTestCase
 {
     /**
      * @var IndexAnalyzer

--- a/tests/QueryType/Luke/Result/Schema/Type/QueryAnalyzerTest.php
+++ b/tests/QueryType/Luke/Result/Schema/Type/QueryAnalyzerTest.php
@@ -4,7 +4,7 @@ namespace Solarium\Tests\QueryType\Luke\Result\Schema\Type;
 
 use Solarium\QueryType\Luke\Result\Schema\Type\QueryAnalyzer;
 
-class QueryAnalyzerTest extends AbstractAnalyzerTest
+class QueryAnalyzerTest extends AbstractAnalyzerTestCase
 {
     /**
      * @var QueryAnalyzer

--- a/tests/QueryType/Select/Query/AbstractQueryTestCase.php
+++ b/tests/QueryType/Select/Query/AbstractQueryTestCase.php
@@ -11,7 +11,7 @@ use Solarium\Exception\OutOfBoundsException;
 use Solarium\QueryType\Select\Query\FilterQuery;
 use Solarium\QueryType\Select\Query\Query;
 
-abstract class AbstractQueryTest extends TestCase
+abstract class AbstractQueryTestCase extends TestCase
 {
     /**
      * @var Query

--- a/tests/QueryType/Select/Query/QueryTest.php
+++ b/tests/QueryType/Select/Query/QueryTest.php
@@ -4,7 +4,7 @@ namespace Solarium\Tests\QueryType\Select\Query;
 
 use Solarium\QueryType\Select\Query\Query;
 
-class QueryTest extends AbstractQueryTest
+class QueryTest extends AbstractQueryTestCase
 {
     public function setUp(): void
     {

--- a/tests/QueryType/Select/Result/AbstractDocumentTestCase.php
+++ b/tests/QueryType/Select/Result/AbstractDocumentTestCase.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Solarium\Exception\RuntimeException;
 use Solarium\QueryType\Select\Result\Document;
 
-abstract class AbstractDocumentTest extends TestCase
+abstract class AbstractDocumentTestCase extends TestCase
 {
     /**
      * @var Document

--- a/tests/QueryType/Select/Result/AbstractResultTestCase.php
+++ b/tests/QueryType/Select/Result/AbstractResultTestCase.php
@@ -7,7 +7,7 @@ use Solarium\Component\ComponentAwareQueryInterface;
 use Solarium\QueryType\Select\Result\Document;
 use Solarium\QueryType\Select\Result\Result;
 
-abstract class AbstractResultTest extends TestCase
+abstract class AbstractResultTestCase extends TestCase
 {
     /**
      * @var SelectDummy

--- a/tests/QueryType/Select/Result/DocumentTest.php
+++ b/tests/QueryType/Select/Result/DocumentTest.php
@@ -4,7 +4,7 @@ namespace Solarium\Tests\QueryType\Select\Result;
 
 use Solarium\QueryType\Select\Result\Document;
 
-class DocumentTest extends AbstractDocumentTest
+class DocumentTest extends AbstractDocumentTestCase
 {
     public function setUp(): void
     {

--- a/tests/QueryType/Select/Result/ResultTest.php
+++ b/tests/QueryType/Select/Result/ResultTest.php
@@ -2,6 +2,6 @@
 
 namespace Solarium\Tests\QueryType\Select\Result;
 
-class ResultTest extends AbstractResultTest
+class ResultTest extends AbstractResultTestCase
 {
 }

--- a/tests/QueryType/Update/AbstractResultTestCase.php
+++ b/tests/QueryType/Update/AbstractResultTestCase.php
@@ -4,7 +4,7 @@ namespace Solarium\Tests\QueryType\Update;
 
 use PHPUnit\Framework\TestCase;
 
-abstract class AbstractResultTest extends TestCase
+abstract class AbstractResultTestCase extends TestCase
 {
     protected $result;
 

--- a/tests/QueryType/Update/ResultTest.php
+++ b/tests/QueryType/Update/ResultTest.php
@@ -4,7 +4,7 @@ namespace Solarium\Tests\QueryType\Update;
 
 use Solarium\QueryType\Update\Result as UpdateResult;
 
-class ResultTest extends AbstractResultTest
+class ResultTest extends AbstractResultTestCase
 {
     public function setUp(): void
     {


### PR DESCRIPTION
https://github.com/sebastianbergmann/phpunit/issues/5132 deprecates using the "Test" suffix for abstract test case classes without providing any reason or explanation.

Renaming them from `*Test` to `*TestCase` seems to be the common practice in other projects.