### PR TITLE
Access "response" of CoreAdmin queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Solarium\QueryType\Extract\Query::setStreamType()
 
+### Fixed
+- Solarium\QueryType\Server\CoreAdmin\Result\Result::getResponse() always returns a Solarium\Core\Client\Response object, even if the response data contains a field named `"response"`
+- Solarium\QueryType\Server\CoreAdmin\Result\Result::$response publicly exposes the `"response"` field from the response data
+
 ### Changed
  - Added `void` return type to `Solarium\Core\Plugin\PluginInterface::initPlugin()` method signature
  - Added `void` return type to `Solarium\Core\Plugin\PluginInterface::deinitPlugin()` method signature

--- a/src/QueryType/Server/CoreAdmin/ResponseParser.php
+++ b/src/QueryType/Server/CoreAdmin/ResponseParser.php
@@ -38,6 +38,20 @@ class ResponseParser extends ResponseParserAbstract implements ResponseParserInt
         $data = $this->parseInitFailures($data, $result);
         $data = $this->parseStatus($data, $result);
 
+        if (isset($data['response'])) {
+            /*
+             * The protected property Result::$response always holds the
+             * Response object for the Query and is accessible through
+             * Result::getResponse().
+             *
+             * We store this value as a different property and revert this in
+             * Result::__get() to make it accessible as if it were the public
+             * property Result::$response.
+             */
+            $data['_original_response'] = $data['response'];
+            unset($data['response']);
+        }
+
         return $data;
     }
 

--- a/src/QueryType/Server/CoreAdmin/Result/Result.php
+++ b/src/QueryType/Server/CoreAdmin/Result/Result.php
@@ -132,4 +132,25 @@ class Result extends BaseResult
     {
         return $this->statusResults[$coreName] ?? null;
     }
+
+    /**
+     * Magic method for getting inaccessible or non-existent properties.
+     *
+     * @see \Solarium\QueryType\Server\CoreAdmin\ResponseParser
+     *
+     * @param string $name
+     *
+     * @return mixed|null
+     */
+    public function __get(string $name)
+    {
+        /*
+         * Revert the workaround from ResponseParser::parse() to make
+         * Result::$response publicly accessible without conflicting with
+         * the actual protected property of that name.
+         */
+        if ('response' === $name && isset($this->_original_response)) {
+            return $this->_original_response;
+        }
+    }
 }

--- a/tests/QueryType/Server/CoreAdmin/ResponseParserTest.php
+++ b/tests/QueryType/Server/CoreAdmin/ResponseParserTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Server\CoreAdmin;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Response;
+use Solarium\QueryType\Server\CoreAdmin\Query\Query;
+use Solarium\QueryType\Server\CoreAdmin\ResponseParser;
+use Solarium\QueryType\Server\CoreAdmin\Result\Result;
+
+class ResponseParserTest extends TestCase
+{
+    public function testParseWithResponseProperty(): void
+    {
+        $query = new Query();
+        $action = $query->createSplit();
+        $query->setAction($action);
+
+        $data = [
+            'response' => [
+                'timing' => [
+                    'time' => 318,
+                    'doSplit' => [
+                        'time' => 318,
+                    ],
+                    'findDocSetsPerLeaf' => [
+                        'time' => 0,
+                    ],
+                    'addIndexes' => [
+                        'time' => 21,
+                    ],
+                    'subIWCommit' => [
+                        'time' => 294,
+                    ],
+                ],
+            ],
+        ];
+
+        $response = new Response(json_encode($data), ['HTTP/1.1 200 OK']);
+        $result = new Result($query, $response);
+        $parser = new ResponseParser();
+        $parsed = $parser->parse($result);
+
+        $this->assertSame($data['response'], $parsed['_original_response']);
+        $this->assertArrayNotHasKey('response', $parsed);
+    }
+}

--- a/tests/QueryType/Server/CoreAdmin/Result/ResultTest.php
+++ b/tests/QueryType/Server/CoreAdmin/Result/ResultTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Solarium\Tests\QueryType\Server\CoreAdmin\Result;
+
+use PHPUnit\Framework\TestCase;
+use Solarium\QueryType\Server\CoreAdmin\Result\Result;
+
+class ResultTest extends TestCase
+{
+    /**
+     * @var Result
+     */
+    protected $result;
+
+    public function setUp(): void
+    {
+        $this->result = new CoreAdminDummy();
+    }
+
+    public function testGetWasSuccessful(): void
+    {
+        $this->assertTrue($this->result->getWasSuccessful());
+    }
+
+    public function testGetStatusMessage(): void
+    {
+        $this->assertSame('OK', $this->result->getStatusMessage());
+    }
+
+    /**
+     * @see Solarium\QueryType\Server\CoreAdmin\ResponseParser::parse()
+     * @see Solarium\QueryType\Server\CoreAdmin\Result\Result::__get()
+     */
+    public function testAccessResponseAsProperty(): void
+    {
+        $data = [
+            '_original_response' => [
+                'timing' => [
+                    'time' => 318.0,
+                    'doSplit' => [
+                        'time' => 318.0,
+                    ],
+                    'findDocSetsPerLeaf' => [
+                        'time' => 0.0,
+                    ],
+                    'addIndexes' => [
+                        'time' => 21.0,
+                    ],
+                    'subIWCommit' => [
+                        'time' => 294.0,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->result->mapData($data);
+        $this->assertSame($data['_original_response'], $this->result->response);
+    }
+
+    public function testAccessOtherProperty(): void
+    {
+        $this->result->mapData(['foo' => 'bar']);
+
+        $this->assertSame('bar', $this->result->foo);
+    }
+}
+
+class CoreAdminDummy extends Result
+{
+    protected $parsed = true;
+
+    public function __construct()
+    {
+        $this->wasSuccessful = true;
+        $this->statusMessage = 'OK';
+    }
+
+    public function mapData(array $mapData): void
+    {
+        parent::mapData($mapData);
+    }
+}


### PR DESCRIPTION
`CoreAdmin` queries can have a field named `"response"` in the JSON response data. Parsing that data assigned its value (of type `array`) to `Solarium\Core\Query\Result\Result::$response` (of type `Solarium\Core\Client\Response`).

This caused a `TypeError` when calling `Result::getResponse()` to get the `Response` object.

```
TypeError: Solarium\Core\Query\Result\Result::getResponse(): Return value must be of type Solarium\Core\Client\Response, array returned
```

It also caused an `Error` when trying to access `Result::$response` to get the value.

```
Error: Cannot access protected property Solarium\Tests\QueryType\Server\CoreAdmin\Result\Result::$response
```

This PR fixes both problems by storing it under a different property name but making it accessible under its original name through property overloading.