### PR TITLE
Use 'static' as return for fluent interfaces of Facets

### DIFF
--- a/src/Component/Facet/AbstractFacet.php
+++ b/src/Component/Facet/AbstractFacet.php
@@ -44,10 +44,8 @@ abstract class AbstractFacet extends Configurable implements FacetInterface
      * Set key.
      *
      * @param string $key
-     *
-     * @return self Provides fluent interface
      */
-    public function setKey(string $key): self
+    public function setKey(string $key): static
     {
         $this->getLocalParameters()->setKey($key);
 
@@ -58,10 +56,8 @@ abstract class AbstractFacet extends Configurable implements FacetInterface
      * Add an exclude tag.
      *
      * @param string $exclude
-     *
-     * @return self Provides fluent interface
      */
-    public function addExclude(string $exclude): self
+    public function addExclude(string $exclude): static
     {
         $this->getLocalParameters()->setExclude($exclude);
 
@@ -72,10 +68,8 @@ abstract class AbstractFacet extends Configurable implements FacetInterface
      * Add multiple exclude tags.
      *
      * @param array|string $excludes array or string with comma separated exclude tags
-     *
-     * @return self Provides fluent interface
      */
-    public function addExcludes($excludes): self
+    public function addExcludes($excludes): static
     {
         if (\is_string($excludes)) {
             $excludes = preg_split('/(?<!\\\\),/', $excludes);
@@ -92,10 +86,8 @@ abstract class AbstractFacet extends Configurable implements FacetInterface
      * This overwrites any existing exclude tags.
      *
      * @param array|string $excludes
-     *
-     * @return self Provides fluent interface
      */
-    public function setExcludes($excludes): self
+    public function setExcludes($excludes): static
     {
         $this->clearExcludes()->addExcludes($excludes);
 
@@ -106,10 +98,8 @@ abstract class AbstractFacet extends Configurable implements FacetInterface
      * Remove a single exclude tag.
      *
      * @param string $exclude
-     *
-     * @return self Provides fluent interface
      */
-    public function removeExclude(string $exclude): self
+    public function removeExclude(string $exclude): static
     {
         $this->getLocalParameters()->removeExclude($exclude);
 
@@ -118,10 +108,8 @@ abstract class AbstractFacet extends Configurable implements FacetInterface
 
     /**
      * Remove all exclude tags.
-     *
-     * @return self Provides fluent interface
      */
-    public function clearExcludes(): self
+    public function clearExcludes(): static
     {
         $this->getLocalParameters()->clearExcludes();
 

--- a/src/Component/Facet/FacetInterface.php
+++ b/src/Component/Facet/FacetInterface.php
@@ -36,28 +36,22 @@ interface FacetInterface
      * Set key.
      *
      * @param string $key
-     *
-     * @return self Provides fluent interface
      */
-    public function setKey(string $key): self;
+    public function setKey(string $key): static;
 
     /**
      * Add an exclude tag.
      *
      * @param string $exclude
-     *
-     * @return self Provides fluent interface
      */
-    public function addExclude(string $exclude): self;
+    public function addExclude(string $exclude): static;
 
     /**
      * Add multiple exclude tags.
      *
      * @param array|string $excludes array or string with comma separated exclude tags
-     *
-     * @return self Provides fluent interface
      */
-    public function addExcludes($excludes): self;
+    public function addExcludes($excludes): static;
 
     /**
      * Set the list of exclude tags.
@@ -65,26 +59,20 @@ interface FacetInterface
      * This overwrites any existing exclude tags.
      *
      * @param array|string $excludes
-     *
-     * @return self Provides fluent interface
      */
-    public function setExcludes($excludes): self;
+    public function setExcludes($excludes): static;
 
     /**
      * Remove a single exclude tag.
      *
      * @param string $exclude
-     *
-     * @return self Provides fluent interface
      */
-    public function removeExclude(string $exclude): self;
+    public function removeExclude(string $exclude): static;
 
     /**
      * Remove all exclude tags.
-     *
-     * @return self Provides fluent interface
      */
-    public function clearExcludes(): self;
+    public function clearExcludes(): static;
 
     /**
      * Get the list of exclude tags.

--- a/src/Component/Facet/FieldValueParametersInterface.php
+++ b/src/Component/Facet/FieldValueParametersInterface.php
@@ -48,10 +48,8 @@ interface FieldValueParametersInterface
      * Limit the terms for faceting by a prefix.
      *
      * @param string $prefix
-     *
-     * @return self Provides fluent interface
      */
-    public function setPrefix(string $prefix): self;
+    public function setPrefix(string $prefix): static;
 
     /**
      * Get the facet prefix.
@@ -80,10 +78,8 @@ interface FieldValueParametersInterface
      * Case sensitivity of matching string that facet terms must contain.
      *
      * @param bool $containsIgnoreCase
-     *
-     * @return self Provides fluent interface
      */
-    public function setContainsIgnoreCase(bool $containsIgnoreCase): self;
+    public function setContainsIgnoreCase(bool $containsIgnoreCase): static;
 
     /**
      * Get the case sensitivity of facet contains.
@@ -96,10 +92,8 @@ interface FieldValueParametersInterface
      * Limit facet terms to those matching this regular expression.
      *
      * @param string $matches
-     *
-     * @return self Provides fluent interface
      */
-    public function setMatches(string $matches): self;
+    public function setMatches(string $matches): static;
 
     /**
      * Get the regular expression string that facets must match.
@@ -114,10 +108,8 @@ interface FieldValueParametersInterface
      * Use one of the SORT_* constants as the value.
      *
      * @param string $sort
-     *
-     * @return self Provides fluent interface
      */
-    public function setSort(string $sort): self;
+    public function setSort(string $sort): static;
 
     /**
      * Get the facet sort type.
@@ -130,10 +122,8 @@ interface FieldValueParametersInterface
      * Set the facet limit.
      *
      * @param int $limit
-     *
-     * @return self Provides fluent interface
      */
-    public function setLimit(int $limit): self;
+    public function setLimit(int $limit): static;
 
     /**
      * Get the facet limit.
@@ -146,10 +136,8 @@ interface FieldValueParametersInterface
      * Set the facet offset.
      *
      * @param int $offset
-     *
-     * @return self Provides fluent interface
      */
-    public function setOffset(int $offset): self;
+    public function setOffset(int $offset): static;
 
     /**
      * Get the facet offset.
@@ -162,10 +150,8 @@ interface FieldValueParametersInterface
      * Set the facet mincount.
      *
      * @param int $minCount
-     *
-     * @return self Provides fluent interface
      */
-    public function setMinCount(int $minCount): self;
+    public function setMinCount(int $minCount): static;
 
     /**
      * Get the facet mincount.
@@ -178,10 +164,8 @@ interface FieldValueParametersInterface
      * Set the missing count option.
      *
      * @param bool $missing
-     *
-     * @return self Provides fluent interface
      */
-    public function setMissing(bool $missing): self;
+    public function setMissing(bool $missing): static;
 
     /**
      * Get the facet missing option.
@@ -196,10 +180,8 @@ interface FieldValueParametersInterface
      * Use one of the METHOD_* constants as value.
      *
      * @param string $method
-     *
-     * @return self Provides fluent interface
      */
-    public function setMethod(string $method): self;
+    public function setMethod(string $method): static;
 
     /**
      * Get the facet method.
@@ -214,10 +196,8 @@ interface FieldValueParametersInterface
      * This is only used with METHOD_ENUM.
      *
      * @param int $frequency
-     *
-     * @return self Provides fluent interface
      */
-    public function setEnumCacheMinimumDocumentFrequency(int $frequency): self;
+    public function setEnumCacheMinimumDocumentFrequency(int $frequency): static;
 
     /**
      * Get the minimum document frequency for which the filterCache should be used.
@@ -230,10 +210,8 @@ interface FieldValueParametersInterface
      * Set to true to cap facet counts by 1.
      *
      * @param bool $exists
-     *
-     * @return self Provides fluent interface
      */
-    public function setExists(bool $exists): self;
+    public function setExists(bool $exists): static;
 
     /**
      * Get the exists parameter.
@@ -248,10 +226,8 @@ interface FieldValueParametersInterface
      * Specify a comma separated list. Use \, for a literal comma.
      *
      * @param string $exclude
-     *
-     * @return self Provides fluent interface
      */
-    public function setExcludeTerms(string $exclude): self;
+    public function setExcludeTerms(string $exclude): static;
 
     /**
      * Get terms that should be excluded from the facet.
@@ -264,10 +240,8 @@ interface FieldValueParametersInterface
      * Set the facet overrequest count.
      *
      * @param int $count
-     *
-     * @return self Provides fluent interface
      */
-    public function setOverrequestCount(int $count): self;
+    public function setOverrequestCount(int $count): static;
 
     /**
      * Get the facet overrequest count.
@@ -280,10 +254,8 @@ interface FieldValueParametersInterface
      * Set the facet overrequest ratio.
      *
      * @param float $ratio
-     *
-     * @return self Provides fluent interface
      */
-    public function setOverrequestRatio(float $ratio): self;
+    public function setOverrequestRatio(float $ratio): static;
 
     /**
      * Get the facet overrequest ratio.
@@ -300,10 +272,8 @@ interface FieldValueParametersInterface
      * Specifying a negative number will create up to (Java's) Integer.MAX_VALUE threads.
      *
      * @param int $threads
-     *
-     * @return self Provides fluent interface
      */
-    public function setThreads(int $threads): self;
+    public function setThreads(int $threads): static;
 
     /**
      * Get the maximum number of threads used for parallel execution.

--- a/src/Component/Facet/FieldValueParametersTrait.php
+++ b/src/Component/Facet/FieldValueParametersTrait.php
@@ -18,10 +18,8 @@ trait FieldValueParametersTrait
      * Limit the terms for faceting by a prefix.
      *
      * @param string $prefix
-     *
-     * @return self Provides fluent interface
      */
-    public function setPrefix(string $prefix): self
+    public function setPrefix(string $prefix): static
     {
         $this->setOption('prefix', $prefix);
 
@@ -42,10 +40,8 @@ trait FieldValueParametersTrait
      * Limit the terms for faceting by a string they must contain.
      *
      * @param string $contains
-     *
-     * @return self Provides fluent interface
      */
-    public function setContains(string $contains): self
+    public function setContains(string $contains): static
     {
         $this->setOption('contains', $contains);
 
@@ -66,10 +62,8 @@ trait FieldValueParametersTrait
      * Case sensitivity of matching string that facet terms must contain.
      *
      * @param bool $containsIgnoreCase
-     *
-     * @return self Provides fluent interface
      */
-    public function setContainsIgnoreCase(bool $containsIgnoreCase): self
+    public function setContainsIgnoreCase(bool $containsIgnoreCase): static
     {
         $this->setOption('containsignorecase', $containsIgnoreCase);
 
@@ -90,10 +84,8 @@ trait FieldValueParametersTrait
      * Limit facet terms to those matching this regular expression.
      *
      * @param string $matches
-     *
-     * @return self Provides fluent interface
      */
-    public function setMatches(string $matches): self
+    public function setMatches(string $matches): static
     {
         $this->setOption('matches', $matches);
 
@@ -116,10 +108,8 @@ trait FieldValueParametersTrait
      * Use one of the SORT_* constants as the value.
      *
      * @param string $sort
-     *
-     * @return self Provides fluent interface
      */
-    public function setSort(string $sort): self
+    public function setSort(string $sort): static
     {
         $this->setOption('sort', $sort);
 
@@ -140,10 +130,8 @@ trait FieldValueParametersTrait
      * Set the facet limit.
      *
      * @param int $limit
-     *
-     * @return self Provides fluent interface
      */
-    public function setLimit(int $limit): self
+    public function setLimit(int $limit): static
     {
         $this->setOption('limit', $limit);
 
@@ -164,10 +152,8 @@ trait FieldValueParametersTrait
      * Set the facet offset.
      *
      * @param int $offset
-     *
-     * @return self Provides fluent interface
      */
-    public function setOffset(int $offset): self
+    public function setOffset(int $offset): static
     {
         $this->setOption('offset', $offset);
 
@@ -188,10 +174,8 @@ trait FieldValueParametersTrait
      * Set the facet mincount.
      *
      * @param int $minCount
-     *
-     * @return self Provides fluent interface
      */
-    public function setMinCount(int $minCount): self
+    public function setMinCount(int $minCount): static
     {
         $this->setOption('mincount', $minCount);
 
@@ -212,10 +196,8 @@ trait FieldValueParametersTrait
      * Set the missing count option.
      *
      * @param bool $missing
-     *
-     * @return self Provides fluent interface
      */
-    public function setMissing(bool $missing): self
+    public function setMissing(bool $missing): static
     {
         $this->setOption('missing', $missing);
 
@@ -238,10 +220,8 @@ trait FieldValueParametersTrait
      * Use one of the METHOD_* constants as value.
      *
      * @param string $method
-     *
-     * @return self Provides fluent interface
      */
-    public function setMethod(string $method): self
+    public function setMethod(string $method): static
     {
         $this->setOption('method', $method);
 
@@ -264,10 +244,8 @@ trait FieldValueParametersTrait
      * This is only used with METHOD_ENUM.
      *
      * @param int $frequency
-     *
-     * @return self Provides fluent interface
      */
-    public function setEnumCacheMinimumDocumentFrequency(int $frequency): self
+    public function setEnumCacheMinimumDocumentFrequency(int $frequency): static
     {
         $this->setOption('enum.cache.minDf', $frequency);
 
@@ -288,10 +266,8 @@ trait FieldValueParametersTrait
      * Set to true to cap facet counts by 1.
      *
      * @param bool $exists
-     *
-     * @return self Provides fluent interface
      */
-    public function setExists(bool $exists): self
+    public function setExists(bool $exists): static
     {
         $this->setOption('exists', $exists);
 
@@ -314,10 +290,8 @@ trait FieldValueParametersTrait
      * Specify a comma separated list. Use \, for a literal comma.
      *
      * @param string $exclude
-     *
-     * @return self Provides fluent interface
      */
-    public function setExcludeTerms(string $exclude): self
+    public function setExcludeTerms(string $exclude): static
     {
         $this->setOption('excludeTerms', $exclude);
 
@@ -338,10 +312,8 @@ trait FieldValueParametersTrait
      * Set the facet overrequest count.
      *
      * @param int $count
-     *
-     * @return self Provides fluent interface
      */
-    public function setOverrequestCount(int $count): self
+    public function setOverrequestCount(int $count): static
     {
         $this->setOption('overrequest.count', $count);
 
@@ -362,10 +334,8 @@ trait FieldValueParametersTrait
      * Set the facet overrequest ratio.
      *
      * @param float $ratio
-     *
-     * @return self Provides fluent interface
      */
-    public function setOverrequestRatio(float $ratio): self
+    public function setOverrequestRatio(float $ratio): static
     {
         $this->setOption('overrequest.ratio', $ratio);
 
@@ -390,10 +360,8 @@ trait FieldValueParametersTrait
      * Specifying a negative number will create up to (Java's) Integer.MAX_VALUE threads.
      *
      * @param int $threads
-     *
-     * @return self Provides fluent interface
      */
-    public function setThreads(int $threads): self
+    public function setThreads(int $threads): static
     {
         $this->setOption('threads', $threads);
 

--- a/src/Component/Facet/Interval.php
+++ b/src/Component/Facet/Interval.php
@@ -32,10 +32,8 @@ class Interval extends AbstractFacet
      * Set the field name.
      *
      * @param string $field
-     *
-     * @return self Provides fluent interface
      */
-    public function setField(string $field): self
+    public function setField(string $field): static
     {
         $this->setOption('field', $field);
 
@@ -59,10 +57,8 @@ class Interval extends AbstractFacet
      * If you want to use multiple values supply an array or comma separated string
      *
      * @param string|array $set
-     *
-     * @return self Provides fluent interface
      */
-    public function setSet($set): self
+    public function setSet($set): static
     {
         if (\is_string($set)) {
             $set = explode(',', $set);

--- a/src/Component/Facet/JsonAggregation.php
+++ b/src/Component/Facet/JsonAggregation.php
@@ -35,10 +35,8 @@ class JsonAggregation extends AbstractFacet implements JsonFacetInterface
      * This overwrites the current value
      *
      * @param string $function
-     *
-     * @return self Provides fluent interface
      */
-    public function setFunction(string $function): self
+    public function setFunction(string $function): static
     {
         $this->setOption('function', $function);
 
@@ -63,10 +61,8 @@ class JsonAggregation extends AbstractFacet implements JsonFacetInterface
      * the aggregations returned by Solr.
      *
      * @param int $min
-     *
-     * @return self Provides fluent interface
      */
-    public function setMin(int $min): self
+    public function setMin(int $min): static
     {
         $this->setOption('min', $min);
 

--- a/src/Component/Facet/JsonFacetTrait.php
+++ b/src/Component/Facet/JsonFacetTrait.php
@@ -58,10 +58,8 @@ trait JsonFacetTrait
      *
      * @param string     $query
      * @param array|null $bind  Bind values for placeholders in the query string
-     *
-     * @return self Provides fluent interface
      */
-    public function setDomainFilterQuery(string $query, ?array $bind = null): self
+    public function setDomainFilterQuery(string $query, ?array $bind = null): static
     {
         if (null !== $bind) {
             $helper = new Helper();
@@ -98,10 +96,8 @@ trait JsonFacetTrait
      * Adds a domain filter parameter.
      *
      * @param string $param
-     *
-     * @return self Provides fluent interface
      */
-    public function addDomainFilterParameter(string $param): self
+    public function addDomainFilterParameter(string $param): static
     {
         $filter = $this->getDomainFilter();
         if (!$filter) {
@@ -164,10 +160,8 @@ trait JsonFacetTrait
      * @param FacetInterface|array $facet
      *
      * @throws InvalidArgumentException
-     *
-     * @return self Provides fluent interface
      */
-    public function addFacet($facet): self
+    public function addFacet($facet): static
     {
         if ($facet instanceof JsonFacetInterface) {
             $this->facetSetAddFacet($facet);
@@ -185,10 +179,8 @@ trait JsonFacetTrait
      * You can remove a facet by passing its key or the facet instance
      *
      * @param string|FacetInterface $facet
-     *
-     * @return self Provides fluent interface
      */
-    public function removeFacet($facet): self
+    public function removeFacet($facet): static
     {
         $this->facetSetRemoveFacet($facet);
         $this->serialize();
@@ -198,10 +190,8 @@ trait JsonFacetTrait
 
     /**
      * Remove all facets.
-     *
-     * @return self Provides fluent interface
      */
-    public function clearFacets(): self
+    public function clearFacets(): static
     {
         $this->facetSetClearFacets();
         $this->serialize();

--- a/src/Component/Facet/JsonTerms.php
+++ b/src/Component/Facet/JsonTerms.php
@@ -103,10 +103,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * Set the field name to facet over.
      *
      * @param string $field
-     *
-     * @return self Provides fluent interface
      */
-    public function setField(string $field): self
+    public function setField(string $field): static
     {
         $this->setOption('field', $field);
 
@@ -127,10 +125,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * Set the number of buckets to skip over.
      *
      * @param int $offset
-     *
-     * @return self Provides fluent interface
      */
-    public function setOffset(int $offset): self
+    public function setOffset(int $offset): static
     {
         $this->setOption('offset', $offset);
 
@@ -151,10 +147,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * Set the limit for number of buckets returned.
      *
      * @param int $limit
-     *
-     * @return self Provides fluent interface
      */
-    public function setLimit(int $limit): self
+    public function setLimit(int $limit): static
     {
         $this->setOption('limit', $limit);
 
@@ -180,10 +174,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * @see https://solr.apache.org/guide/json-facet-api.html#sorting-facets-by-nested-functions
      *
      * @param string $sort
-     *
-     * @return self Provides fluent interface
      */
-    public function setSort(string $sort): self
+    public function setSort(string $sort): static
     {
         $this->setOption('sort', $sort);
 
@@ -206,10 +198,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * Number of buckets beyond the limit to request internally during distributed search. -1 means default.
      *
      * @param int $overrequest
-     *
-     * @return self Provides fluent interface
      */
-    public function setOverRequest(int $overrequest): self
+    public function setOverRequest(int $overrequest): static
     {
         $this->setOption('overrequest', $overrequest);
 
@@ -234,10 +224,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * returned buckets exact.
      *
      * @param bool $refine
-     *
-     * @return self Provides fluent interface
      */
-    public function setRefine(bool $refine): self
+    public function setRefine(bool $refine): static
     {
         $this->setOption('refine', $refine);
 
@@ -261,10 +249,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * The default of -1 causes a heuristic to be applied based on other options specified.
      *
      * @param int $overrefine
-     *
-     * @return self Provides fluent interface
      */
-    public function setOverRefine(int $overrefine): self
+    public function setOverRefine(int $overrefine): static
     {
         $this->setOption('overrefine', $overrefine);
 
@@ -285,10 +271,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * Set the mincount for buckets to return.
      *
      * @param int $minCount
-     *
-     * @return self Provides fluent interface
      */
-    public function setMinCount(int $minCount): self
+    public function setMinCount(int $minCount): static
     {
         $this->setOption('mincount', $minCount);
 
@@ -309,10 +293,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * Specify if a special "missing" bucket should be returned.
      *
      * @param bool $missing
-     *
-     * @return self Provides fluent interface
      */
-    public function setMissing(bool $missing): self
+    public function setMissing(bool $missing): static
     {
         $this->setOption('missing', $missing);
 
@@ -336,10 +318,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * facet (as opposed to the number of buckets returned). Defaults to false.
      *
      * @param bool $numBuckets
-     *
-     * @return self Provides fluent interface
      */
-    public function setNumBuckets(bool $numBuckets): self
+    public function setNumBuckets(bool $numBuckets): static
     {
         $this->setOption('numBuckets', $numBuckets);
 
@@ -364,10 +344,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * document can belong to multiple buckets. Defaults to false.
      *
      * @param bool $allBuckets
-     *
-     * @return self Provides fluent interface
      */
-    public function setAllBuckets(bool $allBuckets): self
+    public function setAllBuckets(bool $allBuckets): static
     {
         $this->setOption('allBuckets', $allBuckets);
 
@@ -388,10 +366,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * Only produce buckets for terms starting with the specified prefix.
      *
      * @param string $prefix
-     *
-     * @return self Provides fluent interface
      */
-    public function setPrefix(string $prefix): self
+    public function setPrefix(string $prefix): static
     {
         $this->setOption('prefix', $prefix);
 
@@ -414,10 +390,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * Use one of the METHOD_* constants as value.
      *
      * @param string $method
-     *
-     * @return self Provides fluent interface
      */
-    public function setMethod(string $method): self
+    public function setMethod(string $method): static
     {
         $this->setOption('method', $method);
 
@@ -440,10 +414,8 @@ class JsonTerms extends AbstractFacet implements JsonFacetInterface, FacetSetInt
      * @see setSort() For the possible sort values.
      *
      * @param string $prelimSort
-     *
-     * @return self Provides fluent interface
      */
-    public function setPrelimSort(string $prelimSort): self
+    public function setPrelimSort(string $prelimSort): static
     {
         $this->setOption('prelim_sort', $prelimSort);
 

--- a/src/Component/Facet/MultiQuery.php
+++ b/src/Component/Facet/MultiQuery.php
@@ -50,10 +50,8 @@ class MultiQuery extends AbstractFacet
      * @param array  $excludes
      *
      * @throws OutOfBoundsException
-     *
-     * @return self Provides fluent interface
      */
-    public function createQuery(string $key, string $query, array $excludes = []): self
+    public function createQuery(string $key, string $query, array $excludes = []): static
     {
         // merge excludes with shared excludes
         $excludes = array_merge($this->getLocalParameters()->getExcludes(), $excludes);
@@ -76,10 +74,8 @@ class MultiQuery extends AbstractFacet
      *
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException
-     *
-     * @return self Provides fluent interface
      */
-    public function addQuery($facetQuery): self
+    public function addQuery($facetQuery): static
     {
         if (\is_array($facetQuery)) {
             $facetQuery = new Query($facetQuery);
@@ -111,10 +107,8 @@ class MultiQuery extends AbstractFacet
      * Add multiple facetqueries.
      *
      * @param array $facetQueries Instances or config array
-     *
-     * @return self Provides fluent interface
      */
-    public function addQueries(array $facetQueries): self
+    public function addQueries(array $facetQueries): static
     {
         foreach ($facetQueries as $key => $facetQuery) {
             // in case of a config array: add key to config
@@ -156,10 +150,8 @@ class MultiQuery extends AbstractFacet
      * You can remove a facetquery by passing its key or the facetquery instance.
      *
      * @param string|Query $query
-     *
-     * @return self Provides fluent interface
      */
-    public function removeQuery($query): self
+    public function removeQuery($query): static
     {
         if (\is_object($query)) {
             $query = $query->getKey();
@@ -174,10 +166,8 @@ class MultiQuery extends AbstractFacet
 
     /**
      * Remove all facetqueries.
-     *
-     * @return self Provides fluent interface
      */
-    public function clearQueries(): self
+    public function clearQueries(): static
     {
         $this->facetQueries = [];
 
@@ -190,10 +180,8 @@ class MultiQuery extends AbstractFacet
      * This overwrites any existing facetqueries
      *
      * @param array $facetQueries
-     *
-     * @return self Provides fluent interface
      */
-    public function setQueries(array $facetQueries): self
+    public function setQueries(array $facetQueries): static
     {
         $this->clearQueries();
 
@@ -210,10 +198,8 @@ class MultiQuery extends AbstractFacet
      * specific FacetQuery instance instead.
      *
      * @param string $exclude
-     *
-     * @return self Provides fluent interface
      */
-    public function addExclude(string $exclude): self
+    public function addExclude(string $exclude): static
     {
         foreach ($this->facetQueries as $facetQuery) {
             $facetQuery->addExclude($exclude);
@@ -234,10 +220,8 @@ class MultiQuery extends AbstractFacet
      * specific FacetQuery instance instead.
      *
      * @param array|string $excludes array or string with comma separated exclude tags
-     *
-     * @return self Provides fluent interface
      */
-    public function addExcludes($excludes): self
+    public function addExcludes($excludes): static
     {
         if (\is_string($excludes)) {
             $excludes = preg_split('/(?<!\\\\),/', $excludes);
@@ -262,10 +246,8 @@ class MultiQuery extends AbstractFacet
      * specific FacetQuery instance instead.
      *
      * @param array|string $excludes array or string with comma separated exclude tags
-     *
-     * @return self Provides fluent interface
      */
-    public function setExcludes($excludes): self
+    public function setExcludes($excludes): static
     {
         if (\is_string($excludes)) {
             $excludes = preg_split('/(?<!\\\\),/', $excludes);
@@ -288,12 +270,8 @@ class MultiQuery extends AbstractFacet
      *
      * If you don't want this use the removeExclude method of a
      * specific FacetQuery instance instead.
-     *
-     * @param string $exclude
-     *
-     * @return self Provides fluent interface
      */
-    public function removeExclude(string $exclude): self
+    public function removeExclude(string $exclude): static
     {
         foreach ($this->facetQueries as $facetQuery) {
             $facetQuery->removeExclude($exclude);
@@ -312,10 +290,8 @@ class MultiQuery extends AbstractFacet
      *
      * If you don't want this use the clearExcludes method of a
      * specific FacetQuery instance instead.
-     *
-     * @return self Provides fluent interface
      */
-    public function clearExcludes(): self
+    public function clearExcludes(): static
     {
         foreach ($this->facetQueries as $facetQuery) {
             $facetQuery->clearExcludes();

--- a/src/Component/Facet/Pivot.php
+++ b/src/Component/Facet/Pivot.php
@@ -53,12 +53,10 @@ class Pivot extends AbstractFacet
      *
      * @param int $minCount
      *
-     * @return self Provides fluent interface
-     *
      * @deprecated This method no longer has effect. Use {@link Solarium\Component\FacetSet::setPivotMinCount()} to
      *    set the global minCount or {@link setPivotMinCount()} to set the minCount for specific pivot fields instead.
      */
-    public function setMinCount(int $minCount): self
+    public function setMinCount(int $minCount): static
     {
         $this->setOption('mincount', $minCount);
 
@@ -81,10 +79,8 @@ class Pivot extends AbstractFacet
      * Set the facet limit.
      *
      * @param int $limit
-     *
-     * @return self Provides fluent interface
      */
-    public function setLimit(int $limit): self
+    public function setLimit(int $limit): static
     {
         $this->setOption('limit', $limit);
 
@@ -105,10 +101,8 @@ class Pivot extends AbstractFacet
      * Set the facet offset.
      *
      * @param int $offset
-     *
-     * @return self Provides fluent interface
      */
-    public function setOffset(int $offset): self
+    public function setOffset(int $offset): static
     {
         $this->setOption('offset', $offset);
 
@@ -131,10 +125,8 @@ class Pivot extends AbstractFacet
      * Use one of the SORT_* constants as the value.
      *
      * @param string $sort
-     *
-     * @return self Provides fluent interface
      */
-    public function setSort(string $sort): self
+    public function setSort(string $sort): static
     {
         $this->setOption('sort', $sort);
 
@@ -155,10 +147,8 @@ class Pivot extends AbstractFacet
      * Set the facet overrequest count.
      *
      * @param int $count
-     *
-     * @return self Provides fluent interface
      */
-    public function setOverrequestCount(int $count): self
+    public function setOverrequestCount(int $count): static
     {
         $this->setOption('overrequest.count', $count);
 
@@ -179,10 +169,8 @@ class Pivot extends AbstractFacet
      * Set the facet overrequest ratio.
      *
      * @param float $ratio
-     *
-     * @return self Provides fluent interface
      */
-    public function setOverrequestRatio(float $ratio): self
+    public function setOverrequestRatio(float $ratio): static
     {
         $this->setOption('overrequest.ratio', $ratio);
 
@@ -203,10 +191,8 @@ class Pivot extends AbstractFacet
      * Specify a field to return in the resultset.
      *
      * @param string $field
-     *
-     * @return self Provides fluent interface
      */
-    public function addField(string $field): self
+    public function addField(string $field): static
     {
         $field = trim($field);
         $this->fields[$field] = true;
@@ -219,10 +205,8 @@ class Pivot extends AbstractFacet
      *
      * @param string|array $fields can be an array or string with comma
      *                             separated fieldnames
-     *
-     * @return self Provides fluent interface
      */
-    public function addFields($fields): self
+    public function addFields($fields): static
     {
         if (\is_string($fields)) {
             $fields = explode(',', $fields);
@@ -239,10 +223,8 @@ class Pivot extends AbstractFacet
      * Remove a field from the field list.
      *
      * @param string $field
-     *
-     * @return self Provides fluent interface
      */
-    public function removeField($field): self
+    public function removeField($field): static
     {
         if (isset($this->fields[$field])) {
             unset($this->fields[$field]);
@@ -253,10 +235,8 @@ class Pivot extends AbstractFacet
 
     /**
      * Remove all fields from the field list.
-     *
-     * @return self Provides fluent interface
      */
-    public function clearFields(): self
+    public function clearFields(): static
     {
         $this->fields = [];
 
@@ -280,10 +260,8 @@ class Pivot extends AbstractFacet
      *
      * @param array|string $fields can be an array or string with comma
      *                             separated fieldnames
-     *
-     * @return self Provides fluent interface
      */
-    public function setFields($fields): self
+    public function setFields($fields): static
     {
         $this->clearFields();
         $this->addFields($fields);
@@ -297,10 +275,8 @@ class Pivot extends AbstractFacet
      * @param string $stat
      *
      * @throws OutOfBoundsException
-     *
-     * @return self Provides fluent interface
      */
-    public function addStat(string $stat): self
+    public function addStat(string $stat): static
     {
         $this
             ->getLocalParameters()
@@ -317,10 +293,8 @@ class Pivot extends AbstractFacet
      *                            separated statnames
      *
      * @throws OutOfBoundsException
-     *
-     * @return self Provides fluent interface
      */
-    public function addStats($stats): self
+    public function addStats($stats): static
     {
         if (false === \is_array($stats)) {
             $stats = array_map('trim', explode(',', $stats));
@@ -340,10 +314,8 @@ class Pivot extends AbstractFacet
      * @param string $stat
      *
      * @throws OutOfBoundsException
-     *
-     * @return self Provides fluent interface
      */
-    public function removeStat($stat): self
+    public function removeStat($stat): static
     {
         $this
             ->getLocalParameters()
@@ -357,10 +329,8 @@ class Pivot extends AbstractFacet
      * Remove all stats from the stats list.
      *
      * @throws OutOfBoundsException
-     *
-     * @return self Provides fluent interface
      */
-    public function clearStats(): self
+    public function clearStats(): static
     {
         $this
             ->getLocalParameters()
@@ -393,10 +363,8 @@ class Pivot extends AbstractFacet
      * @param array $stats
      *
      * @throws OutOfBoundsException
-     *
-     * @return self Provides fluent interface
      */
-    public function setStats(array $stats): self
+    public function setStats(array $stats): static
     {
         $this
             ->getLocalParameters()

--- a/src/Component/Facet/PivotMinCountTrait.php
+++ b/src/Component/Facet/PivotMinCountTrait.php
@@ -18,10 +18,8 @@ trait PivotMinCountTrait
      * Set the minimum number of documents that need to match in order for the facet to be included in results.
      *
      * @param int $minCount
-     *
-     * @return self Provides fluent interface
      */
-    public function setPivotMinCount(int $minCount): self
+    public function setPivotMinCount(int $minCount): static
     {
         $this->setOption('pivot.mincount', $minCount);
 

--- a/src/Component/FacetSetInterface.php
+++ b/src/Component/FacetSetInterface.php
@@ -74,19 +74,15 @@ interface FacetSetInterface
      * @param FacetInterface|array $facet
      *
      * @throws InvalidArgumentException
-     *
-     * @return self Provides fluent interface
      */
-    public function addFacet($facet): self;
+    public function addFacet($facet): static;
 
     /**
      * Add multiple facets.
      *
      * @param array $facets
-     *
-     * @return self Provides fluent interface
      */
-    public function addFacets(array $facets): self;
+    public function addFacets(array $facets): static;
 
     /**
      * Get a facet.
@@ -110,17 +106,13 @@ interface FacetSetInterface
      * You can remove a facet by passing its key or the facet instance
      *
      * @param string|FacetInterface $facet
-     *
-     * @return self Provides fluent interface
      */
-    public function removeFacet($facet): self;
+    public function removeFacet($facet): static;
 
     /**
      * Remove all facets.
-     *
-     * @return self Provides fluent interface
      */
-    public function clearFacets(): self;
+    public function clearFacets(): static;
 
     /**
      * Set multiple facets.
@@ -128,10 +120,8 @@ interface FacetSetInterface
      * This overwrites any existing facets
      *
      * @param FacetInterface[] $facets
-     *
-     * @return self Provides fluent interface
      */
-    public function setFacets(array $facets): self;
+    public function setFacets(array $facets): static;
 
     /**
      * Create a facet instance.

--- a/src/Component/FacetSetTrait.php
+++ b/src/Component/FacetSetTrait.php
@@ -31,10 +31,8 @@ trait FacetSetTrait
      * @param \Solarium\Component\Facet\FacetInterface|array $facet
      *
      * @throws InvalidArgumentException
-     *
-     * @return self Provides fluent interface
      */
-    public function addFacet($facet): self
+    public function addFacet($facet): static
     {
         if (\is_array($facet)) {
             $facet = $this->createFacet($facet['type'], $facet, false);
@@ -60,10 +58,8 @@ trait FacetSetTrait
      * Add multiple facets.
      *
      * @param array $facets
-     *
-     * @return self Provides fluent interface
      */
-    public function addFacets(array $facets): self
+    public function addFacets(array $facets): static
     {
         foreach ($facets as $key => $facet) {
             // in case of a config array: add key to config
@@ -105,10 +101,8 @@ trait FacetSetTrait
      * You can remove a facet by passing its key or the facet instance
      *
      * @param string|\Solarium\Component\Facet\FacetInterface $facet
-     *
-     * @return self Provides fluent interface
      */
-    public function removeFacet($facet): self
+    public function removeFacet($facet): static
     {
         if (\is_object($facet)) {
             $facet = $facet->getKey();
@@ -123,10 +117,8 @@ trait FacetSetTrait
 
     /**
      * Remove all facets.
-     *
-     * @return self Provides fluent interface
      */
-    public function clearFacets(): self
+    public function clearFacets(): static
     {
         $this->facets = [];
 
@@ -139,10 +131,8 @@ trait FacetSetTrait
      * This overwrites any existing facets
      *
      * @param array $facets
-     *
-     * @return self Provides fluent interface
      */
-    public function setFacets(array $facets): self
+    public function setFacets(array $facets): static
     {
         $this->clearFacets();
         $this->addFacets($facets);


### PR DESCRIPTION
This example code:
```
        $facet = (new JsonTerms())
            ->setKey('my-facet')
            ->setField('field_name');
```
Reports an error on PHPStan: `Call to an undefined method Solarium\Component\Facet\AbstractFacet::setField()`

The reason is:
- the class `JsonTerms` has the `setField()` method, but ..
- the `setKey()` method is implemented in the  `AbstractFacet` as `public function setKey(string $key): self`

This is handled as that the returned object from `setKey()` is an instance of `AbstractFacet` not the current instance of `JsonTerms`.

This also solves a PHPStan error (when running at level=2)
```
- tests/Component/FacetSetTest.php
  Call to an undefined method Solarium\\Component\\Facet\\AbstractFacet::setQuery()            
```

Note: this might be a BC-Break, sadly