### PR TITLE
Drop PHP 8.0 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.0, 8.1, 8.2, 8.3, 8.4]
+                php: [8.1, 8.2, 8.3, 8.4]
                 solr: [7, 8, 9]
                 mode: [cloud, server]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Solarium library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Removed
+- PHP 8.0 support
+
 ## [6.3.6]
 ### Added
 - PHP 8.4 support

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please see the [docs](http://solarium.readthedocs.io/en/stable/) for a more deta
 
 ## Requirements
 
-Solarium 6.3.2 and up only supports PHP 8.0 and up.
+Solarium 6.3.7 and up only supports PHP 8.1 and up.
 
 It's highly recommended to have cURL enabled in your PHP environment. However if you don't have cURL available you can
 switch from using cURL (the default) to a pure PHP based HTTP client adapter which works for the essential stuff but

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "halaxa/json-machine": "^1.1",
         "psr/event-dispatcher": "^1.0",

--- a/src/Component/Result/Debug/Detail.php
+++ b/src/Component/Result/Debug/Detail.php
@@ -182,7 +182,7 @@ class Detail implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->debugDump();
     }

--- a/src/Component/Result/Debug/Document.php
+++ b/src/Component/Result/Debug/Document.php
@@ -87,7 +87,7 @@ class Document extends Detail implements \IteratorAggregate, \Countable
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString(): string
     {
         $string = '';
         foreach ($this->getDetails() as $detail) {

--- a/src/Component/Result/Grouping/Result.php
+++ b/src/Component/Result/Grouping/Result.php
@@ -55,6 +55,8 @@ class Result implements \IteratorAggregate, \Countable
         if (isset($this->groups[$key])) {
             return $this->groups[$key];
         }
+
+        return null;
     }
 
     /**

--- a/src/Core/Client/Client.php
+++ b/src/Core/Client/Client.php
@@ -807,7 +807,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface
      */
-    public function execute(QueryInterface $query, $endpoint = null): ResultInterface
+    public function execute(QueryInterface $query, Endpoint|string|null $endpoint = null): ResultInterface
     {
         $event = new PreExecuteEvent($query);
         $this->eventDispatcher->dispatch($event);
@@ -833,7 +833,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return Response
      */
-    public function executeRequest(Request $request, $endpoint = null): Response
+    public function executeRequest(Request $request, Endpoint|string|null $endpoint = null): Response
     {
         // load endpoint by string or by using the default one in case of a null value
         if (!($endpoint instanceof Endpoint)) {
@@ -872,7 +872,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Ping\Result
      */
-    public function ping(QueryInterface $query, $endpoint = null): PingResult
+    public function ping(QueryInterface $query, Endpoint|string|null $endpoint = null): PingResult
     {
         return $this->execute($query, $endpoint);
     }
@@ -896,7 +896,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Update\Result
      */
-    public function update(QueryInterface $query, $endpoint = null): UpdateResult
+    public function update(QueryInterface $query, Endpoint|string|null $endpoint = null): UpdateResult
     {
         return $this->execute($query, $endpoint);
     }
@@ -919,7 +919,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Select\Result\Result
      */
-    public function select(QueryInterface $query, $endpoint = null): SelectResult
+    public function select(QueryInterface $query, Endpoint|string|null $endpoint = null): SelectResult
     {
         return $this->execute($query, $endpoint);
     }
@@ -942,7 +942,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\MoreLikeThis\Result
      */
-    public function moreLikeThis(QueryInterface $query, $endpoint = null): MoreLikeThisResult
+    public function moreLikeThis(QueryInterface $query, Endpoint|string|null $endpoint = null): MoreLikeThisResult
     {
         return $this->execute($query, $endpoint);
     }
@@ -958,7 +958,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Analysis\Result\Document|\Solarium\QueryType\Analysis\Result\Field
      */
-    public function analyze(QueryInterface $query, $endpoint = null): ResultInterface
+    public function analyze(QueryInterface $query, Endpoint|string|null $endpoint = null): ResultInterface
     {
         return $this->execute($query, $endpoint);
     }
@@ -974,7 +974,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Terms\Result
      */
-    public function terms(QueryInterface $query, $endpoint = null): TermsResult
+    public function terms(QueryInterface $query, Endpoint|string|null $endpoint = null): TermsResult
     {
         return $this->execute($query, $endpoint);
     }
@@ -990,7 +990,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Spellcheck\Result\Result
      */
-    public function spellcheck(QueryInterface $query, $endpoint = null): SpellcheckResult
+    public function spellcheck(QueryInterface $query, Endpoint|string|null $endpoint = null): SpellcheckResult
     {
         return $this->execute($query, $endpoint);
     }
@@ -1006,7 +1006,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Suggester\Result\Result
      */
-    public function suggester(QueryInterface $query, $endpoint = null): SuggesterResult
+    public function suggester(QueryInterface $query, Endpoint|string|null $endpoint = null): SuggesterResult
     {
         return $this->execute($query, $endpoint);
     }
@@ -1022,7 +1022,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Extract\Result
      */
-    public function extract(QueryInterface $query, $endpoint = null): ExtractResult
+    public function extract(QueryInterface $query, Endpoint|string|null $endpoint = null): ExtractResult
     {
         return $this->execute($query, $endpoint);
     }
@@ -1038,7 +1038,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\RealtimeGet\Result
      */
-    public function realtimeGet(QueryInterface $query, $endpoint = null): RealtimeGetResult
+    public function realtimeGet(QueryInterface $query, Endpoint|string|null $endpoint = null): RealtimeGetResult
     {
         return $this->execute($query, $endpoint);
     }
@@ -1054,7 +1054,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Luke\Result\Result
      */
-    public function luke(QueryInterface $query, $endpoint = null): LukeResult
+    public function luke(QueryInterface $query, Endpoint|string|null $endpoint = null): LukeResult
     {
         return $this->execute($query, $endpoint);
     }
@@ -1070,7 +1070,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Server\CoreAdmin\Result\Result
      */
-    public function coreAdmin(QueryInterface $query, $endpoint = null): CoreAdminResult
+    public function coreAdmin(QueryInterface $query, Endpoint|string|null $endpoint = null): CoreAdminResult
     {
         return $this->execute($query, $endpoint);
     }
@@ -1086,7 +1086,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Server\Collections\Result\ClusterStatusResult
      */
-    public function collections(QueryInterface $query, $endpoint = null): ResultInterface
+    public function collections(QueryInterface $query, Endpoint|string|null $endpoint = null): ResultInterface
     {
         return $this->execute($query, $endpoint);
     }
@@ -1102,7 +1102,7 @@ class Client extends Configurable implements ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Server\Configsets\Result\ListConfigsetsResult
      */
-    public function configsets(QueryInterface $query, $endpoint = null): ResultInterface
+    public function configsets(QueryInterface $query, Endpoint|string|null $endpoint = null): ResultInterface
     {
         return $this->execute($query, $endpoint);
     }

--- a/src/Core/Client/ClientInterface.php
+++ b/src/Core/Client/ClientInterface.php
@@ -317,7 +317,7 @@ interface ClientInterface
      *
      * @return ResultInterface
      */
-    public function execute(QueryInterface $query, $endpoint = null): ResultInterface;
+    public function execute(QueryInterface $query, Endpoint|string|null $endpoint = null): ResultInterface;
 
     /**
      * Execute a request and return the response.
@@ -327,7 +327,7 @@ interface ClientInterface
      *
      * @return Response
      */
-    public function executeRequest(Request $request, $endpoint = null): Response;
+    public function executeRequest(Request $request, Endpoint|string|null $endpoint = null): Response;
 
     /**
      * Execute a ping query.
@@ -349,7 +349,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Ping\Result
      */
-    public function ping(QueryInterface $query, $endpoint = null): PingResult;
+    public function ping(QueryInterface $query, Endpoint|string|null $endpoint = null): PingResult;
 
     /**
      * Execute an update query.
@@ -373,7 +373,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Update\Result
      */
-    public function update(QueryInterface $query, $endpoint = null): UpdateResult;
+    public function update(QueryInterface $query, Endpoint|string|null $endpoint = null): UpdateResult;
 
     /**
      * Execute a select query.
@@ -396,7 +396,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Select\Result\Result
      */
-    public function select(QueryInterface $query, $endpoint = null): SelectResult;
+    public function select(QueryInterface $query, Endpoint|string|null $endpoint = null): SelectResult;
 
     /**
      * Execute a MoreLikeThis query.
@@ -419,7 +419,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\MoreLikeThis\Result
      */
-    public function moreLikeThis(QueryInterface $query, $endpoint = null): MoreLikeThisResult;
+    public function moreLikeThis(QueryInterface $query, Endpoint|string|null $endpoint = null): MoreLikeThisResult;
 
     /**
      * Execute an analysis query.
@@ -432,7 +432,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Analysis\Result\Document|\Solarium\QueryType\Analysis\Result\Field
      */
-    public function analyze(QueryInterface $query, $endpoint = null): ResultInterface;
+    public function analyze(QueryInterface $query, Endpoint|string|null $endpoint = null): ResultInterface;
 
     /**
      * Execute a terms query.
@@ -445,7 +445,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Terms\Result
      */
-    public function terms(QueryInterface $query, $endpoint = null): TermsResult;
+    public function terms(QueryInterface $query, Endpoint|string|null $endpoint = null): TermsResult;
 
     /**
      * Execute a spellcheck query.
@@ -458,7 +458,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Spellcheck\Result\Result
      */
-    public function spellcheck(QueryInterface $query, $endpoint = null): SpellcheckResult;
+    public function spellcheck(QueryInterface $query, Endpoint|string|null $endpoint = null): SpellcheckResult;
 
     /**
      * Execute a suggester query.
@@ -471,7 +471,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Suggester\Result\Result
      */
-    public function suggester(QueryInterface $query, $endpoint = null): SuggesterResult;
+    public function suggester(QueryInterface $query, Endpoint|string|null $endpoint = null): SuggesterResult;
 
     /**
      * Execute an extract query.
@@ -484,7 +484,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Extract\Result
      */
-    public function extract(QueryInterface $query, $endpoint = null): ExtractResult;
+    public function extract(QueryInterface $query, Endpoint|string|null $endpoint = null): ExtractResult;
 
     /**
      * Execute a RealtimeGet query.
@@ -497,7 +497,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\RealtimeGet\Result
      */
-    public function realtimeGet(QueryInterface $query, $endpoint = null): RealtimeGetResult;
+    public function realtimeGet(QueryInterface $query, Endpoint|string|null $endpoint = null): RealtimeGetResult;
 
     /**
      * Execute a Luke query.
@@ -510,7 +510,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Luke\Result\Result
      */
-    public function luke(QueryInterface $query, $endpoint = null): LukeResult;
+    public function luke(QueryInterface $query, Endpoint|string|null $endpoint = null): LukeResult;
 
     /**
      * Execute a CoreAdmin query.
@@ -523,7 +523,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Server\CoreAdmin\Result\Result
      */
-    public function coreAdmin(QueryInterface $query, $endpoint = null): CoreAdminResult;
+    public function coreAdmin(QueryInterface $query, Endpoint|string|null $endpoint = null): CoreAdminResult;
 
     /**
      * Execute a Collections API query.
@@ -536,7 +536,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Server\Collections\Result\ClusterStatusResult
      */
-    public function collections(QueryInterface $query, $endpoint = null): ResultInterface;
+    public function collections(QueryInterface $query, Endpoint|string|null $endpoint = null): ResultInterface;
 
     /**
      * Execute a Configsets API query.
@@ -549,7 +549,7 @@ interface ClientInterface
      *
      * @return ResultInterface|\Solarium\QueryType\Server\Configsets\Result\ListConfigsetsResult
      */
-    public function configsets(QueryInterface $query, $endpoint = null): ResultInterface;
+    public function configsets(QueryInterface $query, Endpoint|string|null $endpoint = null): ResultInterface;
 
     /**
      * Create a query instance.

--- a/src/Core/Client/Endpoint.php
+++ b/src/Core/Client/Endpoint.php
@@ -44,7 +44,7 @@ class Endpoint extends Configurable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         $output = __CLASS__.'::__toString'."\n".'host: '.$this->getHost()."\n".'port: '.$this->getPort()."\n".'path: '.$this->getPath()."\n".'context: '.$this->getContext()."\n".'collection: '.$this->getCollection()."\n".'core: '.$this->getCore()."\n".'authentication: '.print_r($this->getAuthentication() + $this->getAuthorizationToken(), true);
 

--- a/src/Core/Client/Request.php
+++ b/src/Core/Client/Request.php
@@ -116,7 +116,7 @@ class Request extends Configurable implements RequestParamsInterface
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         $output =
             __CLASS__.'::__toString'."\n"

--- a/src/Core/Query/AbstractRequestBuilder.php
+++ b/src/Core/Query/AbstractRequestBuilder.php
@@ -26,13 +26,13 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
     protected $helper;
 
     /**
-     * Build request for a select query.
+     * Build request for a generic query.
      *
-     * @param AbstractQuery|QueryInterface $query
+     * @param QueryInterface|AbstractQuery $query
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|AbstractQuery $query): Request
     {
         $request = new Request();
         $request->setHandler($query->getHandler());

--- a/src/Core/Query/Helper.php
+++ b/src/Core/Query/Helper.php
@@ -21,32 +21,24 @@ class Helper
 {
     /**
      * Placeholder pattern for use in the assemble method.
-     *
-     * @var string
      */
-    protected $placeHolderPattern = '/%(L|P|T|)(\d+)%/i';
+    protected string $placeHolderPattern = '/%(L|P|T|)(\d+)%/i';
 
     /**
      * Array of parts to use for assembling a query string.
-     *
-     * @var array
      */
-    protected $assembleParts;
+    protected array $assembleParts;
 
     /**
      * Counter to keep dereferenced params unique (within a single query instance).
-     *
-     * @var int
      */
-    protected $derefencedParamsLastKey = 0;
+    protected int $derefencedParamsLastKey = 0;
 
     /**
      * Solarium Query instance, optional.
      * Used for dereferenced params.
-     *
-     * @var QueryInterface
      */
-    protected $query;
+    protected ?QueryInterface $query;
 
     /**
      * Constructor.
@@ -153,7 +145,7 @@ class Helper
      *
      * @return string|false false is returned in case of invalid input
      */
-    public function formatDate($input)
+    public function formatDate($input): string|false
     {
         switch (true) {
             case $input instanceof \DateTimeInterface:
@@ -216,7 +208,7 @@ class Helper
      *
      * @return string
      */
-    public function rangeQuery(string $field, $from, $to, $inclusive = true): string
+    public function rangeQuery(string $field, int|float|string|null $from, int|float|string|null $to, bool|array $inclusive = true): string
     {
         if (null === $from) {
             $from = '*';

--- a/src/Core/Query/QueryInterface.php
+++ b/src/Core/Query/QueryInterface.php
@@ -60,7 +60,7 @@ interface QueryInterface extends ConfigurableInterface
      * or a manual require before calling this method. This is your
      * responsibility.
      *
-     * Also you need to make sure this class implements the ResultInterface
+     * Also you need to make sure this class implements the ResultInterface.
      *
      * @param string $classname
      *

--- a/src/Core/Query/RequestBuilderInterface.php
+++ b/src/Core/Query/RequestBuilderInterface.php
@@ -17,11 +17,11 @@ use Solarium\Core\Client\Request;
 interface RequestBuilderInterface
 {
     /**
-     * Build request for a select query.
+     * Build request for a generic query.
      *
-     * @param AbstractQuery $query
+     * @param QueryInterface $query
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request;
+    public function build(QueryInterface $query): Request;
 }

--- a/src/Plugin/AbstractBufferedUpdate/AbstractBufferedUpdate.php
+++ b/src/Plugin/AbstractBufferedUpdate/AbstractBufferedUpdate.php
@@ -166,7 +166,7 @@ abstract class AbstractBufferedUpdate extends AbstractPlugin
      *
      * @return UpdateResult|false
      */
-    abstract public function flush();
+    abstract public function flush(): UpdateResult|false;
 
     /**
      * Commit changes.

--- a/src/Plugin/BufferedAdd/BufferedAdd.php
+++ b/src/Plugin/BufferedAdd/BufferedAdd.php
@@ -57,7 +57,7 @@ class BufferedAdd extends BufferedAddLite
      *
      * @return UpdateResult|false
      */
-    public function flush(?bool $overwrite = null, ?int $commitWithin = null)
+    public function flush(?bool $overwrite = null, ?int $commitWithin = null): UpdateResult|false
     {
         if (0 === \count($this->buffer)) {
             // nothing to do

--- a/src/Plugin/BufferedAdd/BufferedAddLite.php
+++ b/src/Plugin/BufferedAdd/BufferedAddLite.php
@@ -149,7 +149,7 @@ class BufferedAddLite extends AbstractBufferedUpdate
      *
      * @return UpdateResult|false
      */
-    public function flush(?bool $overwrite = null, ?int $commitWithin = null)
+    public function flush(?bool $overwrite = null, ?int $commitWithin = null): UpdateResult|false
     {
         if (0 === \count($this->buffer)) {
             // nothing to do

--- a/src/Plugin/BufferedDelete/BufferedDelete.php
+++ b/src/Plugin/BufferedDelete/BufferedDelete.php
@@ -78,7 +78,7 @@ class BufferedDelete extends BufferedDeleteLite
      *
      * @return UpdateResult|false
      */
-    public function flush()
+    public function flush(): UpdateResult|false
     {
         if (0 === \count($this->buffer)) {
             // nothing to do

--- a/src/Plugin/BufferedDelete/BufferedDeleteLite.php
+++ b/src/Plugin/BufferedDelete/BufferedDeleteLite.php
@@ -118,7 +118,7 @@ class BufferedDeleteLite extends AbstractBufferedUpdate
      *
      * @return UpdateResult|false
      */
-    public function flush()
+    public function flush(): UpdateResult|false
     {
         if (0 === \count($this->buffer)) {
             // nothing to do

--- a/src/QueryType/Analysis/Query/Field.php
+++ b/src/QueryType/Analysis/Query/Field.php
@@ -14,6 +14,7 @@ use Solarium\Core\Query\RequestBuilderInterface;
 use Solarium\Core\Query\ResponseParserInterface;
 use Solarium\QueryType\Analysis\RequestBuilder\Field as RequestBuilder;
 use Solarium\QueryType\Analysis\ResponseParser\Field as ResponseParser;
+use Solarium\QueryType\Analysis\Result\Field as ResultField;
 
 /**
  * Analysis document query.
@@ -27,7 +28,7 @@ class Field extends AbstractQuery
      */
     protected $options = [
         'handler' => 'analysis/field',
-        'resultclass' => 'Solarium\QueryType\Analysis\Result\Field',
+        'resultclass' => ResultField::class,
         'omitheader' => true,
     ];
 

--- a/src/QueryType/Analysis/RequestBuilder/Document.php
+++ b/src/QueryType/Analysis/RequestBuilder/Document.php
@@ -10,7 +10,6 @@
 namespace Solarium\QueryType\Analysis\RequestBuilder;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 use Solarium\QueryType\Analysis\Query\Document as QueryDocument;
@@ -23,11 +22,11 @@ class Document extends BaseRequestBuilder
     /**
      * Build request for an analysis document query.
      *
-     * @param AbstractQuery|QueryInterface|QueryDocument $query
+     * @param QueryInterface|QueryDocument $query
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|QueryDocument $query): Request
     {
         $request = parent::build($query);
         $request->setRawData($this->getRawData($query));

--- a/src/QueryType/Analysis/RequestBuilder/Field.php
+++ b/src/QueryType/Analysis/RequestBuilder/Field.php
@@ -10,7 +10,6 @@
 namespace Solarium\QueryType\Analysis\RequestBuilder;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\QueryInterface;
 use Solarium\QueryType\Analysis\Query\Field as QueryField;
 
@@ -26,7 +25,7 @@ class Field extends RequestBuilder
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|QueryField $query): Request
     {
         $request = parent::build($query);
 

--- a/src/QueryType/Analysis/RequestBuilder/RequestBuilder.php
+++ b/src/QueryType/Analysis/RequestBuilder/RequestBuilder.php
@@ -10,9 +10,9 @@
 namespace Solarium\QueryType\Analysis\RequestBuilder;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
+use Solarium\QueryType\Analysis\Query\AbstractQuery as AbstractAnalysisQuery;
 
 /**
  * Build an analysis request.
@@ -22,13 +22,12 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build request for an analysis query.
      *
-     * @param QueryInterface|AbstractQuery $query
+     * @param QueryInterface|AbstractAnalysisQuery $query
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|AbstractAnalysisQuery $query): Request
     {
-        /** @var \Solarium\QueryType\Analysis\Query\AbstractQuery $query */
         $request = parent::build($query);
         $request->addParam('analysis.query', $query->getQuery());
         $request->addParam('analysis.showmatch', $query->getShowMatch());

--- a/src/QueryType/Extract/RequestBuilder.php
+++ b/src/QueryType/Extract/RequestBuilder.php
@@ -10,7 +10,6 @@
 namespace Solarium\QueryType\Extract;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 use Solarium\Exception\RuntimeException;
@@ -23,13 +22,13 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build the request.
      *
-     * @param Query|QueryInterface $query
+     * @param QueryInterface|Query $query
      *
      * @throws RuntimeException
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|Query $query): Request
     {
         $request = parent::build($query);
 

--- a/src/QueryType/Luke/RequestBuilder.php
+++ b/src/QueryType/Luke/RequestBuilder.php
@@ -10,7 +10,6 @@
 namespace Solarium\QueryType\Luke;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 
@@ -26,7 +25,7 @@ class RequestBuilder extends AbstractRequestBuilder
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|Query $query): Request
     {
         $request = parent::build($query);
 

--- a/src/QueryType/ManagedResources/RequestBuilder/Resource.php
+++ b/src/QueryType/ManagedResources/RequestBuilder/Resource.php
@@ -10,8 +10,8 @@
 namespace Solarium\QueryType\ManagedResources\RequestBuilder;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder;
+use Solarium\Core\Query\QueryInterface;
 use Solarium\Exception\RuntimeException;
 use Solarium\QueryType\ManagedResources\Query\AbstractCommand;
 use Solarium\QueryType\ManagedResources\Query\AbstractQuery as BaseQuery;
@@ -24,13 +24,13 @@ class Resource extends AbstractRequestBuilder
     /**
      * Build request for a resource query.
      *
-     * @param \Solarium\Core\Query\AbstractQuery $query
+     * @param QueryInterface|BaseQuery $query
      *
-     * @throws \Solarium\Exception\RuntimeException
+     * @throws RuntimeException
      *
-     * @return \Solarium\Core\Client\Request
+     * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|BaseQuery $query): Request
     {
         if (empty($query->getName())) {
             throw new RuntimeException('Name of the resource is not set in the query.');
@@ -56,10 +56,10 @@ class Resource extends AbstractRequestBuilder
     }
 
     /**
-     * @param \Solarium\Core\Client\Request                              $request
-     * @param \Solarium\QueryType\ManagedResources\Query\AbstractCommand $command
+     * @param Request         $request
+     * @param AbstractCommand $command
      *
-     * @throws \Solarium\Exception\RuntimeException
+     * @throws RuntimeException
      *
      * @return self Provides fluent interface
      */

--- a/src/QueryType/ManagedResources/Result/Resources/ResourceList.php
+++ b/src/QueryType/ManagedResources/Result/Resources/ResourceList.php
@@ -13,6 +13,7 @@ use Solarium\Core\Client\Response;
 use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\Result\QueryType as BaseResult;
 use Solarium\Core\Query\Result\Result;
+use Solarium\QueryType\ManagedResources\Result\Resources\Resource as ManagedResource;
 
 /**
  * ResourceList.
@@ -29,15 +30,15 @@ class ResourceList extends BaseResult implements \IteratorAggregate, \Countable
     /**
      * List items.
      *
-     * @var \Solarium\QueryType\ManagedResources\Result\Resources\Resource[]
+     * @var ManagedResource[]
      */
     protected $items = [];
 
     /**
      * Constructor.
      *
-     * @param \Solarium\Core\Query\AbstractQuery $query
-     * @param \Solarium\Core\Client\Response     $response
+     * @param AbstractQuery $query
+     * @param Response      $response
      */
     public function __construct(AbstractQuery $query, Response $response)
     {
@@ -57,7 +58,7 @@ class ResourceList extends BaseResult implements \IteratorAggregate, \Countable
     /**
      * Get all items.
      *
-     * @return \Solarium\QueryType\ManagedResources\Result\Resources\Resource[]
+     * @return ManagedResource[]
      */
     public function getItems(): array
     {

--- a/src/QueryType/ManagedResources/Result/Stopwords/WordSet.php
+++ b/src/QueryType/ManagedResources/Result/Stopwords/WordSet.php
@@ -67,8 +67,8 @@ class WordSet extends BaseResult implements \IteratorAggregate, \Countable
     /**
      * Constructor.
      *
-     * @param \Solarium\Core\Query\AbstractQuery $query
-     * @param \Solarium\Core\Client\Response     $response
+     * @param AbstractQuery $query
+     * @param Response      $response
      */
     public function __construct(AbstractQuery $query, Response $response)
     {

--- a/src/QueryType/ManagedResources/Result/Synonyms/SynonymMappings.php
+++ b/src/QueryType/ManagedResources/Result/Synonyms/SynonymMappings.php
@@ -74,8 +74,8 @@ class SynonymMappings extends BaseResult implements \IteratorAggregate, \Countab
     /**
      * Constructor.
      *
-     * @param \Solarium\Core\Query\AbstractQuery $query
-     * @param \Solarium\Core\Client\Response     $response
+     * @param AbstractQuery $query
+     * @param Response      $response
      */
     public function __construct(AbstractQuery $query, Response $response)
     {

--- a/src/QueryType/MoreLikeThis/RequestBuilder.php
+++ b/src/QueryType/MoreLikeThis/RequestBuilder.php
@@ -10,7 +10,6 @@
 namespace Solarium\QueryType\MoreLikeThis;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\QueryInterface;
 use Solarium\QueryType\Select\RequestBuilder as SelectRequestBuilder;
 
@@ -26,7 +25,7 @@ class RequestBuilder extends SelectRequestBuilder
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|Query $query): Request
     {
         $request = parent::build($query);
 

--- a/src/QueryType/Ping/RequestBuilder.php
+++ b/src/QueryType/Ping/RequestBuilder.php
@@ -10,7 +10,6 @@
 namespace Solarium\QueryType\Ping;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 
@@ -26,7 +25,7 @@ class RequestBuilder extends BaseRequestBuilder
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|Query $query): Request
     {
         $request = parent::build($query);
         $request->setMethod(Request::METHOD_GET);

--- a/src/QueryType/RealtimeGet/RequestBuilder.php
+++ b/src/QueryType/RealtimeGet/RequestBuilder.php
@@ -10,7 +10,6 @@
 namespace Solarium\QueryType\RealtimeGet;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 
@@ -26,7 +25,7 @@ class RequestBuilder extends BaseRequestBuilder
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|Query $query): Request
     {
         $request = parent::build($query);
         $request->setMethod(Request::METHOD_GET);

--- a/src/QueryType/Select/RequestBuilder.php
+++ b/src/QueryType/Select/RequestBuilder.php
@@ -10,7 +10,6 @@
 namespace Solarium\QueryType\Select;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 use Solarium\QueryType\Select\Query\Query as SelectQuery;
@@ -23,11 +22,11 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build request for a select query.
      *
-     * @param QueryInterface&SelectQuery $query
+     * @param QueryInterface|SelectQuery $query
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|SelectQuery $query): Request
     {
         $request = parent::build($query);
 

--- a/src/QueryType/Server/Api/RequestBuilder.php
+++ b/src/QueryType/Server/Api/RequestBuilder.php
@@ -10,7 +10,6 @@
 namespace Solarium\QueryType\Server\Api;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 use Solarium\QueryType\Server\Api\Query as ApiQuery;
@@ -27,7 +26,7 @@ class RequestBuilder extends BaseRequestBuilder
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|ApiQuery $query): Request
     {
         $request = parent::build($query);
 

--- a/src/QueryType/Server/Configsets/Query/Query.php
+++ b/src/QueryType/Server/Configsets/Query/Query.php
@@ -22,7 +22,7 @@ use Solarium\QueryType\Server\Query\Action\ActionInterface;
 use Solarium\QueryType\Server\Query\ResponseParser;
 
 /**
- * Collections query.
+ * Configsets query.
  *
  * Can be used to perform an action on the Configsets API admin endpoint
  */

--- a/src/QueryType/Server/Configsets/RequestBuilder.php
+++ b/src/QueryType/Server/Configsets/RequestBuilder.php
@@ -10,23 +10,24 @@
 namespace Solarium\QueryType\Server\Configsets;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
+use Solarium\Core\Query\QueryInterface;
 use Solarium\QueryType\Server\Configsets\Query\Action\Upload;
+use Solarium\QueryType\Server\Configsets\Query\Query as ConfigsetsQuery;
 use Solarium\QueryType\Server\Query\RequestBuilder as ServerRequestBuilder;
 
 /**
- * Build an Configsets API request.
+ * Build a Configsets API request.
  */
 class RequestBuilder extends ServerRequestBuilder
 {
     /**
      * Build request for an API query.
      *
-     * @param \Solarium\Core\Query\AbstractQuery $query
+     * @param QueryInterface|ConfigsetsQuery $query
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|ConfigsetsQuery $query): Request
     {
         $request = parent::build($query);
 

--- a/src/QueryType/Server/Query/RequestBuilder.php
+++ b/src/QueryType/Server/Query/RequestBuilder.php
@@ -10,8 +10,9 @@
 namespace Solarium\QueryType\Server\Query;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
+use Solarium\Core\Query\QueryInterface;
+use Solarium\QueryType\Server\AbstractServerQuery;
 use Solarium\QueryType\Server\Query\Action\ActionInterface;
 
 /**
@@ -22,11 +23,11 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build request for an API query.
      *
-     * @param \Solarium\Core\Query\AbstractQuery $query
+     * @param QueryInterface|AbstractServerQuery $query
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|AbstractServerQuery $query): Request
     {
         $request = parent::build($query);
         $request->setMethod(Request::METHOD_GET);

--- a/src/QueryType/Spellcheck/RequestBuilder.php
+++ b/src/QueryType/Spellcheck/RequestBuilder.php
@@ -11,8 +11,8 @@ namespace Solarium\QueryType\Spellcheck;
 
 use Solarium\Component\RequestBuilder\Spellcheck;
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
+use Solarium\Core\Query\QueryInterface;
 
 /**
  * Build a Spellcheck query request.
@@ -22,11 +22,11 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build request for a Spellcheck query.
      *
-     * @param \Solarium\Core\Query\AbstractQuery $query
+     * @param QueryInterface|Query $query
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|Query $query): Request
     {
         $request = parent::build($query);
 

--- a/src/QueryType/Stream/RequestBuilder.php
+++ b/src/QueryType/Stream/RequestBuilder.php
@@ -10,7 +10,7 @@
 namespace Solarium\QueryType\Stream;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
+use Solarium\Core\Query\QueryInterface;
 use Solarium\Core\Query\RequestBuilderInterface;
 
 /**
@@ -21,11 +21,11 @@ class RequestBuilder implements RequestBuilderInterface
     /**
      * Build request for a stream query.
      *
-     * @param \Solarium\Core\Query\AbstractQuery $query
+     * @param QueryInterface|Query $query
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|Query $query): Request
     {
         $request = new Request();
         $request->setHandler($query->getHandler());

--- a/src/QueryType/Suggester/RequestBuilder.php
+++ b/src/QueryType/Suggester/RequestBuilder.php
@@ -11,7 +11,6 @@ namespace Solarium\QueryType\Suggester;
 
 use Solarium\Component\RequestBuilder\Suggester;
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 
@@ -23,11 +22,11 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build request for a Suggester query.
      *
-     * @param QueryInterface|AbstractQuery|Query $query
+     * @param QueryInterface|Query $query
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|Query $query): Request
     {
         $request = parent::build($query);
 

--- a/src/QueryType/Terms/RequestBuilder.php
+++ b/src/QueryType/Terms/RequestBuilder.php
@@ -11,7 +11,6 @@ namespace Solarium\QueryType\Terms;
 
 use Solarium\Component\RequestBuilder\Terms;
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder as BaseRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 
@@ -23,11 +22,11 @@ class RequestBuilder extends BaseRequestBuilder
     /**
      * Build request for a Terms query.
      *
-     * @param QueryInterface|AbstractQuery|Query $query
+     * @param QueryInterface|Query $query
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|Query $query): Request
     {
         $request = parent::build($query);
 

--- a/src/QueryType/Update/RequestBuilder/Json.php
+++ b/src/QueryType/Update/RequestBuilder/Json.php
@@ -10,7 +10,6 @@
 namespace Solarium\QueryType\Update\RequestBuilder;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 use Solarium\Exception\RuntimeException;
@@ -28,13 +27,13 @@ class Json extends AbstractRequestBuilder
     /**
      * Build request for an update query.
      *
-     * @param QueryInterface|AbstractQuery|UpdateQuery $query
+     * @param QueryInterface|UpdateQuery $query
      *
      * @throws RuntimeException
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|UpdateQuery $query): Request
     {
         $inputEncoding = $query->getInputEncoding();
 

--- a/src/QueryType/Update/RequestBuilder/Xml.php
+++ b/src/QueryType/Update/RequestBuilder/Xml.php
@@ -10,7 +10,6 @@
 namespace Solarium\QueryType\Update\RequestBuilder;
 
 use Solarium\Core\Client\Request;
-use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\AbstractRequestBuilder;
 use Solarium\Core\Query\QueryInterface;
 use Solarium\Exception\RuntimeException;
@@ -30,11 +29,11 @@ class Xml extends AbstractRequestBuilder
     /**
      * Build request for an update query.
      *
-     * @param QueryInterface|AbstractQuery|UpdateQuery $query
+     * @param QueryInterface|UpdateQuery $query
      *
      * @return Request
      */
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|UpdateQuery $query): Request
     {
         $request = parent::build($query);
         $request->setMethod(Request::METHOD_POST);

--- a/tests/Core/Client/Adapter/CurlTest.php
+++ b/tests/Core/Client/Adapter/CurlTest.php
@@ -88,7 +88,7 @@ class CurlTest extends TestCase
         $request = new Request();
         $endpoint = new Endpoint();
 
-        /** @var Curl|MockObject $mock */
+        /** @var Curl&MockObject $mock */
         $mock = $this->getMockBuilder(Curl::class)
             ->onlyMethods(['getData'])
             ->getMock();

--- a/tests/Core/Client/Adapter/HttpTest.php
+++ b/tests/Core/Client/Adapter/HttpTest.php
@@ -33,7 +33,7 @@ class HttpTest extends TestCase
         $request->setIsServerRequest(true);
         $endpoint = new Endpoint();
 
-        /** @var Http|MockObject $mock */
+        /** @var Http&MockObject $mock */
         $mock = $this->getMockBuilder(Http::class)
             ->onlyMethods(['getData'])
             ->getMock();
@@ -52,7 +52,7 @@ class HttpTest extends TestCase
         $request->setIsServerRequest(true);
         $endpoint = new Endpoint();
 
-        /** @var Http|MockObject $mock */
+        /** @var Http&MockObject $mock */
         $mock = $this->getMockBuilder(Http::class)
             ->onlyMethods(['getData'])
             ->getMock();

--- a/tests/Integration/AbstractTechproductsTestCase.php
+++ b/tests/Integration/AbstractTechproductsTestCase.php
@@ -23,6 +23,7 @@ use Solarium\Core\Event\Events;
 use Solarium\Core\Query\AbstractDocument;
 use Solarium\Core\Query\AbstractQuery;
 use Solarium\Core\Query\Helper;
+use Solarium\Core\Query\QueryInterface;
 use Solarium\Core\Query\RequestBuilderInterface;
 use Solarium\Exception\HttpException;
 use Solarium\Exception\RuntimeException;
@@ -47,6 +48,7 @@ use Solarium\QueryType\Luke\Result\Doc\DocInfo as LukeDocInfo;
 use Solarium\QueryType\Luke\Result\Fields\FieldInfo as LukeFieldInfo;
 use Solarium\QueryType\Luke\Result\Index\Index as LukeIndexResult;
 use Solarium\QueryType\Luke\Result\Schema\Schema as LukeSchemaResult;
+use Solarium\QueryType\ManagedResources\Query\AbstractQuery as AbstractManagedResourcesQuery;
 use Solarium\QueryType\ManagedResources\Query\Stopwords as StopwordsQuery;
 use Solarium\QueryType\ManagedResources\Query\Synonyms as SynonymsQuery;
 use Solarium\QueryType\ManagedResources\Query\Synonyms\Synonyms;
@@ -5391,7 +5393,7 @@ class NonControlCharFilteringUpdateRequestBuilder extends XmlUpdateRequestBuilde
  */
 class CompliantManagedResourceRequestBuilder extends ResourceRequestBuilder
 {
-    public function build(AbstractQuery $query): Request
+    public function build(QueryInterface|AbstractManagedResourcesQuery $query): Request
     {
         $request = parent::build($query);
 

--- a/tests/Plugin/BufferedAdd/BufferedAddLiteTest.php
+++ b/tests/Plugin/BufferedAdd/BufferedAddLiteTest.php
@@ -439,7 +439,7 @@ class BufferedAddLiteTest extends TestCase
     /**
      * @param EventDispatcherInterface|null $dispatcher
      *
-     * @return Client|MockObject
+     * @return Client&MockObject
      */
     protected function getClient(?EventDispatcherInterface $dispatcher = null): ClientInterface
     {
@@ -449,7 +449,7 @@ class BufferedAddLiteTest extends TestCase
                 ->method('dispatch');
         }
 
-        /** @var Client|MockObject $client */
+        /** @var Client&MockObject $client */
         $client = $this->createMock(ClientInterface::class);
 
         $client->expects($this->any())

--- a/tests/Plugin/BufferedDelete/BufferedDeleteLiteTest.php
+++ b/tests/Plugin/BufferedDelete/BufferedDeleteLiteTest.php
@@ -427,7 +427,7 @@ class BufferedDeleteLiteTest extends TestCase
     /**
      * @param EventDispatcherInterface|null $dispatcher
      *
-     * @return Client|MockObject
+     * @return Client&MockObject
      */
     protected function getClient(?EventDispatcherInterface $dispatcher = null): ClientInterface
     {
@@ -437,7 +437,7 @@ class BufferedDeleteLiteTest extends TestCase
                 ->method('dispatch');
         }
 
-        /** @var Client|MockObject $client */
+        /** @var Client&MockObject $client */
         $client = $this->createMock(ClientInterface::class);
 
         $client->expects($this->any())

--- a/tests/Plugin/MinimumScoreFilter/QueryTest.php
+++ b/tests/Plugin/MinimumScoreFilter/QueryTest.php
@@ -72,7 +72,7 @@ class QueryTest extends AbstractQueryTestCase
 
     public function testGetComponentsWithGrouping()
     {
-        /** @var Grouping|MockObject $mockComponent */
+        /** @var Grouping&MockObject $mock */
         $mock = $this->getMockBuilder(Grouping::class)
             ->onlyMethods(['setOption'])
             ->getMock();

--- a/tests/Plugin/PostBigExtractRequestTest.php
+++ b/tests/Plugin/PostBigExtractRequestTest.php
@@ -16,6 +16,7 @@ use Solarium\Core\Client\Request;
 use Solarium\Core\Event\Events;
 use Solarium\Core\Event\PostCreateRequest;
 use Solarium\Plugin\PostBigExtractRequest;
+use Solarium\QueryType\Extract\Query;
 use Solarium\Tests\Integration\TestClientFactory;
 
 class PostBigExtractRequestTest extends TestCase
@@ -31,7 +32,7 @@ class PostBigExtractRequestTest extends TestCase
     protected $client;
 
     /**
-     * @var Solarium\QueryType\Extract\Query
+     * @var Query
      */
     protected $query;
 

--- a/tests/QueryType/Stream/ExpressionTest.php
+++ b/tests/QueryType/Stream/ExpressionTest.php
@@ -88,7 +88,7 @@ class ExpressionTest extends TestCase
 
 class CollectionDummy
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'dummy';
     }

--- a/tests/Support/DataFixtures/Fixtures/MockFixture2.php
+++ b/tests/Support/DataFixtures/Fixtures/MockFixture2.php
@@ -8,7 +8,7 @@ use Solarium\Support\DataFixtures\FixtureInterface;
 class MockFixture2 implements FixtureInterface
 {
     /**
-     * @param Client $client
+     * @param ClientInterface $client
      */
     public function load(ClientInterface $client)
     {
@@ -19,7 +19,7 @@ class MockFixture2 implements FixtureInterface
 class MockFixture3 implements FixtureInterface
 {
     /**
-     * @param Client $client
+     * @param ClientInterface $client
      */
     public function load(ClientInterface $client)
     {


### PR DESCRIPTION
Closes #1138.

With 8.1 as the minimum version we can now use both union and intersection types for parameter and return typehints. I did a quick sweep for some obvious improvements, I plan on revisiting this later. If nothing else, this change in the requestbuilders improves my IDE's ability to resolve function declarations.