### PR TITLE
Style fixes

### DIFF
--- a/src/QueryType/Select/Query/FilterQuery.php
+++ b/src/QueryType/Select/Query/FilterQuery.php
@@ -165,6 +165,7 @@ class FilterQuery extends Configurable implements QueryInterface
     public function getCache(): bool
     {
         $cache = $this->getLocalParameters()->getCache();
+
         // The default is to cache the filter Query.
         return 'false' !== reset($cache);
     }
@@ -191,6 +192,7 @@ class FilterQuery extends Configurable implements QueryInterface
     public function getCost(): int
     {
         $cost = $this->getLocalParameters()->getCost();
+
         // The default cost for filter queries is 0.
         return (int) reset($cost);
     }

--- a/src/QueryType/Stream/ExpressionBuilder.php
+++ b/src/QueryType/Stream/ExpressionBuilder.php
@@ -264,6 +264,7 @@ class ExpressionBuilder
             if (\is_string($value)) {
                 $value = trim($value);
             }
+
             // Eliminate empty string arguments.
             return '' !== $value;
         })).')';


### PR DESCRIPTION
StyleCI apparently became more strict about `blank_line_before_return`. It probably didn't catch those in the past because of the preceding comment, but it does now.