### PR TITLE
Deprecate WT_PHPS

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -85,6 +85,9 @@ jobs:
                 composer update
                 sed -i "s/'dev-.*'/'76.5.4'/g" vendor/composer/installed.php
 
+            - name: Set environment variable
+              run: echo "SOLR_VERSION=${{ matrix.solr }}" >> $GITHUB_ENV
+
             - name: Run tests
               run: |
                 vendor/bin/phpstan --memory-limit=1G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Solarium\Core\Query\AbstractQuery::setTimeAllowed() and getTimeAllowed(), moved to Solarium\QueryType\Select\Query\Query
 - Solarium\Core\Query\Helper::cacheControl(), use Solarium\QueryType\Select\Query\FilterQuery::setCache() and setCost() instead
 
+### Deprecated
+- Solarium\Core\Query\AbstractQuery::setResponseWriter('phps'), rely on the default 'json' response writer instead
+
 
 ## [6.4.1]
 ### Added

--- a/docs/customizing-solarium.md
+++ b/docs/customizing-solarium.md
@@ -80,6 +80,70 @@ htmlFooter();
 
 ```
 
+This example shows how you can get CSV output from Solr through partial usage.
+
+```php
+<?php
+
+require_once __DIR__.'/init.php';
+
+htmlHeader();
+
+// This example shows how to manually execute the query flow to use Solr's CSV response writer.
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a select query instance
+$query = $client->createSelect();
+
+// you can build your query as usual
+$query->setQuery('electronics');
+$query->setFields(['id', 'manu', 'name', 'price', 'cat', 'inStock']);
+$query->addSort('id', $query::SORT_ASC);
+
+// set up (0-based) pagination, in real life you can set this to a higher number
+$resultsPerPage = 5;
+$currentPage = 0;
+$query->setRows($resultsPerPage);
+$query->setStart($currentPage * $resultsPerPage);
+
+// tell Solr to use the CSV response writer
+$query->setResponseWriter('csv');
+
+// other options for the CSV response can be set as raw parameters
+$query->addParam('csv.mv.separator', '|');
+
+// in real life you can open a stream to append the output to
+echo '<textarea rows="20" cols="200">';
+
+do {
+    // manually create a request for the query
+    $request = $client->createRequest($query);
+
+    // execute the request and get a 'raw' response object
+    $response = $client->executeRequest($request);
+
+    // get the response body
+    $data = $response->getBody();
+
+    // "append" the output to our "stream"
+    echo $data;
+
+    // increment the page for the next iteration
+    $query->setStart(++$currentPage * $resultsPerPage);
+
+    // this loop would never terminate if further requests always return the column headers
+    $query->addParam('csv.header', false);
+} while ('' !== $data);
+
+// close the "stream"
+echo '</textarea>';
+
+htmlFooter();
+
+```
+
 
 Plugin system
 -------------

--- a/docs/solarium-concepts.md
+++ b/docs/solarium-concepts.md
@@ -244,12 +244,18 @@ So while it is still possible to create class instances manually, it is advisabl
 
 If you want to customize Solarium please read the [docs on customizing](customizing-solarium.md) first. While you can simply extend classes that's in most cases not the best way to go.
 
-### Response parser format
+### Response writer format
 
-Solarium supports two Solr responsewriters: json and phps. The ‘phps’ responsewriter returns data as serialized PHP. This can be more efficient to decode than json, especially for large responses. For a benchmark see [this blogpost](https://dzone.com/articles/benchmarks-php-solr-response) (but be sure to test for your own use-case).
+Solarium currently supports two Solr responsewriters: `json` and `phps`. The `phps` responsewriter returns data as serialized PHP. This can be more efficient to decode than JSON, especially for large responses. For a benchmark see [this blogpost](https://dzone.com/articles/benchmarks-php-solr-response) (but be sure to test for your own use-case).
 
 However this comes at the cost of a possible security risk in PHP deserialization. As long as you use a trusted Solr server this should be no issue, but to be safe the default is still JSON.
 
-You can switch to the phps responseparser by setting a query option:
+You can switch to the `phps` responseparser by setting a query option:
 
-`$query = $client->createSelect(['responsewriter' => 'phps']);`
+```php
+$query = $client->createSelect(['responsewriter' => 'phps']);
+```
+
+The `phps` responsewriter has been removed in Solr 10. Therefore its use has been deprecated in Solarium 7 and it will no longer be supported in Solarium 8.
+
+Other responsewriters aren't supported. You can still use Solarium to issue a request for a different response format as long as you don't expect it to also parse that response. The section on [partial usage](customizing-solarium.md#partial-usage) has an example where CSV output is requested through Solarium and further handled in user code.

--- a/examples/5.1.1-partial-usage-csv.php
+++ b/examples/5.1.1-partial-usage-csv.php
@@ -1,0 +1,58 @@
+<?php
+
+require_once __DIR__.'/init.php';
+
+htmlHeader();
+
+// This example shows how to manually execute the query flow to use Solr's CSV response writer.
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// create a select query instance
+$query = $client->createSelect();
+
+// you can build your query as usual
+$query->setQuery('electronics');
+$query->setFields(['id', 'manu', 'name', 'price', 'cat', 'inStock']);
+$query->addSort('id', $query::SORT_ASC);
+
+// set up (0-based) pagination, in real life you can set this to a higher number
+$resultsPerPage = 5;
+$currentPage = 0;
+$query->setRows($resultsPerPage);
+$query->setStart($currentPage * $resultsPerPage);
+
+// tell Solr to use the CSV response writer
+$query->setResponseWriter('csv');
+
+// other options for the CSV response can be set as raw parameters
+$query->addParam('csv.mv.separator', '|');
+
+// in real life you can open a stream to append the output to
+echo '<textarea rows="20" cols="200">';
+
+do {
+    // manually create a request for the query
+    $request = $client->createRequest($query);
+
+    // execute the request and get a 'raw' response object
+    $response = $client->executeRequest($request);
+
+    // get the response body
+    $data = $response->getBody();
+
+    // "append" the output to our "stream"
+    echo $data;
+
+    // increment the page for the next iteration
+    $query->setStart(++$currentPage * $resultsPerPage);
+
+    // this loop would never terminate if further requests always return the column headers
+    $query->addParam('csv.header', false);
+} while ('' !== $data);
+
+// close the "stream"
+echo '</textarea>';
+
+htmlFooter();

--- a/examples/index.html
+++ b/examples/index.html
@@ -167,6 +167,9 @@
             <li>5. Customization</li>
             <ul style="list-style:none;">
                 <li><a href="5.1-partial-usage.php">5.1 Partial usage</a></li>
+                <ul style="list-style:none;">
+                    <li><a href="5.1.1-partial-usage-csv.php">5.1.1 Get CSV output from Solr</a></li>
+                </ul>
                 <li><a href="5.2-extending.php">5.2 Extending</a></li>
                 <li>5.3 Plugin system</li>
                 <ul style="list-style:none;">

--- a/src/Component/ResponseParser/TermVector.php
+++ b/src/Component/ResponseParser/TermVector.php
@@ -68,6 +68,7 @@ class TermVector extends AbstractResponseParser implements ComponentParserInterf
         foreach ($data['termVectors'] as $key => $document) {
             $parsedDocument = $this->parseDocument($responseWriter, $document);
 
+            // @phpstan-ignore classConstant.deprecated (Will be removed in Solarium 8)
             if (null !== $warnings && $query::WT_PHPS === $responseWriter) {
                 $uniqueKey = $parsedDocument->getUniqueKey();
 

--- a/src/Core/Query/AbstractQuery.php
+++ b/src/Core/Query/AbstractQuery.php
@@ -21,6 +21,9 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
 
     public const WT_JSON = 'json';
 
+    /**
+     * @deprecated Will be removed in Solarium 8
+     */
     public const WT_PHPS = 'phps';
 
     /**
@@ -177,13 +180,13 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
     /**
      * Set responsewriter option.
      *
-     * @param string $value
+     * @param self::WT_*|string $responseWriter
      *
      * @return self Provides fluent interface
      */
-    public function setResponseWriter(string $value): self
+    public function setResponseWriter(string $responseWriter): self
     {
-        $this->setOption('responsewriter', $value);
+        $this->setOption('responsewriter', $responseWriter);
 
         return $this;
     }
@@ -197,16 +200,13 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
      * setting the responsewriter to 'phps' (serialized php). This can give a performance advantage,
      * especially with big resultsets.
      *
-     * @return string
+     * @return self::WT_*|string
      */
     public function getResponseWriter(): string
     {
         $responseWriter = $this->getOption('responsewriter');
-        if (null === $responseWriter) {
-            $responseWriter = self::WT_JSON;
-        }
 
-        return $responseWriter;
+        return $responseWriter ?? self::WT_JSON;
     }
 
     /**
@@ -313,5 +313,28 @@ abstract class AbstractQuery extends Configurable implements QueryInterface
     public function getInputEncoding(): ?string
     {
         return $this->getOption('ie');
+    }
+
+    public function setOption(string $name, $value): Configurable
+    {
+        // @phpstan-ignore classConstant.deprecated (Will be removed in Solarium 8)
+        if ('responsewriter' === $name && self::WT_PHPS === $value) {
+            trigger_error('Support for parsing "phps" responses is deprecated in Solarium 7 and will be removed in Solarium 8.', \E_USER_DEPRECATED);
+        }
+
+        return parent::setOption($name, $value);
+    }
+
+    /**
+     * Initialization hook.
+     *
+     * {@internal Check for deprecated 'phps' response writer.}
+     */
+    protected function init(): void
+    {
+        // @phpstan-ignore classConstant.deprecated (Will be removed in Solarium 8)
+        if (isset($this->options['responsewriter']) && self::WT_PHPS === $this->options['responsewriter']) {
+            trigger_error('Support for parsing "phps" responses is deprecated in Solarium 7 and will be removed in Solarium 8.', \E_USER_DEPRECATED);
+        }
     }
 }

--- a/src/Core/Query/Result/Result.php
+++ b/src/Core/Query/Result/Result.php
@@ -104,6 +104,7 @@ class Result implements ResultInterface, \JsonSerializable
     {
         if (null === $this->data) {
             switch ($this->query->getResponseWriter()) {
+                // @phpstan-ignore classConstant.deprecated (Will be removed in Solarium 8)
                 case AbstractQuery::WT_PHPS:
                     $data = unserialize($this->response->getBody(), ['allowed_classes' => false]);
 

--- a/src/QueryType/Luke/ResponseParser/Doc.php
+++ b/src/QueryType/Luke/ResponseParser/Doc.php
@@ -42,6 +42,7 @@ class Doc extends Index
 
         $query = $result->getQuery();
 
+        // @phpstan-ignore classConstant.deprecated (Will be removed in Solarium 8)
         if ($query::WT_PHPS === $query->getResponseWriter()) {
             // workaround for https://github.com/apache/solr/pull/2114
             $response = $result->getResponse();

--- a/tests/Component/Facet/RangeTest.php
+++ b/tests/Component/Facet/RangeTest.php
@@ -15,6 +15,11 @@ class RangeTest extends TestCase
         $this->facet = new Range();
     }
 
+    public function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
     public function testConfigMode(): void
     {
         $options = [
@@ -57,8 +62,6 @@ class RangeTest extends TestCase
         $this->facet->setOptions($options);
 
         $this->assertSame(['e1\,e2', 'e3'], $this->facet->getExcludes());
-
-        restore_error_handler();
     }
 
     public function testConfigModeWithExcludeThrowsDeprecation(): void
@@ -73,8 +76,6 @@ class RangeTest extends TestCase
 
         $this->expectExceptionCode(\E_USER_DEPRECATED);
         $this->facet->setOptions($options);
-
-        restore_error_handler();
     }
 
     public function testGetType(): void

--- a/tests/Component/ResponseParser/TermVectorTest.php
+++ b/tests/Component/ResponseParser/TermVectorTest.php
@@ -151,6 +151,8 @@ class TermVectorTest extends TestCase
 
     /**
      * @dataProvider expectedResultProvider
+     *
+     * @deprecated Will be removed in Solarium 8
      */
     public function testParseWtPhps(Result $expectedResult): void
     {
@@ -225,7 +227,7 @@ class TermVectorTest extends TestCase
             ],
         ];
 
-        $this->query->setResponseWriter($this->query::WT_PHPS);
+        @$this->query->setResponseWriter($this->query::WT_PHPS);
 
         $result = $this->parser->parse($this->query, $this->tv, $data);
 
@@ -335,6 +337,8 @@ class TermVectorTest extends TestCase
 
     /**
      * @dataProvider expectedResultAmbiguousKeysProvider
+     *
+     * @deprecated Will be removed in Solarium 8
      */
     public function testParseAmbiguousKeysWtPhps(Result $expectedResult): void
     {
@@ -350,7 +354,7 @@ class TermVectorTest extends TestCase
             ],
         ];
 
-        $this->query->setResponseWriter($this->query::WT_PHPS);
+        @$this->query->setResponseWriter($this->query::WT_PHPS);
 
         $result = $this->parser->parse($this->query, $this->tv, $data);
 
@@ -428,6 +432,8 @@ class TermVectorTest extends TestCase
 
     /**
      * @dataProvider expectedResultDoubleKeysProvider
+     *
+     * @deprecated Will be removed in Solarium 8
      */
     public function testParseDoubleKeysWtPhps(Result $expectedResult): void
     {
@@ -449,7 +455,7 @@ class TermVectorTest extends TestCase
             ],
         ];
 
-        $this->query->setResponseWriter($this->query::WT_PHPS);
+        @$this->query->setResponseWriter($this->query::WT_PHPS);
 
         $result = $this->parser->parse($this->query, $this->tv, $data);
 
@@ -519,6 +525,8 @@ class TermVectorTest extends TestCase
 
     /**
      * @dataProvider expectedResultNoDocumentsProvider
+     *
+     * @deprecated Will be removed in Solarium 8
      */
     public function testParseNoDocumentsWtPhps(Result $expectedResult): void
     {
@@ -532,7 +540,7 @@ class TermVectorTest extends TestCase
             ],
         ];
 
-        $this->query->setResponseWriter($this->query::WT_PHPS);
+        @$this->query->setResponseWriter($this->query::WT_PHPS);
 
         $result = $this->parser->parse($this->query, $this->tv, $data);
 

--- a/tests/Component/Result/Debug/DetailTest.php
+++ b/tests/Component/Result/Debug/DetailTest.php
@@ -28,6 +28,11 @@ class DetailTest extends TestCase
         );
     }
 
+    public function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
     public function testGetValue(): void
     {
         $this->assertEquals($this->value, $this->result->getValue());
@@ -115,8 +120,6 @@ class DetailTest extends TestCase
 
         $this->expectExceptionMessage('Undefined property');
         $this->result->offsetGet('unknown');
-
-        restore_error_handler();
     }
 
     public function testOffsetSetImmutable(): void

--- a/tests/Component/Result/TermVector/DocumentTest.php
+++ b/tests/Component/Result/TermVector/DocumentTest.php
@@ -25,6 +25,11 @@ class DocumentTest extends TestCase
         $this->document = new Document('key', $this->fields);
     }
 
+    public function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
     public function testGetUniqueKey(): void
     {
         $this->assertSame('key', $this->document->getUniqueKey());
@@ -93,8 +98,6 @@ class DocumentTest extends TestCase
 
         $this->expectExceptionMessage('Undefined array key "unknown"');
         $this->document->offsetGet('unknown');
-
-        restore_error_handler();
     }
 
     public function testOffsetSetImmutable(): void

--- a/tests/Component/Result/TermVector/FieldTest.php
+++ b/tests/Component/Result/TermVector/FieldTest.php
@@ -25,6 +25,11 @@ class FieldTest extends TestCase
         $this->field = new Field('fieldA', $this->terms);
     }
 
+    public function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
     public function testGetName(): void
     {
         $this->assertSame('fieldA', $this->field->getName());
@@ -86,8 +91,6 @@ class FieldTest extends TestCase
 
         $this->expectExceptionMessage('Undefined array key "unknown"');
         $this->field->offsetGet('unknown');
-
-        restore_error_handler();
     }
 
     public function testOffsetSetImmutable(): void

--- a/tests/Component/Result/TermVector/ResultTest.php
+++ b/tests/Component/Result/TermVector/ResultTest.php
@@ -30,6 +30,11 @@ class ResultTest extends TestCase
         $this->result = new Result($this->documents, $this->warnings);
     }
 
+    public function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
     public function testGetDocuments(): void
     {
         $this->assertSame($this->documents, $this->result->getDocuments());
@@ -95,8 +100,6 @@ class ResultTest extends TestCase
 
         $this->expectExceptionMessage('Undefined array key "unknown"');
         $this->result->offsetGet('unknown');
-
-        restore_error_handler();
     }
 
     public function testOffsetSetImmutable(): void

--- a/tests/Component/Result/TermVector/TermTest.php
+++ b/tests/Component/Result/TermVector/TermTest.php
@@ -22,6 +22,11 @@ class TermTest extends TestCase
         $this->term = new Term($term, $tf, $positions, $offsets, $payloads, $df, $tfIdf);
     }
 
+    public function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
     public function testGetTerm(): void
     {
         $this->assertSame('term1', $this->term->getTerm());
@@ -108,8 +113,6 @@ class TermTest extends TestCase
 
         $this->expectExceptionMessage('Undefined property');
         $this->term->offsetGet('unknown');
-
-        restore_error_handler();
     }
 
     public function testOffsetSetImmutable(): void

--- a/tests/Component/Result/TermVector/WarningsTest.php
+++ b/tests/Component/Result/TermVector/WarningsTest.php
@@ -19,6 +19,11 @@ class WarningsTest extends TestCase
         $this->warnings = new Warnings($noTermVectors, $noPositions, $noOffsets, $noPayloads);
     }
 
+    public function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
     public function testGetNoTermVectors(): void
     {
         $this->assertSame(['fieldA', 'fieldB'], $this->warnings->getNoTermVectors());
@@ -84,8 +89,6 @@ class WarningsTest extends TestCase
 
         $this->expectExceptionMessage('Undefined property');
         $this->warnings->offsetGet('unknown');
-
-        restore_error_handler();
     }
 
     public function testOffsetSetImmutable(): void

--- a/tests/Core/Client/Adapter/CurlTest.php
+++ b/tests/Core/Client/Adapter/CurlTest.php
@@ -27,20 +27,42 @@ class CurlTest extends TestCase
         $this->adapter = new Curl();
     }
 
+    public function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
     public function testSetProxyConstructor(): void
     {
-        set_error_handler(static function (int $errno, string $errstr): never {
+        set_error_handler(static function (int $errno, string $errstr) {
+            // ignore deprecation so we can test deprecated functionality
+        }, \E_USER_DEPRECATED);
+
+        $adapter = new Curl(['proxy' => 'proxy.example.org:1234']);
+        $this->assertSame('proxy.example.org:1234', $adapter->getProxy());
+    }
+
+    public function testSetProxyConstructorThrowsDeprecation(): void
+    {
+        set_error_handler(static function (int $errno, string $errstr) {
             throw new \Exception($errstr, $errno);
         }, \E_USER_DEPRECATED);
 
         $this->expectExceptionMessage('Setting proxy as an option is deprecated. Use setProxy() instead.');
-        $adapter = new Curl(['proxy' => 'proxy.example.org:1234']);
-        $this->assertSame('proxy.example.org:1234', $adapter->getProxy());
-
-        restore_error_handler();
+        new Curl(['proxy' => 'proxy.example.org:1234']);
     }
 
     public function testSetProxyConfigMode(): void
+    {
+        set_error_handler(static function (int $errno, string $errstr) {
+            // ignore deprecation so we can test deprecated functionality
+        }, \E_USER_DEPRECATED);
+
+        $this->adapter->setOptions(['proxy' => 'proxy.example.org:5678']);
+        $this->assertSame('proxy.example.org:5678', $this->adapter->getProxy());
+    }
+
+    public function testSetProxyConfigModeThrowsDeprecation(): void
     {
         set_error_handler(static function (int $errno, string $errstr): never {
             throw new \Exception($errstr, $errno);
@@ -48,12 +70,19 @@ class CurlTest extends TestCase
 
         $this->expectExceptionMessage('Setting proxy as an option is deprecated. Use setProxy() instead.');
         $this->adapter->setOptions(['proxy' => 'proxy.example.org:5678']);
-        $this->assertSame('proxy.example.org:5678', $this->adapter->getProxy());
-
-        restore_error_handler();
     }
 
     public function testSetProxyOption(): void
+    {
+        set_error_handler(static function (int $errno, string $errstr) {
+            // ignore deprecation so we can test deprecated functionality
+        }, \E_USER_DEPRECATED);
+
+        $this->adapter->setOption('proxy', 'proxy.example.org:9012');
+        $this->assertSame('proxy.example.org:9012', $this->adapter->getProxy());
+    }
+
+    public function testSetProxyOptionThrowsDeprecation(): void
     {
         set_error_handler(static function (int $errno, string $errstr): never {
             throw new \Exception($errstr, $errno);
@@ -61,9 +90,6 @@ class CurlTest extends TestCase
 
         $this->expectExceptionMessage('Setting proxy as an option is deprecated. Use setProxy() instead.');
         $this->adapter->setOption('proxy', 'proxy.example.org:9012');
-        $this->assertSame('proxy.example.org:9012', $this->adapter->getProxy());
-
-        restore_error_handler();
     }
 
     /**

--- a/tests/Core/Query/QueryTest.php
+++ b/tests/Core/Query/QueryTest.php
@@ -10,6 +10,11 @@ use Solarium\Core\Query\ResponseParserInterface;
 
 class QueryTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
     public function testSetAndGetHandler(): void
     {
         $query = new TestQuery();
@@ -82,8 +87,51 @@ class QueryTest extends TestCase
     public function testSetAndGetResponseWriter(): void
     {
         $query = new TestQuery();
+        $query->setResponseWriter('test');
+        $this->assertSame('test', $query->getResponseWriter());
+    }
+
+    public function testSetResponseWriterPhpsThrowsDeprecation(): void
+    {
+        set_error_handler(static function (int $errno, string $errstr): never {
+            throw new \Exception($errstr, $errno);
+        }, \E_USER_DEPRECATED);
+
+        $query = new TestQuery();
+        $this->expectExceptionCode(\E_USER_DEPRECATED);
         $query->setResponseWriter('phps');
-        $this->assertSame('phps', $query->getResponseWriter());
+    }
+
+    public function testSetResponseWriterPhpsConstructorThrowsDeprecation(): void
+    {
+        set_error_handler(static function (int $errno, string $errstr): never {
+            throw new \Exception($errstr, $errno);
+        }, \E_USER_DEPRECATED);
+
+        $this->expectExceptionCode(\E_USER_DEPRECATED);
+        $query = new TestQuery(['responsewriter' => 'phps']);
+    }
+
+    public function testSetResponseWriterPhpsConfigModeThrowsDeprecation(): void
+    {
+        set_error_handler(static function (int $errno, string $errstr): never {
+            throw new \Exception($errstr, $errno);
+        }, \E_USER_DEPRECATED);
+
+        $query = new TestQuery();
+        $this->expectExceptionCode(\E_USER_DEPRECATED);
+        $query->setOptions(['responsewriter' => 'phps']);
+    }
+
+    public function testSetResponseWriterPhpsOptionThrowsDeprecation(): void
+    {
+        set_error_handler(static function (int $errno, string $errstr): never {
+            throw new \Exception($errstr, $errno);
+        }, \E_USER_DEPRECATED);
+
+        $query = new TestQuery();
+        $this->expectExceptionCode(\E_USER_DEPRECATED);
+        $query->setOption('responsewriter', 'phps');
     }
 
     public function testSetAndGetNow(): void

--- a/tests/Core/Query/Result/ResultTest.php
+++ b/tests/Core/Query/Result/ResultTest.php
@@ -3,20 +3,16 @@
 namespace Solarium\Tests\Core\Query\Result;
 
 use PHPUnit\Framework\TestCase;
-use Solarium\Core\Client\Client;
 use Solarium\Core\Client\Response;
 use Solarium\Core\Query\Result\Result;
 use Solarium\Exception\HttpException;
 use Solarium\Exception\RuntimeException;
 use Solarium\Exception\UnexpectedValueException;
 use Solarium\QueryType\Select\Query\Query as SelectQuery;
-use Solarium\Tests\Integration\TestClientFactory;
 
 class ResultTest extends TestCase
 {
     protected Result $result;
-
-    protected Client $client;
 
     protected SelectQuery $query;
 
@@ -28,7 +24,6 @@ class ResultTest extends TestCase
 
     public function setUp(): void
     {
-        $this->client = TestClientFactory::createWithCurlAdapter();
         $this->query = new SelectQuery();
         $this->headers = ['HTTP/1.0 304 Not Modified'];
         $this->data = '{"responseHeader":{"status":0,"QTime":1,"params":{"wt":"json","q":"xyz"}},'.
@@ -36,6 +31,11 @@ class ResultTest extends TestCase
         $this->response = new Response($this->data, $this->headers);
 
         $this->result = new Result($this->query, $this->response);
+    }
+
+    public function tearDown(): void
+    {
+        restore_error_handler();
     }
 
     public function testResultWithErrorResponse(): void
@@ -79,13 +79,16 @@ class ResultTest extends TestCase
         $this->assertEquals($data, $this->result->getData());
     }
 
+    /**
+     * @deprecated Will be removed in Solarium 8
+     */
     public function testGetDataWithPhps(): void
     {
         $phpsData = 'a:2:{s:14:"responseHeader";a:3:{s:6:"status";i:0;s:5:"QTime";i:0;s:6:"params";'.
             'a:6:{s:6:"indent";s:2:"on";s:5:"start";s:1:"0";s:1:"q";s:3:"*:*";s:2:"wt";s:4:"phps";s:7:"version";'.
             's:3:"2.2";s:4:"rows";s:1:"0";}}s:8:"response";a:3:{s:8:"numFound";i:57;s:5:"start";i:0;s:4:"docs";'.
             'a:0:{}}}';
-        $this->query->setResponseWriter('phps');
+        @$this->query->setResponseWriter('phps');
         $resultData = [
             'responseHeader' => [
                 'status' => 0,
@@ -129,13 +132,16 @@ class ResultTest extends TestCase
         $this->result->getData();
     }
 
+    /**
+     * @deprecated Will be removed in Solarium 8
+     */
     public function testGetInvalidPhpsData(): void
     {
         set_error_handler(static function (int $errno, string $errstr): void {
             // ignore E_NOTICE or E_WARNING from unserialize() to check that we throw an exception
         }, version_compare(PHP_VERSION, '8.3.0', '>=') ? \E_WARNING : \E_NOTICE);
 
-        $this->query->setResponseWriter($this->query::WT_PHPS);
+        @$this->query->setResponseWriter($this->query::WT_PHPS);
 
         $data = 'invalid';
         $this->response = new Response($data, $this->headers);
@@ -143,8 +149,6 @@ class ResultTest extends TestCase
 
         $this->expectException(UnexpectedValueException::class);
         $this->result->getData();
-
-        restore_error_handler();
     }
 
     public function testJsonSerialize(): void

--- a/tests/Integration/AbstractTechproductsTestCase.php
+++ b/tests/Integration/AbstractTechproductsTestCase.php
@@ -228,11 +228,17 @@ abstract class AbstractTechproductsTestCase extends TestCase
      */
     public static function responseWriterProvider(): array
     {
-        return [
+        $responseWriters = [
             [AbstractQuery::WT_JSON],
-            // no longer supported in Solr 10
-            // [AbstractQuery::WT_PHPS],
         ];
+
+        // PHPUnit evaluates this before self::$solrVersion is set
+        if (10 > (int) getenv('SOLR_VERSION')) {
+            // @phpstan-ignore classConstant.deprecated (Will be removed in Solarium 8)
+            $responseWriters[] = [AbstractQuery::WT_PHPS];
+        }
+
+        return $responseWriters;
     }
 
     /**

--- a/tests/QueryType/Luke/ResponseParser/DocTest.php
+++ b/tests/QueryType/Luke/ResponseParser/DocTest.php
@@ -61,6 +61,8 @@ class DocTest extends TestCase
 
     /**
      * @depends testParseJson
+     *
+     * @deprecated Will be removed in Solarium 8
      */
     public function testParsePhps(DocInfo $doc): void
     {
@@ -73,7 +75,7 @@ class DocTest extends TestCase
         );
 
         $query = new Query();
-        $query->setResponseWriter($query::WT_PHPS);
+        @$query->setResponseWriter($query::WT_PHPS);
         $query->setShow(Query::SHOW_DOC);
         $query->setDocId(1701);
 

--- a/tests/QueryType/Luke/ResponseParser/FieldsTest.php
+++ b/tests/QueryType/Luke/ResponseParser/FieldsTest.php
@@ -55,6 +55,8 @@ class FieldsTest extends TestCase
 
     /**
      * @depends testParseJson
+     *
+     * @deprecated Will be removed in Solarium 8
      */
     public function testParsePhps(array $fields): void
     {
@@ -69,7 +71,7 @@ class FieldsTest extends TestCase
         ];
 
         $query = new Query();
-        $query->setResponseWriter(Query::WT_PHPS);
+        @$query->setResponseWriter(Query::WT_PHPS);
         $query->setShow(Query::SHOW_ALL);
         $query->setFields('*');
 

--- a/tests/QueryType/Luke/ResponseParser/IndexTest.php
+++ b/tests/QueryType/Luke/ResponseParser/IndexTest.php
@@ -48,6 +48,8 @@ class IndexTest extends TestCase
 
     /**
      * @depends testParseJson
+     *
+     * @deprecated Will be removed in Solarium 8
      */
     public function testParsePhps(Index $index): void
     {
@@ -60,7 +62,7 @@ class IndexTest extends TestCase
         ];
 
         $query = new Query();
-        $query->setResponseWriter($query::WT_PHPS);
+        @$query->setResponseWriter($query::WT_PHPS);
         $query->setShow(Query::SHOW_INDEX);
 
         $resultStub = $this->createMock(Result::class);

--- a/tests/QueryType/Luke/ResponseParser/InfoTest.php
+++ b/tests/QueryType/Luke/ResponseParser/InfoTest.php
@@ -47,6 +47,8 @@ class InfoTest extends TestCase
 
     /**
      * @depends testParseJson
+     *
+     * @deprecated Will be removed in Solarium 8
      */
     public function testParsePhps(Info $info): void
     {
@@ -61,7 +63,7 @@ class InfoTest extends TestCase
         ];
 
         $query = new Query();
-        $query->setResponseWriter(Query::WT_PHPS);
+        @$query->setResponseWriter(Query::WT_PHPS);
 
         $resultStub = $this->createMock(Result::class);
         $resultStub->expects($this->any())

--- a/tests/Support/UtilityTest.php
+++ b/tests/Support/UtilityTest.php
@@ -15,18 +15,30 @@ class UtilityTest extends TestCase
         $this->fixtures = realpath(__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Integration'.DIRECTORY_SEPARATOR.'Fixtures');
     }
 
+    public function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
     public function testGetXmlEncodingNoFile(): void
+    {
+        set_error_handler(static function (int $errno, string $errstr) {
+            // ignore warning so we can test the return value
+        }, \E_WARNING);
+
+        $this->assertNull(
+            Utility::getXmlEncoding('nosuchfile')
+        );
+    }
+
+    public function testGetXmlEncodingNoFileThrowsException(): void
     {
         set_error_handler(static function (int $errno, string $errstr): never {
             throw new \Exception($errstr, $errno);
         }, \E_WARNING);
 
         $this->expectExceptionMessage('No such file or directory');
-        $this->assertNull(
-            Utility::getXmlEncoding('nosuchfile')
-        );
-
-        restore_error_handler();
+        Utility::getXmlEncoding('nosuchfile');
     }
 
     public function testGetXmlEncodingWithoutUtf8BomWithoutXmlDeclaration(): void


### PR DESCRIPTION
Closes #1169.

Also added an example of another way `setResponseWriter()` can be used.

Turns out unit tests that end with `restore_error_handler()` never actually executed this function. This caused a problem with my new unit tests in combination with some of the existing ones so I just fixed them all.