### PR TITLE
PHP 8.4 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.0, 8.1, 8.2, 8.3]
+                php: [8.0, 8.1, 8.2, 8.3, 8.4]
                 solr: [7, 8, 9]
                 mode: [cloud, server]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- PHP 8.4 support
 - Solarium\Core\Query\AbstractQuery::setCpuAllowed()
 
 ### Fixed

--- a/src/Component/ComponentAwareQueryInterface.php
+++ b/src/Component/ComponentAwareQueryInterface.php
@@ -139,7 +139,7 @@ interface ComponentAwareQueryInterface
      *
      * @return object|null
      */
-    public function getComponent(string $key, $autoload = false, array $config = null);
+    public function getComponent(string $key, $autoload = false, ?array $config = null);
 
     /**
      * Set a component instance.

--- a/src/Component/ComponentAwareQueryTrait.php
+++ b/src/Component/ComponentAwareQueryTrait.php
@@ -79,7 +79,7 @@ trait ComponentAwareQueryTrait
      *
      * @return object|null
      */
-    public function getComponent(string $key, $autoload = false, array $config = null)
+    public function getComponent(string $key, $autoload = false, ?array $config = null)
     {
         if (isset($this->components[$key])) {
             return $this->components[$key];

--- a/src/Component/DisMax.php
+++ b/src/Component/DisMax.php
@@ -271,11 +271,11 @@ class DisMax extends AbstractComponent
     /**
      * Get BoostQuery option.
      *
-     * @param string $key
+     * @param string|null $key
      *
      * @return string|null
      */
-    public function getBoostQuery(string $key = null): ?string
+    public function getBoostQuery(?string $key = null): ?string
     {
         if (null !== $key) {
             if (\array_key_exists($key, $this->boostQueries)) {

--- a/src/Component/Facet/JsonFacetTrait.php
+++ b/src/Component/Facet/JsonFacetTrait.php
@@ -56,12 +56,12 @@ trait JsonFacetTrait
      *
      * This overwrites the current value.
      *
-     * @param string $query
-     * @param array  $bind  Bind values for placeholders in the query string
+     * @param string     $query
+     * @param array|null $bind  Bind values for placeholders in the query string
      *
      * @return self Provides fluent interface
      */
-    public function setDomainFilterQuery(string $query, array $bind = null): self
+    public function setDomainFilterQuery(string $query, ?array $bind = null): self
     {
         if (null !== $bind) {
             $helper = new Helper();

--- a/src/Component/QueryInterface.php
+++ b/src/Component/QueryInterface.php
@@ -19,12 +19,12 @@ interface QueryInterface
      *
      * This overwrites the current value of a query or 'q' parameter.
      *
-     * @param string $query
-     * @param array  $bind  Bind values for placeholders in the query string
+     * @param string     $query
+     * @param array|null $bind  Bind values for placeholders in the query string
      *
      * @return self Provides fluent interface
      */
-    public function setQuery(string $query, array $bind = null): self;
+    public function setQuery(string $query, ?array $bind = null): self;
 
     /**
      * Get query option.

--- a/src/Component/QueryTrait.php
+++ b/src/Component/QueryTrait.php
@@ -19,12 +19,12 @@ trait QueryTrait
      *
      * This overwrites the current value of a query or 'q' parameter.
      *
-     * @param string $query
-     * @param array  $bind  Bind values for placeholders in the query string
+     * @param string     $query
+     * @param array|null $bind  Bind values for placeholders in the query string
      *
      * @return self Provides fluent interface
      */
-    public function setQuery(string $query, array $bind = null): QueryInterface
+    public function setQuery(string $query, ?array $bind = null): QueryInterface
     {
         if (null !== $bind) {
             $helper = $this->getHelper();

--- a/src/Component/Result/MoreLikeThis/Result.php
+++ b/src/Component/Result/MoreLikeThis/Result.php
@@ -42,11 +42,11 @@ class Result implements \IteratorAggregate, \Countable
     /**
      * Constructor.
      *
-     * @param int   $numFound
-     * @param float $maxScore
-     * @param array $documents
+     * @param int        $numFound
+     * @param float|null $maxScore
+     * @param array      $documents
      */
-    public function __construct(int $numFound, float $maxScore = null, array $documents = [])
+    public function __construct(int $numFound, ?float $maxScore = null, array $documents = [])
     {
         $this->numFound = $numFound;
         $this->maximumScore = $maxScore;

--- a/src/Component/Stats/Stats.php
+++ b/src/Component/Stats/Stats.php
@@ -73,11 +73,11 @@ class Stats extends AbstractComponent
      * When no key is supplied the field cannot be added, in that case you will need to add it manually
      * after setting the key, by using the addField method.
      *
-     * @param string|array $options
+     * @param string|array|null $options
      *
      * @return Field
      */
-    public function createField(string|array $options = null): Field
+    public function createField(string|array|null $options = null): Field
     {
         if (\is_string($options)) {
             $fq = new Field();

--- a/src/Core/Client/Client.php
+++ b/src/Core/Client/Client.php
@@ -298,9 +298,9 @@ class Client extends Configurable implements ClientInterface
      *
      * @param AdapterInterface         $adapter
      * @param EventDispatcherInterface $eventDispatcher
-     * @param array                    $options
+     * @param array|null               $options
      */
-    public function __construct(AdapterInterface $adapter, EventDispatcherInterface $eventDispatcher, array $options = null)
+    public function __construct(AdapterInterface $adapter, EventDispatcherInterface $eventDispatcher, ?array $options = null)
     {
         $this->adapter = $adapter;
         $this->eventDispatcher = $eventDispatcher;
@@ -405,13 +405,13 @@ class Client extends Configurable implements ClientInterface
     /**
      * Get an endpoint by key.
      *
-     * @param string $key
+     * @param string|null $key
      *
      * @throws OutOfBoundsException
      *
      * @return Endpoint
      */
-    public function getEndpoint(string $key = null): Endpoint
+    public function getEndpoint(?string $key = null): Endpoint
     {
         if (null === $key) {
             $key = $this->defaultEndpoint;
@@ -1110,14 +1110,14 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a query instance.
      *
-     * @param string $type
-     * @param array  $options
+     * @param string     $type
+     * @param array|null $options
      *
      * @throws InvalidArgumentException|UnexpectedValueException
      *
      * @return \Solarium\Core\Query\AbstractQuery|QueryInterface
      */
-    public function createQuery(string $type, array $options = null): QueryInterface
+    public function createQuery(string $type, ?array $options = null): QueryInterface
     {
         $type = strtolower($type);
 
@@ -1147,11 +1147,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a select query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Select\Query\Query
      */
-    public function createSelect(array $options = null): SelectQuery
+    public function createSelect(?array $options = null): SelectQuery
     {
         return $this->createQuery(self::QUERY_SELECT, $options);
     }
@@ -1159,11 +1159,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a MoreLikeThis query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\MoreLikeThis\Query
      */
-    public function createMoreLikeThis(array $options = null): MoreLikeThisQuery
+    public function createMoreLikeThis(?array $options = null): MoreLikeThisQuery
     {
         return $this->createQuery(self::QUERY_MORELIKETHIS, $options);
     }
@@ -1171,11 +1171,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create an update query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Update\Query\Query
      */
-    public function createUpdate(array $options = null): UpdateQuery
+    public function createUpdate(?array $options = null): UpdateQuery
     {
         return $this->createQuery(self::QUERY_UPDATE, $options);
     }
@@ -1183,11 +1183,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a ping query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Ping\Query
      */
-    public function createPing(array $options = null): PingQuery
+    public function createPing(?array $options = null): PingQuery
     {
         return $this->createQuery(self::QUERY_PING, $options);
     }
@@ -1195,11 +1195,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create an analysis field query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Analysis\Query\Field
      */
-    public function createAnalysisField(array $options = null): AnalysisQueryField
+    public function createAnalysisField(?array $options = null): AnalysisQueryField
     {
         return $this->createQuery(self::QUERY_ANALYSIS_FIELD, $options);
     }
@@ -1207,11 +1207,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create an analysis document query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Analysis\Query\Document
      */
-    public function createAnalysisDocument(array $options = null): AnalysisQueryDocument
+    public function createAnalysisDocument(?array $options = null): AnalysisQueryDocument
     {
         return $this->createQuery(self::QUERY_ANALYSIS_DOCUMENT, $options);
     }
@@ -1219,11 +1219,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a terms query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Terms\Query
      */
-    public function createTerms(array $options = null): TermsQuery
+    public function createTerms(?array $options = null): TermsQuery
     {
         return $this->createQuery(self::QUERY_TERMS, $options);
     }
@@ -1231,11 +1231,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a specllcheck query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Spellcheck\Query
      */
-    public function createSpellcheck(array $options = null): SpellcheckQuery
+    public function createSpellcheck(?array $options = null): SpellcheckQuery
     {
         return $this->createQuery(self::QUERY_SPELLCHECK, $options);
     }
@@ -1243,11 +1243,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a suggester query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Suggester\Query
      */
-    public function createSuggester(array $options = null): SuggesterQuery
+    public function createSuggester(?array $options = null): SuggesterQuery
     {
         return $this->createQuery(self::QUERY_SUGGESTER, $options);
     }
@@ -1255,11 +1255,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create an extract query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Extract\Query
      */
-    public function createExtract(array $options = null): ExtractQuery
+    public function createExtract(?array $options = null): ExtractQuery
     {
         return $this->createQuery(self::QUERY_EXTRACT, $options);
     }
@@ -1267,11 +1267,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a stream query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Stream\Query
      */
-    public function createStream(array $options = null): StreamQuery
+    public function createStream(?array $options = null): StreamQuery
     {
         // Streaming expressions tend to be very long. Therfore we use the 'postbigrequest' plugin. The plugin needs to
         // be loaded before the request is created.
@@ -1283,11 +1283,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a graph query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Graph\Query
      */
-    public function createGraph(array $options = null): GraphQuery
+    public function createGraph(?array $options = null): GraphQuery
     {
         // Streaming expressions tend to be very long. Therfore we use the 'postbigrequest' plugin. The plugin needs to
         // be loaded before the request is created.
@@ -1299,11 +1299,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a RealtimeGet query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\RealtimeGet\Query
      */
-    public function createRealtimeGet(array $options = null): RealtimeGetQuery
+    public function createRealtimeGet(?array $options = null): RealtimeGetQuery
     {
         return $this->createQuery(self::QUERY_REALTIME_GET, $options);
     }
@@ -1311,11 +1311,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a Luke query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Luke\Query
      */
-    public function createLuke(array $options = null): LukeQuery
+    public function createLuke(?array $options = null): LukeQuery
     {
         return $this->createQuery(self::QUERY_LUKE, $options);
     }
@@ -1323,11 +1323,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a CoreAdmin query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Server\CoreAdmin\Query\Query
      */
-    public function createCoreAdmin(array $options = null): CoreAdminQuery
+    public function createCoreAdmin(?array $options = null): CoreAdminQuery
     {
         return $this->createQuery(self::QUERY_CORE_ADMIN, $options);
     }
@@ -1335,11 +1335,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a Collections API query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Server\Collections\Query\Query
      */
-    public function createCollections(array $options = null): CollectionsQuery
+    public function createCollections(?array $options = null): CollectionsQuery
     {
         return $this->createQuery(self::QUERY_COLLECTIONS, $options);
     }
@@ -1347,11 +1347,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a Configsets API query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Server\Configsets\Query\Query
      */
-    public function createConfigsets(array $options = null): ConfigsetsQuery
+    public function createConfigsets(?array $options = null): ConfigsetsQuery
     {
         return $this->createQuery(self::QUERY_CONFIGSETS, $options);
     }
@@ -1359,11 +1359,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create an API query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\Server\Api\Query
      */
-    public function createApi(array $options = null): ApiQuery
+    public function createApi(?array $options = null): ApiQuery
     {
         return $this->createQuery(self::QUERY_API, $options);
     }
@@ -1371,11 +1371,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a managed resources query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\ManagedResources\Query\Resources
      */
-    public function createManagedResources(array $options = null): ManagedResourcesQuery
+    public function createManagedResources(?array $options = null): ManagedResourcesQuery
     {
         return $this->createQuery(self::QUERY_MANAGED_RESOURCES, $options);
     }
@@ -1383,11 +1383,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a managed stopwords query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\ManagedResources\Query\Stopwords
      */
-    public function createManagedStopwords(array $options = null): ManagedStopwordsQuery
+    public function createManagedStopwords(?array $options = null): ManagedStopwordsQuery
     {
         return $this->createQuery(self::QUERY_MANAGED_STOPWORDS, $options);
     }
@@ -1395,11 +1395,11 @@ class Client extends Configurable implements ClientInterface
     /**
      * Create a managed synonyms query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\Core\Query\AbstractQuery|\Solarium\QueryType\ManagedResources\Query\Synonyms
      */
-    public function createManagedSynonyms(array $options = null): ManagedSynonymsQuery
+    public function createManagedSynonyms(?array $options = null): ManagedSynonymsQuery
     {
         return $this->createQuery(self::QUERY_MANAGED_SYNONYMS, $options);
     }

--- a/src/Core/Client/ClientInterface.php
+++ b/src/Core/Client/ClientInterface.php
@@ -111,13 +111,13 @@ interface ClientInterface
     /**
      * Get an endpoint by key.
      *
-     * @param string $key
+     * @param string|null $key
      *
      * @throws OutOfBoundsException
      *
      * @return Endpoint
      */
-    public function getEndpoint(string $key = null): Endpoint;
+    public function getEndpoint(?string $key = null): Endpoint;
 
     /**
      * Get all endpoints.
@@ -554,201 +554,201 @@ interface ClientInterface
     /**
      * Create a query instance.
      *
-     * @param string $type
-     * @param array  $options
+     * @param string     $type
+     * @param array|null $options
      *
      * @throws InvalidArgumentException|UnexpectedValueException
      *
      * @return \Solarium\Core\Query\AbstractQuery|QueryInterface
      */
-    public function createQuery(string $type, array $options = null): QueryInterface;
+    public function createQuery(string $type, ?array $options = null): QueryInterface;
 
     /**
      * Create a select query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Select\Query\Query
      */
-    public function createSelect(array $options = null): SelectQuery;
+    public function createSelect(?array $options = null): SelectQuery;
 
     /**
      * Create a MoreLikeThis query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\MoreLikeThis\Query
      */
-    public function createMoreLikeThis(array $options = null): MoreLikeThisQuery;
+    public function createMoreLikeThis(?array $options = null): MoreLikeThisQuery;
 
     /**
      * Create an update query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Update\Query\Query
      */
-    public function createUpdate(array $options = null): UpdateQuery;
+    public function createUpdate(?array $options = null): UpdateQuery;
 
     /**
      * Create a ping query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Ping\Query
      */
-    public function createPing(array $options = null): PingQuery;
+    public function createPing(?array $options = null): PingQuery;
 
     /**
      * Create an analysis field query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return AnalysisQueryField
      */
-    public function createAnalysisField(array $options = null): AnalysisQueryField;
+    public function createAnalysisField(?array $options = null): AnalysisQueryField;
 
     /**
      * Create an analysis document query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return AnalysisQueryDocument
      */
-    public function createAnalysisDocument(array $options = null): AnalysisQueryDocument;
+    public function createAnalysisDocument(?array $options = null): AnalysisQueryDocument;
 
     /**
      * Create a terms query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Terms\Query
      */
-    public function createTerms(array $options = null): TermsQuery;
+    public function createTerms(?array $options = null): TermsQuery;
 
     /**
      * Create a spellcheck query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Spellcheck\Query
      */
-    public function createSpellcheck(array $options = null): SpellcheckQuery;
+    public function createSpellcheck(?array $options = null): SpellcheckQuery;
 
     /**
      * Create a suggester query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Suggester\Query
      */
-    public function createSuggester(array $options = null): SuggesterQuery;
+    public function createSuggester(?array $options = null): SuggesterQuery;
 
     /**
      * Create an extract query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Extract\Query
      */
-    public function createExtract(array $options = null): ExtractQuery;
+    public function createExtract(?array $options = null): ExtractQuery;
 
     /**
      * Create a stream query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Stream\Query
      */
-    public function createStream(array $options = null): StreamQuery;
+    public function createStream(?array $options = null): StreamQuery;
 
     /**
      * Create a graph query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Graph\Query
      */
-    public function createGraph(array $options = null): GraphQuery;
+    public function createGraph(?array $options = null): GraphQuery;
 
     /**
      * Create a RealtimeGet query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\RealtimeGet\Query
      */
-    public function createRealtimeGet(array $options = null): RealtimeGetQuery;
+    public function createRealtimeGet(?array $options = null): RealtimeGetQuery;
 
     /**
      * Create a Luke query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Luke\Query
      */
-    public function createLuke(array $options = null): LukeQuery;
+    public function createLuke(?array $options = null): LukeQuery;
 
     /**
      * Create a CoreAdmin query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Server\CoreAdmin\Query\Query
      */
-    public function createCoreAdmin(array $options = null): CoreAdminQuery;
+    public function createCoreAdmin(?array $options = null): CoreAdminQuery;
 
     /**
      * Create a Collections API query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Server\Collections\Query\Query
      */
-    public function createCollections(array $options = null): CollectionsQuery;
+    public function createCollections(?array $options = null): CollectionsQuery;
 
     /**
      * Create a Configsets API query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Server\Configsets\Query\Query
      */
-    public function createConfigsets(array $options = null): ConfigsetsQuery;
+    public function createConfigsets(?array $options = null): ConfigsetsQuery;
 
     /**
      * Create an API query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\Server\Api\Query
      */
-    public function createApi(array $options = null): ApiQuery;
+    public function createApi(?array $options = null): ApiQuery;
 
     /**
      * Create a managed resources query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\ManagedResources\Query\Resources
      */
-    public function createManagedResources(array $options = null): ManagedResourcesQuery;
+    public function createManagedResources(?array $options = null): ManagedResourcesQuery;
 
     /**
      * Create a managed stopwords query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\ManagedResources\Query\Stopwords
      */
-    public function createManagedStopwords(array $options = null): ManagedStopwordsQuery;
+    public function createManagedStopwords(?array $options = null): ManagedStopwordsQuery;
 
     /**
      * Create a managed synonyms query instance.
      *
-     * @param array $options
+     * @param array|null $options
      *
      * @return \Solarium\QueryType\ManagedResources\Query\Synonyms
      */
-    public function createManagedSynonyms(array $options = null): ManagedSynonymsQuery;
+    public function createManagedSynonyms(?array $options = null): ManagedSynonymsQuery;
 }

--- a/src/Core/Configurable.php
+++ b/src/Core/Configurable.php
@@ -33,9 +33,9 @@ class Configurable implements ConfigurableInterface
      *
      * After handling the options the {@link _init()} method is called.
      *
-     * @param array $options
+     * @param array|null $options
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         if (null !== $options) {
             $this->setOptions($options);

--- a/src/Core/Event/PreCreateQuery.php
+++ b/src/Core/Event/PreCreateQuery.php
@@ -38,7 +38,7 @@ class PreCreateQuery extends Event
      * @param string     $type
      * @param array|null $options
      */
-    public function __construct(string $type, array $options = null)
+    public function __construct(string $type, ?array $options = null)
     {
         $this->type = $type;
         $this->options = $options;

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -51,9 +51,9 @@ class Helper
     /**
      * Constructor.
      *
-     * @param QueryInterface $query
+     * @param QueryInterface|null $query
      */
-    public function __construct(QueryInterface $query = null)
+    public function __construct(?QueryInterface $query = null)
     {
         $this->query = $query;
     }
@@ -118,12 +118,12 @@ class Helper
      *
      * @see https://solr.apache.org/guide/local-parameters-in-queries.html#basic-syntax-of-local-parameters
      *
-     * @param string $value
-     * @param string $preEscapedSeparator Separator character that is already escaped with a backslash
+     * @param string      $value
+     * @param string|null $preEscapedSeparator Separator character that is already escaped with a backslash
      *
      * @return string
      */
-    public function escapeLocalParamValue(string $value, string $preEscapedSeparator = null): string
+    public function escapeLocalParamValue(string $value, ?string $preEscapedSeparator = null): string
     {
         if (preg_match('/[ \'"}]/', $value)) {
             $pattern = "/('|\\\\)/";
@@ -474,7 +474,7 @@ class Helper
      *
      * @deprecated Will be removed in Solarium 6. Use FilterQuery::setCache() and FilterQuery::setCost() instead.
      */
-    public function cacheControl(bool $useCache, float $cost = null): string
+    public function cacheControl(bool $useCache, ?float $cost = null): string
     {
         $cache = 'false';
 

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -54,7 +54,7 @@ class HttpException extends \RuntimeException implements RuntimeExceptionInterfa
      * @param int|null    $code
      * @param string|null $body
      */
-    public function __construct(string $statusMessage, int $code = null, string $body = null)
+    public function __construct(string $statusMessage, ?int $code = null, ?string $body = null)
     {
         $this->statusMessage = $statusMessage;
         $this->body = $body;

--- a/src/Plugin/CustomizeRequest/CustomizeRequest.php
+++ b/src/Plugin/CustomizeRequest/CustomizeRequest.php
@@ -40,11 +40,11 @@ class CustomizeRequest extends AbstractPlugin
      * When no key is supplied the Customization cannot be added, in that case you will need to add it manually
      * after setting the key, by using the addCustomization method.
      *
-     * @param string|array $options
+     * @param string|array|null $options
      *
      * @return Customization
      */
-    public function createCustomization(string|array $options = null): Customization
+    public function createCustomization(string|array|null $options = null): Customization
     {
         if (\is_string($options)) {
             $fq = new Customization();

--- a/src/QueryType/ManagedResources/Query/AbstractQuery.php
+++ b/src/QueryType/ManagedResources/Query/AbstractQuery.php
@@ -174,14 +174,14 @@ abstract class AbstractQuery extends BaseQuery implements Status4xxNoExceptionIn
     /**
      * Create a command instance.
      *
-     * @param string $type
-     * @param array  $options
+     * @param string     $type
+     * @param array|null $options
      *
      * @throws \Solarium\Exception\InvalidArgumentException
      *
      * @return \Solarium\QueryType\ManagedResources\Query\AbstractCommand
      */
-    public function createCommand(string $type, array $options = null): AbstractCommand
+    public function createCommand(string $type, ?array $options = null): AbstractCommand
     {
         $type = strtolower($type);
 
@@ -235,9 +235,9 @@ abstract class AbstractQuery extends BaseQuery implements Status4xxNoExceptionIn
     /**
      * Create an init args instance.
      *
-     * @param array $initArgs
+     * @param array|null $initArgs
      *
      * @return \Solarium\QueryType\ManagedResources\Query\InitArgsInterface
      */
-    abstract public function createInitArgs(array $initArgs = null): InitArgsInterface;
+    abstract public function createInitArgs(?array $initArgs = null): InitArgsInterface;
 }

--- a/src/QueryType/ManagedResources/Query/InitArgsInterface.php
+++ b/src/QueryType/ManagedResources/Query/InitArgsInterface.php
@@ -17,9 +17,9 @@ interface InitArgsInterface
     /**
      * Constructor.
      *
-     * @param array $initArgs
+     * @param array|null $initArgs
      */
-    public function __construct(array $initArgs = null);
+    public function __construct(?array $initArgs = null);
 
     /**
      * Sets the configuration parameters to be sent to Solr.

--- a/src/QueryType/ManagedResources/Query/Stopwords.php
+++ b/src/QueryType/ManagedResources/Query/Stopwords.php
@@ -99,11 +99,11 @@ class Stopwords extends AbstractQuery
     /**
      * Create an init args instance.
      *
-     * @param array $initArgs
+     * @param array|null $initArgs
      *
      * @return \Solarium\QueryType\ManagedResources\Query\Stopwords\InitArgs
      */
-    public function createInitArgs(array $initArgs = null): InitArgsInterface
+    public function createInitArgs(?array $initArgs = null): InitArgsInterface
     {
         return new InitArgs($initArgs);
     }

--- a/src/QueryType/ManagedResources/Query/Stopwords/InitArgs.php
+++ b/src/QueryType/ManagedResources/Query/Stopwords/InitArgs.php
@@ -26,9 +26,9 @@ class InitArgs implements InitArgsInterface
     /**
      * Constructor.
      *
-     * @param array $initArgs
+     * @param array|null $initArgs
      */
-    public function __construct(array $initArgs = null)
+    public function __construct(?array $initArgs = null)
     {
         if (null !== $initArgs) {
             $this->setInitArgs($initArgs);

--- a/src/QueryType/ManagedResources/Query/Synonyms.php
+++ b/src/QueryType/ManagedResources/Query/Synonyms.php
@@ -99,11 +99,11 @@ class Synonyms extends AbstractQuery
     /**
      * Create an init args instance.
      *
-     * @param array $initArgs
+     * @param array|null $initArgs
      *
      * @return \Solarium\QueryType\ManagedResources\Query\Synonyms\InitArgs
      */
-    public function createInitArgs(array $initArgs = null): InitArgsInterface
+    public function createInitArgs(?array $initArgs = null): InitArgsInterface
     {
         return new InitArgs($initArgs);
     }

--- a/src/QueryType/ManagedResources/Query/Synonyms/InitArgs.php
+++ b/src/QueryType/ManagedResources/Query/Synonyms/InitArgs.php
@@ -48,9 +48,9 @@ class InitArgs implements InitArgsInterface
     /**
      * Constructor.
      *
-     * @param array $initArgs
+     * @param array|null $initArgs
      */
-    public function __construct(array $initArgs = null)
+    public function __construct(?array $initArgs = null)
     {
         if (null !== $initArgs) {
             $this->setInitArgs($initArgs);

--- a/src/QueryType/Select/Query/Query.php
+++ b/src/QueryType/Select/Query/Query.php
@@ -151,7 +151,7 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface, Query
     /**
      * @param array|null $options
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         $this->componentTypes = [
             ComponentAwareQueryInterface::COMPONENT_MORELIKETHIS => MoreLikeThis::class,
@@ -520,11 +520,11 @@ class Query extends AbstractQuery implements ComponentAwareQueryInterface, Query
      * When no key is supplied the filterquery cannot be added, in that case you will need to add it manually
      * after setting the key, by using the addFilterQuery method.
      *
-     * @param string|array $options
+     * @param string|array|null $options
      *
      * @return FilterQuery
      */
-    public function createFilterQuery(string|array $options = null): FilterQuery
+    public function createFilterQuery(string|array|null $options = null): FilterQuery
     {
         if (\is_string($options)) {
             $fq = new FilterQuery();

--- a/src/QueryType/Server/AbstractServerQuery.php
+++ b/src/QueryType/Server/AbstractServerQuery.php
@@ -35,14 +35,14 @@ abstract class AbstractServerQuery extends AbstractQuery implements ActionInterf
     /**
      * Create a command instance.
      *
-     * @param string $type
-     * @param array  $options
+     * @param string     $type
+     * @param array|null $options
      *
      * @throws InvalidArgumentException
      *
      * @return ActionInterface
      */
-    public function createAction(string $type, array $options = null): ActionInterface
+    public function createAction(string $type, ?array $options = null): ActionInterface
     {
         if (!isset($this->actionTypes[$type])) {
             throw new InvalidArgumentException(sprintf('Action unknown: %s', $type));

--- a/src/QueryType/Update/Query/Document.php
+++ b/src/QueryType/Update/Query/Document.php
@@ -416,14 +416,14 @@ class Document extends AbstractDocument
     /**
      * Sets the modifier type for the provided field.
      *
-     * @param string $key
-     * @param string $modifier
+     * @param string      $key
+     * @param string|null $modifier
      *
      * @throws RuntimeException
      *
      * @return self Provides fluent interface
      */
-    public function setFieldModifier(string $key, string $modifier = null): self
+    public function setFieldModifier(string $key, ?string $modifier = null): self
     {
         if (!\in_array($modifier, [self::MODIFIER_SET, self::MODIFIER_ADD, self::MODIFIER_ADD_DISTINCT, self::MODIFIER_REMOVE, self::MODIFIER_REMOVEREGEX, self::MODIFIER_INC], true)) {
             throw new RuntimeException('Attempt to set an atomic update modifier that is not supported');

--- a/src/QueryType/Update/Query/Query.php
+++ b/src/QueryType/Update/Query/Query.php
@@ -193,14 +193,14 @@ class Query extends BaseQuery
     /**
      * Create a command instance.
      *
-     * @param string $type
-     * @param array  $options
+     * @param string     $type
+     * @param array|null $options
      *
      * @throws InvalidArgumentException
      *
      * @return AbstractCommand
      */
-    public function createCommand(string $type, array $options = null): AbstractCommand
+    public function createCommand(string $type, ?array $options = null): AbstractCommand
     {
         $type = strtolower($type);
 
@@ -291,12 +291,12 @@ class Query extends BaseQuery
      * If you need more control, like choosing a key for the command you need to
      * create you own command instance and use the add method.
      *
-     * @param string $query
-     * @param array  $bind  Bind values for placeholders in the query string
+     * @param string     $query
+     * @param array|null $bind  Bind values for placeholders in the query string
      *
      * @return self Provides fluent interface
      */
-    public function addDeleteQuery(string $query, array $bind = null): self
+    public function addDeleteQuery(string $query, ?array $bind = null): self
     {
         if (null !== $bind) {
             $query = $this->getHelper()->assemble($query, $bind);
@@ -369,12 +369,12 @@ class Query extends BaseQuery
      * create you own command instance and use the add method.
      *
      * @param DocumentInterface $document
-     * @param bool              $overwrite
-     * @param int               $commitWithin
+     * @param bool|null         $overwrite
+     * @param int|null          $commitWithin
      *
      * @return self Provides fluent interface
      */
-    public function addDocument(DocumentInterface $document, bool $overwrite = null, int $commitWithin = null): self
+    public function addDocument(DocumentInterface $document, ?bool $overwrite = null, ?int $commitWithin = null): self
     {
         return $this->addDocuments([$document], $overwrite, $commitWithin);
     }
@@ -385,13 +385,13 @@ class Query extends BaseQuery
      * If you need more control, like choosing a key for the command you need to
      * create you own command instance and use the add method.
      *
-     * @param array $documents
-     * @param bool  $overwrite
-     * @param int   $commitWithin
+     * @param array     $documents
+     * @param bool|null $overwrite
+     * @param int|null  $commitWithin
      *
      * @return self Provides fluent interface
      */
-    public function addDocuments(array $documents, bool $overwrite = null, int $commitWithin = null): self
+    public function addDocuments(array $documents, ?bool $overwrite = null, ?int $commitWithin = null): self
     {
         $add = new AddCommand();
 
@@ -414,13 +414,13 @@ class Query extends BaseQuery
      * If you need more control, like choosing a key for the command you need to
      * create you own command instance and use the add method.
      *
-     * @param bool $softCommit
-     * @param bool $waitSearcher
-     * @param bool $expungeDeletes
+     * @param bool|null $softCommit
+     * @param bool|null $waitSearcher
+     * @param bool|null $expungeDeletes
      *
      * @return self Provides fluent interface
      */
-    public function addCommit(bool $softCommit = null, bool $waitSearcher = null, bool $expungeDeletes = null): self
+    public function addCommit(?bool $softCommit = null, ?bool $waitSearcher = null, ?bool $expungeDeletes = null): self
     {
         $commit = new CommitCommand();
 
@@ -445,13 +445,13 @@ class Query extends BaseQuery
      * If you need more control, like choosing a key for the command you need to
      * create you own command instance and use the add method.
      *
-     * @param bool $softCommit
-     * @param bool $waitSearcher
-     * @param int  $maxSegments
+     * @param bool|null $softCommit
+     * @param bool|null $waitSearcher
+     * @param int|null  $maxSegments
      *
      * @return self Provides fluent interface
      */
-    public function addOptimize(bool $softCommit = null, bool $waitSearcher = null, int $maxSegments = null): self
+    public function addOptimize(?bool $softCommit = null, ?bool $waitSearcher = null, ?int $maxSegments = null): self
     {
         $optimize = new OptimizeCommand();
 

--- a/tests/Integration/Query/CustomQueryInterfaceQuery.php
+++ b/tests/Integration/Query/CustomQueryInterfaceQuery.php
@@ -13,7 +13,7 @@ class CustomQueryInterfaceQuery extends SelectQuery
     /**
      * @return self Provides fluent interface
      */
-    public function setQuery(string $query, array $bind = null): QueryInterface
+    public function setQuery(string $query, ?array $bind = null): QueryInterface
     {
         return parent::setQuery($query, $bind);
     }

--- a/tests/Integration/Query/CustomSelfQuery.php
+++ b/tests/Integration/Query/CustomSelfQuery.php
@@ -12,7 +12,7 @@ class CustomSelfQuery extends SelectQuery
     /**
      * @return self Provides fluent interface
      */
-    public function setQuery(string $query, array $bind = null): self
+    public function setQuery(string $query, ?array $bind = null): self
     {
         return parent::setQuery($query, $bind);
     }

--- a/tests/Integration/Query/CustomStaticQuery.php
+++ b/tests/Integration/Query/CustomStaticQuery.php
@@ -12,7 +12,7 @@ class CustomStaticQuery extends SelectQuery
     /**
      * @return static Provides fluent interface
      */
-    public function setQuery(string $query, array $bind = null): static
+    public function setQuery(string $query, ?array $bind = null): static
     {
         return parent::setQuery($query, $bind);
     }

--- a/tests/Integration/TestClientFactory.php
+++ b/tests/Integration/TestClientFactory.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class TestClientFactory
 {
-    public static function createWithPsr18Adapter(array $options = null, EventDispatcherInterface $eventDispatcher = null): Client
+    public static function createWithPsr18Adapter(?array $options = null, ?EventDispatcherInterface $eventDispatcher = null): Client
     {
         $factory = new Psr17Factory();
 
@@ -24,7 +24,7 @@ final class TestClientFactory
         );
     }
 
-    public static function createWithCurlAdapter(array $options = null, EventDispatcherInterface $eventDispatcher = null): Client
+    public static function createWithCurlAdapter(?array $options = null, ?EventDispatcherInterface $eventDispatcher = null): Client
     {
         return new Client(
             new Curl(),
@@ -33,7 +33,7 @@ final class TestClientFactory
         );
     }
 
-    public static function createWithHttpAdapter(array $options = null, EventDispatcherInterface $eventDispatcher = null): Client
+    public static function createWithHttpAdapter(?array $options = null, ?EventDispatcherInterface $eventDispatcher = null): Client
     {
         return new Client(
             new Http(),

--- a/tests/Plugin/BufferedAdd/BufferedAddLiteTest.php
+++ b/tests/Plugin/BufferedAdd/BufferedAddLiteTest.php
@@ -441,7 +441,7 @@ class BufferedAddLiteTest extends TestCase
      *
      * @return Client|MockObject
      */
-    protected function getClient(EventDispatcherInterface $dispatcher = null): ClientInterface
+    protected function getClient(?EventDispatcherInterface $dispatcher = null): ClientInterface
     {
         if (!$dispatcher) {
             $dispatcher = $this->createMock(EventDispatcherInterface::class);

--- a/tests/Plugin/BufferedDelete/BufferedDeleteLiteTest.php
+++ b/tests/Plugin/BufferedDelete/BufferedDeleteLiteTest.php
@@ -429,7 +429,7 @@ class BufferedDeleteLiteTest extends TestCase
      *
      * @return Client|MockObject
      */
-    protected function getClient(EventDispatcherInterface $dispatcher = null): ClientInterface
+    protected function getClient(?EventDispatcherInterface $dispatcher = null): ClientInterface
     {
         if (!$dispatcher) {
             $dispatcher = $this->createMock(EventDispatcherInterface::class);

--- a/tests/QueryType/ManagedResources/Query/Command/ConfigTest.php
+++ b/tests/QueryType/ManagedResources/Query/Command/ConfigTest.php
@@ -71,9 +71,9 @@ class DummyInitArgs implements InitArgsInterface
     /**
      * Constructor.
      *
-     * @param array $initArgs
+     * @param array|null $initArgs
      */
-    public function __construct(array $initArgs = null)
+    public function __construct(?array $initArgs = null)
     {
         if (null !== $initArgs) {
             $this->setInitArgs($initArgs);


### PR DESCRIPTION
https://github.com/php/php-src/blob/cc09e3f8d0030517ba4f355d8a576433549aab23/UPGRADING#L497-L498:

>   . Implicitly nullable parameter types are now deprecated.
>     RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types