### PR TITLE
Add min/max scaling to query re-ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Solarium\Component\ReRankQuery::setOperator()
+- Solarium\Component\ReRankQuery::setScale() and setMainScale()
 
 ### Fixed
 - MinimumScoreFilter can have a null value in a ValueGroupResult

--- a/docs/queries/select-query/building-a-select-query/components/query-rerankquery-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/query-rerankquery-component.md
@@ -7,12 +7,14 @@ For more info see <https://solr.apache.org/guide/query-re-ranking.html>.
 Options
 -------
 
-| Name     | Type    | Default value | Description                                                                                                                                                                                                                                          |
-|----------|---------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| query    | string  | null          | The query string for your complex ranking query.                                                                                                                                                                                                     |
-| docs     | integer | 200           | The number of top _N_ documents from the original query that should be re-ranked. This number will be treated as a minimum, and may be increased internally automatically in order to rank enough documents to satisfy the query (i.e., start+rows). |
-| weight   | float   | 2.0           | A multiplicative factor that will be applied to the score from the reRankQuery for each of the top matching documents, before that score is added to the original score.                                                                             |
-| operator | string  | add           | The operator determines whether the re-ranked score is added to, multiplied by, or replaces the original score. Use one of the `OPERATOR_*` class constants as value.                                                                                |
+| Name      | Type    | Default value | Description                                                                                                                                                                                                                                          |
+|-----------|---------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| query     | string  | null          | The query string for your complex ranking query.                                                                                                                                                                                                     |
+| docs      | integer | 200           | The number of top _N_ documents from the original query that should be re-ranked. This number will be treated as a minimum, and may be increased internally automatically in order to rank enough documents to satisfy the query (i.e., start+rows). |
+| weight    | float   | 2.0           | A multiplicative factor that will be applied to the score from the reRankQuery for each of the top matching documents, before that score is added to the original score.                                                                             |
+| scale     | string  | null          | Scales the rerank scores between min and max values. The format of this parameter value is `min-max` where min and max are positive integers.                                                                                                        |
+| mainscale | string  | null          | Scales the main query scores between min and max values. The format of this parameter value is `min-max` where min and max are positive integers.                                                                                                    |
+| operator  | string  | add           | The operator determines whether the re-ranked score is added to, multiplied by, or replaces the original score. Use one of the `OPERATOR_*` class constants as value.                                                                                |
 ||
 
 Example
@@ -39,6 +41,12 @@ $rerank->setQuery('popularity:10');
 
 // set the "boost factor"
 $rerank->setWeight(3);
+
+// set the scale for the rerank scores
+$rerank->setScale('0-1');
+
+// set the scale for the main query scores
+$rerank->setMainScale('0-1');
 
 // multiply the original score by the re-ranked score
 $rerank->setOperator($rerank::OPERATOR_MULTIPLY);

--- a/examples/2.1.5.13-rerankquery.php
+++ b/examples/2.1.5.13-rerankquery.php
@@ -19,6 +19,12 @@ $rerank->setQuery('popularity:10');
 // set the "boost factor"
 $rerank->setWeight(3);
 
+// set the scale for the rerank scores
+$rerank->setScale('0-1');
+
+// set the scale for the main query scores
+$rerank->setMainScale('0-1');
+
 // multiply the original score by the re-ranked score
 $rerank->setOperator($rerank::OPERATOR_MULTIPLY);
 

--- a/src/Component/ReRankQuery.php
+++ b/src/Component/ReRankQuery.php
@@ -11,6 +11,7 @@ namespace Solarium\Component;
 
 use Solarium\Component\RequestBuilder\ComponentRequestBuilderInterface;
 use Solarium\Component\RequestBuilder\ReRankQuery as RequestBuilder;
+use Solarium\Exception\DomainException;
 
 /**
  * Rerank query.
@@ -105,6 +106,70 @@ class ReRankQuery extends AbstractComponent implements QueryInterface
     }
 
     /**
+     * Get reRankScale value.
+     *
+     * @return string|null
+     */
+    public function getScale(): ?string
+    {
+        return $this->getOption('scale');
+    }
+
+    /**
+     * Set reRankScale value.
+     *
+     * The format of this parameter value is 'min-max' where min and max are positive integers.
+     *
+     * @param string $value
+     *
+     * @throws DomainException if the value has an invalid format
+     *
+     * @return self Provides fluent interface
+     */
+    public function setScale(string $value): self
+    {
+        if (!self::isValidScale($value)) {
+            throw new DomainException(sprintf('\'%s\' doesn\'t match the format \'min-max\' where min and max are positive integers.', $value));
+        }
+
+        $this->setOption('scale', $value);
+
+        return $this;
+    }
+
+    /**
+     * Get reRankMainScale value.
+     *
+     * @return string|null
+     */
+    public function getMainScale(): ?string
+    {
+        return $this->getOption('mainscale');
+    }
+
+    /**
+     * Set reRankMainScale value.
+     *
+     * The format of this parameter value is 'min-max' where min and max are positive integers.
+     *
+     * @param string $value
+     *
+     * @throws DomainException if the value has an invalid format
+     *
+     * @return self Provides fluent interface
+     */
+    public function setMainScale(string $value): self
+    {
+        if (!self::isValidScale($value)) {
+            throw new DomainException(sprintf('\'%s\' doesn\'t match the format \'min-max\' where min and max are positive integers.', $value));
+        }
+
+        $this->setOption('mainscale', $value);
+
+        return $this;
+    }
+
+    /**
      * Get reRankOperator value.
      *
      * @return string|null
@@ -128,5 +193,19 @@ class ReRankQuery extends AbstractComponent implements QueryInterface
         $this->setOption('operator', $value);
 
         return $this;
+    }
+
+    /**
+     * Check if a value is valid for a scale parameter.
+     *
+     * The format of a valid parameter value is 'min-max' where min and max are positive integers.
+     *
+     * @param string $value
+     *
+     * @return bool
+     */
+    public static function isValidScale(string $value): bool
+    {
+        return 1 === preg_match('/^\d+-\d+$/', $value);
     }
 }

--- a/src/Component/RequestBuilder/ReRankQuery.php
+++ b/src/Component/RequestBuilder/ReRankQuery.php
@@ -32,6 +32,8 @@ class ReRankQuery implements ComponentRequestBuilderInterface
         $subRequest->addParam('reRankQuery', '$rqq');
         $subRequest->addParam('reRankDocs', $component->getDocs());
         $subRequest->addParam('reRankWeight', $component->getWeight());
+        $subRequest->addParam('reRankScale', $component->getScale());
+        $subRequest->addParam('reRankMainScale', $component->getMainScale());
         $subRequest->addParam('reRankOperator', $component->getOperator());
 
         $request->addParam('rq', $subRequest->getSubQuery());

--- a/tests/Component/RequestBuilder/ReRankQueryTest.php
+++ b/tests/Component/RequestBuilder/ReRankQueryTest.php
@@ -18,13 +18,15 @@ class ReRankQueryTest extends TestCase
         $component->setQuery('foo:bar');
         $component->setDocs(42);
         $component->setWeight(48.2233);
+        $component->setScale('0-1');
+        $component->setMainScale('1-5');
         $component->setOperator($component::OPERATOR_MULTIPLY);
 
         $request = $builder->buildComponent($component, $request);
 
         $this->assertEquals(
             [
-                'rq' => '{!rerank reRankQuery=$rqq reRankDocs=42 reRankWeight=48.2233 reRankOperator=multiply}',
+                'rq' => '{!rerank reRankQuery=$rqq reRankDocs=42 reRankWeight=48.2233 reRankScale=0-1 reRankMainScale=1-5 reRankOperator=multiply}',
                 'rqq' => 'foo:bar',
             ],
             $request->getParams()
@@ -40,13 +42,15 @@ class ReRankQueryTest extends TestCase
         $component->setQuery('foo:[1 TO *]');
         $component->setDocs(42);
         $component->setWeight(48.2233);
+        $component->setScale('0-1');
+        $component->setMainScale('1-5');
         $component->setOperator($component::OPERATOR_REPLACE);
 
         $request = $builder->buildComponent($component, $request);
 
         $this->assertEquals(
             [
-                'rq' => '{!rerank reRankQuery=$rqq reRankDocs=42 reRankWeight=48.2233 reRankOperator=replace}',
+                'rq' => '{!rerank reRankQuery=$rqq reRankDocs=42 reRankWeight=48.2233 reRankScale=0-1 reRankMainScale=1-5 reRankOperator=replace}',
                 'rqq' => 'foo:[1 TO *]',
             ],
             $request->getParams()


### PR DESCRIPTION
[`reRankScale`/`reRankMainScale`](https://solr.apache.org/guide/solr/latest/query-guide/query-re-ranking.html#rerank-query-parser) was added in [SOLR-16827](https://issues.apache.org/jira/projects/SOLR/issues/SOLR-16827) for Solr 9.3.