### PR TITLE
Update `Result::jsonSerializable` return type

### DIFF
--- a/src/Core/Query/Result/Result.php
+++ b/src/Core/Query/Result/Result.php
@@ -131,6 +131,8 @@ class Result implements ResultInterface, \JsonSerializable
     #[\ReturnTypeWillChange]
     /**
      * {@inheritdoc}
+     *
+     * @return array
      */
     public function jsonSerialize()
     {


### PR DESCRIPTION
See https://github.com/symfony/symfony/issues/61275

I choose `array` as a more specific type, but im also fine with `mixed` from the contract.