### PR TITLE
Complete list of pitfalls on Getting Started page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,155 +28,20 @@ Example:
 composer require solarium/solarium
 ```
 
-### Pitfall when upgrading to 6.3.2
+## Pitfalls when upgrading from earlier versions
 
-Support for PHP 7 was removed in Solarium 6.3.2. Upgrade to PHP 8 first to use the latest Solarium version.
+When upgrading from an earlier version, you should be aware of a number of pitfalls.
 
-### Pitfall when upgrading to 6.3
-
-With Solarium 6.3 update queries use the JSON request format by default.
-
-If you do require XML specific functionality, set the request format to XML explicitly.
-
-```php
-// get an update query instance
-$update = $client->createUpdate();
-
-// set XML request format
-$update->setRequestFormat($update::REQUEST_FORMAT_XML);
-```
-
-### Pitfalls when upgrading from 3.x or 4.x or 5.x
-
-#### Setting a timeout
-
-Setting "timeout" as "option" in the HTTP Client Adapter is deprecated since Solarium 5.2.0 because not all adapters
-could handle it. The adapters which can handle it now implement the `TimeoutAwareInterface` and you need to set the
-timeout using the `setTimeout()` function after creating the adapter instance.
-
-#### `Solarium\Client()` constructor
-
-With Solarium 6 you need to pass an adapter instance and an event dispatcher instance to the `Solarium\Client()`
-constructor as the first and second parameter. An optional options array can now be passed as the third parameter.
-Previous versions used the `Curl` adapter and the Symfony EventDispatcher by default. Solarium 5.2
-already informed you about the deprecation of calling this constructor with the old signature.
-
-Solarium 5:
-```php
-$options = [
-    // ...
-];
-
-$client = new Solarium\Client($options);
-```
-
-Solarium 6:
-```php
-$adapter = new Solarium\Core\Client\Adapter\Curl();
-$eventDispatcher = new Symfony\Component\EventDispatcher\EventDispatcher();
-$options = [
-    // ...
-];
-
-$client = new Solarium\Client($adapter, $eventDispatcher, $options);
-```
-
-The Symfony EventDispatcher is also no longer automatically available for autoloading.
-If you want to keep using it, you can add it to your project's `composer.json`.
-Alternatively you can use any [PSR-14](https://www.php-fig.org/psr/psr-14/) compatible event dispatcher.
-
-```json
-{
-    "require": {
-        "solarium/solarium": "~6.3",
-        "symfony/event-dispatcher": "^5.0 || ^6.0"
-    }
-}
-```
-
-#### Adapters
-
-The `Zend2HttpAdapter`, `GuzzleAdapter`, and `Guzzle3Adapter` were removed in Solarium 6.
-You can use the `Psr18Adapter` with any [PSR-18](https://www.php-fig.org/psr/psr-18/) compliant HTTP client instead.
-
-Example:
-```sh
-composer require php-http/guzzle7-adapter
-composer require nyholm/psr7
-```
-
-```php
-$httpClient = new Http\Adapter\Guzzle7\Client();
-$factory = new Nyholm\Psr7\Factory\Psr17Factory();
-$adapter = new Solarium\Core\Client\Adapter\Psr18Adapter($httpClient, $factory, $factory);
-```
-
-#### Local parameter names
-
-In order to fix some issues with complex queries using local parameters Solarium 6 distinguishes between query parameters
-and local parameters to be embedded in a query. Solarium 5.2 already informed you about the deprecation of some
-parameter names which are in fact local parameters. Solarium doen't convert them magically anymore.
-Local parameter names now have to be prefixed with `local_` if set as option of a constructor.
-
-Solarium 5:
-```php
-$categoriesTerms = new Solarium\Component\Facet\JsonTerms([
-    'key' => 'categories',
-    'field' => 'cat',
-    'limit' => 4,
-    'numBuckets' => true,
-]);
-```
-
-Solarium 6:
-```php
-$categoriesTerms = new Solarium\Component\Facet\JsonTerms([
-    'local_key' => 'categories',
-    'field' => 'cat',
-    'limit' => 4,
-    'numBuckets' => true,
-]);
-```
-
-See https://solr.apache.org/guide/local-parameters-in-queries.html for an introduction about local parameters.
-
-### Pitfall when upgrading from 3.x or 4.x
-
-In the past, the V1 API endpoint `solr` was not added automatically, so most users set it as path on the endpoint.
-This bug was discovered with the addition of V2 API support. In almost every setup, the path has to be set to `/`
-instead of `/solr` with this release!
-
-For the same reason it is a must to explicitly configure the _core_ or _collection_.
-
-So an old setting like
-```
-'path' => '/solr/xxxx/'
-```
-has to be changed to something like
-```
-'path' => '/',
-'collection' => 'xxxx',
-```
-
-This led to a problem if the endpoint _isn't_ the default `solr`. Since 6.2.1, a different context can be configured.
-
-An old settings like
-```
-'path' => '/index/xxxx/'
-```
-can be changed to something like
-```
-'path' => '/',
-'context' => 'index',
-'collection' => 'xxxx',
-```
-
-This works for SolrCloud instances with a non-default `hostContext` and Solr instances behind a reverse proxy.
+* [Pitfall when upgrading to 6.3.2](https://solarium.readthedocs.io/en/stable/getting-started/#pitfall-when-upgrading-to-632)
+* [Pitfall when upgrading to 6.3](https://solarium.readthedocs.io/en/stable/getting-started/#pitfall-when-upgrading-to-63)
+* [Pitfalls when upgrading from 3.x or 4.x or 5.x](https://solarium.readthedocs.io/en/stable/getting-started/#pitfalls-when-upgrading-from-3x-or-4x-or-5x)
+* [Pitfall when upgrading from 3.x or 4.x](https://solarium.readthedocs.io/en/stable/getting-started/#pitfall-when-upgrading-from-3x-or-4x)
 
 ## Run the examples
 
-To run the examples read through the _Example code_ section of
-https://solarium.readthedocs.io/en/stable/getting-started/
+To run the examples read through the
+[Example code](https://solarium.readthedocs.io/en/stable/getting-started/#example-code)
+section of the documentation.
 
 ## Run the tests
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,9 +9,9 @@ Installation
 
 ### Requirements
 
-For installing Solarium a minimal PHP version 8.0 is required. It's highly recommended to always use an [actively supported version](https://www.php.net/supported-versions.php) in production.
+For installing Solarium a minimal PHP version 8.0 is required. It's highly recommended to always use an [actively supported PHP version](https://www.php.net/supported-versions.php) in production.
 
-There is no Solr version requirement. But it's highly recommended that you use at least 7.7. All older versions are EOL.
+There is no Solr version requirement. But Solarium development is only actively tested against Solr 7.7 and higher. It's highly recommended to always use an [actively supported Solr version](https://solr.apache.org/downloads.html#about-versions-and-support).
 
 ### Getting Solarium
 
@@ -28,7 +28,7 @@ See [<https://packagist.org>](https://packagist.org) for other packages.
 ```json
 {
     "require": {
-        "solarium/solarium": "~6.4"
+        "solarium/solarium": "~6.3"
     }
 }
 ```
@@ -44,7 +44,7 @@ Also you need to make sure that a PSR-14 compatible event dispatcher is availabl
 ```json
 {
     "require": {
-        "solarium/solarium": "~6.4",
+        "solarium/solarium": "~6.3",
         "symfony/event-dispatcher": "^5.0 || ^6.0"
     }
 }
@@ -84,10 +84,44 @@ htmlFooter();
 
 ```
 
-### Pitfall when upgrading from earlier versions to 6.x
+
+Upgrading
+---------
+
+When upgrading from an earlier version, you should be aware of a number of pitfalls.
+
+### Pitfall when upgrading to 6.3.2
+
+Support for PHP 7 was removed in Solarium 6.3.2. Upgrade to PHP 8 first to use the latest Solarium version.
+
+### Pitfall when upgrading to 6.3
+
+With Solarium 6.3 update queries use the JSON request format by default.
+
+If you do require XML specific functionality, set the request format to XML explicitly.
+
+```php
+// get an update query instance
+$update = $client->createUpdate();
+
+// set XML request format
+$update->setRequestFormat($update::REQUEST_FORMAT_XML);
+```
+
+### Pitfalls when upgrading from 3.x or 4.x or 5.x
+
+#### Setting a timeout
+
+Setting "timeout" as "option" in the HTTP Client Adapter is deprecated since Solarium 5.2.0 because not all adapters
+could handle it. The adapters which can handle it now implement the `TimeoutAwareInterface` and you need to set the
+timeout using the `setTimeout()` function after creating the adapter instance.
+
+#### `Solarium\Client()` constructor
 
 With Solarium 6 you need to pass an adapter instance and an event dispatcher instance to the `Solarium\Client()`
 constructor as the first and second parameter. An optional options array can now be passed as the third parameter.
+Previous versions used the `Curl` adapter and the Symfony EventDispatcher by default. Solarium 5.2
+already informed you about the deprecation of calling this constructor with the old signature.
 
 Solarium 5:
 ```php
@@ -109,13 +143,72 @@ $options = [
 $client = new Solarium\Client($adapter, $eventDispatcher, $options);
 ```
 
-### Pitfall when upgrading from earlier versions to 5.x
+The Symfony EventDispatcher is also no longer automatically available for autoloading.
+If you want to keep using it, you can add it to your project's `composer.json`.
+Alternatively you can use any [PSR-14](https://www.php-fig.org/psr/psr-14/) compatible event dispatcher.
+
+```json
+{
+    "require": {
+        "solarium/solarium": "~6.3",
+        "symfony/event-dispatcher": "^5.0 || ^6.0"
+    }
+}
+```
+
+#### Adapters
+
+The `Zend2HttpAdapter`, `GuzzleAdapter`, and `Guzzle3Adapter` were removed in Solarium 6.
+You can use the `Psr18Adapter` with any [PSR-18](https://www.php-fig.org/psr/psr-18/) compliant HTTP client instead.
+
+Example:
+```sh
+composer require php-http/guzzle7-adapter
+composer require nyholm/psr7
+```
+
+```php
+$httpClient = new Http\Adapter\Guzzle7\Client();
+$factory = new Nyholm\Psr7\Factory\Psr17Factory();
+$adapter = new Solarium\Core\Client\Adapter\Psr18Adapter($httpClient, $factory, $factory);
+```
+
+#### Local parameter names
+
+In order to fix some issues with complex queries using local parameters Solarium 6 distinguishes between query parameters
+and local parameters to be embedded in a query. Solarium 5.2 already informed you about the deprecation of some
+parameter names which are in fact local parameters. Solarium doen't convert them magically anymore.
+Local parameter names now have to be prefixed with `local_` if set as option of a constructor.
+
+Solarium 5:
+```php
+$categoriesTerms = new Solarium\Component\Facet\JsonTerms([
+    'key' => 'categories',
+    'field' => 'cat',
+    'limit' => 4,
+    'numBuckets' => true,
+]);
+```
+
+Solarium 6:
+```php
+$categoriesTerms = new Solarium\Component\Facet\JsonTerms([
+    'local_key' => 'categories',
+    'field' => 'cat',
+    'limit' => 4,
+    'numBuckets' => true,
+]);
+```
+
+See https://solr.apache.org/guide/local-parameters-in-queries.html for an introduction about local parameters.
+
+### Pitfall when upgrading from 3.x or 4.x
 
 In the past, the V1 API endpoint `solr` was not added automatically, so most users set it as path on the endpoint.
 This bug was discovered with the addition of V2 API support. In almost every setup, the path has to be set to `/`
 instead of `/solr` with this release!
 
-For the same reason it is a must to explicit configure the _core_ or _collection_.
+For the same reason it is a must to explicitly configure the _core_ or _collection_.
 
 So an old setting like
 ```
@@ -142,7 +235,9 @@ can be changed to something like
 
 This works for SolrCloud instances with a non-default `hostContext` and Solr instances behind a reverse proxy.
 
-### Available integrations
+
+Available integrations
+----------------------
 
 Some users of Solarium have been nice enough to create easy ways of integrating Solarium:
 


### PR DESCRIPTION
The list of pitfalls on the [Getting Started](https://solarium.readthedocs.io/en/stable/getting-started/) page is lagging behind the README. And they take up a lot of space in the README while they are irrelevant for new users and hopefully existing users have upgraded by now. Keeping the "official" list in the full documentation and linking it from the README solves both issues.