### PR TITLE
Solr 9.4 → 9.5 for integration tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,12 +51,12 @@ jobs:
                 ref: branch_8_11
                 path: lucene-solr
 
-            - name: Checkout solr 9.4
+            - name: Checkout solr 9.5
               if: matrix.solr == 9
               uses: actions/checkout@v4
               with:
                 repository: apache/solr
-                ref: branch_9_4
+                ref: branch_9_5
                 path: lucene-solr
 
             - name: Start Solr ${{ matrix.solr }} in ${{ matrix.mode }} mode

--- a/tests/Integration/Proxy/AbstractProxyTestCase.php
+++ b/tests/Integration/Proxy/AbstractProxyTestCase.php
@@ -10,6 +10,7 @@ use Solarium\Core\Client\Request;
  * Abstract test for connecting through a proxy.
  *
  * @group integration
+ * @group proxy
  */
 abstract class AbstractProxyTestCase extends TestCase
 {

--- a/tests/Integration/Proxy/CurlTest.php
+++ b/tests/Integration/Proxy/CurlTest.php
@@ -10,6 +10,7 @@ use Solarium\Tests\Integration\TestClientFactory;
  * Test connecting through a proxy with the Curl adapter.
  *
  * @group integration
+ * @group proxy
  */
 class CurlTest extends AbstractProxyTestCase
 {

--- a/tests/Integration/Proxy/CustomizedCurlTest.php
+++ b/tests/Integration/Proxy/CustomizedCurlTest.php
@@ -11,6 +11,7 @@ use Solarium\Tests\Integration\TestClientFactory;
  * Test connecting through a proxy with a customized Curl adapter that sets the proxy options differently.
  *
  * @group integration
+ * @group proxy
  */
 class CustomizedCurlTest extends CurlTest
 {

--- a/tests/Integration/Proxy/CustomizedHttpTest.php
+++ b/tests/Integration/Proxy/CustomizedHttpTest.php
@@ -11,6 +11,7 @@ use Solarium\Tests\Integration\TestClientFactory;
  * Test connecting through a proxy with a customized Http adapter that sets the proxy options differently.
  *
  * @group integration
+ * @group proxy
  */
 class CustomizedHttpTest extends HttpTest
 {

--- a/tests/Integration/Proxy/HttpTest.php
+++ b/tests/Integration/Proxy/HttpTest.php
@@ -8,6 +8,7 @@ use Solarium\Tests\Integration\TestClientFactory;
  * Test connecting through a proxy with the Http adapter.
  *
  * @group integration
+ * @group proxy
  */
 class HttpTest extends AbstractProxyTestCase
 {

--- a/tests/Integration/Query/CustomQueryClassTest.php
+++ b/tests/Integration/Query/CustomQueryClassTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Solarium\Tests\Integration\Query;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Component\QueryInterface;
+
+class CustomQueryClassTest extends TestCase
+{
+    /**
+     * Test the various return types that are valid for custom query classes that
+     * override the {@see \Solarium\Component\QueryTrait::setQuery()} method.
+     *
+     * If this test throws a fatal error, the return type of the parent might no
+     * longer be backward compatible with existing code that overrides it.
+     *
+     * @see https://github.com/solariumphp/solarium/issues/1097
+     *
+     * @dataProvider customQueryClassProvider
+     */
+    public function testCustomQueryClassSetQueryReturnType(string $queryClass)
+    {
+        $query = new $queryClass();
+        $this->assertInstanceOf(QueryInterface::class, $query->setQuery('*:*'));
+    }
+
+    public function customQueryClassProvider(): array
+    {
+        return [
+            [CustomStaticQuery::class],
+            [CustomSelfQuery::class],
+            [CustomQueryInterfaceQuery::class],
+        ];
+    }
+}


### PR DESCRIPTION
Four changes to the tests:
* Workaround for [SOLR-17176](https://issues.apache.org/jira/browse/SOLR-17176) that causes test failures against Solr 9.5
* Updated test for [SOLR-6853](https://issues.apache.org/jira/browse/SOLR-6853) workaround to test a fix introduced in Solr 9.4.1
* Added `@group proxy` to tests that require a running proxy so you can easily exclude them when testing locally
* Moved a test that doesn't require a running Solr instance out of `AbstractTechproductsTestCase`