### PR TITLE
Return type of field/function grouping value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the Solarium library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Solarium\Component\Result\Grouping\ValueGroup::getValue() returns `string|float|int|bool|null` according to field type or function return type instead of always coercing to `?string`
+
+
 ## [7.0.0]
 ### Added
 - Solr 10 support

--- a/docs/queries/select-query/building-a-select-query/components/grouping-component.md
+++ b/docs/queries/select-query/building-a-select-query/components/grouping-component.md
@@ -24,7 +24,7 @@ Options
 Examples
 --------
 
-Grouping by field: 
+### Grouping by field
 
 ```php
 <?php
@@ -58,7 +58,8 @@ foreach ($groups as $groupKey => $fieldGroup) {
     echo 'Number of groups: '.$fieldGroup->getNumberOfGroups();
 
     foreach ($fieldGroup as $valueGroup) {
-        echo '<h2>'.(int)$valueGroup->getValue().'</h2>';
+        $value = $valueGroup->getValue();
+        echo '<h2>'.(null !== $value ? ($value ? 'true' : 'false') : 'NULL').'</h2>';
 
         foreach ($valueGroup as $document) {
             echo '<hr/><table>';
@@ -82,7 +83,65 @@ htmlFooter();
 
 ```
 
-Grouping by query: 
+### Grouping by function
+
+The result format when grouping by function is the same as when grouping by field.
+
+```
+<?php
+
+require_once __DIR__.'/init.php';
+
+htmlHeader();
+
+// create a client instance
+$client = new Solarium\Client($adapter, $eventDispatcher, $config);
+
+// get a select query instance
+$query = $client->createSelect();
+$query->setRows(50);
+
+// get grouping component and set a function to group by
+$groupComponent = $query->getGrouping();
+$groupComponent->setFunction('exists(features)');
+// maximum number of items per group
+$groupComponent->setLimit(3);
+
+// this executes the query and returns the result
+$resultset = $client->select($query);
+
+$groups = $resultset->getGrouping();
+foreach ($groups as $groupKey => $functionGroup) {
+    echo '<h1>'.$groupKey.'</h1>';
+    echo 'Matches: '.$functionGroup->getMatches().'<br/>';
+
+    foreach ($functionGroup as $valueGroup) {
+        $value = $valueGroup->getValue();
+        echo '<h2>'.($value ? 'true' : 'false').'</h2>';
+
+        foreach ($valueGroup as $document) {
+            echo '<hr/><table>';
+
+            // the documents are also iterable, to get all fields
+            foreach ($document as $field => $value) {
+                // this converts multivalue fields to a comma-separated string
+                if (is_array($value)) {
+                    $value = implode(', ', $value);
+                }
+
+                echo '<tr><th>'.$field.'</th><td>'.$value.'</td></tr>';
+            }
+
+            echo '</table>';
+        }
+    }
+}
+
+htmlFooter();
+
+```
+
+### Grouping by query
 
 ```php
 <?php

--- a/examples/2.1.5.6-grouping-by-function.php
+++ b/examples/2.1.5.6-grouping-by-function.php
@@ -11,26 +11,23 @@ $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 $query = $client->createSelect();
 $query->setRows(50);
 
-// get grouping component and set a field to group by
+// get grouping component and set a function to group by
 $groupComponent = $query->getGrouping();
-$groupComponent->addField('inStock');
+$groupComponent->setFunction('exists(features)');
 // maximum number of items per group
 $groupComponent->setLimit(3);
-// get a group count
-$groupComponent->setNumberOfGroups(true);
 
 // this executes the query and returns the result
 $resultset = $client->select($query);
 
 $groups = $resultset->getGrouping();
-foreach ($groups as $groupKey => $fieldGroup) {
+foreach ($groups as $groupKey => $functionGroup) {
     echo '<h1>'.$groupKey.'</h1>';
-    echo 'Matches: '.$fieldGroup->getMatches().'<br/>';
-    echo 'Number of groups: '.$fieldGroup->getNumberOfGroups();
+    echo 'Matches: '.$functionGroup->getMatches().'<br/>';
 
-    foreach ($fieldGroup as $valueGroup) {
+    foreach ($functionGroup as $valueGroup) {
         $value = $valueGroup->getValue();
-        echo '<h2>'.(null !== $value ? ($value ? 'true' : 'false') : 'NULL').'</h2>';
+        echo '<h2>'.($value ? 'true' : 'false').'</h2>';
 
         foreach ($valueGroup as $document) {
             echo '<hr/><table>';

--- a/examples/execute_all.php
+++ b/examples/execute_all.php
@@ -195,6 +195,7 @@ try {
 
     // examples that can't be run in cloud mode
     $skipForCloud = [
+        '2.1.5.6-grouping-by-function.php',
         '2.1.5.7-grouping-by-query.php',
         '2.2.5-rollback.php',
         '2.10.2-managedresources-stopwords.php',

--- a/examples/index.html
+++ b/examples/index.html
@@ -77,6 +77,7 @@
                         <li><a href="2.1.5.4-dismax.php">2.1.5.4 Dismax</a></li>
                         <li><a href="2.1.5.5-edismax.php">2.1.5.5 Edismax</a></li>
                         <li><a href="2.1.5.6-grouping-by-field.php">2.1.5.6 Grouping by field</a></li>
+                        <li><a href="2.1.5.6-grouping-by-function.php">2.1.5.6 Grouping by function</a></li>
                         <li><a href="2.1.5.7-grouping-by-query.php">2.1.5.7 Grouping by query</a></li>
                         <li><a href="2.1.5.8-distributed-search.php">2.1.5.8 Distributed search (sharding)</a></li>
                         <li><a href="2.1.5.9-spellcheck.php">2.1.5.9 Spellcheck</a></li>

--- a/src/Component/Grouping.php
+++ b/src/Component/Grouping.php
@@ -446,7 +446,7 @@ class Grouping extends AbstractComponent
     }
 
     /**
-     * Get truncate option.
+     * Get function option.
      *
      * @return string|null
      */

--- a/src/Component/ResponseParser/Grouping.php
+++ b/src/Component/ResponseParser/Grouping.php
@@ -43,7 +43,13 @@ class Grouping implements ComponentParserInterface
         $documentClass = $query->getOption('documentclass');
 
         // check grouping fields as well as the grouping function (either can be used in the query)
-        foreach (array_merge($grouping->getFields(), [$grouping->getFunction()]) as $field) {
+        $fields = $grouping->getFields();
+
+        if (null !== $function = $grouping->getFunction()) {
+            $fields[] = $function;
+        }
+
+        foreach ($fields as $field) {
             if (!isset($data['grouped'][$field])) {
                 continue;
             }

--- a/src/Component/Result/Grouping/ValueGroup.php
+++ b/src/Component/Result/Grouping/ValueGroup.php
@@ -12,16 +12,16 @@ namespace Solarium\Component\Result\Grouping;
 use Solarium\Core\Query\AbstractQuery;
 
 /**
- * Select component grouping field value group result.
+ * Select component grouping field or function value group result.
  *
  * @since 2.1.0
  */
 class ValueGroup implements \IteratorAggregate, \Countable
 {
     /**
-     * Field value.
+     * Field or function value.
      */
-    protected ?string $value;
+    protected string|float|int|bool|null $value;
 
     /**
      * NumFound.
@@ -48,14 +48,14 @@ class ValueGroup implements \IteratorAggregate, \Countable
     /**
      * Constructor.
      *
-     * @param string|null        $value
-     * @param int|null           $numFound
-     * @param int|null           $start
-     * @param array              $documents
-     * @param float|null         $maxScore
-     * @param AbstractQuery|null $query
+     * @param string|float|int|bool|null $value
+     * @param int|null                   $numFound
+     * @param int|null                   $start
+     * @param array                      $documents
+     * @param float|null                 $maxScore
+     * @param AbstractQuery|null         $query
      */
-    public function __construct(?string $value, ?int $numFound, ?int $start, array $documents, ?float $maxScore = null, ?AbstractQuery $query = null)
+    public function __construct(string|float|int|bool|null $value, ?int $numFound, ?int $start, array $documents, ?float $maxScore = null, ?AbstractQuery $query = null)
     {
         $this->value = $value;
         $this->numFound = $numFound;
@@ -68,9 +68,9 @@ class ValueGroup implements \IteratorAggregate, \Countable
     /**
      * Get value.
      *
-     * @return string|null
+     * @return string|float|int|bool|null
      */
-    public function getValue(): ?string
+    public function getValue(): string|float|int|bool|null
     {
         return $this->value;
     }

--- a/tests/Component/ResponseParser/GroupingTest.php
+++ b/tests/Component/ResponseParser/GroupingTest.php
@@ -26,6 +26,8 @@ class GroupingTest extends TestCase
         $this->query = new Query();
         $this->grouping = $this->query->getGrouping();
         $this->grouping->addField('fieldA');
+        $this->grouping->addField('fieldB');
+        $this->grouping->addField('fieldC');
         $this->grouping->setFunction('functionF');
         $this->grouping->addQuery('cat:1');
 
@@ -42,6 +44,68 @@ class GroupingTest extends TestCase
                                 'start' => 0,
                                 'docs' => [
                                     ['id' => 1, 'name' => 'test'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'fieldB' => [
+                    'matches' => 25,
+                    'ngroups' => 2,
+                    'groups' => [
+                        [
+                            'groupValue' => 3.14,
+                            'doclist' => [
+                                'numFound' => 1,
+                                'start' => 0,
+                                'docs' => [
+                                    ['id' => 2, 'name' => 'float test'],
+                                ],
+                            ],
+                        ],
+                        [
+                            'groupValue' => 42,
+                            'doclist' => [
+                                'numFound' => 1,
+                                'start' => 0,
+                                'docs' => [
+                                    ['id' => 3, 'name' => 'int test'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'fieldC' => [
+                    'matches' => 25,
+                    'ngroups' => 3,
+                    'groups' => [
+                        [
+                            'groupValue' => true,
+                            'doclist' => [
+                                'numFound' => 1,
+                                'start' => 0,
+                                'docs' => [
+                                    ['id' => 1, 'name' => 'true test'],
+                                ],
+                            ],
+                        ],
+                        [
+                            'groupValue' => false,
+                            'doclist' => [
+                                'numFound' => 1,
+                                'start' => 0,
+                                'docs' => [
+                                    ['id' => 2, 'name' => 'false test'],
+                                ],
+                            ],
+                        ],
+                        [
+                            'groupValue' => null,
+                            'doclist' => [
+                                'numFound' => 1,
+                                'start' => 0,
+                                'docs' => [
+                                    ['id' => 3, 'name' => 'null test'],
                                 ],
                             ],
                         ],
@@ -84,7 +148,7 @@ class GroupingTest extends TestCase
 
     public function testGroupParsing(): void
     {
-        $this->assertCount(3, $this->result->getGroups());
+        $this->assertCount(5, $this->result->getGroups());
 
         $fieldGroup = $this->result->getGroup('fieldA');
         $queryGroup = $this->result->getGroup('cat:1');
@@ -105,12 +169,29 @@ class GroupingTest extends TestCase
         $this->assertCount(1, $valueGroups);
 
         $valueGroup = $valueGroups[0];
+        $this->assertEquals('test value', $valueGroup->getValue());
         $this->assertEquals(13, $valueGroup->getNumFound());
         $this->assertEquals(0, $valueGroup->getStart());
         $this->assertNull($valueGroup->getMaximumScore());
 
         $docs = $valueGroup->getDocuments();
         $this->assertEquals('test', $docs[0]->name);
+
+        $fieldGroup = $this->result->getGroup('fieldB');
+        $valueGroups = $fieldGroup->getValueGroups();
+
+        $this->assertCount(2, $valueGroups);
+        $this->assertEquals(3.14, $valueGroups[0]->getValue());
+        $this->assertIsInt($valueGroups[1]->getValue());
+        $this->assertEquals(42, $valueGroups[1]->getValue());
+
+        $fieldGroup = $this->result->getGroup('fieldC');
+        $valueGroups = $fieldGroup->getValueGroups();
+
+        $this->assertCount(3, $valueGroups);
+        $this->assertTrue($valueGroups[0]->getValue());
+        $this->assertFalse($valueGroups[1]->getValue());
+        $this->assertNull($valueGroups[2]->getValue());
     }
 
     public function testQueryGroupParsing(): void
@@ -211,6 +292,7 @@ class GroupingTest extends TestCase
         $this->assertCount(1, $valueGroups);
 
         $valueGroup = $valueGroups[0];
+        $this->assertTrue($valueGroup->getValue());
         $this->assertEquals(5, $valueGroup->getNumFound());
         $this->assertEquals(0, $valueGroup->getStart());
         $this->assertEquals(0.97027725, $valueGroup->getMaximumScore());
@@ -249,6 +331,7 @@ class GroupingTest extends TestCase
         $this->assertCount(1, $valueGroups);
 
         $valueGroup = $valueGroups[0];
+        $this->assertNull($valueGroup->getValue());
         $this->assertEquals(13, $valueGroup->getNumFound());
 
         $docs = $valueGroup->getDocuments();

--- a/tests/Integration/AbstractTechproductsTestCase.php
+++ b/tests/Integration/AbstractTechproductsTestCase.php
@@ -985,7 +985,10 @@ abstract class AbstractTechproductsTestCase extends TestCase
         $select->setFields('id');
         $select->addSort('manu_exact', SelectQuery::SORT_ASC);
         $grouping = $select->getGrouping();
-        $grouping->setFields('manu_exact');
+        $grouping->addField('manu_exact');
+        $grouping->addField('price');
+        $grouping->addField('popularity');
+        $grouping->addField('inStock');
         $grouping->setSort('price asc');
         $result = self::$client->select($select);
         /** @var GroupingResult $groupingComponentResult */
@@ -1043,8 +1046,65 @@ abstract class AbstractTechproductsTestCase extends TestCase
         $doc = $docIterator->current();
         $this->assertSame('VS1GB400C3', $doc->getFields()['id']);
 
+        $fieldGroup = $groupingComponentResult->getGroup('price');
+        $valueGroup = $fieldGroup->getValueGroups()[0];
+        $this->assertNull($valueGroup->getValue());
+        $valueGroup = $fieldGroup->getValueGroups()[1];
+        $this->assertSame(479.95, $valueGroup->getValue());
+
+        $fieldGroup = $groupingComponentResult->getGroup('popularity');
+        $valueGroup = $fieldGroup->getValueGroups()[0];
+        $this->assertSame(0, $valueGroup->getValue());
+
+        $fieldGroup = $groupingComponentResult->getGroup('inStock');
+        $valueGroup = $fieldGroup->getValueGroups()[0];
+        $this->assertTrue($valueGroup->getValue());
+        $valueGroup = $fieldGroup->getValueGroups()[1];
+        $this->assertFalse($valueGroup->getValue());
+
+        // Grouping by function is not supported in distributed searches
+        // https://solr.apache.org/guide/solr/latest/query-guide/result-grouping.html#distributed-result-grouping-caveats
+        if ($this instanceof AbstractServerTestCase) {
+            /** @var GroupingTestQuery $select */
+            $select = self::$client->createQuery('grouping');
+            $select->setResponseWriter($responseWriter);
+            $select->setQuery('memory');
+            $select->setFields('id');
+            $select->addSort('id', SelectQuery::SORT_ASC);
+            $grouping = $select->getGrouping();
+            $grouping->setFunction('exists(features)');
+            $result = self::$client->select($select);
+            /** @var GroupingResult $groupingComponentResult */
+            $groupingComponentResult = $result->getComponent(ComponentAwareQueryInterface::COMPONENT_GROUPING);
+
+            /** @var FieldGroup $fieldGroup */
+            $fieldGroup = $groupingComponentResult->getGroup('exists(features)');
+            $this->assertCount(2, $fieldGroup);
+            $groupIterator = $fieldGroup->getIterator();
+
+            /** @var ValueGroup $valueGroup */
+            $valueGroup = $groupIterator->current();
+            $this->assertSame(4, $valueGroup->getNumFound());
+            $this->assertSame(0, $valueGroup->getStart());
+            $this->assertTrue($valueGroup->getValue());
+            $docIterator = $valueGroup->getIterator();
+            /** @var Document $doc */
+            $doc = $docIterator->current();
+            $this->assertSame('0579B002', $doc->getFields()['id']);
+
+            $groupIterator->next();
+            $valueGroup = $groupIterator->current();
+            $this->assertSame(1, $valueGroup->getNumFound());
+            $this->assertSame(0, $valueGroup->getStart());
+            $this->assertFalse($valueGroup->getValue());
+            $docIterator = $valueGroup->getIterator();
+            $doc = $docIterator->current();
+            $this->assertSame('VS1GB400C3', $doc->getFields()['id']);
+        }
+
         /** @var GroupingTestQuery $select */
         $select = self::$client->createQuery('grouping');
+        $select->setResponseWriter($responseWriter);
         $select->setQuery('memory');
         $select->setFields('id,price');
         $grouping = $select->getGrouping();


### PR DESCRIPTION
Using `null` as an array key is deprecated in PHP 8.5. This is what happened when parsing a `Grouping` result if no grouping function is set. The function was always added to the array that's iterated and used as an array key inside the loop.

https://github.com/solariumphp/solarium/blob/ec841cf4134e1fb0399c9da63ed19acb426ce70b/src/Component/ResponseParser/Grouping.php#L46

I saw there was no example or integration test for grouping by function so I wanted to add those while I was at it. And that's when I noticed the group value was always returned as `?string` while functions can return `float` or `bool` (and grouping by a function returning `string` isn't even currently supported in Solr). The field value can also be `float`, `int`, or `bool` besides `string` or `null`. Coercing these to `string` seems odd when "Solarium is a PHP Solr client library that accurately models Solr concepts." I think it's more natural to keep the type that Solr returns.