### PR TITLE
Remove deprecated curl_close() for PHP 8.5 compatibility (6.4.x backport)

### DIFF
--- a/src/Core/Client/Adapter/Curl.php
+++ b/src/Core/Client/Adapter/Curl.php
@@ -56,15 +56,12 @@ class Curl extends Configurable implements AdapterInterface, TimeoutAwareInterfa
         if (CURLE_OK !== curl_errno($handle)) {
             $errno = curl_errno($handle);
             $error = curl_error($handle);
-            curl_close($handle);
             throw new HttpException(sprintf('HTTP request failed, %s', $error), $errno);
         }
 
         $httpCode = curl_getinfo($handle, CURLINFO_RESPONSE_CODE);
         $headers = [];
         $headers[] = 'HTTP/1.1 '.$httpCode.' OK';
-
-        curl_close($handle);
 
         return new Response($httpResponse, $headers);
     }


### PR DESCRIPTION
## Summary

`curl_close()` has been a no-op since PHP 8.0 (CurlHandle objects are freed automatically) and is deprecated since PHP 8.5, triggering:

> Deprecated function: Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0

This was already fixed on `master` in #1170 but not backported to `6.x`.

Fixes #1177