### PR TITLE
Docker Compose v1 → v2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -70,7 +70,7 @@ jobs:
                 cd -
                 mv solr/server/solr/configsets/sample_techproducts_configs/conf/techproducts.zip ../tests/Integration/Fixtures/
                 cd ../tests/Integration/Fixtures/docker/solr${{ matrix.solr }}_${{ matrix.mode }}
-                docker-compose up -d
+                docker compose up -d
 
             - name: Install dependencies
               run: |


### PR DESCRIPTION
Docker Compose v1 has been removed from `action/runner-images` ([#9557](https://github.com/actions/runner-images/issues/9557)).