### PR TITLE
Block Extract from load balancing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MinimumScoreFilter can have a null value in a ValueGroupResult
 - Warning when building an Extract request from a stream resource without an associated URI/filename
 
+### Changed
+- LoadBalancer plugin blocks Extract queries from load balancing by default
+
 
 ## [6.3.1]
 ### Added

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -269,10 +269,17 @@ This plugin is a code based loadbalancer for when you do need the redundancy and
 
 -   support for multiple servers, each with their own ‘weight’
 -   ability to use a failover mode (try another server on query failure)
--   block querytypes from loadbalancing (update queries are blocked by default)
+-   block query types from loadbalancing (`Update` and `Extract` queries are blocked by default)
 -   force a specific server for the next query
 
-All blocked query types (updates by default) are excluded from loadbalancing so they will use the default adapter settings that point to the master. All other queries will be load balanced.
+All blocked query types (`Update` and `Extract` by default) are excluded from loadbalancing so they will use the default adapter settings that point to the master. All other queries will be load balanced.
+
+If you want to load balance a blocked query type anyway (e.g. when extracting without indexing), you can unblock it.
+
+```php
+$loadbalancer = $client->getPlugin('loadbalancer');
+$loadbalancer->removeBlockedQueryType($client::QUERY_EXTRACT);
+```
 
 Failover mode is disabled by default. If enabled, a query will be retried on another endpoint if a connection to the endpoint can't be established.
 You can optionally specify HTTP response status codes for which you also want to failover to another endpoint. The list of failover status codes is empty by default.

--- a/src/Plugin/Loadbalancer/Loadbalancer.php
+++ b/src/Plugin/Loadbalancer/Loadbalancer.php
@@ -65,6 +65,7 @@ class Loadbalancer extends AbstractPlugin
      * @var array
      */
     protected $blockedQueryTypes = [
+        Client::QUERY_EXTRACT => true,
         Client::QUERY_UPDATE => true,
     ];
 

--- a/tests/Plugin/Loadbalancer/LoadbalancerTest.php
+++ b/tests/Plugin/Loadbalancer/LoadbalancerTest.php
@@ -36,6 +36,16 @@ class LoadbalancerTest extends TestCase
      */
     protected $client;
 
+    /**
+     * Query types that are blocked by default according to the documentation.
+     *
+     * @var array
+     */
+    protected $expectedDefaultBlockedQueryTypes = [
+        Client::QUERY_UPDATE,
+        Client::QUERY_EXTRACT,
+    ];
+
     public function setUp(): void
     {
         $this->plugin = new Loadbalancer();
@@ -326,13 +336,21 @@ class LoadbalancerTest extends TestCase
         $this->plugin->setForcedEndpointForNextQuery('s3');
     }
 
+    public function testDefaultBlockedQueryTypes()
+    {
+        $this->assertEqualsCanonicalizing(
+            $this->expectedDefaultBlockedQueryTypes,
+            $this->plugin->getBlockedQueryTypes()
+        );
+    }
+
     public function testAddBlockedQueryType()
     {
         $this->plugin->addBlockedQueryType('type1');
         $this->plugin->addBlockedQueryType('type2');
 
-        $this->assertSame(
-            [Client::QUERY_UPDATE, 'type1', 'type2'],
+        $this->assertEqualsCanonicalizing(
+            array_merge($this->expectedDefaultBlockedQueryTypes, ['type1', 'type2']),
             $this->plugin->getBlockedQueryTypes()
         );
     }


### PR DESCRIPTION
Both `Update` and `Extract` queries cause updates of the index, making this line in the documentation ambiguous.

https://github.com/solariumphp/solarium/blob/c61a0d5815e023c4d4bfd6b7d293e9a1e7c322a9/docs/plugins.md?plain=1#L275

It makes sense to block `Extract` queries by default too. It's less harmful to have an `extractOnly=true` query not load balanced than having a document indexed against sometimes-not-the-master depending on random chance.