### PR TITLE
: self typehints

### DIFF
--- a/src/Component/ComponentAwareQueryInterface.php
+++ b/src/Component/ComponentAwareQueryInterface.php
@@ -111,7 +111,7 @@ interface ComponentAwareQueryInterface
      *
      * @return self Provides fluent interface
      */
-    public function registerComponentType(string $key, string $component);
+    public function registerComponentType(string $key, string $component): self;
 
     /**
      * Get all registered components.

--- a/src/Component/ComponentAwareQueryTrait.php
+++ b/src/Component/ComponentAwareQueryTrait.php
@@ -48,7 +48,7 @@ trait ComponentAwareQueryTrait
      *
      * @return self Provides fluent interface
      */
-    public function registerComponentType(string $key, string $component)
+    public function registerComponentType(string $key, string $component): self
     {
         $this->componentTypes[$key] = $component;
 
@@ -111,7 +111,7 @@ trait ComponentAwareQueryTrait
      *
      * @return self Provides fluent interface
      */
-    public function setComponent(string $key, AbstractComponent $component): ComponentAwareQueryInterface
+    public function setComponent(string $key, AbstractComponent $component): self
     {
         $component->setQueryInstance($this);
         $this->components[$key] = $component;
@@ -128,7 +128,7 @@ trait ComponentAwareQueryTrait
      *
      * @return self Provides fluent interface
      */
-    public function removeComponent($component): ComponentAwareQueryInterface
+    public function removeComponent($component): self
     {
         if (\is_object($component)) {
             foreach ($this->components as $key => $instance) {
@@ -153,7 +153,7 @@ trait ComponentAwareQueryTrait
      *
      * @return self Provides fluent interface
      */
-    protected function createComponents(array $configs): ComponentAwareQueryInterface
+    protected function createComponents(array $configs): self
     {
         foreach ($configs as $type => $config) {
             $this->getComponent($type, true, $config);

--- a/src/Component/ComponentTraits/SpellcheckTrait.php
+++ b/src/Component/ComponentTraits/SpellcheckTrait.php
@@ -32,7 +32,7 @@ trait SpellcheckTrait
      *
      * @return self Provides fluent interface
      */
-    public function setBuild(bool $build): SpellcheckInterface
+    public function setBuild(bool $build): self
     {
         return $this->setOption('build', $build);
     }
@@ -56,7 +56,7 @@ trait SpellcheckTrait
      *
      * @return self Provides fluent interface
      */
-    public function setReload(bool $reload): SpellcheckInterface
+    public function setReload(bool $reload): self
     {
         return $this->setOption('reload', $reload);
     }
@@ -266,7 +266,7 @@ trait SpellcheckTrait
      *
      * @return self Provides fluent interface
      */
-    public function setMaxCollationEvaluations(int $maxCollationEvaluations): SpellcheckInterface
+    public function setMaxCollationEvaluations(int $maxCollationEvaluations): self
     {
         return $this->setOption('maxcollationevaluations', $maxCollationEvaluations);
     }

--- a/src/Component/ComponentTraits/TermsTrait.php
+++ b/src/Component/ComponentTraits/TermsTrait.php
@@ -9,8 +9,6 @@
 
 namespace Solarium\Component\ComponentTraits;
 
-use Solarium\Component\TermsInterface;
-
 /**
  * Terms component.
  *
@@ -30,7 +28,7 @@ trait TermsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setFields($value): TermsInterface
+    public function setFields($value): self
     {
         if (\is_string($value)) {
             $value = explode(',', $value);
@@ -62,7 +60,7 @@ trait TermsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setLowerbound(string $value): TermsInterface
+    public function setLowerbound(string $value): self
     {
         return $this->setOption('lowerbound', $value);
     }
@@ -84,7 +82,7 @@ trait TermsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setLowerboundInclude(bool $value): TermsInterface
+    public function setLowerboundInclude(bool $value): self
     {
         return $this->setOption('lowerboundinclude', $value);
     }
@@ -106,7 +104,7 @@ trait TermsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setMinCount(int $value): TermsInterface
+    public function setMinCount(int $value): self
     {
         return $this->setOption('mincount', $value);
     }
@@ -128,7 +126,7 @@ trait TermsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setMaxCount(int $value): TermsInterface
+    public function setMaxCount(int $value): self
     {
         return $this->setOption('maxcount', $value);
     }
@@ -150,7 +148,7 @@ trait TermsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setPrefix(string $value): TermsInterface
+    public function setPrefix(string $value): self
     {
         return $this->setOption('prefix', $value);
     }
@@ -172,7 +170,7 @@ trait TermsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setRegex(string $value): TermsInterface
+    public function setRegex(string $value): self
     {
         return $this->setOption('regex', $value);
     }
@@ -196,7 +194,7 @@ trait TermsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setRegexFlags($value): TermsInterface
+    public function setRegexFlags($value): self
     {
         if (\is_string($value)) {
             $value = explode(',', $value);
@@ -230,7 +228,7 @@ trait TermsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setLimit(int $value): TermsInterface
+    public function setLimit(int $value): self
     {
         return $this->setOption('limit', $value);
     }
@@ -252,7 +250,7 @@ trait TermsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setUpperbound(string $value): TermsInterface
+    public function setUpperbound(string $value): self
     {
         return $this->setOption('upperbound', $value);
     }
@@ -274,7 +272,7 @@ trait TermsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setUpperboundInclude(bool $value): TermsInterface
+    public function setUpperboundInclude(bool $value): self
     {
         return $this->setOption('upperboundinclude', $value);
     }
@@ -296,7 +294,7 @@ trait TermsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setRaw(bool $value): TermsInterface
+    public function setRaw(bool $value): self
     {
         return $this->setOption('raw', $value);
     }
@@ -318,7 +316,7 @@ trait TermsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setSort(string $value): TermsInterface
+    public function setSort(string $value): self
     {
         return $this->setOption('sort', $value);
     }

--- a/src/Component/Facet/AbstractFacet.php
+++ b/src/Component/Facet/AbstractFacet.php
@@ -61,7 +61,7 @@ abstract class AbstractFacet extends Configurable implements FacetInterface
      *
      * @return self Provides fluent interface
      */
-    public function addExclude(string $exclude)
+    public function addExclude(string $exclude): self
     {
         $this->getLocalParameters()->setExclude($exclude);
 
@@ -75,7 +75,7 @@ abstract class AbstractFacet extends Configurable implements FacetInterface
      *
      * @return self Provides fluent interface
      */
-    public function addExcludes($excludes)
+    public function addExcludes($excludes): self
     {
         if (\is_string($excludes)) {
             $excludes = preg_split('/(?<!\\\\),/', $excludes);
@@ -95,7 +95,7 @@ abstract class AbstractFacet extends Configurable implements FacetInterface
      *
      * @return self Provides fluent interface
      */
-    public function setExcludes($excludes)
+    public function setExcludes($excludes): self
     {
         $this->clearExcludes()->addExcludes($excludes);
 
@@ -109,7 +109,7 @@ abstract class AbstractFacet extends Configurable implements FacetInterface
      *
      * @return self Provides fluent interface
      */
-    public function removeExclude(string $exclude)
+    public function removeExclude(string $exclude): self
     {
         $this->getLocalParameters()->removeExclude($exclude);
 
@@ -121,7 +121,7 @@ abstract class AbstractFacet extends Configurable implements FacetInterface
      *
      * @return self Provides fluent interface
      */
-    public function clearExcludes()
+    public function clearExcludes(): self
     {
         $this->getLocalParameters()->clearExcludes();
 

--- a/src/Component/Facet/FacetInterface.php
+++ b/src/Component/Facet/FacetInterface.php
@@ -39,7 +39,7 @@ interface FacetInterface
      *
      * @return self Provides fluent interface
      */
-    public function setKey(string $key);
+    public function setKey(string $key): self;
 
     /**
      * Add an exclude tag.
@@ -48,7 +48,7 @@ interface FacetInterface
      *
      * @return self Provides fluent interface
      */
-    public function addExclude(string $exclude);
+    public function addExclude(string $exclude): self;
 
     /**
      * Add multiple exclude tags.
@@ -57,7 +57,7 @@ interface FacetInterface
      *
      * @return self Provides fluent interface
      */
-    public function addExcludes($excludes);
+    public function addExcludes($excludes): self;
 
     /**
      * Set the list of exclude tags.
@@ -68,7 +68,7 @@ interface FacetInterface
      *
      * @return self Provides fluent interface
      */
-    public function setExcludes($excludes);
+    public function setExcludes($excludes): self;
 
     /**
      * Remove a single exclude tag.
@@ -77,14 +77,14 @@ interface FacetInterface
      *
      * @return self Provides fluent interface
      */
-    public function removeExclude(string $exclude);
+    public function removeExclude(string $exclude): self;
 
     /**
      * Remove all exclude tags.
      *
      * @return self Provides fluent interface
      */
-    public function clearExcludes();
+    public function clearExcludes(): self;
 
     /**
      * Get the list of exclude tags.

--- a/src/Component/Facet/FieldValueParametersInterface.php
+++ b/src/Component/Facet/FieldValueParametersInterface.php
@@ -51,7 +51,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setPrefix(string $prefix);
+    public function setPrefix(string $prefix): self;
 
     /**
      * Get the facet prefix.
@@ -67,7 +67,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setContains(string $contains);
+    public function setContains(string $contains): self;
 
     /**
      * Get the facet contains.
@@ -83,7 +83,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setContainsIgnoreCase(bool $containsIgnoreCase);
+    public function setContainsIgnoreCase(bool $containsIgnoreCase): self;
 
     /**
      * Get the case sensitivity of facet contains.
@@ -99,7 +99,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setMatches(string $matches);
+    public function setMatches(string $matches): self;
 
     /**
      * Get the regular expression string that facets must match.
@@ -117,7 +117,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setSort(string $sort);
+    public function setSort(string $sort): self;
 
     /**
      * Get the facet sort type.
@@ -133,7 +133,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setLimit(int $limit);
+    public function setLimit(int $limit): self;
 
     /**
      * Get the facet limit.
@@ -149,7 +149,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setOffset(int $offset);
+    public function setOffset(int $offset): self;
 
     /**
      * Get the facet offset.
@@ -165,7 +165,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setMinCount(int $minCount);
+    public function setMinCount(int $minCount): self;
 
     /**
      * Get the facet mincount.
@@ -181,7 +181,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setMissing(bool $missing);
+    public function setMissing(bool $missing): self;
 
     /**
      * Get the facet missing option.
@@ -199,7 +199,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setMethod(string $method);
+    public function setMethod(string $method): self;
 
     /**
      * Get the facet method.
@@ -217,7 +217,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setEnumCacheMinimumDocumentFrequency(int $frequency);
+    public function setEnumCacheMinimumDocumentFrequency(int $frequency): self;
 
     /**
      * Get the minimum document frequency for which the filterCache should be used.
@@ -233,7 +233,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setExists(bool $exists);
+    public function setExists(bool $exists): self;
 
     /**
      * Get the exists parameter.
@@ -251,7 +251,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setExcludeTerms(string $exclude);
+    public function setExcludeTerms(string $exclude): self;
 
     /**
      * Get terms that should be excluded from the facet.
@@ -267,7 +267,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setOverrequestCount(int $count);
+    public function setOverrequestCount(int $count): self;
 
     /**
      * Get the facet overrequest count.
@@ -283,7 +283,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setOverrequestRatio(float $ratio);
+    public function setOverrequestRatio(float $ratio): self;
 
     /**
      * Get the facet overrequest ratio.
@@ -303,7 +303,7 @@ interface FieldValueParametersInterface
      *
      * @return self Provides fluent interface
      */
-    public function setThreads(int $threads);
+    public function setThreads(int $threads): self;
 
     /**
      * Get the maximum number of threads used for parallel execution.

--- a/src/Component/FacetSetInterface.php
+++ b/src/Component/FacetSetInterface.php
@@ -77,7 +77,7 @@ interface FacetSetInterface
      *
      * @return self Provides fluent interface
      */
-    public function addFacet($facet);
+    public function addFacet($facet): self;
 
     /**
      * Add multiple facets.
@@ -86,7 +86,7 @@ interface FacetSetInterface
      *
      * @return self Provides fluent interface
      */
-    public function addFacets(array $facets);
+    public function addFacets(array $facets): self;
 
     /**
      * Get a facet.
@@ -113,14 +113,14 @@ interface FacetSetInterface
      *
      * @return self Provides fluent interface
      */
-    public function removeFacet($facet);
+    public function removeFacet($facet): self;
 
     /**
      * Remove all facets.
      *
      * @return self Provides fluent interface
      */
-    public function clearFacets();
+    public function clearFacets(): self;
 
     /**
      * Set multiple facets.
@@ -131,7 +131,7 @@ interface FacetSetInterface
      *
      * @return self Provides fluent interface
      */
-    public function setFacets(array $facets);
+    public function setFacets(array $facets): self;
 
     /**
      * Create a facet instance.

--- a/src/Component/FacetSetTrait.php
+++ b/src/Component/FacetSetTrait.php
@@ -34,7 +34,7 @@ trait FacetSetTrait
      *
      * @return self Provides fluent interface
      */
-    public function addFacet($facet): FacetSetInterface
+    public function addFacet($facet): self
     {
         if (\is_array($facet)) {
             $facet = $this->createFacet($facet['type'], $facet, false);
@@ -63,7 +63,7 @@ trait FacetSetTrait
      *
      * @return self Provides fluent interface
      */
-    public function addFacets(array $facets): FacetSetInterface
+    public function addFacets(array $facets): self
     {
         foreach ($facets as $key => $facet) {
             // in case of a config array: add key to config
@@ -108,7 +108,7 @@ trait FacetSetTrait
      *
      * @return self Provides fluent interface
      */
-    public function removeFacet($facet): FacetSetInterface
+    public function removeFacet($facet): self
     {
         if (\is_object($facet)) {
             $facet = $facet->getKey();
@@ -126,7 +126,7 @@ trait FacetSetTrait
      *
      * @return self Provides fluent interface
      */
-    public function clearFacets(): FacetSetInterface
+    public function clearFacets(): self
     {
         $this->facets = [];
 
@@ -140,9 +140,9 @@ trait FacetSetTrait
      *
      * @param array $facets
      *
-     * @return self
+     * @return self Provides fluent interface
      */
-    public function setFacets(array $facets): FacetSetInterface
+    public function setFacets(array $facets): self
     {
         $this->clearFacets();
         $this->addFacets($facets);

--- a/src/Component/Grouping.php
+++ b/src/Component/Grouping.php
@@ -104,7 +104,7 @@ class Grouping extends AbstractComponent
      *
      * @param string $field
      *
-     * @return self fluent interface
+     * @return self Provides fluent interface
      */
     public function addField(string $field): self
     {
@@ -147,7 +147,7 @@ class Grouping extends AbstractComponent
     /**
      * Remove all fields.
      *
-     * @return self fluent interface
+     * @return self Provides fluent interface
      */
     public function clearFields(): self
     {
@@ -180,7 +180,7 @@ class Grouping extends AbstractComponent
      *
      * @param string $query
      *
-     * @return self fluent interface
+     * @return self Provides fluent interface
      */
     public function addQuery(string $query): self
     {
@@ -220,7 +220,7 @@ class Grouping extends AbstractComponent
     /**
      * Remove all queries.
      *
-     * @return self fluent interface
+     * @return self Provides fluent interface
      */
     public function clearQueries(): self
     {

--- a/src/Component/Highlighting/HighlightingInterface.php
+++ b/src/Component/Highlighting/HighlightingInterface.php
@@ -143,7 +143,7 @@ interface HighlightingInterface
      *
      * @deprecated Use {@link setMethod()} for Solr 6.4 and higher
      */
-    public function setUseFastVectorHighlighter(bool $use): HighlightingInterface;
+    public function setUseFastVectorHighlighter(bool $use): self;
 
     /**
      * Get useFastVectorHighlighter option.
@@ -161,7 +161,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setMethod(string $method): HighlightingInterface;
+    public function setMethod(string $method): self;
 
     /**
      * Get highlighter method.
@@ -177,7 +177,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setUsePhraseHighlighter(bool $use): HighlightingInterface;
+    public function setUsePhraseHighlighter(bool $use): self;
 
     /**
      * Get usePhraseHighlighter option.
@@ -193,7 +193,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setHighlightMultiTerm(bool $highlight): HighlightingInterface;
+    public function setHighlightMultiTerm(bool $highlight): self;
 
     /**
      * Get HighlightMultiTerm option.
@@ -211,7 +211,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setSnippets(int $maximum): HighlightingInterface;
+    public function setSnippets(int $maximum): self;
 
     /**
      * Get snippets option.
@@ -229,7 +229,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setFragSize(int $size): HighlightingInterface;
+    public function setFragSize(int $size): self;
 
     /**
      * Get fragsize option.
@@ -247,7 +247,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setTagPrefix(string $prefix): HighlightingInterface;
+    public function setTagPrefix(string $prefix): self;
 
     /**
      * Get tag prefix option.
@@ -267,7 +267,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setTagPostfix(string $postfix): HighlightingInterface;
+    public function setTagPostfix(string $postfix): self;
 
     /**
      * Get tag postfix option.
@@ -287,7 +287,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setEncoder(string $encoder): HighlightingInterface;
+    public function setEncoder(string $encoder): self;
 
     /**
      * Get encoder option.
@@ -305,7 +305,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setMaxAnalyzedChars(int $chars): HighlightingInterface;
+    public function setMaxAnalyzedChars(int $chars): self;
 
     /**
      * Get maxAnalyzedChars option.
@@ -323,7 +323,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setOffsetSource(string $offsetSource): HighlightingInterface;
+    public function setOffsetSource(string $offsetSource): self;
 
     /**
      * Get offsetSource option.
@@ -341,7 +341,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setFragAlignRatio(float $fragAlignRatio): HighlightingInterface;
+    public function setFragAlignRatio(float $fragAlignRatio): self;
 
     /**
      * Get fragAlignRatio option.
@@ -357,7 +357,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setFragsizeIsMinimum(bool $isMinimum): HighlightingInterface;
+    public function setFragsizeIsMinimum(bool $isMinimum): self;
 
     /**
      * Get fragsizeIsMinimum option.
@@ -373,7 +373,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setTagEllipsis(string $ellipsis): HighlightingInterface;
+    public function setTagEllipsis(string $ellipsis): self;
 
     /**
      * Get tag.ellipsis option.
@@ -389,7 +389,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setDefaultSummary(bool $defaultSummary): HighlightingInterface;
+    public function setDefaultSummary(bool $defaultSummary): self;
 
     /**
      * Get defaultSummary option.
@@ -407,7 +407,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setScoreK1(float $k1): HighlightingInterface;
+    public function setScoreK1(float $k1): self;
 
     /**
      * Get score.k1 option.
@@ -425,7 +425,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setScoreB(float $b): HighlightingInterface;
+    public function setScoreB(float $b): self;
 
     /**
      * Get score.b option.
@@ -443,7 +443,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setScorePivot(int $pivot): HighlightingInterface;
+    public function setScorePivot(int $pivot): self;
 
     /**
      * Get score.pivot option.
@@ -459,7 +459,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerLanguage(string $language): HighlightingInterface;
+    public function setBoundaryScannerLanguage(string $language): self;
 
     /**
      * Get breakIterator boundary scanner language option.
@@ -475,7 +475,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerCountry(string $country): HighlightingInterface;
+    public function setBoundaryScannerCountry(string $country): self;
 
     /**
      * Get breakIterator boundary scanner country option.
@@ -491,7 +491,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerVariant(string $variant): HighlightingInterface;
+    public function setBoundaryScannerVariant(string $variant): self;
 
     /**
      * Get breakIterator boundary scanner variant option.
@@ -509,7 +509,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerType(string $type): HighlightingInterface;
+    public function setBoundaryScannerType(string $type): self;
 
     /**
      * Get breakIterator boundary scanner type option.
@@ -527,7 +527,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerSeparator(string $separator): HighlightingInterface;
+    public function setBoundaryScannerSeparator(string $separator): self;
 
     /**
      * Get breakIterator boundary scanner separator option.
@@ -545,7 +545,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setWeightMatches(bool $weightMatches): HighlightingInterface;
+    public function setWeightMatches(bool $weightMatches): self;
 
     /**
      * Get weightMatches option.
@@ -563,7 +563,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setMergeContiguous(bool $merge): HighlightingInterface;
+    public function setMergeContiguous(bool $merge): self;
 
     /**
      * Get mergeContiguous option.
@@ -581,7 +581,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setMaxMultiValuedToExamine(int $maximum): HighlightingInterface;
+    public function setMaxMultiValuedToExamine(int $maximum): self;
 
     /**
      * Get maxMultiValuedToExamine option.
@@ -599,7 +599,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setMaxMultiValuedToMatch(int $maximum): HighlightingInterface;
+    public function setMaxMultiValuedToMatch(int $maximum): self;
 
     /**
      * Get maxMultiValuedToMatch option.
@@ -615,7 +615,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setAlternateField(string $field): HighlightingInterface;
+    public function setAlternateField(string $field): self;
 
     /**
      * Get alternateField option.
@@ -631,7 +631,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setMaxAlternateFieldLength(int $length): HighlightingInterface;
+    public function setMaxAlternateFieldLength(int $length): self;
 
     /**
      * Get maxAlternateFieldLength option.
@@ -647,7 +647,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setHighlightAlternate(bool $highlight): HighlightingInterface;
+    public function setHighlightAlternate(bool $highlight): self;
 
     /**
      * Get highlightAlternate option.
@@ -665,7 +665,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setFormatter(string $formatter = HighlightingInterface::FORMATTER_SIMPLE): HighlightingInterface;
+    public function setFormatter(string $formatter = self::FORMATTER_SIMPLE): self;
 
     /**
      * Get formatter option.
@@ -683,7 +683,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setSimplePrefix(string $prefix): HighlightingInterface;
+    public function setSimplePrefix(string $prefix): self;
 
     /**
      * Get simple prefix option.
@@ -703,7 +703,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setSimplePostfix(string $postfix): HighlightingInterface;
+    public function setSimplePostfix(string $postfix): self;
 
     /**
      * Get simple postfix option.
@@ -723,7 +723,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setFragmenter(string $fragmenter): HighlightingInterface;
+    public function setFragmenter(string $fragmenter): self;
 
     /**
      * Get fragmenter option.
@@ -739,7 +739,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setRegexSlop(float $slop): HighlightingInterface;
+    public function setRegexSlop(float $slop): self;
 
     /**
      * Get regex.slop option.
@@ -755,7 +755,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setRegexPattern(string $pattern): HighlightingInterface;
+    public function setRegexPattern(string $pattern): self;
 
     /**
      * Get regex.pattern option.
@@ -771,7 +771,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setRegexMaxAnalyzedChars(int $chars): HighlightingInterface;
+    public function setRegexMaxAnalyzedChars(int $chars): self;
 
     /**
      * Get regex.maxAnalyzedChars option.
@@ -787,7 +787,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setPreserveMulti(bool $preservemulti): HighlightingInterface;
+    public function setPreserveMulti(bool $preservemulti): self;
 
     /**
      * Get preserveMulti option.
@@ -803,7 +803,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setPayloads(bool $payloads): HighlightingInterface;
+    public function setPayloads(bool $payloads): self;
 
     /**
      * Get payloads option.
@@ -821,7 +821,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setFragListBuilder(string $builder): HighlightingInterface;
+    public function setFragListBuilder(string $builder): self;
 
     /**
      * Get fragListBuilder option.
@@ -839,7 +839,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setFragmentsBuilder(string $builder): HighlightingInterface;
+    public function setFragmentsBuilder(string $builder): self;
 
     /**
      * Get fragmentsBuilder option.
@@ -857,7 +857,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScanner(string $scanner): HighlightingInterface;
+    public function setBoundaryScanner(string $scanner): self;
 
     /**
      * Get boundaryScanner option.
@@ -873,7 +873,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerMaxScan(int $maximum): HighlightingInterface;
+    public function setBoundaryScannerMaxScan(int $maximum): self;
 
     /**
      * Get simple boundary scanner maxScan option.
@@ -889,7 +889,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerChars(string $chars): HighlightingInterface;
+    public function setBoundaryScannerChars(string $chars): self;
 
     /**
      * Get simple boundary scanner cgars option.
@@ -907,7 +907,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setPhraseLimit(int $maximum): HighlightingInterface;
+    public function setPhraseLimit(int $maximum): self;
 
     /**
      * Get phraseLimit option.
@@ -925,7 +925,7 @@ interface HighlightingInterface
      *
      * @return self Provides fluent interface
      */
-    public function setMultiValuedSeparatorChar(string $separator): HighlightingInterface;
+    public function setMultiValuedSeparatorChar(string $separator): self;
 
     /**
      * Get multiValuedSeparatorChar option.

--- a/src/Component/Highlighting/HighlightingTrait.php
+++ b/src/Component/Highlighting/HighlightingTrait.php
@@ -23,7 +23,7 @@ trait HighlightingTrait
      *
      * @deprecated Use {@link setMethod()} for Solr 6.4 and higher
      */
-    public function setUseFastVectorHighlighter(bool $use): HighlightingInterface
+    public function setUseFastVectorHighlighter(bool $use): self
     {
         $this->setOption('usefastvectorhighlighter', $use);
 
@@ -49,7 +49,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setMethod(string $method): HighlightingInterface
+    public function setMethod(string $method): self
     {
         $this->setOption('method', $method);
 
@@ -73,7 +73,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setUsePhraseHighlighter(bool $use): HighlightingInterface
+    public function setUsePhraseHighlighter(bool $use): self
     {
         $this->setOption('usephrasehighlighter', $use);
 
@@ -97,7 +97,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setHighlightMultiTerm(bool $highlight): HighlightingInterface
+    public function setHighlightMultiTerm(bool $highlight): self
     {
         $this->setOption('highlightmultiterm', $highlight);
 
@@ -123,7 +123,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setSnippets(int $maximum): HighlightingInterface
+    public function setSnippets(int $maximum): self
     {
         $this->setOption('snippets', $maximum);
 
@@ -149,7 +149,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setFragSize(int $size): HighlightingInterface
+    public function setFragSize(int $size): self
     {
         $this->setOption('fragsize', $size);
 
@@ -175,7 +175,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setTagPrefix(string $prefix): HighlightingInterface
+    public function setTagPrefix(string $prefix): self
     {
         $this->setOption('tagprefix', $prefix);
 
@@ -203,7 +203,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setTagPostfix(string $postfix): HighlightingInterface
+    public function setTagPostfix(string $postfix): self
     {
         $this->setOption('tagpostfix', $postfix);
 
@@ -231,7 +231,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setEncoder(string $encoder): HighlightingInterface
+    public function setEncoder(string $encoder): self
     {
         $this->setOption('encoder', $encoder);
 
@@ -257,7 +257,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setMaxAnalyzedChars(int $chars): HighlightingInterface
+    public function setMaxAnalyzedChars(int $chars): self
     {
         $this->setOption('maxanalyzedchars', $chars);
 
@@ -283,7 +283,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setOffsetSource(string $source): HighlightingInterface
+    public function setOffsetSource(string $source): self
     {
         $this->setOption('offsetsource', $source);
 
@@ -309,7 +309,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setFragAlignRatio(float $ratio): HighlightingInterface
+    public function setFragAlignRatio(float $ratio): self
     {
         $this->setOption('fragalignratio', $ratio);
 
@@ -333,7 +333,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setFragsizeIsMinimum(bool $isMinimum): HighlightingInterface
+    public function setFragsizeIsMinimum(bool $isMinimum): self
     {
         $this->setOption('fragsizeisminimum', $isMinimum);
 
@@ -357,7 +357,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setTagEllipsis(string $ellipsis): HighlightingInterface
+    public function setTagEllipsis(string $ellipsis): self
     {
         $this->setOption('tagellipsis', $ellipsis);
 
@@ -381,7 +381,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setDefaultSummary(bool $defaultSummary): HighlightingInterface
+    public function setDefaultSummary(bool $defaultSummary): self
     {
         $this->setOption('defaultsummary', $defaultSummary);
 
@@ -407,7 +407,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setScoreK1(float $k1): HighlightingInterface
+    public function setScoreK1(float $k1): self
     {
         $this->setOption('scorek1', $k1);
 
@@ -433,7 +433,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setScoreB(float $b): HighlightingInterface
+    public function setScoreB(float $b): self
     {
         $this->setOption('scoreb', $b);
 
@@ -459,7 +459,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setScorePivot(int $pivot): HighlightingInterface
+    public function setScorePivot(int $pivot): self
     {
         $this->setOption('scorepivot', $pivot);
 
@@ -483,7 +483,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerLanguage(string $language): HighlightingInterface
+    public function setBoundaryScannerLanguage(string $language): self
     {
         $this->setOption('boundaryscannerlanguage', $language);
 
@@ -507,7 +507,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerCountry(string $country): HighlightingInterface
+    public function setBoundaryScannerCountry(string $country): self
     {
         $this->setOption('boundaryscannercountry', $country);
 
@@ -531,7 +531,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerVariant(string $variant): HighlightingInterface
+    public function setBoundaryScannerVariant(string $variant): self
     {
         $this->setOption('boundaryscannervariant', $variant);
 
@@ -557,7 +557,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerType(string $type): HighlightingInterface
+    public function setBoundaryScannerType(string $type): self
     {
         $this->setOption('boundaryscannertype', $type);
 
@@ -583,7 +583,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerSeparator(string $separator): HighlightingInterface
+    public function setBoundaryScannerSeparator(string $separator): self
     {
         $this->setOption('boundaryscannerseparator', $separator);
 
@@ -609,7 +609,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setWeightMatches(bool $weightMatches): HighlightingInterface
+    public function setWeightMatches(bool $weightMatches): self
     {
         $this->setOption('weightmatches', $weightMatches);
 
@@ -635,7 +635,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setMergeContiguous(bool $merge): HighlightingInterface
+    public function setMergeContiguous(bool $merge): self
     {
         $this->setOption('mergecontiguous', $merge);
 
@@ -661,7 +661,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setMaxMultiValuedToExamine(int $maximum): HighlightingInterface
+    public function setMaxMultiValuedToExamine(int $maximum): self
     {
         $this->setOption('maxmultivaluedtoexamine', $maximum);
 
@@ -687,7 +687,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setMaxMultiValuedToMatch(int $maximum): HighlightingInterface
+    public function setMaxMultiValuedToMatch(int $maximum): self
     {
         $this->setOption('maxmultivaluedtomatch', $maximum);
 
@@ -711,7 +711,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setAlternateField(string $field): HighlightingInterface
+    public function setAlternateField(string $field): self
     {
         $this->setOption('alternatefield', $field);
 
@@ -735,7 +735,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setMaxAlternateFieldLength(int $length): HighlightingInterface
+    public function setMaxAlternateFieldLength(int $length): self
     {
         $this->setOption('maxalternatefieldlength', $length);
 
@@ -759,7 +759,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setHighlightAlternate(bool $highlight): HighlightingInterface
+    public function setHighlightAlternate(bool $highlight): self
     {
         $this->setOption('highlightalternate', $highlight);
 
@@ -785,7 +785,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setFormatter(string $formatter = HighlightingInterface::FORMATTER_SIMPLE): HighlightingInterface
+    public function setFormatter(string $formatter = HighlightingInterface::FORMATTER_SIMPLE): self
     {
         $this->setOption('formatter', $formatter);
 
@@ -811,7 +811,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setSimplePrefix(string $prefix): HighlightingInterface
+    public function setSimplePrefix(string $prefix): self
     {
         $this->setOption('simpleprefix', $prefix);
 
@@ -839,7 +839,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setSimplePostfix(string $postfix): HighlightingInterface
+    public function setSimplePostfix(string $postfix): self
     {
         $this->setOption('simplepostfix', $postfix);
 
@@ -867,7 +867,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setFragmenter(string $fragmenter): HighlightingInterface
+    public function setFragmenter(string $fragmenter): self
     {
         $this->setOption('fragmenter', $fragmenter);
 
@@ -891,7 +891,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setRegexSlop(float $slop): HighlightingInterface
+    public function setRegexSlop(float $slop): self
     {
         $this->setOption('regexslop', $slop);
 
@@ -915,7 +915,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setRegexPattern(string $pattern): HighlightingInterface
+    public function setRegexPattern(string $pattern): self
     {
         $this->setOption('regexpattern', $pattern);
 
@@ -939,7 +939,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setRegexMaxAnalyzedChars(int $chars): HighlightingInterface
+    public function setRegexMaxAnalyzedChars(int $chars): self
     {
         $this->setOption('regexmaxanalyzedchars', $chars);
 
@@ -963,7 +963,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setPreserveMulti(bool $preservemulti): HighlightingInterface
+    public function setPreserveMulti(bool $preservemulti): self
     {
         $this->setOption('preservemulti', $preservemulti);
 
@@ -987,7 +987,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setPayloads(bool $payloads): HighlightingInterface
+    public function setPayloads(bool $payloads): self
     {
         $this->setOption('payloads', $payloads);
 
@@ -1013,7 +1013,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setFragListBuilder(string $builder): HighlightingInterface
+    public function setFragListBuilder(string $builder): self
     {
         $this->setOption('fraglistbuilder', $builder);
 
@@ -1039,7 +1039,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setFragmentsBuilder(string $builder): HighlightingInterface
+    public function setFragmentsBuilder(string $builder): self
     {
         $this->setOption('fragmentsbuilder', $builder);
 
@@ -1065,7 +1065,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScanner(string $scanner): HighlightingInterface
+    public function setBoundaryScanner(string $scanner): self
     {
         $this->setOption('boundaryscanner', $scanner);
 
@@ -1089,7 +1089,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerMaxScan(int $maximum): HighlightingInterface
+    public function setBoundaryScannerMaxScan(int $maximum): self
     {
         $this->setOption('boundaryscannermaxscan', $maximum);
 
@@ -1113,7 +1113,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setBoundaryScannerChars(string $chars): HighlightingInterface
+    public function setBoundaryScannerChars(string $chars): self
     {
         $this->setOption('boundaryscannerchars', $chars);
 
@@ -1139,7 +1139,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setPhraseLimit(int $maximum): HighlightingInterface
+    public function setPhraseLimit(int $maximum): self
     {
         $this->setOption('phraselimit', $maximum);
 
@@ -1165,7 +1165,7 @@ trait HighlightingTrait
      *
      * @return self Provides fluent interface
      */
-    public function setMultiValuedSeparatorChar(string $separator): HighlightingInterface
+    public function setMultiValuedSeparatorChar(string $separator): self
     {
         $this->setOption('multivaluedseparatorchar', $separator);
 

--- a/src/Component/QueryElevation.php
+++ b/src/Component/QueryElevation.php
@@ -60,7 +60,7 @@ class QueryElevation extends AbstractComponent
      *
      * @param string $transformer
      *
-     * @return self fluent interface
+     * @return self Provides fluent interface
      */
     public function addTransformer(string $transformer): self
     {
@@ -111,7 +111,7 @@ class QueryElevation extends AbstractComponent
     /**
      * Remove all document transformers.
      *
-     * @return self fluent interface
+     * @return self Provides fluent interface
      */
     public function clearTransformers(): self
     {

--- a/src/Component/QueryTrait.php
+++ b/src/Component/QueryTrait.php
@@ -24,7 +24,7 @@ trait QueryTrait
      *
      * @return self Provides fluent interface
      */
-    public function setQuery(string $query, array $bind = null): QueryInterface
+    public function setQuery(string $query, array $bind = null): self
     {
         if (null !== $bind) {
             $helper = $this->getHelper();

--- a/src/Component/ReRankQuery.php
+++ b/src/Component/ReRankQuery.php
@@ -71,7 +71,7 @@ class ReRankQuery extends AbstractComponent implements QueryInterface
      *
      * @param int $value
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setDocs(int $value): self
     {

--- a/src/Component/RequestBuilder/RequestParamsTrait.php
+++ b/src/Component/RequestBuilder/RequestParamsTrait.php
@@ -57,7 +57,7 @@ trait RequestParamsTrait
      *
      * @return self Provides fluent interface
      */
-    public function setParams(array $params): RequestParamsInterface
+    public function setParams(array $params): self
     {
         $this->clearParams();
         $this->addParams($params);
@@ -80,7 +80,7 @@ trait RequestParamsTrait
      *
      * @return self Provides fluent interface
      */
-    public function addParam(string $key, $value, bool $overwrite = false): RequestParamsInterface
+    public function addParam(string $key, $value, bool $overwrite = false): self
     {
         if (null !== $value && [] !== $value) {
             if (!$overwrite && isset($this->params[$key])) {
@@ -111,7 +111,7 @@ trait RequestParamsTrait
      *
      * @return self Provides fluent interface
      */
-    public function addParams(array $params, bool $overwrite = false): RequestParamsInterface
+    public function addParams(array $params, bool $overwrite = false): self
     {
         foreach ($params as $key => $value) {
             $this->addParam($key, $value, $overwrite);
@@ -127,7 +127,7 @@ trait RequestParamsTrait
      *
      * @return self Provides fluent interface
      */
-    public function removeParam(string $key): RequestParamsInterface
+    public function removeParam(string $key): self
     {
         if (isset($this->params[$key])) {
             unset($this->params[$key]);
@@ -141,7 +141,7 @@ trait RequestParamsTrait
      *
      * @return self Provides fluent interface
      */
-    public function clearParams(): RequestParamsInterface
+    public function clearParams(): self
     {
         $this->params = [];
 

--- a/src/Component/Result/Debug/Detail.php
+++ b/src/Component/Result/Debug/Detail.php
@@ -87,7 +87,7 @@ class Detail implements \ArrayAccess
     /**
      * @param \Solarium\Component\Result\Debug\Detail[]|array $subDetails
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setSubDetails(array $subDetails): self
     {

--- a/src/Core/Client/Adapter/ConnectionTimeoutAwareInterface.php
+++ b/src/Core/Client/Adapter/ConnectionTimeoutAwareInterface.php
@@ -21,7 +21,7 @@ interface ConnectionTimeoutAwareInterface
      *
      * @return self Provides fluent interface
      */
-    public function setConnectionTimeout(?int $timeoutInSeconds);
+    public function setConnectionTimeout(?int $timeoutInSeconds): self;
 
     /**
      * @return int|null

--- a/src/Core/Client/Adapter/ConnectionTimeoutAwareTrait.php
+++ b/src/Core/Client/Adapter/ConnectionTimeoutAwareTrait.php
@@ -24,7 +24,7 @@ trait ConnectionTimeoutAwareTrait
     /**
      * {@inheritdoc}
      */
-    public function setConnectionTimeout(?int $timeoutInSeconds)
+    public function setConnectionTimeout(?int $timeoutInSeconds): self
     {
         $this->connectionTimeout = $timeoutInSeconds;
 

--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -228,7 +228,7 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
      *
      * @return array
      */
-    protected function createOptions(Request $request, Endpoint $endpoint)
+    protected function createOptions(Request $request, Endpoint $endpoint): array
     {
         $options = [
             'timeout' => $this->timeout,

--- a/src/Core/Client/Adapter/ProxyAwareInterface.php
+++ b/src/Core/Client/Adapter/ProxyAwareInterface.php
@@ -21,7 +21,7 @@ interface ProxyAwareInterface
      *
      * @return self Provides fluent interface
      */
-    public function setProxy($proxy);
+    public function setProxy($proxy): self;
 
     /**
      * @return mixed|null

--- a/src/Core/Client/Adapter/ProxyAwareTrait.php
+++ b/src/Core/Client/Adapter/ProxyAwareTrait.php
@@ -24,7 +24,7 @@ trait ProxyAwareTrait
     /**
      * {@inheritdoc}
      */
-    public function setProxy($proxy)
+    public function setProxy($proxy): self
     {
         $this->proxy = $proxy;
 

--- a/src/Core/Client/Adapter/TimeoutAwareInterface.php
+++ b/src/Core/Client/Adapter/TimeoutAwareInterface.php
@@ -26,7 +26,7 @@ interface TimeoutAwareInterface
      *
      * @return self Provides fluent interface
      */
-    public function setTimeout(int $timeoutInSeconds);
+    public function setTimeout(int $timeoutInSeconds): self;
 
     /**
      * @return int

--- a/src/Core/Client/Adapter/TimeoutAwareTrait.php
+++ b/src/Core/Client/Adapter/TimeoutAwareTrait.php
@@ -24,7 +24,7 @@ trait TimeoutAwareTrait
     /**
      * {@inheritdoc}
      */
-    public function setTimeout(int $timeoutInSeconds)
+    public function setTimeout(int $timeoutInSeconds): self
     {
         $this->timeout = $timeoutInSeconds;
 

--- a/src/Core/Client/Client.php
+++ b/src/Core/Client/Client.php
@@ -352,7 +352,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return self Provides fluent interface
      */
-    public function addEndpoint($endpoint): ClientInterface
+    public function addEndpoint($endpoint): self
     {
         if (\is_array($endpoint)) {
             $endpoint = new Endpoint($endpoint);
@@ -386,7 +386,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return self Provides fluent interface
      */
-    public function addEndpoints(array $endpoints): ClientInterface
+    public function addEndpoints(array $endpoints): self
     {
         foreach ($endpoints as $key => $endpoint) {
             // in case of a config array: add key to config
@@ -441,7 +441,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return self Provides fluent interface
      */
-    public function removeEndpoint($endpoint): ClientInterface
+    public function removeEndpoint($endpoint): self
     {
         if (\is_object($endpoint)) {
             $endpoint = $endpoint->getKey();
@@ -459,7 +459,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return self Provides fluent interface
      */
-    public function clearEndpoints(): ClientInterface
+    public function clearEndpoints(): self
     {
         $this->endpoints = [];
         $this->defaultEndpoint = null;
@@ -476,7 +476,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return self Provides fluent interface
      */
-    public function setEndpoints(array $endpoints): ClientInterface
+    public function setEndpoints(array $endpoints): self
     {
         $this->clearEndpoints();
         $this->addEndpoints($endpoints);
@@ -495,7 +495,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return self Provides fluent interface
      */
-    public function setDefaultEndpoint($endpoint): ClientInterface
+    public function setDefaultEndpoint($endpoint): self
     {
         if (\is_object($endpoint)) {
             $endpoint = $endpoint->getKey();
@@ -517,7 +517,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return self Provides fluent interface
      */
-    public function setAdapter(AdapterInterface $adapter): ClientInterface
+    public function setAdapter(AdapterInterface $adapter): self
     {
         $this->adapter = $adapter;
 
@@ -546,7 +546,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return self Provides fluent interface
      */
-    public function registerQueryType(string $type, string $queryClass): ClientInterface
+    public function registerQueryType(string $type, string $queryClass): self
     {
         $this->queryTypes[$type] = $queryClass;
 
@@ -560,7 +560,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return self Provides fluent interface
      */
-    public function registerQueryTypes(array $queryTypes): ClientInterface
+    public function registerQueryTypes(array $queryTypes): self
     {
         foreach ($queryTypes as $type => $class) {
             // support both "key=>value" and "(no-key) => array(key=>x,query=>y)" formats
@@ -604,7 +604,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return self Provides fluent interface
      */
-    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): ClientInterface
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): self
     {
         $this->eventDispatcher = $eventDispatcher;
 
@@ -626,7 +626,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return self Provides fluent interface
      */
-    public function registerPlugin(string $key, $plugin, array $options = []): ClientInterface
+    public function registerPlugin(string $key, $plugin, array $options = []): self
     {
         if (\is_string($plugin)) {
             $plugin = class_exists($plugin) ? $plugin : $plugin.strrchr($plugin, '\\');
@@ -651,7 +651,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return self Provides fluent interface
      */
-    public function registerPlugins(array $plugins): ClientInterface
+    public function registerPlugins(array $plugins): self
     {
         foreach ($plugins as $key => $plugin) {
             if (!isset($plugin['key'])) {
@@ -716,7 +716,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return self Provides fluent interface
      */
-    public function removePlugin($plugin): ClientInterface
+    public function removePlugin($plugin): self
     {
         if (\is_object($plugin)) {
             foreach ($this->pluginInstances as $key => $instance) {

--- a/src/Core/Configurable.php
+++ b/src/Core/Configurable.php
@@ -63,9 +63,9 @@ class Configurable implements ConfigurableInterface
      *
      * @throws InvalidArgumentException
      *
-     * @return self
+     * @return self Provides fluent interface
      */
-    public function setOptions($options, bool $overwrite = false): ConfigurableInterface
+    public function setOptions($options, bool $overwrite = false): self
     {
         if (null !== $options) {
             // first convert to array if needed

--- a/src/Core/ConfigurableInterface.php
+++ b/src/Core/ConfigurableInterface.php
@@ -33,7 +33,7 @@ interface ConfigurableInterface
      *
      * @throws InvalidArgumentException
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setOptions($options, bool $overwrite = false): self;
 

--- a/src/Core/Event/PreCreateRequest.php
+++ b/src/Core/Event/PreCreateRequest.php
@@ -55,7 +55,7 @@ class PreCreateRequest extends Event
      *
      * @param Request $request
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setRequest(Request $request): self
     {

--- a/src/Core/Query/AbstractQuery.php
+++ b/src/Core/Query/AbstractQuery.php
@@ -44,7 +44,7 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
      *
      * @return self Provides fluent interface
      */
-    public function setHandler(string $handler): QueryInterface
+    public function setHandler(string $handler): self
     {
         $this->setOption('handler', $handler);
 
@@ -75,7 +75,7 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
      *
      * @return self Provides fluent interface
      */
-    public function setResultClass(string $classname): QueryInterface
+    public function setResultClass(string $classname): self
     {
         $this->setOption('resultclass', $classname);
 
@@ -99,7 +99,7 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
      *
      * @return self Provides fluent interface
      */
-    public function setTimeAllowed(int $value): QueryInterface
+    public function setTimeAllowed(int $value): self
     {
         $this->setOption('timeallowed', $value);
 
@@ -123,7 +123,7 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
      *
      * @return self Provides fluent interface
      */
-    public function setOmitHeader(bool $value): QueryInterface
+    public function setOmitHeader(bool $value): self
     {
         $this->setOption('omitheader', $value);
 
@@ -167,7 +167,7 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
      *
      * @return self Provides fluent interface
      */
-    public function addParam(string $name, $value): QueryInterface
+    public function addParam(string $name, $value): self
     {
         $this->params[$name] = $value;
 
@@ -183,7 +183,7 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
      *
      * @return self Provides fluent interface
      */
-    public function removeParam(string $name): QueryInterface
+    public function removeParam(string $name): self
     {
         if (isset($this->params[$name])) {
             unset($this->params[$name]);
@@ -209,7 +209,7 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
      *
      * @return self Provides fluent interface
      */
-    public function setResponseWriter(string $value): QueryInterface
+    public function setResponseWriter(string $value): self
     {
         $this->setOption('responsewriter', $value);
 

--- a/src/Plugin/BufferedAdd/BufferedAdd.php
+++ b/src/Plugin/BufferedAdd/BufferedAdd.php
@@ -35,7 +35,7 @@ class BufferedAdd extends BufferedAddLite
      *
      * @return self Provides fluent interface
      */
-    public function addDocument(DocumentInterface $document)
+    public function addDocument(DocumentInterface $document): self
     {
         $this->buffer[] = $document;
 

--- a/src/Plugin/BufferedAdd/BufferedAddLite.php
+++ b/src/Plugin/BufferedAdd/BufferedAddLite.php
@@ -102,7 +102,7 @@ class BufferedAddLite extends AbstractBufferedUpdate
      *
      * @return self Provides fluent interface
      */
-    public function addDocument(DocumentInterface $document)
+    public function addDocument(DocumentInterface $document): self
     {
         $this->buffer[] = $document;
 

--- a/src/Plugin/BufferedDelete/BufferedDelete.php
+++ b/src/Plugin/BufferedDelete/BufferedDelete.php
@@ -36,7 +36,7 @@ class BufferedDelete extends BufferedDeleteLite
      *
      * @return self Provides fluent interface
      */
-    public function addDeleteById($id)
+    public function addDeleteById($id): self
     {
         $delete = new DeleteById($id);
         $this->buffer[] = $delete;
@@ -58,7 +58,7 @@ class BufferedDelete extends BufferedDeleteLite
      *
      * @return self Provides fluent interface
      */
-    public function addDeleteQuery(string $query)
+    public function addDeleteQuery(string $query): self
     {
         $delete = new DeleteQuery($query);
         $this->buffer[] = $delete;

--- a/src/Plugin/BufferedDelete/BufferedDeleteLite.php
+++ b/src/Plugin/BufferedDelete/BufferedDeleteLite.php
@@ -40,7 +40,7 @@ class BufferedDeleteLite extends AbstractBufferedUpdate
      *
      * @return self Provides fluent interface
      */
-    public function addDeleteById($id)
+    public function addDeleteById($id): self
     {
         $this->buffer[] = new DeleteById($id);
 
@@ -74,7 +74,7 @@ class BufferedDeleteLite extends AbstractBufferedUpdate
      *
      * @return self Provides fluent interface
      */
-    public function addDeleteQuery(string $query)
+    public function addDeleteQuery(string $query): self
     {
         $this->buffer[] = new DeleteQuery($query);
 

--- a/src/Plugin/ParallelExecution/ParallelExecution.php
+++ b/src/Plugin/ParallelExecution/ParallelExecution.php
@@ -60,7 +60,7 @@ class ParallelExecution extends AbstractPlugin
      *
      * @return self Provides fluent interface
      */
-    public function addQuery(string $key, QueryInterface $query, $endpoint = null)
+    public function addQuery(string $key, QueryInterface $query, $endpoint = null): self
     {
         if (\is_object($endpoint)) {
             $endpoint = $endpoint->getKey();

--- a/src/QueryType/Extract/Query.php
+++ b/src/QueryType/Extract/Query.php
@@ -102,7 +102,7 @@ class Query extends BaseQuery
      *
      * @param DocumentInterface $document
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setDocument(DocumentInterface $document): self
     {
@@ -126,7 +126,7 @@ class Query extends BaseQuery
      *
      * @param string|resource $file
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setFile($file): self
     {
@@ -150,7 +150,7 @@ class Query extends BaseQuery
      *
      * @param string $uprefix
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setUprefix(string $uprefix): self
     {
@@ -175,7 +175,7 @@ class Query extends BaseQuery
      *
      * @param string $defaultField
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setDefaultField(string $defaultField): self
     {
@@ -201,7 +201,7 @@ class Query extends BaseQuery
      *
      * @param bool $lowerNames
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setLowernames(bool $lowerNames): self
     {

--- a/src/QueryType/Luke/Query.php
+++ b/src/QueryType/Luke/Query.php
@@ -292,7 +292,7 @@ class Query extends BaseQuery
      *
      * @param bool $includeIndexFieldFlags
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setIncludeIndexFieldFlags(bool $includeIndexFieldFlags): self
     {

--- a/src/QueryType/Luke/Result/Doc/DocFieldInfo.php
+++ b/src/QueryType/Luke/Result/Doc/DocFieldInfo.php
@@ -94,7 +94,7 @@ class DocFieldInfo
     /**
      * @param string|null $type
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setType(?string $type): self
     {
@@ -116,7 +116,7 @@ class DocFieldInfo
     /**
      * @param FlagList $schema
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setSchema(FlagList $schema): self
     {
@@ -138,7 +138,7 @@ class DocFieldInfo
     /**
      * @param FlagList $flags
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setFlags($flags): self
     {
@@ -160,7 +160,7 @@ class DocFieldInfo
     /**
      * @param string|null $value
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setValue(?string $value): self
     {
@@ -182,7 +182,7 @@ class DocFieldInfo
     /**
      * @param string|null $internal
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setInternal(?string $internal): self
     {
@@ -204,7 +204,7 @@ class DocFieldInfo
     /**
      * @param string|null $binary
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setBinary(?string $binary): self
     {
@@ -228,7 +228,7 @@ class DocFieldInfo
     /**
      * @param int|null $docFreq
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setDocFreq(?int $docFreq): self
     {
@@ -250,7 +250,7 @@ class DocFieldInfo
     /**
      * @param array|null $termVector
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setTermVector(?array $termVector): self
     {

--- a/src/QueryType/Luke/Result/Doc/DocInfo.php
+++ b/src/QueryType/Luke/Result/Doc/DocInfo.php
@@ -64,7 +64,7 @@ class DocInfo
     /**
      * @param DocFieldInfo[] $lucene
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setLucene(array $lucene): self
     {
@@ -86,7 +86,7 @@ class DocInfo
     /**
      * @param DocumentInterface $solr
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setSolr(DocumentInterface $solr): self
     {

--- a/src/QueryType/Luke/Result/Fields/FieldInfo.php
+++ b/src/QueryType/Luke/Result/Fields/FieldInfo.php
@@ -94,7 +94,7 @@ class FieldInfo
     /**
      * @param string|null $type
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setType(?string $type): self
     {
@@ -116,7 +116,7 @@ class FieldInfo
     /**
      * @param FlagList $schema
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setSchema(FlagList $schema): self
     {
@@ -138,7 +138,7 @@ class FieldInfo
     /**
      * @param string|null $dynamicBase
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setDynamicBase(?string $dynamicBase): self
     {
@@ -160,7 +160,7 @@ class FieldInfo
     /**
      * @param FlagList|string|null $index
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setIndex($index): self
     {
@@ -182,7 +182,7 @@ class FieldInfo
     /**
      * @param int|null $docs
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setDocs(?int $docs): self
     {
@@ -204,7 +204,7 @@ class FieldInfo
     /**
      * @param int|null $distinct
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setDistinct(?int $distinct): self
     {
@@ -226,7 +226,7 @@ class FieldInfo
     /**
      * @param array|null $topTerms
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setTopTerms(?array $topTerms): self
     {
@@ -248,7 +248,7 @@ class FieldInfo
     /**
      * @param array|null $histogram
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setHistogram(?array $histogram): self
     {

--- a/src/QueryType/Luke/Result/Index/Index.php
+++ b/src/QueryType/Luke/Result/Index/Index.php
@@ -90,7 +90,7 @@ class Index
     /**
      * @param int $numDocs
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setNumDocs(int $numDocs): self
     {
@@ -110,7 +110,7 @@ class Index
     /**
      * @param int $maxDoc
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setMaxDoc(int $maxDoc): self
     {
@@ -130,7 +130,7 @@ class Index
     /**
      * @param int $deletedDocs
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setDeletedDocs(int $deletedDocs): self
     {
@@ -150,7 +150,7 @@ class Index
     /**
      * @param int|null $indexHeapUsageBytes
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setIndexHeapUsageBytes(?int $indexHeapUsageBytes): self
     {
@@ -170,7 +170,7 @@ class Index
     /**
      * @param int $version
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setVersion(int $version): self
     {
@@ -190,7 +190,7 @@ class Index
     /**
      * @param int $segmentCount
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setSegmentCount(int $segmentCount): self
     {
@@ -210,7 +210,7 @@ class Index
     /**
      * @param bool $current
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setCurrent(bool $current): self
     {
@@ -238,7 +238,7 @@ class Index
     /**
      * @param bool $hasDeletions
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setHasDeletions(bool $hasDeletions): self
     {
@@ -266,7 +266,7 @@ class Index
     /**
      * @param string $directory
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setDirectory(string $directory): self
     {
@@ -286,7 +286,7 @@ class Index
     /**
      * @param string $segmentsFile
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setSegmentsFile(string $segmentsFile): self
     {
@@ -306,7 +306,7 @@ class Index
     /**
      * @param int $segmentsFileSizeInBytes
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setSegmentsFileSizeInBytes(int $segmentsFileSizeInBytes): self
     {
@@ -326,7 +326,7 @@ class Index
     /**
      * @param UserData $userData
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setUserData(UserData $userData): self
     {

--- a/src/QueryType/Luke/Result/Index/UserData.php
+++ b/src/QueryType/Luke/Result/Index/UserData.php
@@ -37,7 +37,7 @@ class UserData
     /**
      * @param string|null $commitCommandVer
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setCommitCommandVer(?string $commitCommandVer): self
     {
@@ -57,7 +57,7 @@ class UserData
     /**
      * @param string|null $commitTimeMSec
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setCommitTimeMSec(?string $commitTimeMSec): self
     {

--- a/src/QueryType/Luke/Result/Info/Info.php
+++ b/src/QueryType/Luke/Result/Info/Info.php
@@ -35,7 +35,7 @@ class Info
     /**
      * @param array $key
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setKey(array $key): self
     {
@@ -55,7 +55,7 @@ class Info
     /**
      * @param string $note
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setNote(string $note): self
     {

--- a/src/QueryType/Luke/Result/Schema/Field/AbstractField.php
+++ b/src/QueryType/Luke/Result/Schema/Field/AbstractField.php
@@ -91,7 +91,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * @param Type $type
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setType(Type &$type): self
     {
@@ -111,7 +111,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * @param FlagList $flags
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setFlags(FlagList $flags): self
     {
@@ -131,7 +131,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * @param bool|null $required
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setRequired(?bool $required): self
     {
@@ -159,7 +159,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * @param string|null $default
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setDefault(?string $default): self
     {
@@ -179,7 +179,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * @param bool|null $uniqueKey
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setUniqueKey(?bool $uniqueKey): self
     {
@@ -207,7 +207,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * @param int|null $positionIncrementGap
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setPositionIncrementGap(?int $positionIncrementGap): self
     {
@@ -227,7 +227,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * @param CopyFieldDestInterface $copyDest
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function addCopyDest(CopyFieldDestInterface &$copyDest): self
     {
@@ -247,7 +247,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * @param CopyFieldSourceInterface $copySource
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function addCopySource(CopyFieldSourceInterface &$copySource): self
     {

--- a/src/QueryType/Luke/Result/Schema/Field/DynamicBasedField.php
+++ b/src/QueryType/Luke/Result/Schema/Field/DynamicBasedField.php
@@ -33,7 +33,7 @@ class DynamicBasedField extends AbstractField implements CopyFieldDestInterface,
     /**
      * @param DynamicField $dynamicBase
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setDynamicBase(DynamicField &$dynamicBase): self
     {

--- a/src/QueryType/Luke/Result/Schema/Field/WildcardField.php
+++ b/src/QueryType/Luke/Result/Schema/Field/WildcardField.php
@@ -59,7 +59,7 @@ class WildcardField implements CopyFieldSourceInterface, FieldInterface
     /**
      * @param CopyFieldDestInterface $copyDest
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function addCopyDest(CopyFieldDestInterface &$copyDest): self
     {

--- a/src/QueryType/Luke/Result/Schema/Schema.php
+++ b/src/QueryType/Luke/Result/Schema/Schema.php
@@ -64,7 +64,7 @@ class Schema
     /**
      * @param Field[] $fields
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setFields(array $fields): self
     {
@@ -94,7 +94,7 @@ class Schema
     /**
      * @param DynamicField[] $dynamicFields
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setDynamicFields(array $dynamicFields): self
     {
@@ -114,7 +114,7 @@ class Schema
     /**
      * @param Field $uniqueKeyField
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setUniqueKeyField(Field &$uniqueKeyField): self
     {
@@ -134,7 +134,7 @@ class Schema
     /**
      * @param Similarity $similarity
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setSimilarity(Similarity $similarity): self
     {
@@ -164,7 +164,7 @@ class Schema
     /**
      * @param Type[] $types
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setTypes(array $types): self
     {

--- a/src/QueryType/Luke/Result/Schema/Similarity.php
+++ b/src/QueryType/Luke/Result/Schema/Similarity.php
@@ -35,7 +35,7 @@ class Similarity
     /**
      * @param string|null $className
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setClassName(?string $className): self
     {
@@ -55,7 +55,7 @@ class Similarity
     /**
      * @param string|null $details
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setDetails(?string $details): self
     {

--- a/src/QueryType/Luke/Result/Schema/Type/AbstractAnalyzer.php
+++ b/src/QueryType/Luke/Result/Schema/Type/AbstractAnalyzer.php
@@ -63,7 +63,7 @@ abstract class AbstractAnalyzer
     /**
      * @param CharFilter[] $charFilters
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setCharFilters(array $charFilters): self
     {
@@ -83,7 +83,7 @@ abstract class AbstractAnalyzer
     /**
      * @param Tokenizer $tokenizer
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setTokenizer(Tokenizer $tokenizer): self
     {
@@ -103,7 +103,7 @@ abstract class AbstractAnalyzer
     /**
      * @param Filter[] $filters
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setFilters(array $filters): self
     {

--- a/src/QueryType/Luke/Result/Schema/Type/AbstractFilter.php
+++ b/src/QueryType/Luke/Result/Schema/Type/AbstractFilter.php
@@ -58,7 +58,7 @@ abstract class AbstractFilter
     /**
      * @param array $args
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setArgs(array $args): self
     {
@@ -78,7 +78,7 @@ abstract class AbstractFilter
     /**
      * @param string $className
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setClassName(string $className): self
     {

--- a/src/QueryType/Luke/Result/Schema/Type/Tokenizer.php
+++ b/src/QueryType/Luke/Result/Schema/Type/Tokenizer.php
@@ -53,7 +53,7 @@ class Tokenizer
     /**
      * @param array $args
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setArgs(array $args): self
     {

--- a/src/QueryType/Luke/Result/Schema/Type/Type.php
+++ b/src/QueryType/Luke/Result/Schema/Type/Type.php
@@ -81,7 +81,7 @@ class Type
     /**
      * @param SchemaFieldInterface $field
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function addField(SchemaFieldInterface &$field): self
     {
@@ -101,7 +101,7 @@ class Type
     /**
      * @param bool $tokenized
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setTokenized(bool $tokenized): self
     {
@@ -129,7 +129,7 @@ class Type
     /**
      * @param string $className
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setClassName(string $className): self
     {
@@ -149,7 +149,7 @@ class Type
     /**
      * @param IndexAnalyzer $indexAnalyzer
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setIndexAnalyzer(IndexAnalyzer $indexAnalyzer): self
     {
@@ -169,7 +169,7 @@ class Type
     /**
      * @param QueryAnalyzer $queryAnalyzer
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setQueryAnalyzer(QueryAnalyzer $queryAnalyzer): self
     {
@@ -189,7 +189,7 @@ class Type
     /**
      * @param Similarity $similarity
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setSimilarity(Similarity $similarity): self
     {

--- a/src/QueryType/ManagedResources/Query/AbstractQuery.php
+++ b/src/QueryType/ManagedResources/Query/AbstractQuery.php
@@ -126,7 +126,7 @@ abstract class AbstractQuery extends BaseQuery implements Status4xxNoExceptionIn
      *
      * @param string $name
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setName(string $name): self
     {
@@ -150,7 +150,7 @@ abstract class AbstractQuery extends BaseQuery implements Status4xxNoExceptionIn
      *
      * @param string $term
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setTerm(string $term): self
     {
@@ -162,7 +162,7 @@ abstract class AbstractQuery extends BaseQuery implements Status4xxNoExceptionIn
     /**
      * Remove the name of the child resource. This reverts to querying the entire managed resource.
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function removeTerm(): self
     {

--- a/src/QueryType/ManagedResources/Query/Command/Config.php
+++ b/src/QueryType/ManagedResources/Query/Command/Config.php
@@ -61,7 +61,7 @@ class Config extends AbstractCommand
      *
      * @param \Solarium\QueryType\ManagedResources\Query\InitArgsInterface $initArgs
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setInitArgs(InitArgsInterface $initArgs): self
     {

--- a/src/QueryType/ManagedResources/Query/Command/Delete.php
+++ b/src/QueryType/ManagedResources/Query/Command/Delete.php
@@ -60,7 +60,7 @@ class Delete extends AbstractCommand
      *
      * @param string $term
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setTerm(string $term): self
     {

--- a/src/QueryType/ManagedResources/Query/Command/Exists.php
+++ b/src/QueryType/ManagedResources/Query/Command/Exists.php
@@ -74,7 +74,7 @@ class Exists extends AbstractCommand
      *
      * @param string $term
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setTerm(string $term): self
     {
@@ -86,7 +86,7 @@ class Exists extends AbstractCommand
     /**
      * Remove the name of the child resource. This reverts to checking if the managed resource exists.
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function removeTerm(): self
     {
@@ -115,7 +115,7 @@ class Exists extends AbstractCommand
      *
      * @param bool $useHeadRequest
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setUseHeadRequest(bool $useHeadRequest): self
     {

--- a/src/QueryType/ManagedResources/Query/Command/Stopwords/Add.php
+++ b/src/QueryType/ManagedResources/Query/Command/Stopwords/Add.php
@@ -38,7 +38,7 @@ class Add extends AbstractAdd
      *
      * @param array $stopwords
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setStopwords(array $stopwords): self
     {

--- a/src/QueryType/ManagedResources/Query/Command/Synonyms/Add.php
+++ b/src/QueryType/ManagedResources/Query/Command/Synonyms/Add.php
@@ -39,7 +39,7 @@ class Add extends AbstractAdd
      *
      * @param \Solarium\QueryType\ManagedResources\Query\Synonyms\Synonyms $synonyms
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setSynonyms(SynonymsData $synonyms): self
     {

--- a/src/QueryType/ManagedResources/Query/Stopwords/InitArgs.php
+++ b/src/QueryType/ManagedResources/Query/Stopwords/InitArgs.php
@@ -42,7 +42,7 @@ class InitArgs implements InitArgsInterface
      *
      * @return self Provides fluent interface
      */
-    public function setIgnoreCase(bool $ignoreCase): InitArgsInterface
+    public function setIgnoreCase(bool $ignoreCase): self
     {
         $this->ignoreCase = $ignoreCase;
 
@@ -66,7 +66,7 @@ class InitArgs implements InitArgsInterface
      *
      * @return self Provides fluent interface
      */
-    public function setInitArgs(array $initArgs): InitArgsInterface
+    public function setInitArgs(array $initArgs): self
     {
         foreach ($initArgs as $arg => $value) {
             switch ($arg) {

--- a/src/QueryType/ManagedResources/Query/Synonyms/InitArgs.php
+++ b/src/QueryType/ManagedResources/Query/Synonyms/InitArgs.php
@@ -64,7 +64,7 @@ class InitArgs implements InitArgsInterface
      *
      * @return self Provides fluent interface
      */
-    public function setIgnoreCase(bool $ignoreCase): InitArgsInterface
+    public function setIgnoreCase(bool $ignoreCase): self
     {
         $this->ignoreCase = $ignoreCase;
 
@@ -92,7 +92,7 @@ class InitArgs implements InitArgsInterface
      *
      * @return self Provides fluent interface
      */
-    public function setFormat(string $format): InitArgsInterface
+    public function setFormat(string $format): self
     {
         if (!isset($this->formats[$format])) {
             throw new UnexpectedValueException(sprintf('Format unknown: %s', $format));
@@ -120,7 +120,7 @@ class InitArgs implements InitArgsInterface
      *
      * @return self Provides fluent interface
      */
-    public function setInitArgs(array $initArgs): InitArgsInterface
+    public function setInitArgs(array $initArgs): self
     {
         foreach ($initArgs as $arg => $value) {
             switch ($arg) {

--- a/src/QueryType/ManagedResources/Query/Synonyms/Synonyms.php
+++ b/src/QueryType/ManagedResources/Query/Synonyms/Synonyms.php
@@ -39,7 +39,7 @@ class Synonyms
      *
      * @param string $term
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setTerm(string $term): self
     {
@@ -51,7 +51,7 @@ class Synonyms
     /**
      * Remove the term. This reverts to symmetrical synonyms.
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function removeTerm(): self
     {
@@ -73,7 +73,7 @@ class Synonyms
      *
      * @param array $synonyms
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setSynonyms(array $synonyms): self
     {

--- a/src/QueryType/ManagedResources/RequestBuilder/Resource.php
+++ b/src/QueryType/ManagedResources/RequestBuilder/Resource.php
@@ -61,7 +61,7 @@ class Resource extends AbstractRequestBuilder
      *
      * @throws \Solarium\Exception\RuntimeException
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     protected function buildCommand(Request $request, AbstractCommand $command): self
     {

--- a/src/QueryType/ManagedResources/Result/Resources/Resource.php
+++ b/src/QueryType/ManagedResources/Result/Resources/Resource.php
@@ -62,7 +62,7 @@ class Resource
     /**
      * @param string $resourceId
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setResourceId(string $resourceId): self
     {
@@ -82,7 +82,7 @@ class Resource
     /**
      * @param int $numObservers
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setNumObservers(int $numObservers): self
     {
@@ -102,7 +102,7 @@ class Resource
     /**
      * @param string $class
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setClass(string $class): self
     {

--- a/src/QueryType/ManagedResources/Result/Synonyms/Synonyms.php
+++ b/src/QueryType/ManagedResources/Result/Synonyms/Synonyms.php
@@ -51,7 +51,7 @@ class Synonyms
      *
      * @param string $term
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setTerm(string $term): self
     {
@@ -75,7 +75,7 @@ class Synonyms
      *
      * @param array $synonyms
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setSynonyms(array $synonyms): self
     {

--- a/src/QueryType/Server/Collections/Query/Action/Create.php
+++ b/src/QueryType/Server/Collections/Query/Action/Create.php
@@ -39,7 +39,7 @@ class Create extends AbstractAsyncAction
      *
      * @param string $routerName
      *
-     * @return self $this
+     * @return self Provides fluent interface
      */
     public function setRouterName(string $routerName): self
     {
@@ -64,7 +64,7 @@ class Create extends AbstractAsyncAction
      *
      * @param int $numShards
      *
-     * @return self $this
+     * @return self Provides fluent interface
      */
     public function setNumShards(int $numShards): self
     {
@@ -89,7 +89,7 @@ class Create extends AbstractAsyncAction
      *
      * @param string $shards
      *
-     * @return self $this
+     * @return self Provides fluent interface
      */
     public function setShards(string $shards): self
     {

--- a/src/QueryType/Server/Configsets/Query/Action/Create.php
+++ b/src/QueryType/Server/Configsets/Query/Action/Create.php
@@ -38,7 +38,7 @@ class Create extends AbstractAction
      *
      * @param string $baseConfigSet
      *
-     * @return self $this
+     * @return self Provides fluent interface
      */
     public function setBaseConfigSet(string $baseConfigSet): self
     {

--- a/src/QueryType/Server/Configsets/Query/Action/Upload.php
+++ b/src/QueryType/Server/Configsets/Query/Action/Upload.php
@@ -46,7 +46,7 @@ class Upload extends AbstractAction
      *
      * @param string $file
      *
-     * @return self $this
+     * @return self Provides fluent interface
      *
      * @throws InvalidArgumentException
      */
@@ -74,7 +74,7 @@ class Upload extends AbstractAction
      *
      * @param bool $overwrite
      *
-     * @return self $this
+     * @return self Provides fluent interface
      */
     public function setOverwrite(bool $overwrite): self
     {
@@ -100,7 +100,7 @@ class Upload extends AbstractAction
      *
      * @param bool $cleanup
      *
-     * @return self $this
+     * @return self Provides fluent interface
      */
     public function setCleanup(bool $cleanup): self
     {
@@ -127,7 +127,7 @@ class Upload extends AbstractAction
      *
      * @param string $filePath
      *
-     * @return self $this
+     * @return self Provides fluent interface
      */
     public function setFilePath(string $filePath): self
     {

--- a/src/QueryType/Server/CoreAdmin/Query/Action/CoreActionTrait.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/CoreActionTrait.php
@@ -19,9 +19,9 @@ trait CoreActionTrait
      *
      * @param string $core
      *
-     * @return self
+     * @return self Provides fluent interface
      */
-    public function setCore(string $core): CoreActionInterface
+    public function setCore(string $core): self
     {
         $this->setOption('core', $core);
 

--- a/src/QueryType/Server/CoreAdmin/Query/Action/Create.php
+++ b/src/QueryType/Server/CoreAdmin/Query/Action/Create.php
@@ -36,7 +36,7 @@ class Create extends AbstractAsyncAction implements CoreActionInterface
      *
      * @return self Provides fluent interface
      */
-    public function setCore(string $core): CoreActionInterface
+    public function setCore(string $core): self
     {
         // for some reason the core is called "name" in the create action
         $this->setOption('name', $core);

--- a/src/QueryType/Server/CoreAdmin/Result/InitFailureResult.php
+++ b/src/QueryType/Server/CoreAdmin/Result/InitFailureResult.php
@@ -35,7 +35,7 @@ class InitFailureResult
     /**
      * @param string $coreName
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setCoreName(string $coreName): self
     {
@@ -55,7 +55,7 @@ class InitFailureResult
     /**
      * @param string $exception
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setException(string $exception): self
     {

--- a/src/QueryType/Server/CoreAdmin/Result/StatusResult.php
+++ b/src/QueryType/Server/CoreAdmin/Result/StatusResult.php
@@ -55,7 +55,7 @@ class StatusResult
     /**
      * @param string $coreName
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setCoreName(string $coreName): self
     {
@@ -75,7 +75,7 @@ class StatusResult
     /**
      * @param int $numberOfDocuments
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setNumberOfDocuments(int $numberOfDocuments): self
     {
@@ -95,7 +95,7 @@ class StatusResult
     /**
      * @param int $uptime
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setUptime(int $uptime): self
     {
@@ -115,7 +115,7 @@ class StatusResult
     /**
      * @param int $version
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setVersion(int $version): self
     {
@@ -135,7 +135,7 @@ class StatusResult
     /**
      * @param \DateTime|null $startTime
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setStartTime(?\DateTime $startTime): self
     {

--- a/src/QueryType/Server/Query/Action/NameParameterTrait.php
+++ b/src/QueryType/Server/Query/Action/NameParameterTrait.php
@@ -19,7 +19,7 @@ trait NameParameterTrait
      *
      * @param string $collection
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setName(string $collection): self
     {

--- a/src/QueryType/Update/Query/Document.php
+++ b/src/QueryType/Update/Query/Document.php
@@ -421,7 +421,7 @@ class Document extends AbstractDocument
      *
      * @throws RuntimeException
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setFieldModifier(string $key, string $modifier = null): self
     {
@@ -468,7 +468,7 @@ class Document extends AbstractDocument
      *
      * @param int $version
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function setVersion(int $version): self
     {

--- a/src/Support/DataFixtures/FixtureLoader.php
+++ b/src/Support/DataFixtures/FixtureLoader.php
@@ -51,7 +51,7 @@ class FixtureLoader
      *
      * @throws ReflectionException
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function loadFixturesFromDir(string $dir, bool $append = true): self
     {

--- a/src/Support/DataFixtures/Loader.php
+++ b/src/Support/DataFixtures/Loader.php
@@ -40,7 +40,7 @@ class Loader
     /**
      * @param FixtureInterface $fixture
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function addFixture(FixtureInterface $fixture): self
     {
@@ -63,7 +63,7 @@ class Loader
      * @throws InvalidArgumentException
      * @throws ReflectionException
      *
-     * @return self
+     * @return self Provides fluent interface
      */
     public function loadFromDirectory(string $dir): self
     {

--- a/tests/Core/Plugin/PluginTest.php
+++ b/tests/Core/Plugin/PluginTest.php
@@ -3,6 +3,7 @@
 namespace Solarium\Tests\Core\Plugin;
 
 use PHPUnit\Framework\TestCase;
+use Solarium\Client;
 use Solarium\Core\Event\Events;
 use Solarium\Core\Plugin\AbstractPlugin;
 use Solarium\Tests\Integration\TestClientFactory;
@@ -14,8 +15,14 @@ class PluginTest extends TestCase
      */
     protected $plugin;
 
+    /**
+     * @var Client
+     */
     protected $client;
 
+    /**
+     * @var array
+     */
     protected $options;
 
     public function setUp(): void
@@ -44,7 +51,7 @@ class MyPlugin extends AbstractPlugin
 {
     public $eventReceived = false;
 
-    public function getClient()
+    public function getClient(): Client
     {
         return $this->client;
     }

--- a/tests/Core/Query/HelperTest.php
+++ b/tests/Core/Query/HelperTest.php
@@ -756,7 +756,7 @@ class HelperTest extends TestCase
         );
     }
 
-    protected function mockFormatDateOutput($timestamp)
+    protected function mockFormatDateOutput($timestamp): string
     {
         $date = new \DateTime('@'.$timestamp);
 

--- a/tests/Integration/Proxy/CustomizedCurlTest.php
+++ b/tests/Integration/Proxy/CustomizedCurlTest.php
@@ -35,8 +35,10 @@ class CustomizedCurl extends Curl
      * the {@see Curl} adapter's regular proxy handling.
      *
      * @param mixed|array $proxy An associative array with keys 'server' and 'port'
+     *
+     * @return self Provides fluent interface
      */
-    public function setProxy($proxy)
+    public function setProxy($proxy): self
     {
         $this->myProxyOptions = $proxy;
 

--- a/tests/Integration/Proxy/CustomizedHttpTest.php
+++ b/tests/Integration/Proxy/CustomizedHttpTest.php
@@ -35,8 +35,10 @@ class CustomizedHttp extends Http
      * the {@see Http} adapter's regular proxy handling.
      *
      * @param mixed|array $proxy An associative array with keys 'server' and 'port'
+     *
+     * @return self Provides fluent interface
      */
-    public function setProxy($proxy)
+    public function setProxy($proxy): self
     {
         $this->myProxyOptions = $proxy;
 

--- a/tests/QueryType/ManagedResources/Query/Command/ConfigTest.php
+++ b/tests/QueryType/ManagedResources/Query/Command/ConfigTest.php
@@ -87,7 +87,7 @@ class DummyInitArgs implements InitArgsInterface
      *
      * @return self Provides fluent interface
      */
-    public function setInitArgs(array $initArgs): InitArgsInterface
+    public function setInitArgs(array $initArgs): self
     {
         $this->initArgs = $initArgs;
 


### PR DESCRIPTION
No longer supporting PHP 7.3 means we can take advantage of the full covariance support that was introduced in PHP 7.4 and make consistent use of `: self`.