### PR TITLE
Solr 9.9 → 9.10 for integrations tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,12 +51,12 @@ jobs:
                 ref: branch_8_11
                 path: lucene-solr
 
-            - name: Checkout solr 9.9
+            - name: Checkout solr 9.10
               if: matrix.solr == 9
               uses: actions/checkout@v4
               with:
                 repository: apache/solr
-                ref: branch_9_9
+                ref: branch_9_10
                 path: lucene-solr
 
             - name: Start Solr ${{ matrix.solr }} in ${{ matrix.mode }} mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [7.0.0]
+### Added
+- Solarium\QueryType\Extract\Query::setStreamType()
+
 ### Changed
  - Added `void` return type to `Solarium\Core\Plugin\PluginInterface::initPlugin()` method signature
  - Added `void` return type to `Solarium\Core\Plugin\PluginInterface::deinitPlugin()` method signature

--- a/docs/queries/extract-query.md
+++ b/docs/queries/extract-query.md
@@ -15,6 +15,7 @@ See the example code below.
 | omitheader    | boolean | true                          | Disable Solr headers (saves some overhead, as the values aren't actually used in most cases)                                                  |
 | extractonly   | boolean | false                         | If true, returns the extracted content from Tika without indexing the document                                                                |
 | extractformat | string  | null                          | Controls the serialization format of the extracted content. By default 'xml', the other option is 'text'. Only valid if 'extractonly' is true |
+| stream.type   | string  | null                          | Explicitly specify a MIME type for Tika                                                                                                       |
 ||
 
 Executing an extract query

--- a/src/QueryType/Extract/Query.php
+++ b/src/QueryType/Extract/Query.php
@@ -146,6 +146,30 @@ class Query extends BaseQuery
     }
 
     /**
+     * Set an explicit MIME type for Tika.
+     *
+     * @param string $type
+     *
+     * @return self Provides fluent interface
+     */
+    public function setStreamType(string $type): self
+    {
+        $this->setOption('stream.type', $type);
+
+        return $this;
+    }
+
+    /**
+     * Get the explicit MIME type for Tika.
+     *
+     * @return string|null
+     */
+    public function getStreamType(): ?string
+    {
+        return $this->getOption('stream.type');
+    }
+
+    /**
      * Set the prefix for fields that are not defined in the schema.
      *
      * @param string $uprefix

--- a/src/QueryType/Extract/RequestBuilder.php
+++ b/src/QueryType/Extract/RequestBuilder.php
@@ -41,6 +41,7 @@ class RequestBuilder extends BaseRequestBuilder
         $request->addParam('defaultField', $query->getDefaultField());
         $request->addParam('extractOnly', $query->getExtractOnly());
         $request->addParam('extractFormat', $query->getExtractFormat());
+        $request->addParam('stream.type', $query->getStreamType());
 
         foreach ($query->getFieldMappings() as $fromField => $toField) {
             $request->addParam('fmap.'.$fromField, $toField);

--- a/tests/Integration/AbstractTechproductsTestCase.php
+++ b/tests/Integration/AbstractTechproductsTestCase.php
@@ -4522,18 +4522,15 @@ abstract class AbstractTechproductsTestCase extends TestCase
 
         /** @var Document $document */
         $document = $iterator->current();
-        $this->assertSame('application/pdf', $document['content_type'][0], 'Written document does not contain extracted content type');
         $this->assertSame('PDF Test', trim($document['content'][0]), 'Written document does not contain extracted result');
         $this->assertSame(['bar 1'], $document['attr_foo_1']);
         $iterator->next();
         $document = $iterator->current();
-        $this->assertSame('text/html; charset=UTF-8', $document['content_type'][0], 'Written document does not contain extracted content type');
         $this->assertSame('HTML Test Title', $document['title'][0], 'Written document does not contain extracted title');
         $this->assertMatchesRegularExpression('/^HTML Test Title\s+HTML Test Body$/', trim($document['content'][0]), 'Written document does not contain extracted result');
         $this->assertSame(['bar 2'], $document['attr_foo_2']);
         $iterator->next();
         $document = $iterator->current();
-        $this->assertSame('text/html; charset=UTF-8', $document['content_type'][0], 'Written document does not contain extracted content type');
         $this->assertSame('HTML Stream Title', $document['title'][0], 'Written document does not contain extracted title');
         $this->assertMatchesRegularExpression('/^HTML Stream Title\s+HTML Stream Body$/', trim($document['content'][0]), 'Written document does not contain extracted result');
         $this->assertSame(['bar 3'], $document['attr_foo_3']);

--- a/tests/QueryType/Extract/QueryTest.php
+++ b/tests/QueryType/Extract/QueryTest.php
@@ -82,6 +82,12 @@ class QueryTest extends TestCase
         fclose($file);
     }
 
+    public function testSetAndGetStreamType(): void
+    {
+        $this->query->setStreamType('application/x-test');
+        $this->assertSame('application/x-test', $this->query->getStreamType());
+    }
+
     public function testSetAndGetUprefix(): void
     {
         $this->query->setUprefix('dyn_');

--- a/tests/QueryType/Extract/RequestBuilderTest.php
+++ b/tests/QueryType/Extract/RequestBuilderTest.php
@@ -127,6 +127,18 @@ class RequestBuilderTest extends TestCase
         );
     }
 
+    public function testGetUriWithStreamType(): void
+    {
+        $query = $this->query;
+        $query->setStreamType('application/x-test');
+        $request = $this->builder->build($query);
+        $this->assertSame(
+            'update/extract?omitHeader=true&param1=value1&wt=json&json.nl=flat&extractOnly=false&stream.type=application%2Fx-test&fmap.from-field=to-field'.
+            '&resource.name=RequestBuilderTest.php',
+            $request->getUri()
+        );
+    }
+
     public function testGetUriWithExtractFormat(): void
     {
         $query = $this->query;


### PR DESCRIPTION
Solr 9.10 changed how Tika is handled in [SOLR-7632](https://issues.apache.org/jira/browse/SOLR-7632). The returned content type for our extract tests is always `application/octet-stream` now with the out-of-the-box configuration. Since the minutiae of the Tika configuration aren't relevant for our tests, I've removed the failing assertions.

Well, after I tried if the [`stream.type` parameter](https://solr.apache.org/guide/solr/latest/indexing-guide/indexing-with-tika.html#key-solr-cell-concepts) was an easy fix. Didn't help but I've left it in since I wrote the code anyway.