### PR TITLE
Fix PHP 8.2 deprecation for V1 Config/V2 Introspect API results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Solarium\QueryType\Server\Api\Result::getWarning()
+
 ### Fixed
 - ParallelExecution adds a HttpException instead of an empty Result in case of an endpoint failure
 - Facet pivot stats contain all fields (previously only the last field was present in the result)
 - Facet pivot stats return `NAN` for a mean value that's NaN
 - Facet pivot stats return an associative array for percentiles
+- PHP 8.2 deprecation for V1 Config/V2 Introspect API results
 
 ### Changed
 - Facet pivot stats results use the field name instead of `'stats_fields'` as array key

--- a/src/QueryType/Server/Api/ResponseParser.php
+++ b/src/QueryType/Server/Api/ResponseParser.php
@@ -12,7 +12,6 @@ namespace Solarium\QueryType\Server\Api;
 use Solarium\Core\Query\AbstractResponseParser as ResponseParserAbstract;
 use Solarium\Core\Query\ResponseParserInterface;
 use Solarium\Core\Query\Result\ResultInterface;
-use Solarium\QueryType\Server\CoreAdmin\Result\Result;
 
 /**
  * Parse API response data.

--- a/src/QueryType/Server/Api/Result.php
+++ b/src/QueryType/Server/Api/Result.php
@@ -16,4 +16,20 @@ use Solarium\QueryType\Server\Query\AbstractResult;
  */
 class Result extends AbstractResult
 {
+    /**
+     * @var string|null
+     */
+    protected $WARNING;
+
+    /**
+     * Returns a warning for the result or null if Solr didn't set a warning.
+     *
+     * @return string|null
+     */
+    public function getWarning(): ?string
+    {
+        $this->parseResponse();
+
+        return $this->WARNING;
+    }
 }

--- a/tests/Integration/AbstractTechproductsTestCase.php
+++ b/tests/Integration/AbstractTechproductsTestCase.php
@@ -4429,6 +4429,13 @@ abstract class AbstractTechproductsTestCase extends TestCase
             $response = self::$client->execute($query);
             $this->assertArrayHasKey('levels', $response->getData());
             $this->assertArrayHasKey('loggers', $response->getData());
+
+            $query = self::$client->createApi([
+                'version' => Request::API_V2,
+                'handler' => 'node/_introspect',
+            ]);
+            $response = self::$client->execute($query);
+            $this->assertSame('This response format is experimental.  It is likely to change in the future.', $response->getWarning());
         } else {
             $this->markTestSkipped('V2 API requires Solr 7.');
         }

--- a/tests/QueryType/Server/Api/ResponseParserTest.php
+++ b/tests/QueryType/Server/Api/ResponseParserTest.php
@@ -3,6 +3,7 @@
 namespace Solarium\Tests\QueryType\Server\Api;
 
 use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Response;
 use Solarium\QueryType\Server\Api\Query;
 use Solarium\QueryType\Server\Api\ResponseParser;
 use Solarium\QueryType\Server\Api\Result;
@@ -11,33 +12,32 @@ class ResponseParserTest extends TestCase
 {
     public function testParse()
     {
-        $data = [
-            'responseHeader' => [
-                'status' => 0,
-                'QTime' => 13,
-            ],
-            'data' => [
-                'foo' => 'bar',
-            ],
-        ];
+        $data = <<<'EOT'
+            {
+                "responseHeader":{
+                    "status":0,
+                    "QTime":13
+                },
+                "WARNING":"This response format is experimental.  It is likely to change in the future.",
+                "data":{
+                    "foo":"bar"
+                }
+            }
+        EOT;
 
-        $query = new Query();
-
-        $resultStub = $this->createMock(Result::class);
-        $resultStub->expects($this->any())
-             ->method('getData')
-             ->willReturn($data);
-        $resultStub->expects($this->any())
-             ->method('getQuery')
-             ->willReturn($query);
-
+        $response = new Response($data, ['HTTP 1.1 200 OK']);
+        $result = new Result(new Query(), $response);
         $parser = new ResponseParser();
-        $result = $parser->parse($resultStub);
+        $parsed = $parser->parse($result);
+
+        $expected = 'This response format is experimental.  It is likely to change in the future.';
+
+        $this->assertSame($expected, $parsed['WARNING']);
 
         $expected = [
             'foo' => 'bar',
         ];
 
-        $this->assertSame($expected, $result['data']);
+        $this->assertSame($expected, $parsed['data']);
     }
 }

--- a/tests/QueryType/Server/Api/ResultTest.php
+++ b/tests/QueryType/Server/Api/ResultTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Server\Api;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Server\Api\Result;
+
+class ResultTest extends TestCase
+{
+    protected $result;
+
+    public function setUp(): void
+    {
+        $this->result = new ResultDummy();
+    }
+
+    public function testGetStatus()
+    {
+        $this->assertSame(1, $this->result->getStatus());
+    }
+
+    public function testGetWarning()
+    {
+        $expected = 'This response format is experimental.  It is likely to change in the future.';
+
+        $this->assertSame($expected, $this->result->getWarning());
+    }
+
+    public function testGetData()
+    {
+        $expected = ['foo' => 'bar'];
+
+        $this->assertSame($expected, $this->result->getData());
+    }
+}
+
+class ResultDummy extends Result
+{
+    protected $parsed = true;
+
+    public function __construct()
+    {
+        $this->WARNING = 'This response format is experimental.  It is likely to change in the future.';
+        $this->data = ['foo' => 'bar'];
+        $this->responseHeader = ['status' => 1, 'QTime' => 12];
+    }
+}


### PR DESCRIPTION
Two types of API calls can cause a deprecation in PHP 8.2:

> Creation of dynamic property Solarium\QueryType\Server\Api\Result::$WARNING is deprecated

* [V1 Config](https://github.com/apache/solr/blob/9463f666f40f1d72a0ac7b3c46c7f8048ef8eaa9/solr/core/src/java/org/apache/solr/handler/SolrConfigHandler.java#L148)
* [V2 Introspect](https://github.com/apache/solr/blob/9463f666f40f1d72a0ac7b3c46c7f8048ef8eaa9/solr/core/src/java/org/apache/solr/api/V2HttpCall.java#L308)