### PR TITLE
MinimumScoreFilter can have a null value in a ValueGroupResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the Solarium library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- MinimumScoreFilter can have a null value in a ValueGroupResult
+
+
 ## [6.3.1]
 ### Added
 - Loadbalancer plugin can failover on an optional list of HTTP status codes

--- a/src/Plugin/MinimumScoreFilter/ValueGroupResult.php
+++ b/src/Plugin/MinimumScoreFilter/ValueGroupResult.php
@@ -39,14 +39,14 @@ class ValueGroupResult extends StandardValueGroup
     /**
      * Constructor.
      *
-     * @param string     $value
-     * @param int        $numFound
-     * @param int        $start
-     * @param array      $documents
-     * @param float|null $maximumScore
-     * @param Query      $query
+     * @param string|null $value
+     * @param int         $numFound
+     * @param int         $start
+     * @param array       $documents
+     * @param float|null  $maximumScore
+     * @param Query       $query
      */
-    public function __construct(string $value, int $numFound, int $start, array $documents, ?float $maximumScore, Query $query)
+    public function __construct(?string $value, int $numFound, int $start, array $documents, ?float $maximumScore, Query $query)
     {
         $this->filterMode = $query->getFilterMode();
         $this->filterRatio = $query->getFilterRatio();


### PR DESCRIPTION
The example assumes `null` is possible, but the `ValueGroupResult()` constructor doesn't allow it to be nullable in the method signature.

https://github.com/solariumphp/solarium/blob/be762b8db6d75529d967394fbd78a2464989540e/examples/7.7.1-plugin-minimumscorefilter-grouping.php#L38-L39

Since the example happens to select only documents with a value for the field, it doesn't actually deal with `null` values. With a query that does yield a `null` group value, you get a Fatal Error.