### PR TITLE
Fix list markup

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,12 +94,14 @@ When upgrading from an earlier version, you should be aware of a number of pitfa
 ### Pitfalls when upgrading to 7.0.0
 
 Solarium 7.0.0 added type declarations throughout the codebase for:
+
 - class properties
 - union types in method signatures
 - `void` return types
 
 Plugins extending from `Solarium\Core\Plugin\AbstractPlugin` must add `void` return types to the signatures for
 the following methods (when defined):
+
 - `initPlugin()`
 - `deinitPlugin()`
 - `initPluginType()`


### PR DESCRIPTION
Without a new line separating the list, it gets smooshed together like this.

> Solarium 7.0.0 added type declarations throughout the codebase for: - class properties - union types in method signatures - `void` return types

What we want is this.

> Solarium 7.0.0 added type declarations throughout the codebase for:
> 
> - class properties
> - union types in method signatures
> - `void` return types