### PR TITLE
Solr 9.6 → 9.7 for integration tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,12 +51,12 @@ jobs:
                 ref: branch_8_11
                 path: lucene-solr
 
-            - name: Checkout solr 9.6
+            - name: Checkout solr 9.7
               if: matrix.solr == 9
               uses: actions/checkout@v4
               with:
                 repository: apache/solr
-                ref: branch_9_6
+                ref: branch_9_7
                 path: lucene-solr
 
             - name: Start Solr ${{ matrix.solr }} in ${{ matrix.mode }} mode

--- a/src/Support/Utility.php
+++ b/src/Support/Utility.php
@@ -132,4 +132,22 @@ class Utility
     {
         return preg_replace('/(?<=[a-z1-9])[a-z1-9]+(?=\.)/i', '', $className);
     }
+
+    /**
+     * Recursively sorts an array in place by keys in ascending order.
+     *
+     * @param array $array
+     *
+     * @return bool Always returns true
+     */
+    public static function recursiveKeySort(array &$array): bool
+    {
+        foreach ($array as &$value) {
+            if (\is_array($value)) {
+                self::recursiveKeySort($value);
+            }
+        }
+
+        return ksort($array);
+    }
 }

--- a/tests/Integration/Fixtures/schema9.patch
+++ b/tests/Integration/Fixtures/schema9.patch
@@ -6,8 +6,8 @@ index 190214aebad..7a76a28276a 100644
     <!-- points to the root document of a block of nested documents. Required for nested
        document support, may be removed otherwise
     -->
--   <field name="_root_" type="string" indexed="true" stored="false" docValues="false" />
-+   <field name="_root_" type="string" indexed="true" stored="true" docValues="false" />
+-   <field name="_root_" type="string" indexed="true" stored="false" />
++   <field name="_root_" type="string" indexed="true" stored="true" />
 +   <fieldType name="_nest_path_" class="solr.NestPathField" />
 +   <field name="_nest_path_" type="_nest_path_" />
  

--- a/tests/Support/UtilityTest.php
+++ b/tests/Support/UtilityTest.php
@@ -149,4 +149,83 @@ class UtilityTest extends TestCase
     {
         $this->assertSame($expected, Utility::compactSolrClassName($className));
     }
+
+    /**
+     * @dataProvider recursiveKeySortProvider
+     */
+    public function testRecursiveKeySort(array $array, array $expected)
+    {
+        $this->assertTrue(Utility::recursiveKeySort($array));
+        $this->assertSame($expected, $array);
+    }
+
+    public function recursiveKeySortProvider(): array
+    {
+        return [
+            [
+                [
+                    'a' => 1,
+                    'c' => 2,
+                    'b' => 3,
+                ],
+                [
+                    'a' => 1,
+                    'b' => 3,
+                    'c' => 2,
+                ],
+            ],
+            [
+                [
+                    'a' => 1,
+                    'c' => [
+                        'd',
+                        'f',
+                        'e',
+                    ],
+                    'b' => [
+                        'g' => 4,
+                        'i' => 5,
+                        'h' => 6,
+                    ],
+                ],
+                [
+                    'a' => 1,
+                    'b' => [
+                        'g' => 4,
+                        'h' => 6,
+                        'i' => 5,
+                    ],
+                    'c' => [
+                        'd',
+                        'f',
+                        'e',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'b' => [
+                        'd' => [
+                            'e' => 1,
+                            'g' => 2,
+                            'f' => 3,
+                        ],
+                        'c' => true,
+                    ],
+                    'a' => null,
+                ],
+                [
+                    'a' => null,
+                    'b' => [
+                        'c' => true,
+                        'd' => [
+                            'e' => 1,
+                            'f' => 3,
+                            'g' => 2,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Three changes to get the integration tests working with Solr 9.7:

- Small change in the schema regarding `docValues`.
- Returned field order has changed for some queries. Since this field order was actually never guaranteed (we got lucky until now), I've replaced all assertions for document fields with a custom `assertDocumentHasFields()` method that disregards field order.
- Managed resources still need double percent-encoding, but the way a request fails if you don't apply that workaround has changed.