### PR TITLE
PHP 8.5 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.1, 8.2, 8.3, 8.4]
+                php: [8.1, 8.2, 8.3, 8.4, 8.5]
                 solr: [7, 8, 9]
                 mode: [cloud, server]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.0.0]
 ### Added
+- PHP 8.5 support
 - Solarium\QueryType\Extract\Query::setStreamType()
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,9 @@
     ],
     "require": {
         "php": "^8.1",
+        "ext-date": "*",
         "ext-json": "*",
+        "ext-pcre": "*",
         "halaxa/json-machine": "^1.1",
         "psr/event-dispatcher": "^1.0",
         "psr/http-client": "^1.0",
@@ -36,9 +38,10 @@
         "rawr/phpunit-data-provider": "^3.3",
         "roave/security-advisories": "dev-master",
         "spomky-labs/cbor-php": "^3.1",
-        "symfony/event-dispatcher": "^5.0 || ^6.0 || ^7.0"
+        "symfony/event-dispatcher": "^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "suggest": {
+        "ext-curl": "Needed to use the cURL adapter",
         "spomky-labs/cbor-php": "Needed to use CBOR formatted requests with Solr 9.3+"
     },
     "prefer-stable": true,

--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -56,15 +56,13 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
         if (CURLE_OK !== curl_errno($handle)) {
             $errno = curl_errno($handle);
             $error = curl_error($handle);
-            curl_close($handle);
+
             throw new HttpException(sprintf('HTTP request failed, %s', $error), $errno);
         }
 
         $httpCode = curl_getinfo($handle, CURLINFO_RESPONSE_CODE);
         $headers = [];
         $headers[] = 'HTTP/1.1 '.$httpCode.' OK';
-
-        curl_close($handle);
 
         return new Response($httpResponse, $headers);
     }

--- a/src/Core/Client/Adapter/Http.php
+++ b/src/Core/Client/Adapter/Http.php
@@ -161,8 +161,14 @@ class Http implements AdapterInterface, TimeoutAwareInterface, ProxyAwareInterfa
     {
         $data = @file_get_contents($uri, false, $context);
 
+        // $http_response_header is deprecated as of PHP 8.5
+        // http_get_last_response_headers() was introduced in PHP 8.4
+        if (\function_exists('http_get_last_response_headers')) {
+            return [$data, http_get_last_response_headers() ?? []];
+        }
+
         // @see https://www.php.net/manual/en/reserved.variables.httpresponseheader.php
-        // @phpstan-ignore-next-line https://github.com/phpstan/phpstan/issues/3213
+        // @phpstan-ignore nullCoalesce.variable (https://github.com/phpstan/phpstan/issues/3213)
         return [$data, $http_response_header ?? []];
     }
 }

--- a/tests/Core/Client/Adapter/CurlTest.php
+++ b/tests/Core/Client/Adapter/CurlTest.php
@@ -109,8 +109,6 @@ class CurlTest extends TestCase
 
         $this->expectException(HttpException::class);
         $this->adapter->getResponse($handle, false);
-
-        curl_close($handle);
     }
 
     /**
@@ -126,8 +124,6 @@ class CurlTest extends TestCase
         $handle = $this->adapter->createHandle($request, $endpoint);
 
         $this->assertInstanceOf(\CurlHandle::class, $handle);
-
-        curl_close($handle);
     }
 
     public static function methodProvider(): array
@@ -155,8 +151,6 @@ class CurlTest extends TestCase
         $handle = $this->adapter->createHandle($request, $endpoint);
 
         $this->assertInstanceOf(\CurlHandle::class, $handle);
-
-        curl_close($handle);
     }
 
     public function testCreateHandleWithCustomRequestHeaders(): void
@@ -169,8 +163,6 @@ class CurlTest extends TestCase
         $handle = $this->adapter->createHandle($request, $endpoint);
 
         $this->assertInstanceOf(\CurlHandle::class, $handle);
-
-        curl_close($handle);
     }
 
     public function testCreateHandleWithUnknownMethod(): void
@@ -182,9 +174,7 @@ class CurlTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('unsupported method: PSOT');
-        $handle = $this->adapter->createHandle($request, $endpoint);
-
-        curl_close($handle);
+        $this->adapter->createHandle($request, $endpoint);
     }
 
     public function testRequestBasicAuthentication(): void
@@ -197,8 +187,6 @@ class CurlTest extends TestCase
         $handle = $this->adapter->createHandle($request, $endpoint);
 
         $this->assertInstanceOf(\CurlHandle::class, $handle);
-
-        curl_close($handle);
     }
 
     public function testEndpointBasicAuthentication(): void
@@ -211,8 +199,6 @@ class CurlTest extends TestCase
         $handle = $this->adapter->createHandle($request, $endpoint);
 
         $this->assertInstanceOf(\CurlHandle::class, $handle);
-
-        curl_close($handle);
     }
 
     public function testAuthorizationToken(): void
@@ -225,7 +211,5 @@ class CurlTest extends TestCase
         $handle = $this->adapter->createHandle($request, $endpoint);
 
         $this->assertInstanceOf(\CurlHandle::class, $handle);
-
-        curl_close($handle);
     }
 }


### PR DESCRIPTION
`curl_close()` is deprecated in PHP 8.5 but didn't do anything since PHP 8.0 anyway.

https://www.php.net/manual/en/function.curl-close.php

`$http_response_header` is deprecated in PHP 8.5, `http_get_last_response_headers()` is available since PHP 8.4.

https://www.php.net/manual/en/reserved.variables.httpresponseheader.php