### PR TITLE
Fix method forwarding in MinimumScoreFilter\Document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Solarium\QueryType\Server\CoreAdmin\Result\Result::getResponse() always returns a Solarium\Core\Client\Response object, even if the response data contains a field named `"response"`
 - Solarium\QueryType\Server\CoreAdmin\Result\Result::$response publicly exposes the `"response"` field from the response data
+- Solarium\Plugin\MinimumScoreFilter\Document::__call() unpacks the $arguments array when forwarding a method call to the original document
 
 ### Changed
  - Added `void` return type to `Solarium\Core\Plugin\PluginInterface::initPlugin()` method signature

--- a/src/Plugin/MinimumScoreFilter/Document.php
+++ b/src/Plugin/MinimumScoreFilter/Document.php
@@ -50,9 +50,9 @@ class Document implements DocumentInterface, \IteratorAggregate, \Countable, \Ar
      *
      * @return mixed
      */
-    public function __call(string $name, array $arguments)
+    public function __call(string $name, array $arguments): mixed
     {
-        return $this->document->$name($arguments);
+        return $this->document->$name(...$arguments);
     }
 
     /**

--- a/tests/Plugin/MinimumScoreFilter/DocumentTest.php
+++ b/tests/Plugin/MinimumScoreFilter/DocumentTest.php
@@ -22,4 +22,34 @@ class DocumentTest extends AbstractDocumentTestCase
         $filterDoc2 = new FilterDocument($doc2, false);
         $this->assertFalse($filterDoc2->markedAsLowScore());
     }
+
+    public function testMethodCallForwarding(): void
+    {
+        $doc = new class($this->fields) extends Document {
+            protected int $value = 0;
+
+            public function setTestValue(int $value): void
+            {
+                $this->value = $value;
+            }
+
+            public function addTestValues(int $value1, int $value2): void
+            {
+                $this->value += $value1;
+                $this->value += $value2;
+            }
+
+            public function getTestValue(): int
+            {
+                return $this->value;
+            }
+        };
+        $filterDoc = new FilterDocument($doc, true);
+
+        $filterDoc->setTestValue(42);
+        $this->assertSame(42, $filterDoc->getTestValue());
+
+        $filterDoc->addTestValues(3, 4);
+        $this->assertSame(49, $filterDoc->getTestValue());
+    }
 }


### PR DESCRIPTION
When forwarding method calls from `MinimumScoreFilter\Document` the arguments were passed to the original method as a single array instead of unpacked into the correct argument list.