### PR TITLE
Replace strpos() with PHP8 functions

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -83,7 +83,7 @@ class Client extends CoreClient
      */
     public static function checkExact(string $version): bool
     {
-        return 0 === strpos(self::getVersion(), $version);
+        return str_starts_with(self::getVersion(), $version);
     }
 
     /**

--- a/src/Component/RequestBuilder/Analytics.php
+++ b/src/Component/RequestBuilder/Analytics.php
@@ -44,7 +44,7 @@ class Analytics implements ComponentRequestBuilderInterface
 
         if (
             (null !== $currentHeader = $request->getHeader('Content-Type'))
-            && false === strpos($currentHeader, Request::CONTENT_TYPE_APPLICATION_X_WWW_FORM_URLENCODED)
+            && !str_contains($currentHeader, Request::CONTENT_TYPE_APPLICATION_X_WWW_FORM_URLENCODED)
         ) {
             throw new \RuntimeException(sprintf('Unable to build analytics request. required content type is %s while current header is %s', Request::CONTENT_TYPE_APPLICATION_X_WWW_FORM_URLENCODED, $currentHeader));
         }

--- a/src/Core/Client/Request.php
+++ b/src/Core/Client/Request.php
@@ -289,7 +289,7 @@ class Request extends Configurable implements RequestParamsInterface
         if (\is_resource($file)) {
             $meta = stream_get_meta_data($file);
 
-            if (false === strpos($meta['mode'], 'r') && false === strpos($meta['mode'], '+')) {
+            if (!str_contains($meta['mode'], 'r') && !str_contains($meta['mode'], '+')) {
                 throw new RuntimeException(sprintf("Unable to read stream '%s' for upload", $meta['uri'] ?? $meta['stream_type']));
             }
         } elseif (!is_file($file) || !is_readable($file)) {

--- a/src/Core/Client/Response.php
+++ b/src/Core/Client/Response.php
@@ -114,7 +114,7 @@ class Response
         // get the status header
         $statusHeader = null;
         foreach ($headers as $header) {
-            if (0 === strpos($header, 'HTTP')) {
+            if (str_starts_with($header, 'HTTP')) {
                 $statusHeader = $header;
                 break;
             }

--- a/src/Core/Query/AbstractRequestBuilder.php
+++ b/src/Core/Query/AbstractRequestBuilder.php
@@ -73,7 +73,7 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
         $params = '';
         $helper = $this->getHelper();
 
-        if (0 === strpos($value, '{!')) {
+        if (str_starts_with($value, '{!')) {
             $params = substr($value, 2, strpos($value, '}') - 2).' ';
             $value = substr($value, strpos($value, '}') + 1);
         }

--- a/src/QueryType/Update/Query/Command/RawXml.php
+++ b/src/QueryType/Update/Query/Command/RawXml.php
@@ -82,12 +82,12 @@ class RawXml extends AbstractCommand
         }
 
         // discard UTF-8 Byte Order Mark
-        if (0 === strpos($command, pack('CCC', 0xEF, 0xBB, 0xBF))) {
+        if (str_starts_with($command, pack('CCC', 0xEF, 0xBB, 0xBF))) {
             $command = substr($command, 3);
         }
 
         // discard XML declaration
-        if (0 === strpos($command, '<?xml')) {
+        if (str_starts_with($command, '<?xml')) {
             $command = substr($command, strpos($command, '?>') + 2);
         }
 

--- a/src/Support/Utility.php
+++ b/src/Support/Utility.php
@@ -31,12 +31,12 @@ class Utility
 
         if (false !== $xml) {
             // discard UTF-8 Byte Order Mark
-            if (0 === strpos($xml, pack('CCC', 0xEF, 0xBB, 0xBF))) {
+            if (str_starts_with($xml, pack('CCC', 0xEF, 0xBB, 0xBF))) {
                 $xml = substr($xml, 3);
             }
 
             // detect XML declaration
-            if (0 === strpos($xml, '<?xml')) {
+            if (str_starts_with($xml, '<?xml')) {
                 $declaration = substr($xml, 0, strpos($xml, '?>') + 2);
 
                 // detect encoding attribute
@@ -103,10 +103,10 @@ class Utility
 
         if ('*' === $wildcardPattern) {
             $match = true;
-        } elseif (0 === strpos($wildcardPattern, '*')) {
+        } elseif (str_starts_with($wildcardPattern, '*')) {
             $match = substr($wildcardPattern, 1) === substr($fieldName, 1 - \strlen($wildcardPattern));
         } else {
-            $match = 0 === strpos($fieldName, substr($wildcardPattern, 0, -1));
+            $match = str_starts_with($fieldName, substr($wildcardPattern, 0, -1));
         }
 
         return $match;

--- a/tests/Integration/AbstractTechproductsTestCase.php
+++ b/tests/Integration/AbstractTechproductsTestCase.php
@@ -114,7 +114,7 @@ abstract class AbstractTechproductsTestCase extends TestCase
         self::$solrVersion = (int) strstr($solrSpecVersion, '.', true);
 
         $systemName = $system['system']['name'];
-        self::$isSolrOnWindows = 0 === strpos($systemName, 'Windows');
+        self::$isSolrOnWindows = str_starts_with($systemName, 'Windows');
 
         // disable automatic commits for update tests
         $query = self::$client->createApi([
@@ -3966,16 +3966,16 @@ abstract class AbstractTechproductsTestCase extends TestCase
         $query->setFile(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'testpdf.pdf');
 
         $response = self::$client->extract($query);
-        $this->assertSame(0, strpos($response->getFile(), '<?xml version="1.0" encoding="UTF-8"?>'), 'Extracted content from the PDF file is not XML');
-        $this->assertNotFalse(strpos($response->getFile(), '<p>PDF Test</p>'), 'Extracted content from the PDF file not found in XML');
+        $this->assertTrue(str_starts_with($response->getFile(), '<?xml version="1.0" encoding="UTF-8"?>'), 'Extracted content from the PDF file is not XML');
+        $this->assertTrue(str_contains($response->getFile(), '<p>PDF Test</p>'), 'Extracted content from the PDF file not found in XML');
         $this->assertArrayHasKey('stream_size', $response->getFileMetadata());
 
         $query->setFile(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'testhtml.html');
 
         $response = self::$client->extract($query);
-        $this->assertSame(0, strpos($response->getFile(), '<?xml version="1.0" encoding="UTF-8"?>'), 'Extracted content from the HTML file is not XML');
-        $this->assertNotFalse(strpos($response->getFile(), '<title>HTML Test Title</title>'), 'Extracted title from the HTML file not found in XML');
-        $this->assertNotFalse(strpos($response->getFile(), '<p>HTML Test Body</p>'), 'Extracted body from the HTML file not found in XML');
+        $this->assertTrue(str_starts_with($response->getFile(), '<?xml version="1.0" encoding="UTF-8"?>'), 'Extracted content from the HTML file is not XML');
+        $this->assertTrue(str_contains($response->getFile(), '<title>HTML Test Title</title>'), 'Extracted title from the HTML file not found in XML');
+        $this->assertTrue(str_contains($response->getFile(), '<p>HTML Test Body</p>'), 'Extracted body from the HTML file not found in XML');
         $this->assertArrayHasKey('stream_size', $response->getFileMetadata());
 
         if ($usePostBigExtractRequestPlugin) {

--- a/tests/Integration/ConnectionReuseTest.php
+++ b/tests/Integration/ConnectionReuseTest.php
@@ -177,7 +177,7 @@ class ConnectionReuseTest extends TestCase
         $connections = [];
 
         foreach ($docs as $doc) {
-            if ('org.eclipse.jetty.io.AbstractConnection' === $doc['logger'] && 0 === strpos($doc['message'], 'onOpen ')) {
+            if ('org.eclipse.jetty.io.AbstractConnection' === $doc['logger'] && str_starts_with($doc['message'], 'onOpen ')) {
                 $connections[] = $doc['message'];
             }
         }


### PR DESCRIPTION
These common use cases of `strpos()` got dedicated functions in PHP 8. Makes for more readable code and possibly also allows for engine optimisations.