### PR TITLE
Symfony EventDispatcher 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phpunit/phpunit": "^9.6",
         "rawr/phpunit-data-provider": "^3.3",
         "roave/security-advisories": "dev-master",
-        "symfony/event-dispatcher": "^5.0 || ^6.0"
+        "symfony/event-dispatcher": "^5.0 || ^6.0 || ^7.0"
     },
     "prefer-stable": true,
     "config": {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,7 +45,7 @@ Also you need to make sure that a PSR-14 compatible event dispatcher is availabl
 {
     "require": {
         "solarium/solarium": "~6.3",
-        "symfony/event-dispatcher": "^5.0 || ^6.0"
+        "symfony/event-dispatcher": "^5.0 || ^6.0 || ^7.0"
     }
 }
 ```
@@ -156,7 +156,7 @@ Alternatively you can use any [PSR-14](https://www.php-fig.org/psr/psr-14/) comp
 {
     "require": {
         "solarium/solarium": "~6.3",
-        "symfony/event-dispatcher": "^5.0 || ^6.0"
+        "symfony/event-dispatcher": "^5.0 || ^6.0 || ^7.0"
     }
 }
 ```


### PR DESCRIPTION
There's nothing backward incompatible in version 7. I've been running it like that for a while in a production environment without issues and the integration tests all pass. So we shouldn't give the impression that Solarium would only work with an older version.